### PR TITLE
fix(practice): delete dead today-ring computation (#6760)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 441dd17c4abbc58a2a3363dd0bf535f690bb488fc75435777386021db4095aac
+  components_sha256: 145b905bf8e40f9679f1e144803fdd08b7a20eae5ec399a421b0cfbccf09eb7c
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -27,7 +27,6 @@ import {
   extendWithLowerDecks,
   itemIdPresentInDeck,
   computeSessionScope,
-  computeTodayRingDenominator,
   czNorm,
   isCaseClozeDrill,
   isPracticeNewCard,
@@ -1920,7 +1919,6 @@ function LexiconPracticeIsland({
     lastPracticeDate: null,
   });
   const [, setMastered] = useState(0);
-  const [completedToday, setCompletedToday] = useState(0);
   const [dailyNewCount, setDailyNewCount] = useState(0);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const [clozeInput, setClozeInput] = useState('');
@@ -2331,7 +2329,7 @@ function LexiconPracticeIsland({
   }, [sessionPhase]);
 
   // Eager-load ONLY the lightweight per-level index shards on mount (and on a
-  // pre-session level change) so the «До повторення» tile + today ring reflect the
+  // pre-session level change) so the «До повторення» tile reflects the
   // learner's real SRS due-count immediately — the most motivating number on the
   // home, and the reason a returning learner opens this page. The heavy
   // lexeme/cloze shards stay lazy until a mode actually starts (ensureDeck). Once a
@@ -3605,7 +3603,6 @@ function LexiconPracticeIsland({
     setHistory((items) => [...items.slice(-49), historyFromSelection(current)]);
     const nextCompleted = sessionCompleted + 1;
     setSessionCompleted(nextCompleted);
-    setCompletedToday((value) => value + 1);
     refreshProgress();
     persistSessionSnapshot({ completed: nextCompleted });
     const decision = resolveSessionCompletion({
@@ -3827,20 +3824,6 @@ function LexiconPracticeIsland({
         : { pendingDue: [], pendingNew: [], done: [] },
     [dailySnapshot, reviewLog],
   );
-  const todayDenominator = useMemo(
-    () =>
-      indexForStats.length
-        ? computeTodayRingDenominator(indexForStats, { dailyNewCount })
-        : 0,
-    [completedToday, dailyNewCount, indexForStats, revision],
-  );
-  const todayPct =
-    todayDenominator > 0
-      ? Math.min(100, (completedToday / todayDenominator) * 100)
-      : completedToday > 0
-        ? 100
-        : 0;
-  const todayRingStyle = { '--pct': String(todayPct) } as CSSProperties;
   const stageMode: PracticeModeFilter = selection?.mode ?? mode;
   const visibleStageMode = visiblePracticeMode(stageMode);
   const stageTitleUk =


### PR DESCRIPTION
## What & why

Fixes the P1 finding from the learner-layout UX audit (P1-2 / P1-11): the "today ring" was **computed but never rendered**.

`todayDenominator`, `todayPct`, `todayRingStyle` and the `completedToday` counter lived in `LexiconPractice.tsx` but no element ever consumed `todayRingStyle`, and there was **no production CSS** for the ring (only the `docs/poc` POC had `.ring`/`--pct`).

**Why delete rather than wire:**
- The dashboard stats strip already renders today's progress — **Due / New / Done** — from the persisted, rehydrated `dailyRows`. A ring would duplicate it.
- The ring's numerator `completedToday` was **never rehydrated** (`useState(0)`, reset on every reload), so rendering it as-is would show stale "0 of N" progress — a regression in data accuracy vs. the existing persisted stats.

## Changes
`site/src/components/LexiconPractice.tsx` (-18/+1):
- Dropped the `computeTodayRingDenominator` import.
- Dropped the `completedToday`/`setCompletedToday` state (only fed the ring).
- Dropped the `setCompletedToday(...)` increment in `completeSelection`.
- Dropped the `todayDenominator`/`todayPct`/`todayRingStyle` locals.
- Updated the stale "tile + today ring" comment.

**Kept:** `computeTodayRingDenominator` in `srs.ts` — it is documented SRS API (`docs/practice/K3-BUILD-SPEC.md` §76), unit-tested, and explicitly protected by the audit's P1-2 *do-not-change*.

## Verification
- `astro check` — no new errors (all pre-existing errors are unrelated: `antonym`/`nextDeck`/custom-set lines untouched by this change).
- `vitest run tests/unit/practice-session.test.ts` — **14/14 pass** (incl. the `today-ring denominator excludes uncapped deck size` test for the kept srs.ts function).
- `vitest run tests/unit/LexiconPractice.test.tsx` — **166/166 pass**.

No UI was added, so no new UI tests are required; the existing component suite covers the affected screen.

Refs #6760. No merge.