### PR TITLE
fix(lexicon): unify /lexicon learner JSON with /api aliases

### DIFF
--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -5,16 +5,35 @@ as static JSON, not as a live backend service.
 
 ## Canonical Endpoints
 
+Learner-facing artifacts use the `/lexicon/…` prefix (what Practice, Atlas
+typeahead, and Daily Words actually `fetch`). Meta/status stay under
+`/api/lexicon/…`.
+
 - `/api/lexicon/status.json` — status counts across Atlas search/browse,
   manifest hydration, Daily Word, Practice, cloze, and source-inventory
   admission.
-- `/api/lexicon/search-index.json` — compact approved-article typeahead rows.
+- `/api/lexicon/contract.json` — machine-readable surface contract.
+- `/lexicon/search-index.json` — compact approved-article typeahead rows.
 - `/lexicon/search-aliases.json` — public alias resolvers; every row
   targets an approved article slug and is not an Atlas entry itself.
-- `/api/lexicon/daily-pool.json` — Daily Word pool.
-- `/api/lexicon/practice-index.{level}.json` — per-level Practice index.
-- `/api/lexicon/practice-lexemes.{level}.json` — per-level Practice lexeme deck.
-- `/api/lexicon/practice-cloze.{level}.json` — per-level reviewed cloze deck.
+- `/lexicon/search-shards.json` — search shard map for typeahead paging.
+- `/lexicon/daily-pool.json` — Daily Word pool.
+- `/lexicon/practice-index.{level}.json` — per-level Practice index.
+- `/lexicon/practice-lexemes.{level}.json` — per-level Practice lexeme deck.
+- `/lexicon/practice-cloze.{level}.json` — per-level reviewed cloze deck.
+
+### Compatibility aliases (`/api/lexicon/…`)
+
+These URLs remain published so existing bookmarks and older contract links keep
+working. They are thin twins of the canonical `/lexicon/…` artifacts, not a
+second source of truth:
+
+- `/api/lexicon/search-index.json` — re-exports `/lexicon/search-index.json`
+- `/api/lexicon/daily-pool.json` — re-exports `/lexicon/daily-pool.json`
+- `/api/lexicon/practice-index.{level}.json` (and lexemes/cloze) — hydrate
+  copies of `public/lexicon/*.json` into `public/api/lexicon/`
+
+Do not delete a public `/api/lexicon/…` URL without operator authorization.
 
 ## Entry-Model Snapshot
 
@@ -66,9 +85,10 @@ Do not add FastAPI routes for public Atlas learner data unless the deployment
 target changes away from GitHub Pages or the route is explicitly local/admin
 only. Public learner data must stay available as static JSON.
 
-Practice and search shard JSON under `public/api/lexicon/` and
-`public/lexicon/search/` is materialized by `hydrate-lexicon-api-shards.ts`
-during `npm run hydrate`. GitHub Pages serves these as static files (default
-cache headers); the `search-api-shard` / `practice-api-shard` helpers document
-the intended `Cache-Control: public, max-age=3600` contract for tests and any
-future CDN `_headers` wiring.
+Practice shards under `public/lexicon/` (canonical) and the hydrate copy under
+`public/api/lexicon/`, plus search shards under `public/lexicon/search/`, are
+materialized by `hydrate-lexicon-api-shards.ts` during `npm run hydrate`.
+GitHub Pages serves these as static files (default cache headers); the
+`search-api-shard` / `practice-api-shard` helpers document the intended
+`Cache-Control: public, max-age=3600` contract for tests and any future CDN
+`_headers` wiring.

