### PR TITLE
test(site): advisory UI policy gate — locale purity, selector state, no-auto-advance, axe, deck variety (#5376)

### DIFF
--- a/.github/workflows/ui-policy-gate.yml
+++ b/.github/workflows/ui-policy-gate.yml
@@ -1,0 +1,88 @@
+name: UI Policy Gate (advisory)
+
+# #5376 — advisory UI policy gate: locale purity (EN/UK), selector-state rule,
+# no-auto-advance, axe-core serious/critical, and build-time deck variety
+# metrics. ADVISORY BY DESIGN: this workflow is deliberately NOT part of
+# .github/workflows/ci.yml's ci-gate.needs and must not be added to branch
+# protection's required checks without an explicit operator/advisor decision.
+# A red run here signals a policy regression to investigate; it never blocks
+# a merge on its own.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'scripts/practice/**'
+      - '.github/workflows/ui-policy-gate.yml'
+  workflow_dispatch:
+
+jobs:
+  ui-policy:
+    name: UI policy checks (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          # jsonschema: `npm run build` imports scripts/audit via meta_validator —
+          # keep in sync with the ci.yml frontend job venv.
+          .venv/bin/python -m pip install PyYAML jsonschema
+
+      - name: Restore Atlas lexicon manifest cache
+        id: atlas-manifest-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
+      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        run: |
+          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+
+      - name: Save Atlas lexicon manifest cache
+        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
+      - name: Install dependencies
+        working-directory: site
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: site
+        run: npx playwright install --with-deps chromium
+
+      - name: Build site for Playwright preview
+        working-directory: site
+        run: npm run build
+
+      # Checks 1-4 (#5376): locale purity, selector state, no-auto-advance, axe.
+      - name: Run UI policy Playwright specs
+        working-directory: site
+        run: npx playwright test ui-policy
+
+      # Check 5 (#5376): build-time deck variety metrics over the hydrated
+      # practice shards. Warns on thin pools, fails on degenerate decks.
+      - name: Deck variety metrics
+        run: .venv/bin/python scripts/practice/deck_variety_metrics.py --practice-dir site/public/lexicon

--- a/scripts/practice/deck_variety_metrics.py
+++ b/scripts/practice/deck_variety_metrics.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Deck variety metrics for the practice gate (#5376 check 5).
+
+Build-time (non-playwright) guard that turns "the deck feels samey" into
+numbers. Reads the hydrated practice deck shards (``practice-index.<LEVEL>.json``)
+and reports, per level:
+
+- exercise-type mix: distinct modes offered, mean modes per item, and the
+  share of items that offer only a single exercise type;
+- pool size per type: items offering each mode (a focused session draws from
+  exactly this pool);
+- per-session repetition rate: for a focused session of size S over a mode
+  pool P, ``max(0, S - P) / S`` — the share of the session that MUST be
+  repeats when the pool cannot fill it;
+- simulated mixed-session type diversity: seeded deterministic sessions of
+  size S drawn without replacement, one random offered mode per card.
+
+Thresholds (warn vs fail) are constants below; the gate exits 1 on any FAIL.
+Zero-pool modes are reported but not penalized: modes with no authored
+content are honestly disabled in the UI (e.g. cloze before #3797), which is a
+product state, not a variety regression.
+
+No network, stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+INDEX_RE = re.compile(r"^practice-index\.(?P<level>[A-C][12])\.json$")
+DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
+
+# Fixed seed: simulations are deterministic so CI results are reproducible.
+SIM_SEED = 20260717
+SIM_SESSIONS = 200
+
+# --- Thresholds (tune deliberately; each has a justification) ---------------
+# A level with fewer than 3 distinct exercise types is a "samey" deck by
+# definition — one or two activity shapes repeated.
+FAIL_MIN_DISTINCT_MODES = 3
+# If most items can only be practiced one way, mixed sessions cannot vary.
+FAIL_MAX_SINGLE_MODE_SHARE = 0.50
+# A mode pool of exactly 1 means every focused session is the same card.
+# (Pool 0 = mode honestly disabled; reported, not penalized.)
+FAIL_MIN_NONZERO_MODE_POOL = 2
+# Simulated mixed sessions should routinely show at least 3 distinct types.
+FAIL_MIN_SESSION_TYPE_DIVERSITY = 3.0
+# Warn when a non-empty mode pool cannot fill one focused session without
+# repeats, and when mixed-session diversity dips below 5 types.
+WARN_MIN_MODE_POOL_VS_SESSION = True
+WARN_MIN_SESSION_TYPE_DIVERSITY = 5.0
+
+
+def load_index(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data.get("items"), list):
+        raise ValueError(f"{path.name}: missing items list")
+    return data
+
+
+def simulate_mixed_diversity(items: list[dict[str, Any]], session_size: int) -> float:
+    """Mean distinct exercise types across seeded mixed sessions."""
+    pool = [item for item in items if item.get("modes")]
+    if not pool:
+        return 0.0
+    rng = random.Random(SIM_SEED)
+    draws = min(session_size, len(pool))
+    total = 0
+    for _ in range(SIM_SESSIONS):
+        session_items = rng.sample(pool, draws)
+        types = {rng.choice(item["modes"]) for item in session_items}
+        total += len(types)
+    return total / SIM_SESSIONS
+
+
+def evaluate_level(level: str, items: list[dict[str, Any]], session_size: int) -> dict[str, Any]:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if not items:
+        return {
+            "level": level,
+            "items": 0,
+            "failures": [f"{level}: deck has 0 items"],
+            "warnings": [],
+        }
+
+    mode_pools: Counter[str] = Counter()
+    single_mode = 0
+    modes_per_item: list[int] = []
+    for item in items:
+        modes = list(item.get("modes") or [])
+        modes_per_item.append(len(modes))
+        if len(modes) == 1:
+            single_mode += 1
+        for mode in set(modes):
+            mode_pools[mode] += 1
+
+    distinct_modes = len(mode_pools)
+    single_mode_share = single_mode / len(items)
+    mean_modes = sum(modes_per_item) / len(modes_per_item)
+    diversity = simulate_mixed_diversity(items, session_size)
+
+    if distinct_modes < FAIL_MIN_DISTINCT_MODES:
+        failures.append(
+            f"{level}: only {distinct_modes} distinct exercise types "
+            f"(fail floor {FAIL_MIN_DISTINCT_MODES})"
+        )
+    if single_mode_share > FAIL_MAX_SINGLE_MODE_SHARE:
+        failures.append(
+            f"{level}: {single_mode_share:.0%} of items offer exactly one exercise type "
+            f"(fail ceiling {FAIL_MAX_SINGLE_MODE_SHARE:.0%})"
+        )
+    if diversity < FAIL_MIN_SESSION_TYPE_DIVERSITY:
+        failures.append(
+            f"{level}: simulated {session_size}-card mixed sessions average "
+            f"{diversity:.2f} distinct types (fail floor {FAIL_MIN_SESSION_TYPE_DIVERSITY})"
+        )
+    elif diversity < WARN_MIN_SESSION_TYPE_DIVERSITY:
+        warnings.append(
+            f"{level}: simulated {session_size}-card mixed sessions average "
+            f"{diversity:.2f} distinct types (warn floor {WARN_MIN_SESSION_TYPE_DIVERSITY})"
+        )
+
+    repetition: dict[str, float] = {}
+    for mode, pool_size in sorted(mode_pools.items()):
+        repetition[mode] = round(max(0, session_size - pool_size) / session_size, 3)
+        if pool_size < FAIL_MIN_NONZERO_MODE_POOL:
+            failures.append(
+                f"{level}: mode '{mode}' pool is {pool_size} — every focused session "
+                f"is the same card (fail floor {FAIL_MIN_NONZERO_MODE_POOL})"
+            )
+        elif WARN_MIN_MODE_POOL_VS_SESSION and pool_size < session_size:
+            warnings.append(
+                f"{level}: mode '{mode}' pool {pool_size} < session size {session_size} — "
+                f"a focused session is {repetition[mode]:.0%} repeats"
+            )
+
+    return {
+        "level": level,
+        "items": len(items),
+        "distinctModes": distinct_modes,
+        "meanModesPerItem": round(mean_modes, 2),
+        "singleModeShare": round(single_mode_share, 3),
+        "modePools": dict(sorted(mode_pools.items())),
+        "focusedSessionRepetition": repetition,
+        "mixedSessionTypeDiversity": round(diversity, 2),
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--practice-dir",
+        type=Path,
+        default=DEFAULT_PRACTICE_DIR,
+        help="Directory holding practice-index.<LEVEL>.json shards (default: %(default)s)",
+    )
+    parser.add_argument("--session-size", type=int, default=10, help="Session size S (default: 10)")
+    parser.add_argument("--json", type=Path, default=None, help="Optional JSON report output path")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Promote warnings to failures",
+    )
+    args = parser.parse_args(argv)
+
+    index_files = sorted(
+        p for p in args.practice_dir.glob("practice-index.*.json") if INDEX_RE.match(p.name)
+    )
+    if not index_files:
+        print(f"FAIL: no practice-index.<LEVEL>.json shards in {args.practice_dir}")
+        return 1
+
+    reports = []
+    for path in index_files:
+        data = load_index(path)
+        level = str(data.get("level") or INDEX_RE.match(path.name).group("level"))  # type: ignore[union-attr]
+        reports.append(evaluate_level(level, data["items"], args.session_size))
+
+    total_failures = 0
+    total_warnings = 0
+    for report in reports:
+        failures = report["failures"]
+        warnings = report["warnings"]
+        if args.strict:
+            failures = failures + warnings
+            warnings = []
+        total_failures += len(failures)
+        total_warnings += len(warnings)
+        status = "FAIL" if failures else ("WARN" if warnings else "OK")
+        print(f"[{status}] {report['level']}: items={report.get('items')} "
+              f"distinctModes={report.get('distinctModes')} "
+              f"meanModesPerItem={report.get('meanModesPerItem')} "
+              f"singleModeShare={report.get('singleModeShare')} "
+              f"mixedSessionTypeDiversity={report.get('mixedSessionTypeDiversity')}")
+        for mode, pool in (report.get("modePools") or {}).items():
+            rep = report["focusedSessionRepetition"][mode]
+            print(f"       pool {mode}: {pool} (focused-session repetition {rep:.0%})")
+        for warning in warnings:
+            print(f"       warn: {warning}")
+        for failure in failures:
+            print(f"       FAIL: {failure}")
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(
+            json.dumps({"sessionSize": args.session_size, "levels": reports}, indent=2, ensure_ascii=False)
+            + "\n",
+            encoding="utf-8",
+        )
+
+    print(
+        f"deck variety: {len(reports)} levels, {total_failures} failures, {total_warnings} warnings"
+    )
+    return 1 if total_failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/e2e/ui-policy-axe.spec.ts
+++ b/site/e2e/ui-policy-axe.spec.ts
@@ -1,0 +1,77 @@
+import { AxeBuilder } from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+/**
+ * #5376 check 4 — axe-core accessibility scan.
+ *
+ * Policy: the practice and Atlas surfaces must have ZERO axe violations at
+ * impact serious or critical, in both color themes. Moderate/minor findings
+ * are logged but do not fail the gate.
+ *
+ * PRE-EXISTING VIOLATIONS ON MAIN (residual findings — product fixes are
+ * outside this gate's owned paths, reported in the #5376 PR body):
+ *
+ * - `color-contrast` [serious]: the practice dashboard fails contrast minimums
+ *   in BOTH themes (.daily-deck-example, .daily-deck-origin, .due/.new/.done
+ *   status counters; dark theme adds .k3-levels > .active and
+ *   .flashcard-back > .flashcard-subtitle). The rule is DISABLED below until
+ *   the product CSS fix lands — every other serious/critical rule stays
+ *   enforced fail-closed.
+ * - `definition-list` [serious] on /lexicon/: `.atlas-runtime-grid` <dl> cards
+ *   interleave a <p data-runtime-detail> between dd and the next dt/dd group.
+ *   Excluded by selector below until the markup is fixed.
+ */
+
+const SURFACES = [
+  { path: '/words-of-the-day/practice/', waitForPractice: true },
+  { path: '/lexicon/', waitForPractice: false },
+];
+
+const FAIL_IMPACTS = new Set(['serious', 'critical']);
+
+const KNOWN_VIOLATION_EXCLUSIONS: Record<string, string[]> = {
+  '/lexicon/': ['.atlas-runtime-grid'], // definition-list [serious], see header
+};
+
+const DISABLED_RULES = ['color-contrast']; // pre-existing failures, see header
+
+for (const surface of SURFACES) {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`axe: ${surface.path} [${theme}] has no serious/critical violations`, async ({ page }) => {
+      await page.addInitScript((t) => {
+        window.localStorage.setItem('lu-theme', t);
+        document.documentElement.setAttribute('data-theme', t);
+      }, theme);
+      await page.goto(surface.path);
+      if (surface.waitForPractice) {
+        await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
+      }
+      await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
+
+      let builder = new AxeBuilder({ page }).disableRules(DISABLED_RULES);
+      for (const selector of KNOWN_VIOLATION_EXCLUSIONS[surface.path] ?? []) {
+        builder = builder.exclude(selector);
+      }
+      const results = await builder.analyze();
+
+      const failing = results.violations.filter((v) => FAIL_IMPACTS.has(v.impact ?? ''));
+      const advisory = results.violations.filter((v) => !FAIL_IMPACTS.has(v.impact ?? ''));
+      if (advisory.length > 0) {
+        console.log(
+          `axe advisory (moderate/minor, non-failing): ${advisory
+            .map((v) => `${v.id}(${v.impact})×${v.nodes.length}`)
+            .join(', ')}`,
+        );
+      }
+
+      const message = failing
+        .map(
+          (v) =>
+            `${v.id} [${v.impact}] ${v.help} — ${v.helpUrl}\n` +
+            v.nodes.map((n) => `  ${n.target.join(' ')}: ${n.failureSummary?.split('\n')[0]}`).join('\n'),
+        )
+        .join('\n');
+      expect(failing.length, `axe serious/critical violations on ${surface.path} [${theme}]:\n${message}`).toBe(0);
+    });
+  }
+}

--- a/site/e2e/ui-policy-locale-purity.spec.ts
+++ b/site/e2e/ui-policy-locale-purity.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * #5376 check 1 — locale purity (EN/UK chrome).
+ *
+ * Policy: the chrome locale toggle (`lu-chrome-locale`) must produce a PURE
+ * interface locale. EN mode → zero Cyrillic in interface text; UK mode → zero
+ * English chrome. A single label must never mix both scripts ('УКР / ENG'
+ * dual-label class, the 2026-07-17 defects).
+ *
+ * FAIL-CLOSED DESIGN (binding per #5376): every visible text node is chrome
+ * unless its element sits under an explicit content-allowlist selector below.
+ * An unknown new text region is checked, not skipped — extending the allowlist
+ * is a deliberate, reviewed act.
+ *
+ * ChromeText dual-renders both locales into the DOM and CSS-hides one
+ * (`html[data-chrome-locale]`); visibility is resolved via checkVisibility(),
+ * so the hidden variant is never inspected.
+ */
+
+const CYRILLIC_RE = /[Ѐ-ӿԀ-ԯ]/;
+
+/**
+ * Latin tokens tolerated in UK chrome. Fail-closed: a token not listed here
+ * fails the check. Level codes, brand names, and technical acronyms only.
+ */
+const UK_LATIN_TOKEN_ALLOWLIST = new Set([
+  'A1', 'A2', 'B1', 'B2', 'C1', 'C2', // CEFR level codes
+  'LU', // logo monogram
+  'GitHub', // brand
+  'API', // technical acronym
+  'ULP', // Ukrainian Lessons Podcast brand
+  'VESUM', // Ukrainian morphological dictionary acronym (cited in mode descriptions)
+]);
+
+/** Selectors excluded on EVERY surface, each with its justification. */
+const GLOBAL_CONTENT_ALLOWLIST = [
+  '.lu-locale-label', // the toggle displays the TARGET locale name (УКР in EN mode)
+  '.lu-logo', // brand wordmark ("Learn Ukrainian", "LU")
+  '.lu-footer h2', // footer brand heading ("Learn Ukrainian")
+  '.lu-footer a[href^="http"]', // external resources are proper-brand names (Ukrainian Lessons, ULP Podcast)
+  '.lu-footer-bottom', // deliberately bilingual motto in both locales
+  '.lu-footer p', // authored mission prose; may name Latin-script brands mid-sentence
+];
+
+interface Surface {
+  path: string;
+  /** Authored-content regions (Ukrainian-first by design), per surface. */
+  contentAllowlist: string[];
+}
+
+const SURFACES: Surface[] = [
+  {
+    path: '/words-of-the-day/practice/',
+    contentAllowlist: [
+      '.k3-hero-epigraph', // authored Ukrainian epigraph (lang="uk")
+      '[data-testid="practice-daily-deck"]', // words-of-the-day content: lemmas, EN glosses, etymology
+      'button[data-zno-deck]', // official ЗНО/НМТ exam section names are Ukrainian content
+      '.lexicon-weak-chip', // weak-spot chips render learner vocabulary
+    ],
+  },
+  {
+    path: '/lexicon/',
+    contentAllowlist: [
+      '.atlas-typeahead-landing', // Ukrainian-first dictionary search label/placeholder (hardcoded by design)
+      '.atlas-runtime-grid', // technical build metadata: counts, version hashes, API paths
+    ],
+  },
+  {
+    path: '/lexicon/browse/',
+    contentAllowlist: [
+      '.atlas-index', // the A–Z browser is an authored Ukrainian-first immersion surface
+    ],
+  },
+];
+
+interface TextNodeReport {
+  text: string;
+  path: string;
+}
+
+async function collectVisibleText(page: Page, allowlist: string[]): Promise<TextNodeReport[]> {
+  return page.evaluate((excludedSelectors) => {
+    const skipTags = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE']);
+    const out: { text: string; path: string }[] = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const el = node.parentElement;
+      const text = (node.textContent ?? '').replace(/\s+/g, ' ').trim();
+      if (el && text && !skipTags.has(el.tagName)) {
+        const visible = el.checkVisibility({ checkOpacity: false, checkVisibilityCSS: true });
+        const excluded = el.closest(excludedSelectors.join(',')) !== null;
+        if (visible && !excluded) {
+          const testid = el.getAttribute('data-testid');
+          const cls =
+            typeof el.className === 'string' && el.className
+              ? `.${el.className.trim().split(/\s+/).join('.')}`
+              : '';
+          out.push({
+            text: text.slice(0, 120),
+            path: `${el.tagName.toLowerCase()}${cls}${testid ? `[data-testid="${testid}"]` : ''}`,
+          });
+        }
+      }
+      node = walker.nextNode();
+    }
+    return out;
+  }, allowlist);
+}
+
+function formatViolations(title: string, violations: TextNodeReport[]): string {
+  const lines = violations.map((v) => `  ${v.path}  ::  ${v.text}`);
+  return `${title} (${violations.length}):\n${lines.join('\n')}`;
+}
+
+for (const surface of SURFACES) {
+  for (const locale of ['en', 'uk'] as const) {
+    test(`locale purity: ${surface.path} in ${locale.toUpperCase()} chrome`, async ({ page, context }) => {
+      await context.clearCookies();
+      await page.addInitScript((loc) => window.localStorage.setItem('lu-chrome-locale', loc), locale);
+      await page.goto(surface.path);
+      await page.waitForLoadState('networkidle');
+      // Practice is a React island — wait for it to hydrate before sampling.
+      if (surface.path.includes('/practice/')) {
+        await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
+      }
+
+      const nodes = await collectVisibleText(page, [
+        ...GLOBAL_CONTENT_ALLOWLIST,
+        ...surface.contentAllowlist,
+      ]);
+      expect(nodes.length, 'sanity: the check must actually inspect visible text').toBeGreaterThan(10);
+
+      const failures: string[] = [];
+
+      const cyrillicHits = nodes.filter((n) => CYRILLIC_RE.test(n.text));
+      if (locale === 'en' && cyrillicHits.length > 0) {
+        failures.push(formatViolations('EN chrome contains Cyrillic interface text', cyrillicHits));
+      }
+
+      if (locale === 'uk') {
+        const latinHits = nodes.filter((n) => {
+          const tokens = n.text.match(/[A-Za-z][A-Za-z0-9]*/g) ?? [];
+          return tokens.some((token) => !UK_LATIN_TOKEN_ALLOWLIST.has(token));
+        });
+        if (latinHits.length > 0) {
+          failures.push(
+            formatViolations('UK chrome contains non-allowlisted English interface text', latinHits),
+          );
+        }
+      }
+
+      // Mixed-label trap ('УКР / ENG' class): one visible label must never mix
+      // scripts, regardless of locale. Allowlisted Latin tokens (A1, GitHub…)
+      // do not count as the Latin side of a mix.
+      const mixedHits = nodes.filter((n) => {
+        if (!CYRILLIC_RE.test(n.text)) return false;
+        const latinWords = (n.text.match(/[A-Za-z][A-Za-z0-9]*/g) ?? []).filter(
+          (token) => token.length >= 2 && !UK_LATIN_TOKEN_ALLOWLIST.has(token),
+        );
+        return latinWords.length > 0;
+      });
+      if (mixedHits.length > 0) {
+        failures.push(formatViolations('single label mixes Cyrillic and Latin scripts', mixedHits));
+      }
+
+      expect(failures, failures.join('\n\n')).toEqual([]);
+    });
+  }
+}

--- a/site/e2e/ui-policy-no-auto-advance.spec.ts
+++ b/site/e2e/ui-policy-no-auto-advance.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * #5376 check 3 — no-auto-advance policy (behavioral, timers mocked).
+ *
+ * Policy: after ANY answer, the next item must NOT render until the learner
+ * activates «Далі» / «Next» (`practice-advance-button`). Auto-advance on a
+ * timer steals the learner's review moment. Timers are mocked (page.clock) and
+ * fast-forwarded far past any conceivable delay: if a setTimeout/setInterval
+ * drives advancement, the session moves and the check fails.
+ */
+
+test('flashcards: rating never auto-advances; only «Далі» moves the session', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.clock.install();
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.locator('button[data-mode="flashcards"]').click();
+  const card = page.locator('[data-activity="flashcard"]');
+  await expect(card).toBeVisible();
+
+  await card.click();
+  await expect(card).toHaveAttribute('data-flipped', 'true');
+  const firstWord = (await card.locator('.flashcard-word').first().textContent()) ?? '';
+
+  await page.locator('[data-rate="good"]').click();
+  await expect(card).toHaveAttribute('data-rated', 'true');
+  const progress = page.getByTestId('practice-session-progress');
+  await expect(progress).toContainText('0/');
+
+  // Fast-forward 60 virtual seconds — several orders of magnitude past any
+  // legitimate UI timer. Nothing about the session may change on its own.
+  await page.clock.runFor(60_000);
+
+  await expect(progress, 'session advanced without «Далі»').toContainText('0/');
+  await expect(card, 'card un-rated itself without «Далі»').toHaveAttribute('data-rated', 'true');
+  expect(
+    (await card.locator('.flashcard-word').first().textContent()) ?? '',
+    'a different card rendered without «Далі»',
+  ).toBe(firstWord);
+  await expect(page.getByTestId('practice-advance-button')).toBeVisible();
+
+  // Explicit activation is the ONLY path forward.
+  await page.getByTestId('practice-advance-button').click();
+  await expect(progress).toContainText('1/');
+});
+
+test('choice mode: answering never auto-advances; only «Далі» moves the session', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.clock.install();
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.locator('button[data-mode="choice"]').click();
+  const option = page.locator('.mc-opt').first();
+  await expect(option).toBeVisible();
+
+  const progress = page.getByTestId('practice-session-progress');
+  await expect(progress).toContainText('0/');
+
+  await option.click();
+  await expect(page.getByTestId('practice-advance-button')).toBeVisible();
+
+  await page.clock.runFor(60_000);
+
+  await expect(progress, 'session advanced without «Далі»').toContainText('0/');
+  await expect(page.getByTestId('practice-advance-button')).toBeVisible();
+
+  await page.getByTestId('practice-advance-button').click();
+  await expect(progress).toContainText('1/');
+});

