### PR TITLE
fix(site): translate WotD hub chrome on en/uk toggle (#6711)

### DIFF
--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -1,16 +1,13 @@
 ---
 import { CEFR_LEVELS } from "../lib/lexicon/levels";
+import ChromeText from "../components/chrome/ChromeText.astro";
 
 type Props = {
-  title?: string;
-  description?: string;
   count?: number;
   showLevelSelector?: boolean;
 };
 
 const {
-  title = "Слова дня",
-  description = "Коротка щоденна добірка для повторення й відкриття словникових статей.",
   count = 8,
   showLevelSelector = false,
 } = Astro.props as Props;
@@ -26,13 +23,13 @@ const dailyCount = Math.max(1, Math.floor(count));
   data-daily-level-selector={showLevelSelector ? "true" : "false"}
 >
   <div class="lexicon-daily-heading">
-    <h2 id="lexicon-daily-title">{title}</h2>
-    <p>{description}</p>
+    <h2 id="lexicon-daily-title"><ChromeText k="wotd.todayTitle" /></h2>
+    <p><ChromeText k="wotd.todayDescription" /></p>
   </div>
 
   {showLevelSelector && (
     <div class="lexicon-daily-controls" aria-label="Learner level">
-      <span class="lexicon-daily-control-label">Рівень</span>
+      <span class="lexicon-daily-control-label"><ChromeText k="practice.level" /></span>
       <div class="lexicon-daily-levels" role="list" data-daily-levels>
         {CEFR_LEVELS.map((level) => (
           <button
@@ -48,20 +45,25 @@ const dailyCount = Math.max(1, Math.floor(count));
     </div>
   )}
 
-  <p class="lexicon-daily-status" data-daily-status>Завантажуємо добірку...</p>
+  <p
+    class="lexicon-daily-status"
+    data-daily-status
+    data-daily-loading="true"
+  >
+    <ChromeText k="wotd.loading" />
+  </p>
   <div class="lexicon-daily-fallback" data-daily-fallback hidden>
-    <p>Не вдалося завантажити добірку.</p>
-    <button type="button" data-daily-retry>Спробувати ще раз</button>
+    <p><ChromeText k="wotd.loadError" /></p>
+    <button type="button" data-daily-retry><ChromeText k="practice.retry" /></button>
   </div>
   <ul id="lexicon-daily-list" class="lexicon-daily-grid" aria-live="polite" data-daily-list></ul>
 </section>
 
 {/* Inline watchdog: if the processed DailyWords module never runs (CDN 503 on
-    the chunk, etc.), do not leave «Завантажуємо добірку...» as a dead end (#6771). */}
+    the chunk, etc.), do not leave the loading status as a dead end (#6771). */}
 <script is:inline>
 (() => {
   const TIMEOUT_MS = 10000;
-  const LOADING_COPY = 'Завантажуємо добірку...';
 
   function showSectionFallback(section) {
     if (section.dataset.dailyReady === 'true') return;
@@ -72,6 +74,7 @@ const dailyCount = Math.max(1, Math.floor(count));
     if (status) {
       status.hidden = true;
       status.textContent = '';
+      status.removeAttribute('data-daily-loading');
     }
     if (fallback) fallback.hidden = false;
     section.hidden = false;
@@ -94,7 +97,7 @@ const dailyCount = Math.max(1, Math.floor(count));
       const stillLoading =
         status &&
         !status.hidden &&
-        (status.textContent || '').trim() === LOADING_COPY;
+        status.getAttribute('data-daily-loading') === 'true';
       const list = section.querySelector('[data-daily-list]');
       const emptyList = !list || list.children.length === 0;
       if (stillLoading && emptyList) showSectionFallback(section);
@@ -127,6 +130,12 @@ const dailyCount = Math.max(1, Math.floor(count));
     normalizeCefrLevel,
     type CefrLevel,
   } from "../lib/lexicon/levels";
+  import {
+    CHROME_STRINGS,
+    chromeDualHtml,
+    formatWotdEmptyLevel,
+    formatWotdLevelCount,
+  } from "../lib/i18n/chrome";
 
   const readLearnerLevel = (): CefrLevel => {
     try {
@@ -142,6 +151,28 @@ const dailyCount = Math.max(1, Math.floor(count));
     } catch {
       // Storage can be unavailable in hardened browser contexts.
     }
+  };
+
+  const setLoadingStatus = (status: HTMLElement | null) => {
+    if (!status) return;
+    status.hidden = false;
+    status.dataset.dailyLoading = "true";
+    status.innerHTML = chromeDualHtml(
+      CHROME_STRINGS.en["wotd.loading"],
+      CHROME_STRINGS.uk["wotd.loading"],
+    );
+  };
+
+  const setStatusDual = (
+    status: HTMLElement | null,
+    variants: { en: string; uk: string },
+    opts: { loading?: boolean; hidden?: boolean } = {},
+  ) => {
+    if (!status) return;
+    status.hidden = Boolean(opts.hidden);
+    if (opts.loading) status.dataset.dailyLoading = "true";
+    else status.removeAttribute("data-daily-loading");
+    status.innerHTML = chromeDualHtml(variants.en, variants.uk);
   };
 
   const hydrateDailySection = (dailySection: HTMLElement) => {
@@ -174,6 +205,7 @@ const dailyCount = Math.max(1, Math.floor(count));
       if (dailyStatus) {
         dailyStatus.hidden = true;
         dailyStatus.textContent = "";
+        dailyStatus.removeAttribute("data-daily-loading");
       }
       if (dailyFallback) dailyFallback.hidden = false;
       dailySection.hidden = false;
@@ -183,10 +215,7 @@ const dailyCount = Math.max(1, Math.floor(count));
 
     const clearLoadError = () => {
       if (dailyFallback) dailyFallback.hidden = true;
-      if (dailyStatus) {
-        dailyStatus.hidden = false;
-        dailyStatus.textContent = "Завантажуємо добірку...";
-      }
+      setLoadingStatus(dailyStatus);
       dailySection.dataset.dailyReady = "false";
     };
 
@@ -210,10 +239,7 @@ const dailyCount = Math.max(1, Math.floor(count));
 
       if (picks.length === 0) {
         dailyList.innerHTML = "";
-        if (dailyStatus) {
-          dailyStatus.hidden = false;
-          dailyStatus.textContent = `Немає слів для рівня ${activeLevel}.`;
-        }
+        setStatusDual(dailyStatus, formatWotdEmptyLevel(activeLevel));
         if (dailyFallback) dailyFallback.hidden = true;
         dailySection.dataset.dailyReady = "true";
         return;
@@ -224,12 +250,12 @@ const dailyCount = Math.max(1, Math.floor(count));
         bindDailyCardInteractions(dailyList);
         interactionsBound = true;
       }
-      if (dailyStatus) {
-        dailyStatus.hidden = false;
-        dailyStatus.textContent = useLevelSelector
-          ? `${activeLevel} · ${picks.length} слів`
-          : "";
-        dailyStatus.hidden = !useLevelSelector;
+      if (useLevelSelector) {
+        setStatusDual(dailyStatus, formatWotdLevelCount(activeLevel, picks.length));
+      } else if (dailyStatus) {
+        dailyStatus.hidden = true;
+        dailyStatus.textContent = "";
+        dailyStatus.removeAttribute("data-daily-loading");
       }
       if (dailyFallback) dailyFallback.hidden = true;
       dailySection.dataset.dailyReady = "true";

--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -136,6 +136,17 @@ const dailyCount = Math.max(1, Math.floor(count));
     formatWotdEmptyLevel,
     formatWotdLevelCount,
   } from "../lib/i18n/chrome";
+  import {
+    applyDailyLoadFallback,
+    beginDailyReload,
+    markDailyLoadSuccess,
+  } from "../lib/lexicon/daily-loading";
+
+  const loadingHtml = () =>
+    chromeDualHtml(
+      CHROME_STRINGS.en["wotd.loading"],
+      CHROME_STRINGS.uk["wotd.loading"],
+    );
 
   const readLearnerLevel = (): CefrLevel => {
     try {
@@ -153,31 +164,8 @@ const dailyCount = Math.max(1, Math.floor(count));
     }
   };
 
-  const setLoadingStatus = (status: HTMLElement | null) => {
-    if (!status) return;
-    status.hidden = false;
-    status.dataset.dailyLoading = "true";
-    status.innerHTML = chromeDualHtml(
-      CHROME_STRINGS.en["wotd.loading"],
-      CHROME_STRINGS.uk["wotd.loading"],
-    );
-  };
-
-  const setStatusDual = (
-    status: HTMLElement | null,
-    variants: { en: string; uk: string },
-    opts: { loading?: boolean; hidden?: boolean } = {},
-  ) => {
-    if (!status) return;
-    status.hidden = Boolean(opts.hidden);
-    if (opts.loading) status.dataset.dailyLoading = "true";
-    else status.removeAttribute("data-daily-loading");
-    status.innerHTML = chromeDualHtml(variants.en, variants.uk);
-  };
-
   const hydrateDailySection = (dailySection: HTMLElement) => {
     const dailyList = dailySection.querySelector<HTMLUListElement>("[data-daily-list]");
-    const dailyStatus = dailySection.querySelector<HTMLElement>("[data-daily-status]");
     const dailyFallback = dailySection.querySelector<HTMLElement>("[data-daily-fallback]");
     const levelButtons = Array.from(
       dailySection.querySelectorAll<HTMLButtonElement>("[data-daily-level]"),
@@ -201,22 +189,13 @@ const dailyCount = Math.max(1, Math.floor(count));
     };
 
     const showLoadError = () => {
-      if (dailyList) dailyList.innerHTML = "";
-      if (dailyStatus) {
-        dailyStatus.hidden = true;
-        dailyStatus.textContent = "";
-        dailyStatus.removeAttribute("data-daily-loading");
-      }
-      if (dailyFallback) dailyFallback.hidden = false;
-      dailySection.hidden = false;
-      // Mark ready so the inline watchdog does not race a second error paint.
-      dailySection.dataset.dailyReady = "true";
+      // Clear ready so applyDailyLoadFallback can paint (inline watchdog may have raced).
+      dailySection.dataset.dailyReady = "false";
+      applyDailyLoadFallback(dailySection);
     };
 
     const clearLoadError = () => {
-      if (dailyFallback) dailyFallback.hidden = true;
-      setLoadingStatus(dailyStatus);
-      dailySection.dataset.dailyReady = "false";
+      beginDailyReload(dailySection, loadingHtml());
     };
 
     const syncLevelButtons = () => {
@@ -239,9 +218,13 @@ const dailyCount = Math.max(1, Math.floor(count));
 
       if (picks.length === 0) {
         dailyList.innerHTML = "";
-        setStatusDual(dailyStatus, formatWotdEmptyLevel(activeLevel));
-        if (dailyFallback) dailyFallback.hidden = true;
-        dailySection.dataset.dailyReady = "true";
+        markDailyLoadSuccess(
+          dailySection,
+          chromeDualHtml(
+            formatWotdEmptyLevel(activeLevel).en,
+            formatWotdEmptyLevel(activeLevel).uk,
+          ),
+        );
         return;
       }
 
@@ -251,14 +234,14 @@ const dailyCount = Math.max(1, Math.floor(count));
         interactionsBound = true;
       }
       if (useLevelSelector) {
-        setStatusDual(dailyStatus, formatWotdLevelCount(activeLevel, picks.length));
-      } else if (dailyStatus) {
-        dailyStatus.hidden = true;
-        dailyStatus.textContent = "";
-        dailyStatus.removeAttribute("data-daily-loading");
+        const countLine = formatWotdLevelCount(activeLevel, picks.length);
+        markDailyLoadSuccess(
+          dailySection,
+          chromeDualHtml(countLine.en, countLine.uk),
+        );
+      } else {
+        markDailyLoadSuccess(dailySection, null);
       }
-      if (dailyFallback) dailyFallback.hidden = true;
-      dailySection.dataset.dailyReady = "true";
       syncLevelButtons();
     };
 

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -16,6 +16,8 @@
  * always Ukrainian — this toggle never touches it.
  */
 
+import { pluralizeUk } from './plural';
+
 export type ChromeLocale = 'uk' | 'en';
 
 /** No-JS / non-Ukrainian-browser fallback. See ADR "Default language". */
@@ -248,6 +250,15 @@ const en = {
   'readings.searchLabel': 'Search the reading reference',
   'readings.searchPlaceholder': 'Search a text, genre, or author…',
   'readings.empty': 'No matches. Try another word.',
+
+  // Words of the Day hub chrome (#6711) — interface only; lemmas stay content.
+  'wotd.subtitle': 'A daily Word Atlas pick capped to your current level.',
+  'wotd.practiceCta': 'Practice — spaced repetition for your level →',
+  'wotd.todayTitle': "Today's pick",
+  'wotd.todayDescription':
+    'Words refresh by calendar date; tap a card to flip, or the word itself to open its Atlas entry.',
+  'wotd.loading': "Loading today's pick…",
+  'wotd.loadError': "Couldn't load today's pick.",
 
   // Practice dashboard (K3 redesign)
   'practice.title': 'Practice',
@@ -581,6 +592,15 @@ const uk: Record<ChromeKey, string> = {
   'readings.searchPlaceholder': 'Шукайте текст, жанр або автора…',
   'readings.empty': 'Немає збігів. Спробуйте інше слово.',
 
+  // Words of the Day hub chrome (#6711)
+  'wotd.subtitle': 'Щоденна добірка слів з Атласу, обмежена вашим поточним рівнем.',
+  'wotd.practiceCta': 'Практика — інтервальне повторення вашого рівня →',
+  'wotd.todayTitle': 'Добірка на сьогодні',
+  'wotd.todayDescription':
+    'Слова оновлюються за календарною датою; торкніться картки, щоб перевернути, або самого слова — щоб відкрити статтю в Атласі.',
+  'wotd.loading': 'Завантажуємо добірку…',
+  'wotd.loadError': 'Не вдалося завантажити добірку.',
+
   // Practice dashboard (K3 redesign)
   'practice.title': 'Практика',
   'practice.heroTitle': 'Практикуйте українську',
@@ -700,4 +720,55 @@ export const CHROME_STRINGS = { en, uk } satisfies Record<ChromeLocale, Record<C
 /** Both locale variants for a key — used by ChromeText for FOUC-safe dual-render. */
 export function chromeBoth(key: ChromeKey): Record<ChromeLocale, string> {
   return { en: CHROME_STRINGS.en[key], uk: CHROME_STRINGS.uk[key] };
+}
+
+/** Escape text for safe interpolation into dual-render chrome HTML fragments. */
+function escapeChromeHtml(value: string): string {
+  return value.replace(
+    /[&<>"]/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] ?? c,
+  );
+}
+
+/**
+ * FOUC-safe dual-render HTML for client-built chrome (status lines, counts).
+ * Same `.lu-i18n` / `data-loc` contract as ChromeText — CSS shows one locale.
+ */
+export function chromeDualHtml(enText: string, ukText: string): string {
+  return (
+    `<span class="lu-i18n">` +
+    `<span data-loc="en" lang="en">${escapeChromeHtml(enText)}</span>` +
+    `<span data-loc="uk" lang="uk">${escapeChromeHtml(ukText)}</span>` +
+    `</span>`
+  );
+}
+
+/** Pluralized «N word(s) / слово|слова|слів» for WotD status chrome (#6711). */
+export function formatWotdWordCount(count: number): Record<ChromeLocale, string> {
+  const enNoun = count === 1 ? 'word' : 'words';
+  const ukNoun = pluralizeUk(count, ['слово', 'слова', 'слів']);
+  return {
+    en: `${count} ${enNoun}`,
+    uk: `${count} ${ukNoun}`,
+  };
+}
+
+/** Level · count line, e.g. `A2 · 12 words` / `A2 · 12 слів`. */
+export function formatWotdLevelCount(
+  level: string,
+  count: number,
+): Record<ChromeLocale, string> {
+  const words = formatWotdWordCount(count);
+  return {
+    en: `${level} · ${words.en}`,
+    uk: `${level} · ${words.uk}`,
+  };
+}
+
+/** Empty-pool status when a CEFR tab has no daily words. */
+export function formatWotdEmptyLevel(level: string): Record<ChromeLocale, string> {
+  return {
+    en: `No words for level ${level}.`,
+    uk: `Немає слів для рівня ${level}.`,
+  };
 }

--- a/site/src/lib/lexicon/daily-loading.ts
+++ b/site/src/lib/lexicon/daily-loading.ts
@@ -1,0 +1,108 @@
+/**
+ * DailyWords loading / error / watchdog DOM state (#6771, #6711 review).
+ * Shared by the processed DailyWords module script and unit tests.
+ * The inline CDN-fail watchdog in DailyWords.astro mirrors applyDailyLoadFallback.
+ */
+
+export const DAILY_WATCHDOG_TIMEOUT_MS = 10_000;
+
+export function setDailyLoadingStatus(
+  status: HTMLElement | null,
+  loadingHtml: string,
+): void {
+  if (!status) return;
+  status.hidden = false;
+  status.dataset.dailyLoading = "true";
+  status.innerHTML = loadingHtml;
+}
+
+export function setDailyStatusContent(
+  status: HTMLElement | null,
+  html: string,
+  opts: { loading?: boolean; hidden?: boolean } = {},
+): void {
+  if (!status) return;
+  status.hidden = Boolean(opts.hidden);
+  if (opts.loading) status.dataset.dailyLoading = "true";
+  else status.removeAttribute("data-daily-loading");
+  status.innerHTML = html;
+}
+
+/** Paint the load-error fallback and clear the loading spinner. */
+export function applyDailyLoadFallback(section: HTMLElement): void {
+  if (section.dataset.dailyReady === "true") return;
+  const status = section.querySelector<HTMLElement>("[data-daily-status]");
+  const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]");
+  const list = section.querySelector("[data-daily-list]");
+  if (list) list.innerHTML = "";
+  if (status) {
+    status.hidden = true;
+    status.textContent = "";
+    status.removeAttribute("data-daily-loading");
+  }
+  if (fallback) fallback.hidden = false;
+  section.hidden = false;
+  section.dataset.dailyReady = "true";
+}
+
+/** Hide fallback and restore the loading status (retry / fresh fetch). */
+export function beginDailyReload(
+  section: HTMLElement,
+  loadingHtml: string,
+): void {
+  const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]");
+  const status = section.querySelector<HTMLElement>("[data-daily-status]");
+  if (fallback) fallback.hidden = true;
+  setDailyLoadingStatus(status, loadingHtml);
+  section.dataset.dailyReady = "false";
+}
+
+/** Mark success: loading attr gone, section ready (list may already be filled). */
+export function markDailyLoadSuccess(
+  section: HTMLElement,
+  statusHtml?: string | null,
+): void {
+  const status = section.querySelector<HTMLElement>("[data-daily-status]");
+  const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]");
+  if (fallback) fallback.hidden = true;
+  if (status) {
+    if (statusHtml == null) {
+      status.hidden = true;
+      status.textContent = "";
+      status.removeAttribute("data-daily-loading");
+    } else {
+      setDailyStatusContent(status, statusHtml, { loading: false, hidden: false });
+    }
+  }
+  section.dataset.dailyReady = "true";
+}
+
+export function isDailyWatchdogDue(section: HTMLElement): boolean {
+  if (section.dataset.dailyReady === "true") return false;
+  const status = section.querySelector<HTMLElement>("[data-daily-status]");
+  const stillLoading =
+    Boolean(status) &&
+    !status!.hidden &&
+    status!.getAttribute("data-daily-loading") === "true";
+  const list = section.querySelector("[data-daily-list]");
+  const emptyList = !list || list.children.length === 0;
+  return stillLoading && emptyList;
+}
+
+/**
+ * Arm the watchdog timer. If the module never marks ready and the status is
+ * still loading with an empty list, paint the same fallback as a fetch error.
+ */
+export function armDailyWatchdog(
+  section: HTMLElement,
+  opts: {
+    timeoutMs?: number;
+    setTimeoutFn?: typeof setTimeout;
+  } = {},
+): ReturnType<typeof setTimeout> {
+  const timeoutMs = opts.timeoutMs ?? DAILY_WATCHDOG_TIMEOUT_MS;
+  const schedule = opts.setTimeoutFn ?? setTimeout;
+  return schedule(() => {
+    if (isDailyWatchdogDue(section)) applyDailyLoadFallback(section);
+  }, timeoutMs);
+}

--- a/site/src/lib/lexicon/daily-loading.ts
+++ b/site/src/lib/lexicon/daily-loading.ts
@@ -1,10 +1,10 @@
 /**
- * DailyWords loading / error / watchdog DOM state (#6771, #6711 review).
+ * DailyWords loading / error DOM state (#6771, #6711 review).
  * Shared by the processed DailyWords module script and unit tests.
- * The inline CDN-fail watchdog in DailyWords.astro mirrors applyDailyLoadFallback.
+ *
+ * The is:inline CDN-fail watchdog in DailyWords.astro intentionally duplicates
+ * the fallback paint path and must NOT import this module (#6771 resilience).
  */
-
-export const DAILY_WATCHDOG_TIMEOUT_MS = 10_000;
 
 export function setDailyLoadingStatus(
   status: HTMLElement | null,
@@ -75,34 +75,4 @@ export function markDailyLoadSuccess(
     }
   }
   section.dataset.dailyReady = "true";
-}
-
-export function isDailyWatchdogDue(section: HTMLElement): boolean {
-  if (section.dataset.dailyReady === "true") return false;
-  const status = section.querySelector<HTMLElement>("[data-daily-status]");
-  const stillLoading =
-    Boolean(status) &&
-    !status!.hidden &&
-    status!.getAttribute("data-daily-loading") === "true";
-  const list = section.querySelector("[data-daily-list]");
-  const emptyList = !list || list.children.length === 0;
-  return stillLoading && emptyList;
-}
-
-/**
- * Arm the watchdog timer. If the module never marks ready and the status is
- * still loading with an empty list, paint the same fallback as a fetch error.
- */
-export function armDailyWatchdog(
-  section: HTMLElement,
-  opts: {
-    timeoutMs?: number;
-    setTimeoutFn?: typeof setTimeout;
-  } = {},
-): ReturnType<typeof setTimeout> {
-  const timeoutMs = opts.timeoutMs ?? DAILY_WATCHDOG_TIMEOUT_MS;
-  const schedule = opts.setTimeoutFn ?? setTimeout;
-  return schedule(() => {
-    if (isDailyWatchdogDue(section)) applyDailyLoadFallback(section);
-  }, timeoutMs);
 }

--- a/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
+++ b/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
@@ -20,36 +20,58 @@ const readingsIndex = readFileSync(resolve(root, "src/pages/readings/index.astro
 const chromeDict = readFileSync(resolve(root, "src/lib/i18n/chrome.ts"), "utf8");
 const courseLayout = readFileSync(resolve(root, "src/layouts/CourseLayout.astro"), "utf8");
 
-/**
- * happy-dom does not recompute attribute-selector CSS when data-chrome-locale
- * flips. Apply the same show/hide contract CourseLayout's .lu-i18n rules define
- * so tests assert actual per-locale visibility, not mere span existence.
- */
-function applyLuI18nVisibilityContract(doc: Document = document): void {
-  const locale = doc.documentElement.dataset.chromeLocale === "uk" ? "uk" : "en";
-  for (const span of doc.querySelectorAll(".lu-i18n [data-loc]")) {
-    const el = span as HTMLElement;
-    el.style.display = el.getAttribute("data-loc") === locale ? "inline" : "none";
+/** Production .lu-i18n show/hide rules shipped by CourseLayout (not a test copy). */
+function extractProductionLuI18nCss(layoutSource: string): string {
+  const rules = [
+    /\.lu-i18n \[data-loc='uk'\] \{[^}]+\}/,
+    /html\[data-chrome-locale='uk'\] \.lu-i18n \[data-loc='uk'\] \{[^}]+\}/,
+    /html\[data-chrome-locale='uk'\] \.lu-i18n \[data-loc='en'\] \{[^}]+\}/,
+  ];
+  const parts: string[] = [];
+  for (const re of rules) {
+    const match = layoutSource.match(re);
+    if (!match) {
+      throw new Error("CourseLayout is missing the production .lu-i18n show/hide CSS contract");
+    }
+    parts.push(match[0]);
   }
+  return parts.join("\n");
 }
 
-function expectOnlyLocaleVisible(rootEl: Element, locale: "en" | "uk"): void {
-  applyLuI18nVisibilityContract();
+function injectProductionLuI18nCss(css: string): HTMLStyleElement {
+  document.querySelectorAll("style[data-test-lu-i18n]").forEach((el) => el.remove());
+  const style = document.createElement("style");
+  style.setAttribute("data-test-lu-i18n", "production");
+  style.textContent = css;
+  document.head.appendChild(style);
+  return style;
+}
+
+/**
+ * happy-dom does not recompute attribute-selector CSS when data-chrome-locale
+ * flips on an already-mounted tree — set locale first, then mount, then assert
+ * computed visibility against the injected production stylesheet.
+ */
+function mountDualAndExpectVisible(
+  enText: string,
+  ukText: string,
+  locale: "en" | "uk",
+): Element {
+  document.documentElement.dataset.chromeLocale = locale;
+  document.body.innerHTML = chromeDualHtml(enText, ukText);
+  const rootEl = document.querySelector(".lu-i18n")!;
   const en = rootEl.querySelector<HTMLElement>('[data-loc="en"]');
   const uk = rootEl.querySelector<HTMLElement>('[data-loc="uk"]');
   expect(en).toBeTruthy();
   expect(uk).toBeTruthy();
   if (locale === "en") {
-    expect(en!.style.display).toBe("inline");
-    expect(uk!.style.display).toBe("none");
-    expect(getComputedStyle(en!).display).not.toBe("none");
     expect(getComputedStyle(uk!).display).toBe("none");
+    expect(getComputedStyle(en!).display).not.toBe("none");
   } else {
-    expect(uk!.style.display).toBe("inline");
-    expect(en!.style.display).toBe("none");
-    expect(getComputedStyle(uk!).display).not.toBe("none");
     expect(getComputedStyle(en!).display).toBe("none");
+    expect(getComputedStyle(uk!).display).not.toBe("none");
   }
+  return rootEl;
 }
 
 describe("readings chrome locale (#6750 already on HEAD)", () => {
@@ -126,22 +148,15 @@ describe("WotD hub chrome locale (#6711)", () => {
     expect(few.en).toBe("B1 · 3 words");
     expect(few.uk).toBe("B1 · 3 слова");
 
-    // CourseLayout CSS contract must still hide the inactive locale.
-    expect(courseLayout).toContain(".lu-i18n [data-loc='uk'] { display: none; }");
-    expect(courseLayout).toContain(
-      "html[data-chrome-locale='uk'] .lu-i18n [data-loc='en'] { display: none; }",
-    );
+    // Inject the real CourseLayout stylesheet — not a duplicated show/hide copy.
+    const productionCss = extractProductionLuI18nCss(courseLayout);
+    injectProductionLuI18nCss(productionCss);
 
-    document.body.innerHTML = chromeDualHtml(en, uk);
-    const rootEl = document.querySelector(".lu-i18n")!;
+    const enRoot = mountDualAndExpectVisible(en, uk, "en");
+    expect(enRoot.querySelector('[data-loc="en"]')?.textContent).toBe(en);
 
-    document.documentElement.dataset.chromeLocale = "en";
-    expectOnlyLocaleVisible(rootEl, "en");
-    expect(rootEl.querySelector('[data-loc="en"]')?.textContent).toBe(en);
-
-    document.documentElement.dataset.chromeLocale = "uk";
-    expectOnlyLocaleVisible(rootEl, "uk");
-    expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toContain("слів");
+    const ukRoot = mountDualAndExpectVisible(en, uk, "uk");
+    expect(ukRoot.querySelector('[data-loc="uk"]')?.textContent).toContain("слів");
   });
 
   test("chromeDualHtml escapes angle brackets, ampersand, and quotes", () => {

--- a/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
+++ b/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+/**
+ * #6711 — WotD hub chrome must follow the en/uk toggle (chrome only, never content).
+ * Readings hero/search half was fixed in #6750; this covers the leftover hub body.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  CHROME_STRINGS,
+  chromeDualHtml,
+  formatWotdEmptyLevel,
+  formatWotdLevelCount,
+} from "@site/src/lib/i18n/chrome";
+
+const root = process.cwd();
+const wotdHub = readFileSync(resolve(root, "src/pages/words-of-the-day.astro"), "utf8");
+const dailyWords = readFileSync(resolve(root, "src/lexicon/DailyWords.astro"), "utf8");
+const readingsIndex = readFileSync(resolve(root, "src/pages/readings/index.astro"), "utf8");
+const chromeDict = readFileSync(resolve(root, "src/lib/i18n/chrome.ts"), "utf8");
+
+describe("readings chrome locale (#6750 already on HEAD)", () => {
+  test("readings index wires hero + search through Chrome Locale Runtime", () => {
+    expect(readingsIndex).toContain('titleKey="nav.readings"');
+    expect(readingsIndex).toContain('subtitleKey="readings.subtitle"');
+    expect(readingsIndex).toContain("data-i18n-placeholder");
+    expect(readingsIndex).toContain("readings.searchPlaceholder");
+  });
+});
+
+describe("WotD hub chrome locale (#6711)", () => {
+  test("hub hero dual-renders title, subtitle, badge, and practice CTA via ChromeText", () => {
+    expect(wotdHub).toContain("ChromeText");
+    expect(wotdHub).toMatch(/ChromeText\s+k="nav\.dailyWords"/);
+    expect(wotdHub).toMatch(/ChromeText\s+k="wotd\.subtitle"/);
+    expect(wotdHub).toMatch(/ChromeText\s+k="wotd\.practiceCta"/);
+    // No slash-dual leftovers (#5503) and no Ukrainian-only hero chrome.
+    expect(wotdHub).not.toContain("Слова дня / Words of the Day");
+    expect(wotdHub).not.toMatch(/<h1[^>]*>\s*Слова дня/);
+    expect(wotdHub).not.toContain("Практика — інтервальне повторення вашого рівня →");
+  });
+
+  test("DailyWords section chrome uses ChromeText / dual-render, not Ukrainian-only literals", () => {
+    expect(dailyWords).toContain("ChromeText");
+    expect(dailyWords).toMatch(/ChromeText\s+k="wotd\.todayTitle"/);
+    expect(dailyWords).toMatch(/ChromeText\s+k="wotd\.todayDescription"/);
+    expect(dailyWords).toMatch(/ChromeText\s+k="practice\.level"/);
+    expect(dailyWords).toMatch(/ChromeText\s+k="wotd\.loading"/);
+    expect(dailyWords).toMatch(/ChromeText\s+k="wotd\.loadError"/);
+    expect(dailyWords).toMatch(/ChromeText\s+k="practice\.retry"/);
+    expect(dailyWords).not.toContain(">Добірка на сьогодні<");
+    expect(dailyWords).not.toContain(">Рівень<");
+    expect(dailyWords).not.toContain("Завантажуємо добірку...");
+    expect(dailyWords).not.toContain("${activeLevel} · ${picks.length} слів");
+  });
+
+  test("dictionary holds both-locale WotD hub chrome strings", () => {
+    for (const key of [
+      "wotd.subtitle",
+      "wotd.practiceCta",
+      "wotd.todayTitle",
+      "wotd.todayDescription",
+      "wotd.loading",
+      "wotd.loadError",
+    ] as const) {
+      expect(CHROME_STRINGS.en[key].length).toBeGreaterThan(0);
+      expect(CHROME_STRINGS.uk[key].length).toBeGreaterThan(0);
+      expect(CHROME_STRINGS.en[key]).not.toEqual(CHROME_STRINGS.uk[key]);
+    }
+    expect(chromeDict).toContain("'wotd.todayTitle'");
+  });
+
+  test("pluralized level count line dual-renders in both locales (DOM)", () => {
+    const { en, uk } = formatWotdLevelCount("A2", 12);
+    expect(en).toBe("A2 · 12 words");
+    expect(uk).toBe("A2 · 12 слів");
+
+    const one = formatWotdLevelCount("A1", 1);
+    expect(one.en).toBe("A1 · 1 word");
+    expect(one.uk).toBe("A1 · 1 слово");
+
+    const few = formatWotdLevelCount("B1", 3);
+    expect(few.en).toBe("B1 · 3 words");
+    expect(few.uk).toBe("B1 · 3 слова");
+
+    document.body.innerHTML = chromeDualHtml(en, uk);
+    const rootEl = document.querySelector(".lu-i18n")!;
+    expect(rootEl.querySelector('[data-loc="en"]')?.textContent).toBe(en);
+    expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toBe(uk);
+
+    // CSS show/hide contract: English visible by default; UK when attribute set.
+    document.documentElement.dataset.chromeLocale = "en";
+    expect(rootEl.querySelector('[data-loc="en"]')).toBeTruthy();
+    document.documentElement.dataset.chromeLocale = "uk";
+    expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toContain("слів");
+  });
+
+  test("empty-level status is bilingual chrome, not Ukrainian-only", () => {
+    const empty = formatWotdEmptyLevel("C2");
+    expect(empty.en).toContain("C2");
+    expect(empty.en.toLowerCase()).toContain("no words");
+    expect(empty.uk).toContain("C2");
+    expect(empty.uk).toContain("Немає слів");
+  });
+
+  test("DailyWords client status uses chromeDualHtml / formatWotdLevelCount", () => {
+    expect(dailyWords).toContain("chromeDualHtml");
+    expect(dailyWords).toContain("formatWotdLevelCount");
+    expect(dailyWords).toContain("formatWotdEmptyLevel");
+  });
+});

--- a/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
+++ b/site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts
@@ -18,6 +18,39 @@ const wotdHub = readFileSync(resolve(root, "src/pages/words-of-the-day.astro"), 
 const dailyWords = readFileSync(resolve(root, "src/lexicon/DailyWords.astro"), "utf8");
 const readingsIndex = readFileSync(resolve(root, "src/pages/readings/index.astro"), "utf8");
 const chromeDict = readFileSync(resolve(root, "src/lib/i18n/chrome.ts"), "utf8");
+const courseLayout = readFileSync(resolve(root, "src/layouts/CourseLayout.astro"), "utf8");
+
+/**
+ * happy-dom does not recompute attribute-selector CSS when data-chrome-locale
+ * flips. Apply the same show/hide contract CourseLayout's .lu-i18n rules define
+ * so tests assert actual per-locale visibility, not mere span existence.
+ */
+function applyLuI18nVisibilityContract(doc: Document = document): void {
+  const locale = doc.documentElement.dataset.chromeLocale === "uk" ? "uk" : "en";
+  for (const span of doc.querySelectorAll(".lu-i18n [data-loc]")) {
+    const el = span as HTMLElement;
+    el.style.display = el.getAttribute("data-loc") === locale ? "inline" : "none";
+  }
+}
+
+function expectOnlyLocaleVisible(rootEl: Element, locale: "en" | "uk"): void {
+  applyLuI18nVisibilityContract();
+  const en = rootEl.querySelector<HTMLElement>('[data-loc="en"]');
+  const uk = rootEl.querySelector<HTMLElement>('[data-loc="uk"]');
+  expect(en).toBeTruthy();
+  expect(uk).toBeTruthy();
+  if (locale === "en") {
+    expect(en!.style.display).toBe("inline");
+    expect(uk!.style.display).toBe("none");
+    expect(getComputedStyle(en!).display).not.toBe("none");
+    expect(getComputedStyle(uk!).display).toBe("none");
+  } else {
+    expect(uk!.style.display).toBe("inline");
+    expect(en!.style.display).toBe("none");
+    expect(getComputedStyle(uk!).display).not.toBe("none");
+    expect(getComputedStyle(en!).display).toBe("none");
+  }
+}
 
 describe("readings chrome locale (#6750 already on HEAD)", () => {
   test("readings index wires hero + search through Chrome Locale Runtime", () => {
@@ -29,14 +62,24 @@ describe("readings chrome locale (#6750 already on HEAD)", () => {
 });
 
 describe("WotD hub chrome locale (#6711)", () => {
+  test("document title stays bilingual — titleKey does not drive <title>", () => {
+    // CourseLayout titleKey dual-renders hero <h1> only; <title> stays the
+    // plain `title` prop (same as readings after #6750). Restore bilingual tab
+    // title so УКР mode is not English-only in browser chrome.
+    expect(wotdHub).toContain('title: "Слова дня / Words of the Day"');
+    expect(courseLayout).toContain("<title>{title} · Learn Ukrainian</title>");
+    expect(courseLayout).toMatch(/titleKey\s*\?\s*<ChromeText/);
+    expect(courseLayout).not.toMatch(/<title>\{[^}]*titleKey/);
+  });
+
   test("hub hero dual-renders title, subtitle, badge, and practice CTA via ChromeText", () => {
     expect(wotdHub).toContain("ChromeText");
     expect(wotdHub).toMatch(/ChromeText\s+k="nav\.dailyWords"/);
     expect(wotdHub).toMatch(/ChromeText\s+k="wotd\.subtitle"/);
     expect(wotdHub).toMatch(/ChromeText\s+k="wotd\.practiceCta"/);
-    // No slash-dual leftovers (#5503) and no Ukrainian-only hero chrome.
-    expect(wotdHub).not.toContain("Слова дня / Words of the Day");
-    expect(wotdHub).not.toMatch(/<h1[^>]*>\s*Слова дня/);
+    // No slash-dual leftovers in visible hero (#5503) and no Ukrainian-only hero chrome.
+    expect(wotdHub).not.toMatch(/<h1[^>]*>\s*Слова дня\s*\/\s*Words of the Day/);
+    expect(wotdHub).not.toMatch(/<h1[^>]*>\s*Слова дня\s*</);
     expect(wotdHub).not.toContain("Практика — інтервальне повторення вашого рівня →");
   });
 
@@ -70,7 +113,7 @@ describe("WotD hub chrome locale (#6711)", () => {
     expect(chromeDict).toContain("'wotd.todayTitle'");
   });
 
-  test("pluralized level count line dual-renders in both locales (DOM)", () => {
+  test("pluralized level count line dual-renders with per-locale visibility", () => {
     const { en, uk } = formatWotdLevelCount("A2", 12);
     expect(en).toBe("A2 · 12 words");
     expect(uk).toBe("A2 · 12 слів");
@@ -83,16 +126,49 @@ describe("WotD hub chrome locale (#6711)", () => {
     expect(few.en).toBe("B1 · 3 words");
     expect(few.uk).toBe("B1 · 3 слова");
 
+    // CourseLayout CSS contract must still hide the inactive locale.
+    expect(courseLayout).toContain(".lu-i18n [data-loc='uk'] { display: none; }");
+    expect(courseLayout).toContain(
+      "html[data-chrome-locale='uk'] .lu-i18n [data-loc='en'] { display: none; }",
+    );
+
     document.body.innerHTML = chromeDualHtml(en, uk);
     const rootEl = document.querySelector(".lu-i18n")!;
+
+    document.documentElement.dataset.chromeLocale = "en";
+    expectOnlyLocaleVisible(rootEl, "en");
+    expect(rootEl.querySelector('[data-loc="en"]')?.textContent).toBe(en);
+
+    document.documentElement.dataset.chromeLocale = "uk";
+    expectOnlyLocaleVisible(rootEl, "uk");
+    expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toContain("слів");
+  });
+
+  test("chromeDualHtml escapes angle brackets, ampersand, and quotes", () => {
+    const en = `A <b>bold</b> & "quoted" path`;
+    const uk = `Шляхх <img src=x onerror=alert(1)> & 'лапк'`;
+    const html = chromeDualHtml(en, uk);
+
+    // Assert entities on the fragment string before the DOM re-serializes text nodes.
+    expect(html).toContain("&lt;b&gt;");
+    expect(html).toContain("&lt;/b&gt;");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&quot;quoted&quot;");
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(html).not.toMatch(/<b>|<img\b/);
+
+    document.body.innerHTML = html;
+    const rootEl = document.querySelector(".lu-i18n")!;
+
+    // No injected element nodes — only the two locale spans under .lu-i18n.
+    expect(rootEl.querySelectorAll("*")).toHaveLength(2);
+    expect(rootEl.querySelector("b")).toBeNull();
+    expect(rootEl.querySelector("img")).toBeNull();
+    expect(document.body.querySelectorAll("script")).toHaveLength(0);
+
+    // Exact text preserved after parse.
     expect(rootEl.querySelector('[data-loc="en"]')?.textContent).toBe(en);
     expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toBe(uk);
-
-    // CSS show/hide contract: English visible by default; UK when attribute set.
-    document.documentElement.dataset.chromeLocale = "en";
-    expect(rootEl.querySelector('[data-loc="en"]')).toBeTruthy();
-    document.documentElement.dataset.chromeLocale = "uk";
-    expect(rootEl.querySelector('[data-loc="uk"]')?.textContent).toContain("слів");
   });
 
   test("empty-level status is bilingual chrome, not Ukrainian-only", () => {
@@ -107,5 +183,8 @@ describe("WotD hub chrome locale (#6711)", () => {
     expect(dailyWords).toContain("chromeDualHtml");
     expect(dailyWords).toContain("formatWotdLevelCount");
     expect(dailyWords).toContain("formatWotdEmptyLevel");
+    expect(dailyWords).toContain("applyDailyLoadFallback");
+    expect(dailyWords).toContain("beginDailyReload");
+    expect(dailyWords).toContain("markDailyLoadSuccess");
   });
 });

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -1,9 +1,10 @@
 ---
 import CourseLayout from "../layouts/CourseLayout.astro";
+import ChromeText from "../components/chrome/ChromeText.astro";
 import DailyWords from "../lexicon/DailyWords.astro";
 
 const frontmatter = {
-  title: "Слова дня / Words of the Day",
+  title: "Words of the Day",
   description: "A daily Word Atlas surface with CEFR-capped Ukrainian vocabulary picks.",
 };
 ---
@@ -18,21 +19,16 @@ const frontmatter = {
 >
   <main class="word-atlas words-day-page" data-word-atlas>
     <section class="words-day-hero" aria-labelledby="words-day-title">
-      <span class="words-day-badge">Слова дня</span>
-      <h1 id="words-day-title">Слова дня / Words of the Day</h1>
-      <p>Щоденна добірка слів з Атласу, обмежена вашим поточним рівнем.</p>
+      <span class="words-day-badge"><ChromeText k="nav.dailyWords" /></span>
+      <h1 id="words-day-title"><ChromeText k="nav.dailyWords" /></h1>
+      <p><ChromeText k="wotd.subtitle" /></p>
       <a class="words-day-practice-cta" href="/words-of-the-day/practice/">
-        Практика — інтервальне повторення вашого рівня →
+        <ChromeText k="wotd.practiceCta" />
       </a>
     </section>
 
     {/* Practice daily set density (#5502): 12 first — atlas daily-pool.json unchanged. */}
-    <DailyWords
-      title="Добірка на сьогодні"
-      description="Слова оновлюються за календарною датою; торкніться картки, щоб перевернути, або самого слова — щоб відкрити статтю в Атласі."
-      count={12}
-      showLevelSelector
-    />
+    <DailyWords count={12} showLevelSelector />
   </main>
 </CourseLayout>
 

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -4,7 +4,10 @@ import ChromeText from "../components/chrome/ChromeText.astro";
 import DailyWords from "../lexicon/DailyWords.astro";
 
 const frontmatter = {
-  title: "Words of the Day",
+  // Document <title> only — CourseLayout titleKey dual-renders the hero <h1>, not
+  // <title> (same limit as #6750 readings). Keep the prior bilingual tab title so
+  // УКР mode is not English-only in the browser chrome.
+  title: "Слова дня / Words of the Day",
   description: "A daily Word Atlas surface with CEFR-capped Ukrainian vocabulary picks.",
 };
 ---

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -9,7 +9,6 @@ import {
   bindDailyCardInteractions,
   dailyCardAtlasHref,
   isDailyCardAtlasLinkTarget,
-  pickDailyForLevel,
   renderDailyCardHtml,
   toggleDailyCardFlip,
 } from "@site/src/lib/lexicon/daily-card";
@@ -20,6 +19,10 @@ const dailyWordsSource = readFileSync(
 );
 const wordsOfTheDaySource = readFileSync(
   resolve(process.cwd(), "src/pages/words-of-the-day.astro"),
+  "utf8",
+);
+const chromeSource = readFileSync(
+  resolve(process.cwd(), "src/lib/i18n/chrome.ts"),
   "utf8",
 );
 
@@ -78,8 +81,10 @@ describe("DailyWords list example sentence (GH #5434)", () => {
 describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
   test("hub copy no longer claims every card goes to Atlas", () => {
     expect(wordsOfTheDaySource).not.toContain("кожна картка веде до повної статті Атласу");
-    expect(wordsOfTheDaySource).toContain("торкніться картки, щоб перевернути");
-    expect(wordsOfTheDaySource).toContain("Атласі");
+    // Helper copy lives in the chrome dictionary; DailyWords dual-renders it.
+    expect(dailyWordsSource).toContain('k="wotd.todayDescription"');
+    expect(chromeSource).toContain("торкніться картки, щоб перевернути");
+    expect(chromeSource).toContain("Атласі");
   });
 
   test("card chrome is a flip control, not a single Atlas anchor", () => {
@@ -156,11 +161,14 @@ describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
     expect(dailyWordsSource).not.toContain("words-of-the-day/daily-pool");
     expect(dailyWordsSource).toContain("data-daily-fallback");
     expect(dailyWordsSource).toContain("data-daily-retry");
-    expect(dailyWordsSource).toContain("Не вдалося завантажити добірку.");
-    expect(dailyWordsSource).toContain("Спробувати ще раз");
+    expect(dailyWordsSource).toContain('k="wotd.loadError"');
+    expect(dailyWordsSource).toContain('k="practice.retry"');
+    expect(chromeSource).toContain("Не вдалося завантажити добірку.");
+    expect(chromeSource).toContain("Спробувати ще раз");
     expect(dailyWordsSource).toContain("showLoadError");
     expect(dailyWordsSource).toContain("script is:inline");
     expect(dailyWordsSource).toContain("TIMEOUT_MS");
+    expect(dailyWordsSource).toContain("data-daily-loading");
     // Must not silently hide the section on transport/server failure.
     expect(dailyWordsSource).toMatch(/catch\s*\{\s*showLoadError\(\);/);
   });

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
 import type { DailyWord } from "@site/src/lib/lexicon/daily";
 import {
@@ -12,6 +12,15 @@ import {
   renderDailyCardHtml,
   toggleDailyCardFlip,
 } from "@site/src/lib/lexicon/daily-card";
+import {
+  DAILY_WATCHDOG_TIMEOUT_MS,
+  applyDailyLoadFallback,
+  armDailyWatchdog,
+  beginDailyReload,
+  isDailyWatchdogDue,
+  markDailyLoadSuccess,
+} from "@site/src/lib/lexicon/daily-loading";
+import { chromeDualHtml } from "@site/src/lib/i18n/chrome";
 
 const dailyWordsSource = readFileSync(
   resolve(process.cwd(), "src/lexicon/DailyWords.astro"),
@@ -34,6 +43,20 @@ const sampleWord: DailyWord = {
   example: "У кошику яблука.",
   exampleEn: "There are apples in the basket.",
 };
+
+function mountDailySection(): HTMLElement {
+  document.body.innerHTML = `
+    <section data-daily-words>
+      <p data-daily-status data-daily-loading="true">Loading…</p>
+      <div data-daily-fallback hidden>
+        <p>Load failed</p>
+        <button type="button" data-daily-retry>Retry</button>
+      </div>
+      <ul data-daily-list></ul>
+    </section>
+  `;
+  return document.querySelector<HTMLElement>("[data-daily-words]")!;
+}
 
 describe("DailyWords list example sentence (GH #5434)", () => {
   test("DailyWords Astro renders an example slot with bilingual scaffolding", () => {
@@ -166,10 +189,114 @@ describe("DailyWords card flip vs Atlas lemma (#6726)", () => {
     expect(chromeSource).toContain("Не вдалося завантажити добірку.");
     expect(chromeSource).toContain("Спробувати ще раз");
     expect(dailyWordsSource).toContain("showLoadError");
+    expect(dailyWordsSource).toContain("applyDailyLoadFallback");
     expect(dailyWordsSource).toContain("script is:inline");
     expect(dailyWordsSource).toContain("TIMEOUT_MS");
     expect(dailyWordsSource).toContain("data-daily-loading");
     // Must not silently hide the section on transport/server failure.
     expect(dailyWordsSource).toMatch(/catch\s*\{\s*showLoadError\(\);/);
+  });
+});
+
+describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  test("initial markup is loading with data-daily-loading=true", () => {
+    expect(dailyWordsSource).toMatch(
+      /data-daily-status[\s\S]*?data-daily-loading="true"/,
+    );
+    const section = mountDailySection();
+    const status = section.querySelector<HTMLElement>("[data-daily-status]")!;
+    expect(status.getAttribute("data-daily-loading")).toBe("true");
+    expect(status.hidden).toBe(false);
+    expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
+    expect(isDailyWatchdogDue(section)).toBe(true);
+  });
+
+  test("success clears loading and marks ready", () => {
+    const section = mountDailySection();
+    const list = section.querySelector("[data-daily-list]")!;
+    list.innerHTML = "<li>word</li>";
+    markDailyLoadSuccess(
+      section,
+      chromeDualHtml("A1 · 1 word", "A1 · 1 слово"),
+    );
+
+    const status = section.querySelector<HTMLElement>("[data-daily-status]")!;
+    expect(status.getAttribute("data-daily-loading")).toBeNull();
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toContain("1 word");
+    expect(section.dataset.dailyReady).toBe("true");
+    expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
+    expect(isDailyWatchdogDue(section)).toBe(false);
+  });
+
+  test("load failure paints fallback and clears data-daily-loading", () => {
+    const section = mountDailySection();
+    applyDailyLoadFallback(section);
+
+    const status = section.querySelector<HTMLElement>("[data-daily-status]")!;
+    const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]")!;
+    expect(status.hidden).toBe(true);
+    expect(status.getAttribute("data-daily-loading")).toBeNull();
+    expect(fallback.hidden).toBe(false);
+    expect(section.dataset.dailyReady).toBe("true");
+    expect(isDailyWatchdogDue(section)).toBe(false);
+  });
+
+  test("retry restores loading state after failure", () => {
+    const section = mountDailySection();
+    applyDailyLoadFallback(section);
+    beginDailyReload(section, chromeDualHtml("Loading…", "Завантаження…"));
+
+    const status = section.querySelector<HTMLElement>("[data-daily-status]")!;
+    const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]")!;
+    expect(fallback.hidden).toBe(true);
+    expect(status.hidden).toBe(false);
+    expect(status.getAttribute("data-daily-loading")).toBe("true");
+    expect(status.textContent).toContain("Loading…");
+    expect(section.dataset.dailyReady).toBe("false");
+    expect(isDailyWatchdogDue(section)).toBe(true);
+  });
+
+  test("watchdog fallback fires when still loading after timeout", () => {
+    vi.useFakeTimers();
+    const section = mountDailySection();
+    expect(DAILY_WATCHDOG_TIMEOUT_MS).toBe(10_000);
+
+    armDailyWatchdog(section, { setTimeoutFn: setTimeout });
+    expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
+
+    vi.advanceTimersByTime(DAILY_WATCHDOG_TIMEOUT_MS - 1);
+    expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
+    expect(section.querySelector("[data-daily-status]")!.getAttribute("data-daily-loading")).toBe(
+      "true",
+    );
+
+    vi.advanceTimersByTime(1);
+    const status = section.querySelector<HTMLElement>("[data-daily-status]")!;
+    const fallback = section.querySelector<HTMLElement>("[data-daily-fallback]")!;
+    expect(status.hidden).toBe(true);
+    expect(status.getAttribute("data-daily-loading")).toBeNull();
+    expect(fallback.hidden).toBe(false);
+    expect(section.dataset.dailyReady).toBe("true");
+  });
+
+  test("watchdog does not override a successful load", () => {
+    vi.useFakeTimers();
+    const section = mountDailySection();
+    armDailyWatchdog(section, { setTimeoutFn: setTimeout });
+
+    const list = section.querySelector("[data-daily-list]")!;
+    list.innerHTML = "<li>ok</li>";
+    markDailyLoadSuccess(section, null);
+
+    vi.advanceTimersByTime(DAILY_WATCHDOG_TIMEOUT_MS + 50);
+    expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
+    expect(section.dataset.dailyReady).toBe("true");
+    expect(list.children).toHaveLength(1);
   });
 });

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -13,11 +13,8 @@ import {
   toggleDailyCardFlip,
 } from "@site/src/lib/lexicon/daily-card";
 import {
-  DAILY_WATCHDOG_TIMEOUT_MS,
   applyDailyLoadFallback,
-  armDailyWatchdog,
   beginDailyReload,
-  isDailyWatchdogDue,
   markDailyLoadSuccess,
 } from "@site/src/lib/lexicon/daily-loading";
 import { chromeDualHtml } from "@site/src/lib/i18n/chrome";
@@ -34,6 +31,21 @@ const chromeSource = readFileSync(
   resolve(process.cwd(), "src/lib/i18n/chrome.ts"),
   "utf8",
 );
+const dailyLoadingSource = readFileSync(
+  resolve(process.cwd(), "src/lib/lexicon/daily-loading.ts"),
+  "utf8",
+);
+
+/** Extract the intentional is:inline CDN-fail watchdog (must not import modules). */
+function extractInlineWatchdogSource(astroSource: string): string {
+  const match = astroSource.match(/<script is:inline>\s*([\s\S]*?)\s*<\/script>/);
+  if (!match) {
+    throw new Error("DailyWords.astro is missing the is:inline watchdog script");
+  }
+  return match[1]!;
+}
+
+const INLINE_WATCHDOG_TIMEOUT_MS = 10_000;
 
 const sampleWord: DailyWord = {
   lemma: "кошик",
@@ -213,7 +225,6 @@ describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
     expect(status.getAttribute("data-daily-loading")).toBe("true");
     expect(status.hidden).toBe(false);
     expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
-    expect(isDailyWatchdogDue(section)).toBe(true);
   });
 
   test("success clears loading and marks ready", () => {
@@ -231,7 +242,6 @@ describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
     expect(status.textContent).toContain("1 word");
     expect(section.dataset.dailyReady).toBe("true");
     expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
-    expect(isDailyWatchdogDue(section)).toBe(false);
   });
 
   test("load failure paints fallback and clears data-daily-loading", () => {
@@ -244,7 +254,6 @@ describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
     expect(status.getAttribute("data-daily-loading")).toBeNull();
     expect(fallback.hidden).toBe(false);
     expect(section.dataset.dailyReady).toBe("true");
-    expect(isDailyWatchdogDue(section)).toBe(false);
   });
 
   test("retry restores loading state after failure", () => {
@@ -259,18 +268,30 @@ describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
     expect(status.getAttribute("data-daily-loading")).toBe("true");
     expect(status.textContent).toContain("Loading…");
     expect(section.dataset.dailyReady).toBe("false");
-    expect(isDailyWatchdogDue(section)).toBe(true);
   });
 
-  test("watchdog fallback fires when still loading after timeout", () => {
+  test("inline watchdog is self-contained (no module imports) and no parallel armDailyWatchdog", () => {
+    const inline = extractInlineWatchdogSource(dailyWordsSource);
+    expect(inline).toContain("TIMEOUT_MS");
+    expect(inline).toContain("10000");
+    expect(inline).not.toMatch(/\bimport\b/);
+    expect(inline).not.toContain("armDailyWatchdog");
+    expect(inline).not.toContain("../lib/lexicon/daily-loading");
+    // Dead parallel watchdog removed — production never called it.
+    expect(dailyLoadingSource).not.toContain("armDailyWatchdog");
+    expect(dailyLoadingSource).not.toContain("isDailyWatchdogDue");
+  });
+
+  test("production is:inline watchdog paints fallback when still loading after timeout", () => {
     vi.useFakeTimers();
     const section = mountDailySection();
-    expect(DAILY_WATCHDOG_TIMEOUT_MS).toBe(10_000);
+    // Evaluate the real inline script from DailyWords.astro against this DOM.
+    // eslint-disable-next-line no-eval -- intentional: exercise production is:inline source
+    (0, eval)(extractInlineWatchdogSource(dailyWordsSource));
 
-    armDailyWatchdog(section, { setTimeoutFn: setTimeout });
     expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
 
-    vi.advanceTimersByTime(DAILY_WATCHDOG_TIMEOUT_MS - 1);
+    vi.advanceTimersByTime(INLINE_WATCHDOG_TIMEOUT_MS - 1);
     expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
     expect(section.querySelector("[data-daily-status]")!.getAttribute("data-daily-loading")).toBe(
       "true",
@@ -282,21 +303,22 @@ describe("DailyWords data-daily-loading state machine (#6771 review)", () => {
     expect(status.hidden).toBe(true);
     expect(status.getAttribute("data-daily-loading")).toBeNull();
     expect(fallback.hidden).toBe(false);
-    expect(section.dataset.dailyReady).toBe("true");
   });
 
-  test("watchdog does not override a successful load", () => {
+  test("production is:inline watchdog leaves a ready section alone", () => {
     vi.useFakeTimers();
     const section = mountDailySection();
-    armDailyWatchdog(section, { setTimeoutFn: setTimeout });
-
     const list = section.querySelector("[data-daily-list]")!;
     list.innerHTML = "<li>ok</li>";
     markDailyLoadSuccess(section, null);
 
-    vi.advanceTimersByTime(DAILY_WATCHDOG_TIMEOUT_MS + 50);
+    // eslint-disable-next-line no-eval -- intentional: exercise production is:inline source
+    (0, eval)(extractInlineWatchdogSource(dailyWordsSource));
+
+    vi.advanceTimersByTime(INLINE_WATCHDOG_TIMEOUT_MS + 50);
     expect(section.querySelector("[data-daily-fallback]")!).toHaveProperty("hidden", true);
     expect(section.dataset.dailyReady).toBe("true");
     expect(list.children).toHaveLength(1);
+    expect(section.querySelector<HTMLElement>("[data-daily-status]")!.hidden).toBe(true);
   });
 });

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -15,7 +15,10 @@ export default getViteConfig({
     environment: 'happy-dom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
-    include: ['tests/unit/**/*.{test,spec}.{ts,tsx}'],
+    include: [
+      'tests/unit/**/*.{test,spec}.{ts,tsx}',
+      'src/pages/__tests__/**/*.{test,spec}.{ts,tsx}',
+    ],
     // build-renders.test.ts shells out to `npm run build`; parallel file workers
     // contend on data/atlas.db and can surface transient "Caught error rendering".
     fileParallelism: false,


### PR DESCRIPTION
## Summary
- Fixes the remaining #6711 case: `/words-of-the-day/` hub body chrome stayed Ukrainian after toggling to English (title, subtitle, practice CTA, «Добірка на сьогодні», helper copy, «РІВЕНЬ», and the pluralized `A2 · 12 слів` / `words` count line).
- Root cause: hub + `DailyWords` rendered Ukrainian-only literals instead of the shared Chrome Locale Runtime (`ChromeText` / `.lu-i18n` dual-render) that #6750 already wired for `/readings/`.
- Added `wotd.*` keys plus `chromeDualHtml` / `formatWotdLevelCount` / `formatWotdEmptyLevel` in `site/src/lib/i18n/chrome.ts`; hub + DailyWords consume them. Readings half verified still present on HEAD (no re-implementation).

## Scope decisions
- **Home hero** left English by design (English-interface product line), matching #6711 notes and #6750.
- **Did not edit** `LexiconPractice.tsx` or `site/src/components/__tests__/**` (owned by another lane).
- Shared files touched: `site/src/lib/i18n/chrome.ts`, `site/src/lexicon/DailyWords.astro` (hub body owner), `site/vitest.config.ts` (include `src/pages/__tests__`).

## Test plan
- [x] Failing repro under `site/src/pages/__tests__/wotd-hub-chrome-locale.test.ts` on unmodified HEAD; passes after fix
- [x] Mutation check: strip hub `ChromeText` wiring → hero test fails; restore → passes
- [x] `npx vitest run src/pages/__tests__/wotd-hub-chrome-locale.test.ts tests/unit/daily-words-example.test.ts tests/unit/k3-chrome-locale.test.ts` — 29 passed
- [x] `npx eslint <changed files> --quiet` — clean
- [x] `npx tsc --noEmit` — no new errors in changed files (pre-existing errors elsewhere)
- [ ] Manual: open `/words-of-the-day/`, toggle УКР ↔ EN; confirm hub chrome flips and lemmas stay Ukrainian

Closes #6711


Made with [Cursor](https://cursor.com)