--- a/site/scripts/hydrate-lexicon-api-shards.ts
+++ b/site/scripts/hydrate-lexicon-api-shards.ts
@@ -16,8 +16,8 @@ const siteRoot = resolve(scriptDir, "..");
 function hydrate(): void {
   copyPracticeApiShards(siteRoot);
   const searchShardCount = writeSearchShardFiles(siteRoot);
-  console.log(
-    `✓ lexicon API shards: ${3 * 5} practice files under public/api/lexicon, ${searchShardCount} search shards under public/lexicon/search`,
+    console.log(
+    `✓ lexicon API shards: ${3 * 5} practice files under public/lexicon (+ /api/lexicon alias), ${searchShardCount} search shards under public/lexicon/search`,
   );
 }
 

--- a/site/src/lib/lexicon/atlasDb.ts
+++ b/site/src/lib/lexicon/atlasDb.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { normalizeAtlasText as normalizeAtlasSearchText } from './normalize.ts';
+import { readPracticeIndexItems } from './practice-index-files.ts';
 
 export interface CourseUsage {
   track: string;
@@ -354,32 +355,17 @@ let _practiceLemmasCache: Set<string> | null = null;
 export function getPracticeLemmas(): Set<string> {
   if (_practiceLemmasCache) return _practiceLemmasCache;
   const lemmas = new Set<string>();
+  // Include C2 so a future deck is visible without a second probe path.
   const levels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
   const dbDir = dirname(atlasDbPath());
   let resolvedAny = false;
 
   for (const level of levels) {
-    const paths = [
-      resolve(dbDir, `../site/public/api/lexicon/practice-index.${level}.json`),
-      resolve(dbDir, `../site/public/lexicon/practice-index.${level}.json`),
-    ];
-    for (const p of paths) {
-      if (existsSync(p)) {
-        try {
-          const content = JSON.parse(readFileSync(p, 'utf-8'));
-          if (content && Array.isArray(content.items)) {
-            for (const item of content.items) {
-              if (item.lemmaId) {
-                lemmas.add(item.lemmaId);
-              }
-            }
-          }
-          resolvedAny = true;
-          break;
-        } catch (e) {
-          // ignore parsing/reading errors
-        }
-      }
+    const items = readPracticeIndexItems(dbDir, level);
+    if (items === null) continue;
+    resolvedAny = true;
+    for (const item of items) {
+      if (item.lemmaId) lemmas.add(item.lemmaId);
     }
   }
 

--- a/site/src/lib/lexicon/practice-api-shard.ts
+++ b/site/src/lib/lexicon/practice-api-shard.ts
@@ -25,8 +25,10 @@ export function readPracticeShardBytes(kind: PracticeShardKind, level: PracticeL
 }
 
 /**
- * Copy practice shards to public/api/lexicon/ for static GitHub Pages hosting.
- * Astro 7 cannot prerender practice-*.{level}.json.ts routes with trailingSlash.
+ * Copy practice shards to public/api/lexicon/ as a compatibility alias of the
+ * canonical public/lexicon/ learner prefix. Astro 7 cannot prerender
+ * practice-*.{level}.json.ts routes with trailingSlash; pre-copied static
+ * files keep both URL prefixes working on GitHub Pages.
  */
 export function copyPracticeApiShards(siteRoot: string): void {
   const lexiconPublicDir = resolve(siteRoot, "public/lexicon");
@@ -44,7 +46,8 @@ export function copyPracticeApiShards(siteRoot: string): void {
   }
 }
 
-/** Contract helper for tests; production serves pre-generated public/api/lexicon/*.json. */
+/** Contract helper for tests; production serves pre-generated public/lexicon/*.json
+ *  (canonical) with a hydrate copy under public/api/lexicon/*.json (alias). */
 export function practiceShardResponse(
   kind: PracticeShardKind,
   level: string | undefined,

--- a/site/src/lib/lexicon/practice-index-files.ts
+++ b/site/src/lib/lexicon/practice-index-files.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared practice-index shard probe for SSG / catalog readers.
+ *
+ * Canonical learner files live under `public/lexicon/`. Hydrate also copies
+ * them to `public/api/lexicon/` as a compatibility alias (Astro 7 trailingSlash
+ * cannot prerender `practice-*.{level}.json.ts`). Prefer the canonical path.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface PracticeIndexItem {
+  lemmaId?: string;
+  lemma?: string;
+}
+
+/** Candidate filesystem paths for one practice-index level (canonical first). */
+export function practiceIndexCandidatePaths(dbDir: string, level: string): string[] {
+  return [
+    resolve(dbDir, `../site/public/lexicon/practice-index.${level}.json`),
+    resolve(dbDir, `../site/public/api/lexicon/practice-index.${level}.json`),
+  ];
+}
+
+/**
+ * Read the first readable practice-index shard for `level`.
+ * Returns null when no candidate exists or every candidate fails to parse.
+ */
+export function readPracticeIndexItems(
+  dbDir: string,
+  level: string,
+): PracticeIndexItem[] | null {
+  for (const path of practiceIndexCandidatePaths(dbDir, level)) {
+    if (!existsSync(path)) continue;
+    try {
+      const payload = JSON.parse(readFileSync(path, "utf-8")) as {
+        items?: PracticeIndexItem[];
+      };
+      return Array.isArray(payload?.items) ? payload.items : [];
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}

--- a/site/src/lib/lexicon/runtime-contract.ts
+++ b/site/src/lib/lexicon/runtime-contract.ts
@@ -261,16 +261,20 @@ export function buildLexiconRuntimeStatus(input: BuildRuntimeStatusInput): Lexic
     generatedAt: input.generatedAt ?? new Date().toISOString(),
     status,
     endpoints: {
+      // Meta/status stay under /api/lexicon. Learner artifacts match the URLs
+      // LexiconPractice / Atlas typeahead / Daily Words actually fetch (/lexicon/…).
+      // Hydrate still copies practice (and keeps twin routes) under /api/lexicon/
+      // as a compatibility alias — see docs/runbooks/word-atlas-static-api.md.
       contract: "/api/lexicon/contract.json",
       status: "/api/lexicon/status.json",
-      searchIndex: "/api/lexicon/search-index.json",
+      searchIndex: "/lexicon/search-index.json",
       searchAliases: "/lexicon/search-aliases.json",
       searchShards: "/lexicon/search-shards.json",
-      dailyPool: "/api/lexicon/daily-pool.json",
+      dailyPool: "/lexicon/daily-pool.json",
       browseShardTemplate: "/lexicon/browse/{letter}.json",
-      practiceIndexTemplate: "/api/lexicon/practice-index.{level}.json",
-      practiceLexemesTemplate: "/api/lexicon/practice-lexemes.{level}.json",
-      practiceClozeTemplate: "/api/lexicon/practice-cloze.{level}.json",
+      practiceIndexTemplate: "/lexicon/practice-index.{level}.json",
+      practiceLexemesTemplate: "/lexicon/practice-lexemes.{level}.json",
+      practiceClozeTemplate: "/lexicon/practice-cloze.{level}.json",
     },
     manifest: {
       hydrated: entries !== null,

--- a/site/src/lib/lexicon/sqlite-atlas-data-source.ts
+++ b/site/src/lib/lexicon/sqlite-atlas-data-source.ts
@@ -5,10 +5,10 @@
  * projection the live renderer uses today, then attaches aliases, relations,
  * provenance, and renderContext to match the versioned EntryRecord contract.
  *
- * Practice-index reconciliation (PR #2): match legacy ``getPracticeLemmas`` —
- * prefer ``public/api/lexicon/`` over ``public/lexicon/``, and index only
- * ``lemmaId`` (lookup still falls back to ``entry.lemma``, mirroring
- * ``has(url_slug) || has(lemma)``).
+ * Practice-index reconciliation (PR #2): shared ``readPracticeIndexItems`` —
+ * prefer ``public/lexicon/`` (canonical) then ``public/api/lexicon/`` alias,
+ * and index only ``lemmaId`` (lookup still falls back to ``entry.lemma``,
+ * mirroring ``has(url_slug) || has(lemma)``).
  */
 
 import Database from "better-sqlite3";
@@ -34,6 +34,7 @@ import {
   type SearchResponse,
 } from "./atlas-data-source.ts";
 import { normalizeAtlasText } from "./normalize.ts";
+import { readPracticeIndexItems } from "./practice-index-files.ts";
 import { PRACTICE_LEVELS, type PracticeLevel } from "./runtime-contract.ts";
 import { rankSearchResults, type SearchAlias, type SearchRow } from "./search.ts";
 import type { PracticeDeckData } from "./srs.ts";
@@ -73,29 +74,15 @@ function loadPracticeLevelsBySlug(): Map<string, PracticeLevel[]> {
   const levelsBySlug = new Map<string, Set<PracticeLevel>>();
   const dbDir = dirname(atlasDbPath());
   for (const level of PRACTICE_LEVELS) {
-    // Legacy getPracticeLemmas checks api/lexicon before lexicon/. Keep that order.
-    const candidates = [
-      resolve(dbDir, `../site/public/api/lexicon/practice-index.${level}.json`),
-      resolve(dbDir, `../site/public/lexicon/practice-index.${level}.json`),
-    ];
-    for (const path of candidates) {
-      if (!existsSync(path)) continue;
-      try {
-        const payload = JSON.parse(readFileSync(path, "utf-8")) as {
-          items?: Array<{ lemmaId?: string; lemma?: string }>;
-        };
-        for (const item of payload.items ?? []) {
-          // Legacy indexes only lemmaId; hasPractice then checks url_slug OR lemma
-          // against that set. Indexing lemma here would widen visibility.
-          if (!item.lemmaId) continue;
-          const set = levelsBySlug.get(item.lemmaId) ?? new Set<PracticeLevel>();
-          set.add(level);
-          levelsBySlug.set(item.lemmaId, set);
-        }
-        break;
-      } catch {
-        // ignore unreadable practice index
-      }
+    const items = readPracticeIndexItems(dbDir, level);
+    if (items === null) continue;
+    for (const item of items) {
+      // Legacy indexes only lemmaId; hasPractice then checks url_slug OR lemma
+      // against that set. Indexing lemma here would widen visibility.
+      if (!item.lemmaId) continue;
+      const set = levelsBySlug.get(item.lemmaId) ?? new Set<PracticeLevel>();
+      set.add(level);
+      levelsBySlug.set(item.lemmaId, set);
     }
   }
   const out = new Map<string, PracticeLevel[]>();

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -9,6 +9,7 @@ import {
   type RecordLogItem,
 } from 'ts-fsrs';
 import { CEFR_LEVELS, type CefrLevel } from './levels';
+import { PRACTICE_LEVELS } from './runtime-contract';
 
 export const SRS_STORAGE_KEY = 'lu-lexicon-srs';
 export const SRS_SETTINGS_KEY = 'lu-lexicon-srs-settings';
@@ -30,7 +31,7 @@ export const DEFAULT_NEW_PER_DAY = 20;
 export const SESSION_CLOSURE_EXTENSION_MAX = 5;
 export const SESSION_ITEM_ESTIMATE_SEC = 20;
 /** Levels with published practice shards (C2 ships «скоро» until deck exists). */
-export const PUBLISHED_PRACTICE_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1'] as const;
+export const PUBLISHED_PRACTICE_LEVELS = PRACTICE_LEVELS;
 
 const CURRENT_VERSION = 4;
 const SETTINGS_VERSION = 1;

--- a/site/src/pages/api/lexicon/daily-pool.json.ts
+++ b/site/src/pages/api/lexicon/daily-pool.json.ts
@@ -1,12 +1,5 @@
-import type { APIRoute } from "astro";
-import pool from "../../../data/lexicon-daily-pool.json";
-
-export const prerender = true;
-
-export const GET: APIRoute = () =>
-  new Response(JSON.stringify(pool), {
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
-    },
-  });
+/**
+ * Compatibility alias of the canonical `/lexicon/daily-pool.json` learner URL.
+ * Kept so existing /api/lexicon bookmarks and docs links keep working.
+ */
+export { prerender, GET } from "../../lexicon/daily-pool.json.ts";

--- a/site/src/pages/api/lexicon/search-index.json.ts
+++ b/site/src/pages/api/lexicon/search-index.json.ts
@@ -1,12 +1,5 @@
-import type { APIRoute } from "astro";
-import index from "../../../data/lexicon-search-index.json";
-
-export const prerender = true;
-
-export const GET: APIRoute = () =>
-  new Response(JSON.stringify(index), {
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
-    },
-  });
+/**
+ * Compatibility alias of the canonical `/lexicon/search-index.json` learner URL.
+ * Kept so existing /api/lexicon bookmarks and docs links keep working.
+ */
+export { prerender, GET } from "../../lexicon/search-index.json.ts";

--- a/site/src/pages/lexicon/daily-pool.json.ts
+++ b/site/src/pages/lexicon/daily-pool.json.ts
@@ -1,6 +1,12 @@
 import type { APIRoute } from "astro";
 import pool from "../../data/lexicon-daily-pool.json";
 
+/**
+ * Canonical Daily Word pool URL for learner fetches.
+ * `/api/lexicon/daily-pool.json` re-exports this route as a compatibility alias.
+ */
+export const prerender = true;
+
 export const GET: APIRoute = () =>
   new Response(JSON.stringify(pool), {
     headers: {

--- a/site/src/pages/lexicon/search-index.json.ts
+++ b/site/src/pages/lexicon/search-index.json.ts
@@ -8,7 +8,12 @@ import index from "../../data/lexicon-search-index.json";
  * `s` (article slug), `g` (gloss), `r` (romanized head), `t` (entry type),
  * and optional `c` (CEFR level). Alias resolvers live in the separate
  * `/lexicon/search-aliases.json` artifact and never add to this entry total.
+ *
+ * Canonical learner URL. `/api/lexicon/search-index.json` re-exports this route
+ * as a compatibility alias.
  */
+export const prerender = true;
+
 export const GET: APIRoute = () =>
   new Response(JSON.stringify(index), {
     headers: {

--- a/site/tests/unit/lexicon-api-routes.test.ts
+++ b/site/tests/unit/lexicon-api-routes.test.ts
@@ -89,18 +89,18 @@ describe("lexicon static API routes", () => {
     expect(status.checks.searchMatchesReviewedEntries).toBe(true);
     expect(status.checks.singlePracticeDeckVersion).toBe(true);
     expect(status.endpoints.contract).toBe("/api/lexicon/contract.json");
-    expect(status.endpoints.searchIndex).toBe("/api/lexicon/search-index.json");
+    expect(status.endpoints.searchIndex).toBe("/lexicon/search-index.json");
     expect(status.endpoints.searchAliases).toBe("/lexicon/search-aliases.json");
-  expect(status.endpoints.searchShards).toBe("/lexicon/search-shards.json");
-  expect(status.endpoints.dailyPool).toBe("/api/lexicon/daily-pool.json");
+    expect(status.endpoints.searchShards).toBe("/lexicon/search-shards.json");
+    expect(status.endpoints.dailyPool).toBe("/lexicon/daily-pool.json");
     expect(status.endpoints.practiceIndexTemplate).toBe(
-      "/api/lexicon/practice-index.{level}.json",
+      "/lexicon/practice-index.{level}.json",
     );
     expect(status.endpoints.practiceLexemesTemplate).toBe(
-      "/api/lexicon/practice-lexemes.{level}.json",
+      "/lexicon/practice-lexemes.{level}.json",
     );
     expect(status.endpoints.practiceClozeTemplate).toBe(
-      "/api/lexicon/practice-cloze.{level}.json",
+      "/lexicon/practice-cloze.{level}.json",
     );
   });
 
@@ -144,11 +144,11 @@ describe("lexicon static API routes", () => {
     expect(contract.surfaces.cloze.totalItems).toBeGreaterThanOrEqual(200);
     expect(contract.surfaces.cloze.reviewedSourceRows).toBeGreaterThan(0);
     expect(contract.endpoints.practiceIndexTemplate).toBe(
-      "/api/lexicon/practice-index.{level}.json",
+      "/lexicon/practice-index.{level}.json",
     );
   });
 
-  test("publishes separate article and alias search artifacts under /api/lexicon", async () => {
+  test("publishes separate article and alias search artifacts under /lexicon (with /api aliases)", async () => {
     const search = await routeJson<unknown[]>(getSearchIndex);
     const aliases = await routeJson<Array<{ a: string; s: string; h: string }>>(getSearchAliases);
     const daily = await routeJson<unknown[]>(getDailyPool);
@@ -159,7 +159,7 @@ describe("lexicon static API routes", () => {
     expect(daily.length).toBeGreaterThanOrEqual(250);
   });
 
-  test("aliases static practice shards under /api/lexicon", async () => {
+  test("aliases static practice shards under /api/lexicon (hydrate copy of /lexicon)", async () => {
     await expect(routePaths(getPracticeIndexPaths)).resolves.toEqual([...PRACTICE_LEVELS]);
     await expect(routePaths(getPracticeLexemesPaths)).resolves.toEqual([...PRACTICE_LEVELS]);
     await expect(routePaths(getPracticeClozePaths)).resolves.toEqual([...PRACTICE_LEVELS]);

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -47,6 +47,7 @@ import {
   type ReviewLogEntry,
   type SelectionHistoryItem,
 } from '@site/src/lib/lexicon/srs';
+import { PRACTICE_LEVELS } from '@site/src/lib/lexicon/runtime-contract';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
 const HOUR_MS = 60 * 60 * 1000;
@@ -1506,6 +1507,7 @@ describe('daily practice deck (K3 chunk 1)', () => {
 
   test('published levels stay A1 through C1 and C2 is not added', () => {
     expect(PUBLISHED_PRACTICE_LEVELS).toEqual(['A1', 'A2', 'B1', 'B2', 'C1']);
+    expect(PUBLISHED_PRACTICE_LEVELS).toBe(PRACTICE_LEVELS);
   });
 
   test('a valid snapshot is stable after SRS mutations and page reload', () => {

--- a/site/tests/unit/practice-index-files.test.ts
+++ b/site/tests/unit/practice-index-files.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  practiceIndexCandidatePaths,
+  readPracticeIndexItems,
+} from "@site/src/lib/lexicon/practice-index-files";
+
+describe("practice-index-files", () => {
+  test("lists canonical /lexicon path before /api/lexicon alias", () => {
+    const paths = practiceIndexCandidatePaths("/tmp/data", "A1");
+    expect(paths[0]).toContain("/site/public/lexicon/practice-index.A1.json");
+    expect(paths[1]).toContain("/site/public/api/lexicon/practice-index.A1.json");
+  });
+
+  test("prefers canonical lexicon shard when both exist", () => {
+    const root = mkdtempSync(join(tmpdir(), "practice-index-"));
+    const dbDir = join(root, "data");
+    mkdirSync(dbDir);
+    const lexiconDir = join(root, "site/public/lexicon");
+    const apiDir = join(root, "site/public/api/lexicon");
+    mkdirSync(lexiconDir, { recursive: true });
+    mkdirSync(apiDir, { recursive: true });
+    writeFileSync(
+      join(lexiconDir, "practice-index.A1.json"),
+      JSON.stringify({ items: [{ lemmaId: "canonical" }] }),
+    );
+    writeFileSync(
+      join(apiDir, "practice-index.A1.json"),
+      JSON.stringify({ items: [{ lemmaId: "alias" }] }),
+    );
+
+    expect(readPracticeIndexItems(dbDir, "A1")).toEqual([{ lemmaId: "canonical" }]);
+  });
+
+  test("falls back to /api/lexicon alias when canonical is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "practice-index-"));
+    const dbDir = join(root, "data");
+    mkdirSync(dbDir);
+    const apiDir = join(root, "site/public/api/lexicon");
+    mkdirSync(apiDir, { recursive: true });
+    writeFileSync(
+      join(apiDir, "practice-index.B1.json"),
+      JSON.stringify({ items: [{ lemmaId: "alias-only" }] }),
+    );
+
+    expect(readPracticeIndexItems(dbDir, "B1")).toEqual([{ lemmaId: "alias-only" }]);
+  });
+
+  test("returns null when no candidate resolves", () => {
+    const root = mkdtempSync(join(tmpdir(), "practice-index-"));
+    const dbDir = join(root, "data");
+    mkdirSync(dbDir);
+    expect(readPracticeIndexItems(dbDir, "C1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Make `/lexicon/…` the canonical learner JSON prefix in `buildLexiconRuntimeStatus().endpoints` so the contract matches Practice / Atlas typeahead / Daily Words fetches.
- Keep `/api/lexicon/…` as documented compatibility aliases (route re-exports for search-index + daily-pool; hydrate copies for practice shards).
- Share one practice-index filesystem probe (`readPracticeIndexItems`) used by `getPracticeLemmas` and `loadPracticeLevelsBySlug`.
- Re-export `PUBLISHED_PRACTICE_LEVELS` from `PRACTICE_LEVELS`; sync prerender on the `/lexicon` search-index and daily-pool routes.

## Changes
- `runtime-contract.ts` learner endpoints → `/lexicon/…` (meta/status stay under `/api/lexicon/…`)
- New `practice-index-files.ts` helper; wired in `atlasDb.ts` + `sqlite-atlas-data-source.ts`
- `/api/lexicon/{search-index,daily-pool}.json.ts` re-export the `/lexicon` routes
- Docs: `docs/runbooks/word-atlas-static-api.md`
- Tests: route contract expectations + new helper unit tests + SRS identity assertion

## Testing
- [x] `vitest run` for `lexicon-api-routes`, `lexicon-runtime-contract`, `practice-index-files`, `getPracticeLemmas` cases, `lexicon-srs` published-levels, `daily-words-example`, fixture `atlas-static-catalog`
- [ ] Full `atlas-db-read` / production `atlas-static-catalog` parity needs a hydrated non-empty `data/atlas.db` (local stub DB is empty in this worktree)
- [ ] Website builds without errors (`cd site && npm run build`)
- [ ] Ukrainian text reviewed for naturalness — N/A (infra only)

## Related Issues
Refs #6764
This PR leaves #6764 open.
This PR leaves #4387 open.


Made with [Cursor](https://cursor.com)