### PR TITLE
fix(practice): refuse a stuck 0/N session on paronym index/content drift (#6734)

### DIFF
--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -56,5 +56,6 @@ One-liner per bug. Grep for symptoms or categories to find relevant detail files
 | 2026-07-10 | #4220 | destructive-restores | Destructive restores — restore tooling silently clobbering newer local work |
 | 2026-07-12 | #4998 | research-registry-p4-gate-wiring | Wiring the P4 strict-adoption gate surfaced two latent bugs |
 | 2026-08-06 | #6415 | review-rail-outage-cascade | Review machinery failed 7:1 against its catches; outage froze all merges; process defeated purpose → detail: 2026-08-06-review-rail-outage-cascade.md |
+| 2026-08-14 | #6734 (residual after #6741) | practice-index-content-shard-drift | A1 Пароніми opened a stuck 0/8 session — index shard declared a lemma paronym-eligible while the paronym content shard had no matching row (a variant #6741's cross-level fix didn't cover). Fix cross-checks declared scope against actually-loaded content before planning a session → detail: practice-index-content-shard-drift.md |
 <!-- INDEX-END -->
 - 2026-07-10 · destructive-restore: `npm run hydrate` overwrote the richer in-flight intake manifest (8,706→5,787) with the published release — restore tools must never destroy more data than they replace by default → detail: destructive-restores.md

--- a/docs/bug-autopsies/practice-index-content-shard-drift.md
+++ b/docs/bug-autopsies/practice-index-content-shard-drift.md
@@ -1,0 +1,58 @@
+# Practice mode: index-vs-content-shard drift opens a stuck 0/N session
+
+**Issue**: #6734 (residual, after #6741) · **Date**: 2026-08-14
+
+## What broke
+
+Live QA: A1 **Пароніми** opened a session reading **0/8** — a nonzero planned
+total with zero exercises ever served, no way forward except leaving the page.
+#6741 had already fixed the *cross-level* variant of this bug for **Синоніми**
+(idle counts leaking A2+ synonym lemmas into the A1 badge). This was a
+different variant of the same failure class that #6741's fix did not cover.
+
+## Why
+
+`site/src/components/LexiconPractice.tsx` plans a session from
+`sessionScopeIndexForMode()`, which trusts only the **declared** `.modes`
+flag baked into the lightweight `practice-index.{level}.json` shard at build
+time. Content-shard-backed modes (paronym, synonym, heritage) additionally
+require a matching per-lemma row in their own dedicated shard
+(`practice-paronym.{level}.json`, etc.), loaded separately by `ensureDeck()`.
+
+Nothing cross-checked the two. If a lemma's index entry declares
+`modes: ['paronym']` but the paronym content shard has no row for that lemma
+(a stale/partial republish, or two shards published at different times), the
+planner counts the index-declared lemma as real (`plannedTotal > 0`) while
+`selectNextPracticeItem()` finds zero actual candidates
+(`maps.paronym.get(lemmaId) ?? []` silently yields nothing). The learner gets
+a session frame with a nonzero counter and no exercise, forever.
+
+`deck.paronym?.length === 0` was checked for the *fully-empty-shard* case
+(shows a "still being prepared" message) but that check is on the array's
+overall length, not on whether the array covers the *specific* lemmas the
+index scoped in — so a partially-populated content shard (nonzero length,
+wrong lemmas) skips that message too and falls through to a contradictory
+"All caught up!" screen while the progress pill still reads `0/N`.
+
+## Prevention
+
+Added `withLoadedModeContent()`: cross-references the declared-eligible index
+scope against the deck's actually-loaded per-lemma content array for any
+mode backed by a dedicated content shard (paronym/synonym/heritage) before
+treating an item as playable. Applied at all three places a session's real
+item count is decided: the `autoStart` effect, the `selection` memo, and
+`beginSession`'s guard. A declared-but-contentless lemma is now dropped from
+the plan, so `plannedTotal` reflects real content and the existing
+empty-mode message (`practice.modeNoExercises` / the mode's own "still being
+prepared" state) fires instead of a stuck `0/N` session.
+
+Regression tests reproduce the exact index/content mismatch and mutation-check
+clean (revert the fix → tests fail on `0/1` instead of `0/0`):
+`site/tests/unit/LexiconPractice.test.tsx` — "#6734 residual" tests.
+
+Not fixed here: the idle mode-card badge still shows the declared (possibly
+stale) count, since idle only fetches the lightweight index shard by design
+(no per-mode content fetch until a session starts). The defense is in
+refusing to *open* a broken session, not in idle-time badge honesty — doing
+the latter would mean eagerly fetching every content shard on every level
+switch, a real cost/architecture tradeoff outside this fix's scope.

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: bc269893855582e32dd3bb671ba63e0c09db44a0e6be3cae31315e99598baa89
+  components_sha256: a672999559bbb5c8b11b165699c63d5fae34f72d36c7cbc22ba0c8a689a98879
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1417,6 +1417,36 @@ function sessionScopeIndexForMode(
 }
 
 /**
+ * #6734 residual (A1 Пароніми): `sessionScopeIndexForMode` only trusts the DECLARED
+ * `.modes` flag baked into the index shard at build time. For modes backed by their own
+ * per-lemma content shard (paronym, synonym, heritage) the index and content shards can
+ * drift out of sync — a stale/partial republish leaves the index still claiming
+ * eligibility for a lemma while the content shard that lemma's item would come from has
+ * no matching row. Left unchecked, that opens a session with plannedTotal > 0 (e.g. a
+ * live 0/8 Пароніми session) and zero real candidates: stuck forever instead of the
+ * empty-mode message a genuinely empty mode already surfaces (#6741). Cross-check the
+ * declared scope against the deck's actually-loaded content before treating an item as
+ * playable — a mode with no dedicated content shard (flashcards, matching, cloze, …)
+ * passes through unchanged.
+ */
+function withLoadedModeContent(
+  index: PracticeIndexItem[],
+  deck: PracticeDeckData | null,
+  modeFilter: PracticeModeFilter,
+): PracticeIndexItem[] {
+  if (!deck) return index;
+  const contentByMode: Partial<Record<PracticeModeFilter, { lemmaId: string }[] | undefined>> = {
+    synonym: deck.synonym,
+    paronym: deck.paronym,
+    heritage: deck.heritage,
+  };
+  const content = contentByMode[modeFilter];
+  if (!content) return index;
+  const lemmaIdsWithContent = new Set(content.map((item) => item.lemmaId));
+  return index.filter((item) => lemmaIdsWithContent.has(item.lemmaId));
+}
+
+/**
  * #6734: idle modeCounts load every published level's index (learner level is a
  * preference, not a shard cap), but a newly started session plans against the
  * selected level first. Counting higher-level synonym lemmas on an A1 home made
@@ -2277,8 +2307,9 @@ function LexiconPracticeIsland({
       }
     }
 
-    const scopedIndex = sessionScopeIndexForMode(
-      filterIndexByDeckFilter(deck.index, deckLemmaKeySet),
+    const scopedIndex = withLoadedModeContent(
+      sessionScopeIndexForMode(filterIndexByDeckFilter(deck.index, deckLemmaKeySet), mode),
+      deck,
       mode,
     );
     // #6734: autoStart must not open an empty-mode session that later bleeds
@@ -2709,8 +2740,9 @@ function LexiconPracticeIsland({
     // synonym with antonym-only inventory). Keying off plannedTotal was too broad —
     // autoStart remounts and borrowed-due picks can have plannedTotal 0 while real
     // mode inventory still exists, which starved heritage / remount flows.
-    const scopedIndex = sessionScopeIndexForMode(
-      filterIndexByDeckFilter(selectionDeck.index, deckLemmaKeySet),
+    const scopedIndex = withLoadedModeContent(
+      sessionScopeIndexForMode(filterIndexByDeckFilter(selectionDeck.index, deckLemmaKeySet), mode),
+      selectionDeck,
       mode,
     );
     if (scopedIndex.length === 0) return null;
@@ -3329,11 +3361,15 @@ function LexiconPracticeIsland({
     // A session is starting for real — drop any stale idle notice (e.g. the empty-focus
     // message) so the active status line reads «Сесія …» cleanly.
     setFeedback(null);
-    const index = sessionScopeIndexForMode(
-      filterIndexByDeckFilter(
-        loadedDeck.index,
-        resolveDeckLemmaKeySet(effectiveDeckFilter, customSets),
+    const index = withLoadedModeContent(
+      sessionScopeIndexForMode(
+        filterIndexByDeckFilter(
+          loadedDeck.index,
+          resolveDeckLemmaKeySet(effectiveDeckFilter, customSets),
+        ),
+        nextMode,
       ),
+      loadedDeck,
       nextMode,
     );
     const plan = computeSessionScope(index, budget, { dailyNewCount });

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2547,6 +2547,86 @@ describe('LexiconPractice', () => {
     expect(container.querySelector('[data-mode="paronym"]')).toHaveTextContent('Пароніми');
   });
 
+  /**
+   * #6734 residual (live QA, post-#6741): A1 Пароніми still opened a 0/8 session. Root
+   * cause is a class #6741 didn't cover — the index shard's DECLARED `.modes` flag can
+   * drift from the actual paronym content shard (stale/partial republish leaves the
+   * index still claiming eligibility for a lemma the content shard has no row for). The
+   * idle card badge still trusts the declared count (no per-mode content fetch at idle
+   * by design), but `beginSession`/`selection`/autoStart now cross-check the real,
+   * already-loaded `deck.paronym` before treating an item as playable — so a tap can no
+   * longer open a session that is stuck at 0/N forever.
+   */
+  function paronymContentMismatchDeck(): PracticeDeckData {
+    const entry = lexeme(
+      'bihate',
+      'бігати',
+      'to run',
+      { nominative: 'бігати', accusative: 'бігати', locative: 'бігати' },
+      { cefr: 'A1' },
+    );
+    return {
+      deckVersion: 'test-paronym-mismatch',
+      level: 'A1',
+      lexemes: [entry],
+      index: [
+        {
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['paronym'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: 0,
+        },
+      ],
+      cloze: [],
+      stress: [],
+      classify: [],
+      paradigm: [],
+      synonym: [],
+      // The mismatch: index says paronym-eligible, but the content shard is empty.
+      paronym: [],
+      // An unrelated loaded row keeps `hasLoadedDrillShards` true so `ensureDeck`
+      // treats the drills as already-fetched instead of refetching over the network.
+      heritage: [heritagePracticeItem()],
+    };
+  }
+
+  test('#6734 residual: paronym tap refuses a stale index/content mismatch instead of a stuck 0/N session', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice initialDeck={paronymContentMismatchDeck()} />);
+
+    // Idle badge still reads the declared index count (1) — the fix is the refusal
+    // to open a session on tap, not idle-time honesty (no content fetch at idle).
+    expect(screen.getByTestId('practice-mode-count-paronym')).toHaveTextContent('1');
+
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="paronym"]')!);
+
+    expect(screen.queryByTestId('practice-paronym')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('practice-session-progress')).not.toBeInTheDocument();
+    expect(screen.getByTestId('practice-dashboard-hero')).toBeInTheDocument();
+    expect(container.querySelector('.lexicon-practice-status')).toHaveTextContent('Немає вправ');
+  });
+
+  test('#6734 residual: paronym autoStart with a stale index/content mismatch stays itemless at 0/0', async () => {
+    render(
+      <LexiconPractice
+        initialDeck={paronymContentMismatchDeck()}
+        autoStart
+        initialMode="paronym"
+      />,
+    );
+
+    // Live bug: the index's declared eligibility (1 lemma) drove plannedTotal, so the
+    // progress pill read a nonzero N (0/8 in production) while zero real items ever
+    // served. Cross-checking against the actually-loaded (confirmed empty) paronym
+    // content shard collapses the plan to the honest 0/0 before the session even opens.
+    expect(await screen.findByTestId('practice-paronym-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('0/0');
+    expect(screen.queryByTestId('practice-paronym')).not.toBeInTheDocument();
+  });
+
   test('focus deep-link: a bare Atlas lemma resolves to its item with no double session start', async () => {
     const originalSearch = window.location.search;
     delete (window as any).location;


### PR DESCRIPTION
## Summary
Live QA (residual after #6741): A1 **Пароніми** still opened a session reading **0/8** — a nonzero planned total that never served an exercise. #6741 fixed the *cross-level* variant of this bug for Синоніми; this is a different variant it didn't cover.

## Root cause
`sessionScopeIndexForMode()` only trusts the index shard's DECLARED `.modes` flag. Content-shard-backed modes (paronym/synonym/heritage) also need a matching per-lemma row in their own dedicated shard, loaded separately by `ensureDeck()`. When the index declares a lemma paronym-eligible but the content shard has no row for it (stale/partial republish), the planner counted the lemma as real (`plannedTotal > 0`) while selection found zero actual candidates — stuck at `0/N` forever instead of the empty-mode message other modes already surface.

## Fix
Added `withLoadedModeContent()`: cross-checks the declared-eligible index scope against the deck's actually-loaded content before treating an item as playable. Applied at the three places a session's real item count is decided: the `autoStart` effect, the `selection` memo, and `beginSession`'s guard.

Per the dispatch brief ("do not invent pairs"), this does not fabricate paronym content — it makes the client refuse to open a session promising content it can't actually serve, same defensive posture #6741 established for synonym.

## Known limitation
Idle-time mode-card badges still show the declared (possibly stale) count — idle only fetches the lightweight index shard by design, not per-mode content. The fix refuses to *open* a broken session; it does not make the idle badge itself honest (that would need eager content fetches on every level switch — a real cost/architecture tradeoff outside this fix's scope).

## Testing
- [x] `npx vitest run tests/unit/LexiconPractice.test.tsx -t "6734 residual"` (2 passed)
- [x] Mutation-check: reverted the production fix, both tests fail on `0/1` instead of `0/0` (confirmed regression coverage is real, not imaginary)
- [x] `npx vitest run tests/unit/LexiconPractice.test.tsx` (169 passed)
- [x] `npx eslint site/src/components/LexiconPractice.tsx site/tests/unit/LexiconPractice.test.tsx --quiet` — zero new errors (pre-existing debt unchanged, confirmed by diffing error sets before/after)
- [x] `npx tsc --noEmit` — zero new errors (pre-existing debt unchanged, confirmed by diffing error sets before/after)
- [ ] `npm run test:unit` full suite — 4 pre-existing failures unrelated to this change (missing `atlas.db` / unhydrated `public/lexicon/*.json` / ActivityKit schema $refs in this fresh worktree; confirmed present without my change too)

## Related Issues
Refs #6734. Leaves #4387 #6734 open per dispatch brief (do not close/merge/arm).

Autopsy: `docs/bug-autopsies/practice-index-content-shard-drift.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
