### PR TITLE
test(bridge): deterministic sys.path for ai_agent_bridge test package

### DIFF
--- a/tests/ai_agent_bridge/conftest.py
+++ b/tests/ai_agent_bridge/conftest.py
@@ -1,0 +1,15 @@
+"""Make `import ai_agent_bridge` deterministic for this test package.
+
+These tests import the bridge as a top-level package (`from ai_agent_bridge
+import …`), which requires `scripts/` on sys.path. In full runs that happened
+only by import-order luck (an earlier module primed the path); Pytest fastlane
+runs changed files alone and failed collection (#6800). Prime it here so any
+subset of this package collects standalone.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = str(Path(__file__).resolve().parents[2] / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)


### PR DESCRIPTION
## What
Adds a 4-line `tests/ai_agent_bridge/conftest.py` priming `scripts/` onto `sys.path` for this test package.

## Why
These tests import the bridge as a top-level package (`from ai_agent_bridge import …`). Full runs passed only by import-order luck (an earlier module primed the path); **Pytest fastlane runs changed files alone and fails collection** — this is what is blocking #6800 (glm-5.3 promotion, operator-ordered merge) with `ModuleNotFoundError: No module named 'ai_agent_bridge'`, a failure whose content is unrelated to that PR.

## Evidence
- Standalone collection of `test_review_pr_lifecycle.py` fails on main; 10/10 pass with this conftest.
- Full `tests/ai_agent_bridge/` package: 343 passed; the single failure (`sealed_acp_python_missing`) is a pre-existing worktree-environment sensitivity — it fails identically with the conftest removed (mutation-checked) and passes on primary checkout and CI where `.venv` exists.
- ruff clean.

## Note
Driver-authored micro-fix (≤5 LOC CI-fix class) — all implement lanes were mid-task and this blocks an operator-ordered merge. Flagged for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)