### PR TITLE
fix(practice): in-memory session when localStorage is blocked (#6780)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 797572378449c901c327b1c9a7a9d4525317eee6e98e5d5dd1fe55eae43085bd
+  components_sha256: 441dd17c4abbc58a2a3363dd0bf535f690bb488fc75435777386021db4095aac
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -18,6 +18,7 @@ import {
   DAILY_PRACTICE_DECK_SIZE,
   PUBLISHED_PRACTICE_LEVELS,
   SRS_STORAGE_FULL_WARNING,
+  SRS_STORAGE_UNAVAILABLE_WARNING,
   buildSessionPoolConstraintState,
   classifyDailyPracticeOrigin,
   clearPracticeSessionSnapshots,
@@ -31,6 +32,7 @@ import {
   isCaseClozeDrill,
   isPracticeNewCard,
   isPracticeSessionResumable,
+  isPracticeStorageEphemeral,
   isWrongCaseAnswer,
   loadState,
   masteredCount,
@@ -508,9 +510,9 @@ function translateStorageWarning(warning: string | null): { uk: string; en: stri
       en: 'Progress not saved — storage is full',
     };
   }
-  if (warning.includes('сховище браузера')) {
+  if (warning.includes('сховище браузера') || warning === SRS_STORAGE_UNAVAILABLE_WARNING) {
     return {
-      uk: 'Прогрес призупинено, доки сховище браузера не стане доступним.',
+      uk: SRS_STORAGE_UNAVAILABLE_WARNING,
       en: 'Progress suspended until browser storage becomes available.',
     };
   }
@@ -2190,8 +2192,13 @@ function LexiconPracticeIsland({
 
     if (state.flags.storageFull) {
       setStorageWarning(SRS_STORAGE_FULL_WARNING);
-    } else if (state.flags.storageWriteFailed || state.flags.corrupt || state.flags.migrationFailed) {
-      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+    } else if (
+      isPracticeStorageEphemeral() ||
+      state.flags.storageWriteFailed ||
+      state.flags.corrupt ||
+      state.flags.migrationFailed
+    ) {
+      setStorageWarning(SRS_STORAGE_UNAVAILABLE_WARNING);
     }
 
     if (typeof window !== 'undefined') {
@@ -2782,7 +2789,7 @@ function LexiconPracticeIsland({
       try {
         rateCard(pair.lemmaId, 'matching', rating, new Date());
       } catch (e) {
-        setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+        setStorageWarning(SRS_STORAGE_UNAVAILABLE_WARNING);
       }
     }
   }, [pairs, selection, sessionCompleted]);
@@ -3517,8 +3524,13 @@ function LexiconPracticeIsland({
     setReviewLog([...state.reviews]);
     if (state.flags.storageFull) {
       setStorageWarning(SRS_STORAGE_FULL_WARNING);
-    } else if (state.flags.storageWriteFailed || state.flags.corrupt || state.flags.migrationFailed) {
-      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+    } else if (
+      isPracticeStorageEphemeral() ||
+      state.flags.storageWriteFailed ||
+      state.flags.corrupt ||
+      state.flags.migrationFailed
+    ) {
+      setStorageWarning(SRS_STORAGE_UNAVAILABLE_WARNING);
     } else if (storageWarning === SRS_STORAGE_FULL_WARNING) {
       setStorageWarning(null);
     }
@@ -3581,7 +3593,7 @@ function LexiconPracticeIsland({
         en: `${current.lemma.lemma}: ${RATING_LABELS[rating].en}`,
       });
     } catch {
-      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+      setStorageWarning(SRS_STORAGE_UNAVAILABLE_WARNING);
     }
     return { nextUnresolved, nextDeferred };
   }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -38,6 +38,9 @@ const SETTINGS_VERSION = 1;
 export const MAX_RAW_REVIEW_LOG_ENTRIES = 2_000;
 const RECOVERY_RAW_REVIEW_LOG_ENTRIES = 0;
 export const SRS_STORAGE_FULL_WARNING = 'Прогрес не зберігається — сховище переповнене';
+/** Shown when browser storage is blocked/disabled and Practice runs on the in-memory fallback. */
+export const SRS_STORAGE_UNAVAILABLE_WARNING =
+  'Прогрес призупинено, доки сховище браузера не стане доступним.';
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const SESSION_RESUME_MAX_MS = 6 * HOUR_MS;
@@ -730,18 +733,54 @@ const memoryStorage: StorageLike = {
 
 let activeState: LoadedSrsState | null = null;
 let activeStorage: StorageLike | null = null;
+/** True when `resolveStorage` fell back because browser localStorage is unusable. */
+let practiceStorageEphemeral = false;
 
+/**
+ * Prefer `window.localStorage`, but probe a read first.
+ *
+ * Chrome `--disable-local-storage` (and some private-mode builds) expose a Storage
+ * object whose `getItem`/`setItem` throw `SecurityError`. Returning that object
+ * made `loadState` / `nextDuePreviewTime` throw during Practice render and trip
+ * the error boundary (#6780). Quota-full storage still allows `getItem`, so a
+ * read probe does not mis-classify the existing quota-recovery path.
+ */
 function resolveStorage(): StorageLike {
-  if (typeof window === 'undefined') return memoryStorage;
+  if (typeof window === 'undefined') {
+    practiceStorageEphemeral = false;
+    return memoryStorage;
+  }
   try {
-    return window.localStorage;
+    const storage = window.localStorage;
+    void storage.getItem('__lu_srs_probe__');
+    practiceStorageEphemeral = false;
+    return storage;
   } catch {
+    practiceStorageEphemeral = true;
     return memoryStorage;
   }
 }
 
 function currentStorage(): StorageLike {
   return activeStorage ?? resolveStorage();
+}
+
+/** Whether Practice is using the session-only in-memory store (blocked localStorage). */
+export function isPracticeStorageEphemeral(): boolean {
+  if (activeStorage === memoryStorage) return true;
+  resolveStorage();
+  return practiceStorageEphemeral;
+}
+
+/**
+ * Drop the cached SRS hydrate so the next read re-resolves browser storage.
+ * Used after storage availability changes (and in unit tests that stub localStorage).
+ */
+export function clearLoadedSrsState(): void {
+  activeState = null;
+  activeStorage = null;
+  practiceStorageEphemeral = false;
+  memoryStore.clear();
 }
 
 function emptyFlags(): SrsFlags {
@@ -1045,17 +1084,26 @@ export function loadState(
   storage: StorageLike = resolveStorage(),
   now: Date | number = Date.now(),
 ): LoadedSrsState {
-  const raw = storage.getItem(SRS_STORAGE_KEY);
+  let resolved = storage;
+  let raw: string | null;
+  try {
+    raw = resolved.getItem(SRS_STORAGE_KEY);
+  } catch {
+    // Explicit broken Storage (or a stale activeStorage) must not crash render.
+    resolved = memoryStorage;
+    practiceStorageEphemeral = true;
+    raw = memoryStorage.getItem(SRS_STORAGE_KEY);
+  }
   if (
     activeState?.flags.storageWriteFailed &&
-    activeStorage === storage &&
+    activeStorage === resolved &&
     activeState.raw === raw
   ) {
     return activeState;
   }
 
-  activeStorage = storage;
-  const { settings, corrupt: settingsCorrupt } = loadSettings(storage);
+  activeStorage = resolved;
+  const { settings, corrupt: settingsCorrupt } = loadSettings(resolved);
   if (!raw) {
     activeState = {
       version: CURRENT_VERSION,
@@ -1092,7 +1140,7 @@ export function loadState(
     });
     if (state) {
       if (compactReviewHistory(state.reviews, state.reviewAggregates, MAX_RAW_REVIEW_LOG_ENTRIES)) {
-        persistWithQuotaRecovery(state, storage, toTime(now) ?? Date.now());
+        persistWithQuotaRecovery(state, resolved, toTime(now) ?? Date.now());
       }
       activeState = state;
       return state;
@@ -1119,7 +1167,7 @@ export function loadState(
     });
     if (!state) throw new Error('migrated SRS schema is invalid');
     activeState = state;
-    persistWithQuotaRecovery(state, storage, toTime(now) ?? Date.now());
+    persistWithQuotaRecovery(state, resolved, toTime(now) ?? Date.now());
     return state;
   } catch {
     activeState = {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -21,6 +21,7 @@ import {
   SRS_STORAGE_KEY,
   DAILY_PRACTICE_DECK_SIZE,
   cardKey,
+  clearLoadedSrsState,
   loadState,
   saveState,
   type PracticeDeckData,
@@ -1346,6 +1347,43 @@ describe('LexiconPractice', () => {
     expect(retry).toBeInTheDocument();
     // No slash-dual button chrome.
     expect(retry.textContent ?? '').not.toMatch(/\/\s*Try again|\/\s*Спробувати/);
+  });
+
+  test('blocked localStorage still mounts practice chrome with an in-memory session (#6780)', async () => {
+    const realStorage = globalThis.localStorage;
+    const denied = () => {
+      throw new DOMException('Access is denied', 'SecurityError');
+    };
+    vi.stubGlobal(
+      'localStorage',
+      {
+        get length() {
+          return 0;
+        },
+        clear: vi.fn(),
+        getItem: denied,
+        key: vi.fn(() => null),
+        removeItem: denied,
+        setItem: denied,
+      } as unknown as Storage,
+    );
+    clearLoadedSrsState();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { fn } = mockShardFetch({ A1: 2 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+    try {
+      render(<LexiconPractice />);
+
+      expect(screen.queryByTestId('practice-error-fallback')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('practice-start-session')).toBeInTheDocument();
+      expect(screen.getByText(/Прогрес призупинено, доки сховище браузера не стане доступним/)).toBeInTheDocument();
+      expect(screen.getByText(/Progress suspended until browser storage becomes available/)).toBeInTheDocument();
+    } finally {
+      vi.stubGlobal('localStorage', realStorage);
+      clearLoadedSrsState();
+    }
   });
 
   test('eager-loads the index and Words-of-the-Day lexemes, but no mode-specific drill shards, before a mode starts', async () => {

--- a/site/tests/unit/practice-storage-fallback.test.ts
+++ b/site/tests/unit/practice-storage-fallback.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  clearLoadedSrsState,
+  isPracticeStorageEphemeral,
+  loadState,
+  nextDuePreviewTime,
+  rateCard,
+  readPracticeSessionSnapshots,
+  writePracticeSessionSnapshot,
+  type PracticeSessionSnapshot,
+} from '../../src/lib/lexicon/srs';
+
+const realLocalStorage = globalThis.localStorage;
+
+/** Storage stub that mimics Chrome `--disable-local-storage` / blocked private mode. */
+function throwingLocalStorage({ onGet = false }: { onGet?: boolean } = {}): Storage {
+  const denied = () => {
+    throw new DOMException('Access is denied', 'SecurityError');
+  };
+  return {
+    get length() {
+      return 0;
+    },
+    clear: vi.fn(),
+    getItem: onGet ? denied : vi.fn(() => null),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: denied,
+  } as unknown as Storage;
+}
+
+afterEach(() => {
+  vi.stubGlobal('localStorage', realLocalStorage);
+  vi.restoreAllMocks();
+  clearLoadedSrsState();
+  realLocalStorage.clear();
+});
+
+describe('practice storage fallback (#6780)', () => {
+  test('loadState and nextDuePreviewTime do not throw when getItem throws', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage({ onGet: true }));
+    clearLoadedSrsState();
+
+    expect(() => loadState()).not.toThrow();
+    expect(isPracticeStorageEphemeral()).toBe(true);
+    expect(() => nextDuePreviewTime()).not.toThrow();
+  });
+
+  test('ratings persist in the in-memory store for the session', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage({ onGet: true }));
+    clearLoadedSrsState();
+
+    loadState();
+    expect(() => rateCard('мир', 'flashcards', 'good', new Date('2026-08-14T12:00:00.000Z'))).not.toThrow();
+
+    const reloaded = loadState();
+    expect(reloaded.cards.has('мир::flashcards')).toBe(true);
+    expect(reloaded.reviews).toHaveLength(1);
+  });
+
+  test('session snapshots use the same in-memory fallback', () => {
+    vi.stubGlobal('localStorage', throwingLocalStorage({ onGet: true }));
+    clearLoadedSrsState();
+
+    const snapshot: PracticeSessionSnapshot = {
+      sessionSeed: 1,
+      history: [],
+      budget: 10,
+      completed: 0,
+      modeFilter: 'mixed',
+      level: 'A1',
+      deckId: 'all',
+      dateSeed: 20260814,
+      startedAt: Date.parse('2026-08-14T12:00:00.000Z'),
+      extensionUsed: 0,
+      sessionNewIntroduced: 0,
+      plannedReviews: 0,
+      plannedNew: 10,
+      plannedTotal: 10,
+      reviewsCompleted: 0,
+      unresolvedCardKeys: [],
+    };
+
+    expect(() => writePracticeSessionSnapshot('mixed', snapshot)).not.toThrow();
+    expect(readPracticeSessionSnapshots().mixed?.sessionSeed).toBe(1);
+  });
+
+  test('accessor-only localStorage (setItem throws, getItem works) still falls back for writes', () => {
+    // setItem-only failure: resolveStorage keeps localStorage (getItem ok), but
+    // writes must not crash the session — save paths already catch; probe stays read-only.
+    vi.stubGlobal('localStorage', throwingLocalStorage({ onGet: false }));
+    clearLoadedSrsState();
+
+    expect(() => loadState()).not.toThrow();
+    expect(isPracticeStorageEphemeral()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

After #6773, `getDeviceId` no longer throws, but Practice still crashed into the error card («We couldn't load practice. Try reloading the page.») when localStorage methods throw (e.g. Chrome `--disable-local-storage`). Root cause: `resolveStorage()` returned a Storage object whose `getItem` throws, and `nextDuePreviewTime()` called `loadState()` during every render.

## Changes

- Probe `localStorage` with a read before adopting it; fall back to the existing in-memory store when the probe fails
- Harden `loadState` so a broken Storage argument cannot take down render
- Show the existing no-persist banner when Practice is on the ephemeral store
- Tests for SRS fallback + LexiconPractice mount (start-session chrome, no error boundary)

## Testing

- [x] `vitest run tests/unit/practice-storage-fallback.test.ts tests/unit/custom-decks-storage-failure.test.ts` — 8 passed
- [x] `vitest run tests/unit/LexiconPractice.test.tsx -t "blocked localStorage still mounts"` — 1 passed
- [x] `vitest run tests/unit/lexicon-srs.test.ts -t "storage|quota|persist|loadState"` — 6 passed
- [ ] Website builds without errors (`cd site && npm run build`) — not run in this dispatch
- [ ] Modules pass audit — N/A (site-only)

## Related Issues

Refs #6780
This PR leaves #4387 #6780 open.

No merge by the worker.

X-Agent: cursor/6780-storage-load

Made with [Cursor](https://cursor.com)