### PR TITLE
fix(practice): teach matching misses instead of only de-selecting (#6789)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 145b905bf8e40f9679f1e144803fdd08b7a20eae5ec399a421b0cfbccf09eb7c
+  components_sha256: bc269893855582e32dd3bb671ba63e0c09db44a0e6be3cae31315e99598baa89
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1215,6 +1215,17 @@ function choiceFeedbackFor(
     : { kind: 'wrong', textUk: `Неправильно. ${pair}`, textEn: 'Incorrect.' };
 }
 
+/**
+ * #6789: matching used to leave a wrong pair as a bare «Спробуйте ще раз» notice
+ * with no explanatory sentence, unlike choice/classify/stress (#6722). The tapped
+ * left tile's word ↔ gloss pair is already attested deck payload (same `left`/
+ * `right` the board renders), so restate it — same bar, same wording as choice.
+ */
+function matchMissFeedback(pair: MatchPair): DrillFeedback {
+  const text = `«${pair.left}» = ${pair.right}.`;
+  return { kind: 'wrong', textUk: `Неправильно. ${text}`, textEn: `Incorrect. ${text}` };
+}
+
 function classifySet(selection: PracticeSelection): PracticeClassifySet | null {
   const sets = selection.classify?.sets ?? [];
   if (!sets.length) return null;
@@ -1580,12 +1591,14 @@ function PracticeMatchBoard({
   pairs,
   instruction,
   isUkrainian,
+  showEnglishSubtitles,
   onComplete,
   onMatch,
 }: {
   pairs: MatchPair[];
   instruction?: ReactNode;
   isUkrainian: boolean;
+  showEnglishSubtitles: boolean;
   onComplete(): void;
   onMatch?: (pairIndex: number, rating: PracticeRating) => void;
 }) {
@@ -1595,6 +1608,7 @@ function PracticeMatchBoard({
   const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
   const [misses, setMisses] = useState<Record<number, number>>({});
   const [missNotice, setMissNotice] = useState(false);
+  const [missTeach, setMissTeach] = useState<DrillFeedback | null>(null);
   const completedRef = useRef(false);
   const missTimerRef = useRef<number | null>(null);
 
@@ -1620,6 +1634,7 @@ function PracticeMatchBoard({
     if (matched.has(index) || wrongPair) return;
     setSelectedLeft(index);
     setMissNotice(false);
+    setMissTeach(null);
   }
 
   function handleRightClick(originalIndex: number) {
@@ -1636,14 +1651,18 @@ function PracticeMatchBoard({
       setMatchedOrder(nextOrder);
       setSelectedLeft(null);
       setMissNotice(false);
+      setMissTeach(null);
       onMatch?.(selectedLeft, rating);
       return;
     }
     // Wrong pair: count the miss (feeds the eventual rating), flash red, and
     // keep a visible «try again» notice — never silently deselect (#6721).
+    // #6789: the notice alone de-selects but doesn't teach anything — pair it
+    // with the attested word ↔ gloss the learner missed (same bar as choice).
     setMisses((prev) => ({ ...prev, [selectedLeft]: (prev[selectedLeft] ?? 0) + 1 }));
     setWrongPair({ left: selectedLeft, right: originalIndex });
     setMissNotice(true);
+    setMissTeach(matchMissFeedback(pairs[selectedLeft]!));
     if (missTimerRef.current !== null) window.clearTimeout(missTimerRef.current);
     missTimerRef.current = window.setTimeout(() => {
       setWrongPair(null);
@@ -1773,6 +1792,11 @@ function PracticeMatchBoard({
           <ChromeDual uk="✗ Спробуйте ще раз" en="✗ Try again" />
         </p>
       ) : null}
+      <DrillFeedbackPanel
+        feedback={missTeach}
+        testId="practice-match-teach"
+        showEnglishSubtitles={showEnglishSubtitles}
+      />
       {allMatched ? (
         <p
           className="lexicon-practice-muted practice-match-success"
@@ -5072,6 +5096,7 @@ function PracticeItem({
             />
           )}
           isUkrainian={chromeLocale === 'uk'}
+          showEnglishSubtitles={showEnglishSubtitles}
           onComplete={onMatchingComplete}
           onMatch={(pairIndex, rating) => {
             matchedPairIndexesRef.current.add(pairIndex);

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -5367,6 +5367,56 @@ describe('LexiconPractice', () => {
       }
     });
 
+    test('#6789 matching wrong pair teaches the missed word ↔ gloss, not just a de-select', async () => {
+      // lemma → gloss straight from matchingDeck() so the assertion tracks whichever
+      // lemma the session actually schedules first, rather than assuming an order.
+      const GLOSS_BY_LEMMA: Record<string, string> = {
+        книга: 'book',
+        робота: 'work',
+        місто: 'city',
+        школа: 'school',
+        сад: 'garden',
+        дім: 'house',
+      };
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const user = userEvent.setup({ delay: null });
+        const { container } = render(
+          <LexiconPractice initialDeck={matchingDeck()} autoStart initialMode="matching" />,
+        );
+        const leftCol = container.querySelector('[data-activity="match-left-column"]') as HTMLElement;
+        const rightCol = container.querySelector('[data-activity="match-right-column"]') as HTMLElement;
+
+        const firstLeft = within(leftCol).getAllByRole('button')[0]!;
+        const missedLemma = firstLeft.textContent!.trim();
+        const missedGloss = GLOSS_BY_LEMMA[missedLemma];
+        expect(missedGloss).toBeDefined();
+        const wrongRight = within(rightCol)
+          .getAllByRole('button')
+          .find((b) => b.getAttribute('data-original-index') !== '0')!;
+
+        // No teaching sentence before the miss.
+        expect(screen.queryByTestId('practice-match-teach')).not.toBeInTheDocument();
+
+        await user.click(firstLeft);
+        await user.click(wrongRight);
+
+        // The miss is taught: the attested word ↔ gloss pair the learner missed,
+        // same bar as choice/classify/stress (#6722), not an invented gloss.
+        const teach = screen.getByTestId('practice-match-teach');
+        expect(teach).toHaveTextContent(missedLemma);
+        expect(teach).toHaveTextContent(missedGloss!);
+
+        // Re-selecting the left tile after the flash clears the teaching sentence,
+        // matching the miss notice's own lifecycle.
+        await advanceFakeTimers(PRACTICE_MATCH_MISS_FLASH_MS);
+        await user.click(within(leftCol).getAllByRole('button')[0]!);
+        expect(screen.queryByTestId('practice-match-teach')).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     test('#6723 stats tiles reflect the just-played session on return home', async () => {
       document.documentElement.dataset.chromeLocale = 'en';
       localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');


### PR DESCRIPTION
## What

After #6751, a wrong matching pair flashes red and shows a persistent «Спробуйте ще раз» notice — but the learner still got no explanation of the pair itself. This adds a teaching sentence on a matching miss, same bar as the choice/classify/stress teaching feedback from #6722.

## How

- `PracticeMatchBoard` tracks a `missTeach` `DrillFeedback` alongside the existing miss notice, sharing its lifecycle (set on a wrong pair, cleared on re-select or a correct match).
- Renders through the existing `DrillFeedbackPanel` under `data-testid="practice-match-teach"`.
- Teaching text is built only from `pairs[selectedLeft].left`/`.right` — the same word/gloss pair already displayed on the tiles. No invented glosses.
- Regenerated `docs/lesson-schema.yaml` (`components_sha256` drift from the `LexiconPractice.tsx` edit).

## Tests

- New `#6789` unit test locks the teach panel's presence, content, and clear-on-reselect lifecycle.
- Full `LexiconPractice.test.tsx` suite (167 tests) passes, run 3x for stability.
- `tsc --noEmit` / `eslint`: no new errors vs. baseline (pre-existing errors unchanged, confirmed via stash diff).
- `pytest -k "lesson_schema or schema_drift"`: 7 passed.
- Does not regress #6751 (miss flash/notice), #6775 (choice/classify/stress teaching), or #6783 (in-memory session fallback) — their existing tests still pass unchanged.

Refs #4387 (stays open). Do not merge — leaving #4387 and #6789 open per dispatch brief.

X-Agent: claude/6789-match-teach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