--- a/site/e2e/ui-policy-selector-state.spec.ts
+++ b/site/e2e/ui-policy-selector-state.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+/**
+ * #5376 check 2 — selector-state rule.
+ *
+ * Policy: every button group with SELECTOR semantics (pick-one-of-N state that
+ * persists: CEFR level, session size, …) must expose its state two ways:
+ *   1. programmatically — every option carries aria-pressed (or aria-checked),
+ *      and exactly one enabled option is pressed;
+ *   2. visually — the pressed option's computed style differs measurably from
+ *      its unpressed siblings (the "10/20 invisibility" and pairing-selection
+ *      invisibility defects were both "state exists, styling doesn't show it").
+ *
+ * The group registry below is explicit and fail-closed in both directions:
+ * removing aria-pressed from a registered group fails, and registering a new
+ * group is a deliberate reviewed act. Known non-compliant groups (e.g. the
+ * Atlas browse filter chips, which carry selection only in the URL) are NOT
+ * registered here; closing that gap is product work outside this gate's scope.
+ */
+
+const STYLE_CHANNELS: string[] = [
+  'background-color',
+  'color',
+  'border-color',
+  'outline-color',
+  'font-weight',
+  'box-shadow',
+];
+
+interface StyleSnapshot {
+  [channel: string]: string;
+}
+
+async function snapshotStyles(locator: Locator): Promise<StyleSnapshot[]> {
+  return locator.evaluateAll((elements, channels) => {
+    return elements.map((el) => {
+      const style = getComputedStyle(el);
+      const snap: Record<string, string> = {};
+      for (const channel of channels as string[]) {
+        snap[channel] = style.getPropertyValue(channel);
+      }
+      return snap;
+    });
+  }, STYLE_CHANNELS);
+}
+
+function differingChannels(selected: StyleSnapshot, sibling: StyleSnapshot): string[] {
+  return Object.keys(selected).filter((channel) => selected[channel] !== sibling[channel]);
+}
+
+interface SelectorGroup {
+  name: string;
+  selector: string;
+}
+
+const PERSISTENT_GROUPS: SelectorGroup[] = [
+  { name: 'CEFR level picker', selector: '.k3-levels button' },
+  { name: 'session size picker', selector: '.k3-session-budgets button' },
+];
+
+test('persistent selector groups expose exactly one pressed, visually distinct option', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.goto('/words-of-the-day/practice/');
+  await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
+
+  for (const group of PERSISTENT_GROUPS) {
+    const options = page.locator(group.selector);
+    const count = await options.count();
+    expect(count, `${group.name}: group must render options`).toBeGreaterThan(1);
+
+    // 1. Every option carries the state attribute (fail-closed on removal).
+    const pressedValues = await options.evaluateAll((elements) =>
+      elements.map((el) => ({
+        pressed: el.getAttribute('aria-pressed') ?? el.getAttribute('aria-checked'),
+        disabled: (el as HTMLButtonElement).disabled,
+      })),
+    );
+    for (const [index, value] of pressedValues.entries()) {
+      expect(
+        value.pressed,
+        `${group.name} option ${index}: missing aria-pressed/aria-checked — state is invisible to AT`,
+      ).not.toBeNull();
+    }
+
+    // 2. Exactly one ENABLED option is pressed.
+    const pressedIndexes = pressedValues
+      .map((value, index) => ({ value, index }))
+      .filter(({ value }) => value.pressed === 'true' && !value.disabled)
+      .map(({ index }) => index);
+    expect(
+      pressedIndexes.length,
+      `${group.name}: expected exactly one pressed option, got [${pressedIndexes.join(', ')}]`,
+    ).toBe(1);
+
+    // 3. The pressed option differs measurably from every enabled unpressed sibling.
+    const styles = await snapshotStyles(options);
+    const selected = styles[pressedIndexes[0]];
+    const unpressed = styles
+      .map((snap, index) => ({ snap, index }))
+      .filter(({ index }) => index !== pressedIndexes[0] && !pressedValues[index].disabled);
+    expect(unpressed.length, `${group.name}: needs at least one unpressed sibling`).toBeGreaterThan(0);
+    for (const { snap, index } of unpressed) {
+      const diff = differingChannels(selected, snap);
+      expect(
+        diff.length,
+        `${group.name}: pressed option ${pressedIndexes[0]} is visually identical to option ${index} ` +
+          `(checked: ${STYLE_CHANNELS.join(', ')})`,
+      ).toBeGreaterThan(0);
+    }
+  }
+});
+
+test('matching pairing: the selected tile is announced and visually distinct', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.locator('button[data-mode="matching"]').click();
+  const leftTiles = page.locator('[data-activity="match-left-tile"]');
+  await expect.poll(() => leftTiles.count()).toBeGreaterThanOrEqual(3);
+
+  // Before any pick: every tile carries the attribute, none is pressed.
+  const initial = await leftTiles.evaluateAll((elements) =>
+    elements.map((el) => el.getAttribute('aria-pressed')),
+  );
+  for (const value of initial) {
+    expect(value, 'matching left tile: missing aria-pressed').not.toBeNull();
+  }
+
+  await leftTiles.first().click();
+
+  // Exactly one tile pressed, and it is measurably distinct from its siblings.
+  const pressedCount = await leftTiles.evaluateAll(
+    (elements) => elements.filter((el) => el.getAttribute('aria-pressed') === 'true').length,
+  );
+  expect(pressedCount, 'matching: exactly one selected tile after a pick').toBe(1);
+
+  const styles = await snapshotStyles(leftTiles);
+  const pressed = await leftTiles.evaluateAll((elements) =>
+    elements.map((el) => el.getAttribute('aria-pressed') === 'true'),
+  );
+  const selectedIndex = pressed.indexOf(true);
+  for (const [index, snap] of styles.entries()) {
+    if (index === selectedIndex) continue;
+    const diff = differingChannels(styles[selectedIndex], snap);
+    expect(
+      diff.length,
+      `matching: selected tile ${selectedIndex} is visually identical to tile ${index}`,
+    ).toBeGreaterThan(0);
+  }
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -30,6 +30,7 @@
         "typescript": "^6.0.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
@@ -517,6 +518,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3761,6 +3775,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {

--- a/site/package.json
+++ b/site/package.json
@@ -53,6 +53,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/tests/test_deck_variety_metrics.py
+++ b/tests/test_deck_variety_metrics.py
@@ -1,0 +1,90 @@
+"""Tests for scripts/practice/deck_variety_metrics.py (#5376 check 5)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.practice.deck_variety_metrics import main
+
+
+def _item(idx: int, modes: list[str]) -> dict:
+    return {
+        "lemmaId": f"w{idx}",
+        "lemma": f"w{idx}",
+        "cefr": "A1",
+        "modes": modes,
+        "hasCloze": False,
+        "clozeIds": [],
+        "newOrder": idx,
+    }
+
+
+def _write_index(dir_path: Path, level: str, items: list[dict]) -> None:
+    (dir_path / f"practice-index.{level}.json").write_text(
+        json.dumps({"deckVersion": "test", "level": level, "items": items}),
+        encoding="utf-8",
+    )
+
+
+def test_healthy_deck_passes(tmp_path: Path) -> None:
+    modes = ["flashcards", "matching", "choice", "cloze", "stress", "classify"]
+    items = [_item(i, modes[: 3 + (i % 4)]) for i in range(60)]
+    _write_index(tmp_path, "A1", items)
+    assert main(["--practice-dir", str(tmp_path)]) == 0
+
+
+def test_samey_single_mode_deck_fails(tmp_path: Path) -> None:
+    items = [_item(i, ["flashcards"]) for i in range(60)]
+    _write_index(tmp_path, "A1", items)
+    assert main(["--practice-dir", str(tmp_path)]) == 1
+
+
+def test_singleton_mode_pool_fails(tmp_path: Path) -> None:
+    items = [_item(i, ["flashcards", "matching", "choice", "cloze"]) for i in range(60)]
+    items[0]["modes"] = items[0]["modes"] + ["heritage"]  # pool of exactly 1
+    _write_index(tmp_path, "A1", items)
+    assert main(["--practice-dir", str(tmp_path)]) == 1
+
+
+def test_empty_deck_fails(tmp_path: Path) -> None:
+    _write_index(tmp_path, "A1", [])
+    assert main(["--practice-dir", str(tmp_path)]) == 1
+
+
+def test_missing_shards_fail_closed(tmp_path: Path) -> None:
+    assert main(["--practice-dir", str(tmp_path)]) == 1
+
+
+def test_thin_pool_warns_but_passes(tmp_path: Path, capsys) -> None:
+    modes = ["flashcards", "matching", "choice", "cloze", "stress"]
+    items = [_item(i, list(modes)) for i in range(60)]
+    for i in range(5):  # thin paronym pool: warns, does not fail
+        items[i]["modes"] = items[i]["modes"] + ["paronym"]
+    _write_index(tmp_path, "A1", items)
+    assert main(["--practice-dir", str(tmp_path)]) == 0
+    assert "warn" in capsys.readouterr().out
+
+
+def test_strict_promotes_warnings(tmp_path: Path) -> None:
+    modes = ["flashcards", "matching", "choice", "cloze", "stress"]
+    items = [_item(i, list(modes)) for i in range(60)]
+    for i in range(5):
+        items[i]["modes"] = items[i]["modes"] + ["paronym"]
+    _write_index(tmp_path, "A1", items)
+    assert main(["--practice-dir", str(tmp_path), "--strict"]) == 1
+
+
+def test_json_report_written(tmp_path: Path) -> None:
+    items = [_item(i, ["flashcards", "matching", "choice", "cloze"]) for i in range(30)]
+    _write_index(tmp_path, "A1", items)
+    out = tmp_path / "report.json"
+    assert main(["--practice-dir", str(tmp_path), "--json", str(out)]) == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["sessionSize"] == 10
+    assert report["levels"][0]["modePools"]["flashcards"] == 30


### PR DESCRIPTION
Closes #5376.

## What

Implements the five encoded-policy checks from #5376 as a **new advisory (non-blocking) workflow**, `.github/workflows/ui-policy-gate.yml`, running on `site/**` PRs:

| # | Check | Implementation |
|---|-------|----------------|
| 1 | Locale purity (EN/UK chrome) | `site/e2e/ui-policy-locale-purity.spec.ts` — practice dashboard, Atlas landing, Atlas browse × EN/UK. Fail-closed: every visible text node is chrome unless under an explicit, justified content-allowlist selector; visibility via `checkVisibility()` so CSS-hidden dual-render variants are never inspected. Includes the mixed `'УКР / ENG'` single-label trap. |
| 2 | Selector-state rule | `site/e2e/ui-policy-selector-state.spec.ts` — registered groups (CEFR level picker, session-size picker, matching pairing): every option carries `aria-pressed`, exactly one enabled option pressed, and the pressed option's computed style (background/color/border/outline/font-weight/box-shadow) differs measurably from every enabled sibling. |
| 3 | No-auto-advance | `site/e2e/ui-policy-no-auto-advance.spec.ts` — timers mocked (`page.clock`); after a flashcard rating or choice answer, a 60s virtual fast-forward must not move the session; only `practice-advance-button` («Далі») does. |
| 4 | axe-core | `site/e2e/ui-policy-axe.spec.ts` — practice + Atlas landing, both themes, fail on serious/critical. Adds `@axe-core/playwright` (devDependency). |
| 5 | Deck variety metrics | `scripts/practice/deck_variety_metrics.py` (+ `tests/test_deck_variety_metrics.py`) — build-time, stdlib-only: exercise-type mix, pool size per mode, focused-session repetition rate `max(0, S−P)/S`, seeded mixed-session type diversity; warn/fail thresholds, exit 1 on fail. |

## Hard boundary: ADVISORY only

The new workflow is deliberately **not** part of `ci-gate.needs` in `ci.yml` and must not be added to branch protection's required checks. It fails loudly (real exit codes, real red check) but never blocks a merge. **Promoting it to a blocking gate is an operator/advisor decision** and is not done here.

## Two-sided evidence (#M-4 — real runs, quoted)

### Pass on current main surfaces

`PLAYWRIGHT_PORT=4399 npx playwright test e2e/ui-policy-locale-purity.spec.ts e2e/ui-policy-selector-state.spec.ts e2e/ui-policy-no-auto-advance.spec.ts e2e/ui-policy-axe.spec.ts` (against a full local `npm run build` + preview):

```
✓ 14 passed (10.3s)   — 6 locale purity, 2 selector-state, 2 no-auto-advance, 4 axe
```

Check 5 on the real hydrated deck (`scripts/practice/deck_variety_metrics.py`):

```
[OK] B1: items=1905 distinctModes=12 meanModesPerItem=5.46 ... mixedSessionTypeDiversity=5.75
[WARN] A1: ... mode 'heritage' pool 2 < session size 10 — a focused session is 80% repeats
...
deck variety: 5 levels, 0 failures, 7 warnings   → exit 0
```

(`pytest tests/test_deck_variety_metrics.py`: 8 passed; `ruff check` clean; `actionlint` + `zizmor` clean on the new workflow.)

### Deliberate local mutations — each caught, then reverted

1. **Locale purity**: set UK `'practice.modesTitle'` to the dual label `'Режими / Modes'` in `chrome.ts`, rebuilt →

   ```
   Error: UK chrome contains non-allowlisted English interface text (1):
     span  ::  Режими / Modes
   single label mixes Cyrillic and Latin scripts (1):
     span  ::  Режими / Modes
   ```

2. **Selector state**: deleted `aria-pressed={learnerLevel === level}` from the CEFR level picker, rebuilt →

   ```
   Error: CEFR level picker option 0: missing aria-pressed/aria-checked — state is invisible to AT
   ```

3. **No-auto-advance**: injected `setTimeout(() => advancePending(), 500)` into `handleFlashcardRating`, rebuilt → the mocked 60s fast-forward fired it →

   ```
   Error: session advanced without «Далі»   (progress showed "1/8", expected "0/")
   ```

4. **axe**: added `<img src="/favicon.svg" />` (no alt) to the practice page, rebuilt →

   ```
   Error: axe serious/critical violations on /words-of-the-day/practice/ [light]:
   image-alt [critical] Images must have alternative text
   ```

5. **Variety metrics**: mutated a copy of `practice-index.A1.json` to flashcards-only →

   ```
   [FAIL] A1: items=1371 distinctModes=1 ... FAIL: only 1 distinct exercise types (fail floor 3) ... exit=1
   ```

All mutations reverted; final tree rebuilt and the 14 specs re-run green before commit. No asserted-but-unrun claims.

## Pre-existing defects the gate surfaced on main (residuals, owners needed)

The gate immediately found real violations on current main. Fixing them is **product work outside this PR's owned paths**, so they are excluded/disabled with in-code documentation and reported here:

- **`color-contrast` [serious]** on the practice dashboard in BOTH themes: `.daily-deck-example`, `.daily-deck-origin`, `.due`/`.new`/`.done` status counters; dark theme adds `.k3-levels > .active` and `.flashcard-back > .flashcard-subtitle`. The rule is disabled in the axe spec until a CSS fix lands; every other serious/critical rule stays enforced.
- **`definition-list` [serious]** on `/lexicon/`: `.atlas-runtime-grid` `<dl>` cards interleave `<p data-runtime-detail>` between `dd` and the next group. Excluded by selector until the markup is fixed.
- **Selector-registry gap**: the Atlas browse filter chips (`/lexicon/browse/`) carry selection only in the URL — no `aria-pressed`. Not registered in check 2 (registering them would fail on main); closing that gap is product work.

Other pre-existing conditions observed while verifying (not caused by this PR): `npx tsc --noEmit` reports 15 errors in existing `tests/unit/*` files (none in this PR's files); the full existing `atlas-practice.spec.ts` run has 4 failures matching the known live frontend-e2e regression documented in `ci.yml` (frontend-e2e is not in `ci-gate.needs` for that reason).

## Notes

- Spec runtime is ~10–20s total for the 14 tests; the job's cost is dominated by the shared site build, same as the existing frontend-e2e job. The variety metrics step runs in <1s.
- Check 1's allowlists are the fail-closed mechanism the issue mandates: an unknown new text region is *checked*, not skipped; every allowlist entry carries an inline justification (locale toggle target label, authored Ukrainian epigraph, daily-deck content, ЗНО/НМТ exam names, Ukrainian-first Atlas browser, brand names, bilingual footer motto).
- No product code changes; no changes to `ci.yml` or any required gate.

X-Agent: kimi/atlas-5376-ui-policy-gate
