### PR TITLE
fix(site): self-host Noto Sans to stop Google Fonts 404s (#6783)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/mdx": "^7.0.5",
         "@astrojs/react": "^6.0.2",
         "@astrojs/sitemap": "^3.7.3",
+        "@fontsource/noto-sans": "^5.3.0",
         "@mdx-js/mdx": "^3.1.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.3",
@@ -1507,6 +1508,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/noto-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans/-/noto-sans-5.3.0.tgz",
+      "integrity": "sha512-fBCog2PY7DiVVTEEqtI/Qdinx/knobHYfoGpjFXdfBX5RoJaBp1Prw2G75p0OIsdlMZg3cLo0c+YbIUYOxnQJw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {

--- a/site/package.json
+++ b/site/package.json
@@ -36,6 +36,7 @@
     "@astrojs/mdx": "^7.0.5",
     "@astrojs/react": "^6.0.2",
     "@astrojs/sitemap": "^3.7.3",
+    "@fontsource/noto-sans": "^5.3.0",
     "@mdx-js/mdx": "^3.1.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.3",

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,4 +1,12 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+/* Self-hosted Noto Sans via Fontsource (OFL-1.1).
+ * Weight CSS includes unicode-range so browsers fetch only latin/Cyrillic
+ * subsets in use — same family/weights as the former Google Fonts import
+ * (400/600/700 + 400 italic). Removes fonts.googleapis.com / fonts.gstatic.com
+ * runtime dependency that 404'd on retired CDN URLs (CourseLayout / WotD). */
+@import '@fontsource/noto-sans/400.css';
+@import '@fontsource/noto-sans/400-italic.css';
+@import '@fontsource/noto-sans/600.css';
+@import '@fontsource/noto-sans/700.css';
 
 /**
  * Learn Ukrainian - Premium Ukrainian Language Learning Platform

--- a/site/tests/unit/noto-sans-self-hosted.test.ts
+++ b/site/tests/unit/noto-sans-self-hosted.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression: CourseLayout typography must not depend on Google Fonts CDN.
+ * Retired fonts.gstatic.com Noto Sans v42 URLs 404'd and failed the
+ * `/words-of-the-day/` Playwright console-error assertion.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const GOOGLE_FONTS_HOSTS = ["fonts.googleapis.com", "fonts.gstatic.com"];
+const CUSTOM_CSS = resolve(process.cwd(), "src/css/custom.css");
+const DIST_DIR = resolve(process.cwd(), "dist");
+const PACKAGE_JSON = resolve(process.cwd(), "package.json");
+
+function collectFiles(dir: string, extensions: Set<string>): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectFiles(path, extensions));
+    } else if ([...extensions].some((ext) => entry.name.endsWith(ext))) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("Noto Sans self-hosted (no Google Fonts runtime)", () => {
+  test("package.json depends on @fontsource/noto-sans", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies?.["@fontsource/noto-sans"]).toMatch(/^\^?5\./);
+  });
+
+  test("custom.css self-hosts Noto Sans weights via Fontsource (unicode-range CSS)", () => {
+    const css = readFileSync(CUSTOM_CSS, "utf8");
+
+    // Comments may name the retired hosts; runtime @import/url must not.
+    expect(css).not.toMatch(
+      /@import\s+url\(['"]?https?:\/\/fonts\.(googleapis|gstatic)\.com/i,
+    );
+    expect(css).not.toMatch(
+      /url\(['"]?https?:\/\/fonts\.(googleapis|gstatic)\.com/i,
+    );
+    expect(css).not.toMatch(/@import\s+url\(['"]?https?:\/\//i);
+    expect(css).toContain("@fontsource/noto-sans/400.css");
+    expect(css).toContain("@fontsource/noto-sans/400-italic.css");
+    expect(css).toContain("@fontsource/noto-sans/600.css");
+    expect(css).toContain("@fontsource/noto-sans/700.css");
+  });
+
+  test("Fontsource weight CSS ships Cyrillic unicode-range for Ukrainian glyphs", () => {
+    const weightCss = resolve(
+      process.cwd(),
+      "node_modules/@fontsource/noto-sans/400.css",
+    );
+    expect(existsSync(weightCss)).toBe(true);
+    const css = readFileSync(weightCss, "utf8");
+    expect(css).toContain("noto-sans-cyrillic-400-normal");
+    // Cyrillic block is typically listed after combining marks (e.g. U+0301,…).
+    expect(css).toMatch(/unicode-range:[^;]*U\+0400-045F/i);
+  });
+
+  test.skipIf(collectFiles(DIST_DIR, new Set([".css", ".html"])).length === 0)(
+    "built dist CSS/HTML has no Google Fonts host references when dist/ is present",
+    () => {
+      const files = collectFiles(DIST_DIR, new Set([".css", ".html"]));
+      expect(files.length).toBeGreaterThan(0);
+
+      const offenders: string[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, "utf8");
+        if (GOOGLE_FONTS_HOSTS.some((host) => text.includes(host))) {
+          offenders.push(file.replace(process.cwd() + "/", ""));
+        }
+      }
+      expect(offenders).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Root cause: `custom.css` loaded Noto Sans from `fonts.googleapis.com`; Chromium then requested retired `fonts.gstatic.com` v42 woff2 URLs that 404'd, failing CourseLayout / WotD Playwright console-error assertions (not DailyWords/shard resolution).
- Fix: depend on `@fontsource/noto-sans` (OFL-1.1) and import weight CSS (`400` / `400-italic` / `600` / `700`) with unicode-range so latin+Cyrillic stay high-quality without any Google Fonts runtime CDN.
- Adds focused vitest regression coverage; leaves `#6781` DailyWords 404-only soft-skip and `atlas-practice.spec.ts` assertions untouched.

## Test plan
- [x] `npx vitest run tests/unit/noto-sans-self-hosted.test.ts` (4 passed with dist)
- [x] `npx vitest run tests/unit/LexiconPractice.test.tsx -t "404 on an unpublished drill shard is soft-skipped"` (preserved)
- [x] `npm run build:shell` (production Astro build; Noto woff2 emitted under `dist/_astro/`; no googleapis/gstatic hosts in dist CSS/HTML)
- [x] `npx playwright test e2e/atlas-practice.spec.ts -g "loads without console errors"` (WotD + lexicon paths)


Made with [Cursor](https://cursor.com)