### PR TITLE
feat(reaper): dynamic first-class daily cap — 25/day with bounded 2x backlog expansion

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -51,7 +51,11 @@ reaping remains enabled. Before removal the reaper writes an
 append-only local journal, reserves the path as reap-pending, and creates a
 `refs/reaper-rescue/...` ref. Set `LU_REAPER_DISABLED=1` to stop automatic
 reaps immediately. The first seven days are capped by
-`LU_REAPER_MAX_REAPS_PER_DAY` (default 10); an approved policy lift uses
+`LU_REAPER_MAX_REAPS_PER_DAY` (default 25); when the eligible backlog of
+fully safety-qualified worktrees exceeds the remaining daily budget, the cap
+may expand up to a hard ceiling of 2x the configured base (journaled as
+`cap-expansion` with the justifying backlog size; the ceiling is not
+env-expandable). An approved policy lift uses
 `LU_REAPER_LIFT_FIRST_CLASS_CAP=1`. Restore only to a new path under
 `.worktrees/`:
 

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -812,6 +812,7 @@ def _reap_qualified_worktree(
     preserve_then_reap: bool,
     prune_merged_branches: bool,
     require_terminal_dispatch_guards: bool,
+    eligible_backlog: int | None = None,
 ) -> ReapResult:
     expected_head = info.head
     if dirty is None:
@@ -853,7 +854,10 @@ def _reap_qualified_worktree(
             pr=_pr_dict(pr_state),
         )
 
-    cap_allowed, cap_reason = reaper_lifecycle.cap_allows_reap(repo_root)
+    cap_allowed, cap_reason = reaper_lifecycle.cap_allows_reap(
+        repo_root,
+        eligible_backlog=eligible_backlog,
+    )
     if not cap_allowed:
         return ReapResult(
             path=str(info.path),
@@ -1081,6 +1085,7 @@ def reap_worktrees(
     repo_root = repo_root.resolve()
     targets = _target_filter(target_paths)
     results: list[ReapResult] = []
+    qualified: list[tuple[WorktreeInfo, str, bool | None, PullRequestState | None]] = []
     active_ids = _active_task_ids()
     if require_activity_probe is None:
         require_activity_probe = bool(apply)
@@ -1220,6 +1225,17 @@ def reap_worktrees(
                 reason=reason,
                 pr=_pr_dict(pr_state),
             )
+            qualified.append((info, reason, dirty, pr_state))
+
+        # The dynamic daily cap may expand only against a known eligible
+        # backlog: worktrees that passed every listing-time safety proof in
+        # this run.  Count conservatively — only clean candidates (a dirty
+        # one fails the "clean" proof until preserve-then-reap re-verifies
+        # it); any doubt means no expansion.
+        eligible_backlog = (
+            sum(1 for _, _, dirty, _ in qualified if dirty is False) if apply else None
+        )
+        for info, reason, dirty, pr_state in qualified:
             results.append(
                 _reap_qualified_worktree(
                     repo_root=repo_root,
@@ -1234,6 +1250,7 @@ def reap_worktrees(
                         include_terminal_dispatches
                         and reason.startswith("settled dispatch task-id=")
                     ),
+                    eligible_backlog=eligible_backlog,
                 )
             )
 

--- a/scripts/orchestration/reaper_lifecycle.py
+++ b/scripts/orchestration/reaper_lifecycle.py
@@ -21,7 +21,11 @@ _PENDING_NAME = "reap-pending.json"
 _CAP_NAME = "first-class-cap.json"
 _JOURNAL_NAME = "journal.jsonl"
 _FIRST_CLASS_DAYS = 7
-_DEFAULT_MAX_REAPS_PER_DAY = 10
+_DEFAULT_MAX_REAPS_PER_DAY = 25
+# Hard blast-radius ceiling for the dynamic cap: a day may expand to at most
+# this multiple of the configured base, no matter how large the backlog is.
+# Deliberately NOT env-configurable so a runaway is always stopped.
+_CAP_EXPANSION_MULTIPLIER = 2
 
 
 def utc_now() -> datetime:
@@ -153,8 +157,21 @@ def _max_reaps_per_day() -> int:
     return max(0, parsed)
 
 
-def cap_allows_reap(repo_root: Path, *, now: datetime | None = None) -> tuple[bool, str | None]:
-    """Apply the first-seven-days daily cap unless the policy flag lifts it."""
+def cap_allows_reap(
+    repo_root: Path,
+    *,
+    now: datetime | None = None,
+    eligible_backlog: int | None = None,
+) -> tuple[bool, str | None]:
+    """Apply the first-seven-days daily cap unless the policy flag lifts it.
+
+    The cap is dynamic: when the eligible backlog (worktrees that already
+    passed every reap safety proof in this run) exceeds the remaining daily
+    budget, the cap may expand — journaled with the justifying backlog size —
+    but never beyond a hard ceiling of 2x the configured base.  The ceiling
+    is not env-expandable, and any doubt about the backlog count means no
+    expansion.
+    """
     if os.environ.get("LU_REAPER_LIFT_FIRST_CLASS_CAP") == "1":
         return True, None
     current = now or utc_now()
@@ -168,8 +185,31 @@ def cap_allows_reap(repo_root: Path, *, now: datetime | None = None) -> tuple[bo
         return True, None
     counts = state.get("counts")
     count = counts.get(current.date().isoformat(), 0) if isinstance(counts, dict) else 0
-    if isinstance(count, int) and count >= _max_reaps_per_day():
-        return False, f"first-class daily reap cap reached ({_max_reaps_per_day()})"
+    if not isinstance(count, int) or isinstance(count, bool):
+        count = 0
+    base = _max_reaps_per_day()
+    ceiling = base * _CAP_EXPANSION_MULTIPLIER
+    if count >= ceiling:
+        return False, f"first-class daily reap cap ceiling reached ({ceiling})"
+    remaining = max(base - count, 0)
+    backlog_known = (
+        isinstance(eligible_backlog, int)
+        and not isinstance(eligible_backlog, bool)
+        and eligible_backlog >= 0
+    )
+    if backlog_known and eligible_backlog > remaining:
+        append_journal(
+            repo_root,
+            "cap-expansion",
+            day=current.date().isoformat(),
+            backlog=eligible_backlog,
+            base=base,
+            ceiling=ceiling,
+            day_count=count,
+        )
+        return True, None
+    if count >= base:
+        return False, f"first-class daily reap cap reached ({base})"
     return True, None
 
 

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1393,3 +1393,185 @@ def test_fresh_branch_on_main_tip_is_not_sha_reaped(
 
     assert result.action == "skipped"
     assert worktree.exists()
+
+
+def _cap_journal_rows(repo: Path, event: str) -> list[dict[str, Any]]:
+    path = reaper_lifecycle.journal_path(repo)
+    if not path.exists():
+        return []
+    return [
+        row
+        for row in (json.loads(line) for line in path.read_text(encoding="utf-8").splitlines())
+        if row.get("event") == event
+    ]
+
+
+def test_p0_dynamic_cap_default_is_25_and_blocks_at_base_without_backlog(
+    tmp_path: Path,
+) -> None:
+    repo = init_repo(tmp_path)
+
+    assert reaper_lifecycle._DEFAULT_MAX_REAPS_PER_DAY == 25
+    assert reaper_lifecycle.cap_allows_reap(repo) == (True, None)
+
+    for _ in range(25):
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    allowed, reason = reaper_lifecycle.cap_allows_reap(repo)
+    assert allowed is False
+    assert reason is not None and "daily reap cap reached (25)" in reason
+
+
+def test_p0_dynamic_cap_expands_when_backlog_exceeds_remaining_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "3")
+    for _ in range(3):
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    allowed, reason = reaper_lifecycle.cap_allows_reap(repo, eligible_backlog=5)
+
+    assert allowed is True
+    assert reason is None
+    rows = _cap_journal_rows(repo, "cap-expansion")
+    assert len(rows) == 1
+    assert rows[0]["backlog"] == 5
+    assert rows[0]["base"] == 3
+    assert rows[0]["ceiling"] == 6
+    assert rows[0]["day_count"] == 3
+
+
+def test_p0_dynamic_cap_expands_before_base_when_backlog_exceeds_remaining(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "5")
+    for _ in range(4):
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    allowed, _reason = reaper_lifecycle.cap_allows_reap(repo, eligible_backlog=3)
+
+    assert allowed is True
+    assert len(_cap_journal_rows(repo, "cap-expansion")) == 1
+
+
+def test_p0_dynamic_cap_no_expansion_when_backlog_fits_remaining_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "5")
+    for _ in range(3):
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    allowed, _reason = reaper_lifecycle.cap_allows_reap(repo, eligible_backlog=2)
+
+    assert allowed is True
+    assert _cap_journal_rows(repo, "cap-expansion") == []
+
+
+def test_p0_dynamic_cap_ceiling_never_exceeded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutation check: raising the 2x ceiling multiplier must fail this test."""
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "3")
+    for _ in range(6):  # exactly 2x the configured base
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    allowed, reason = reaper_lifecycle.cap_allows_reap(repo, eligible_backlog=100)
+
+    assert allowed is False
+    assert reason is not None and "daily reap cap ceiling reached (6)" in reason
+    assert _cap_journal_rows(repo, "cap-expansion") == []
+
+
+def test_p0_dynamic_cap_fail_closed_on_unknown_backlog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "3")
+    for _ in range(3):
+        reaper_lifecycle.record_reap_for_cap(repo)
+
+    for bad_backlog in (None, -1, "5", 2.5, True):
+        allowed, reason = reaper_lifecycle.cap_allows_reap(
+            repo,
+            eligible_backlog=bad_backlog,  # type: ignore[arg-type]
+        )
+        assert allowed is False, bad_backlog
+        assert reason is not None and "daily reap cap reached (3)" in reason
+    assert _cap_journal_rows(repo, "cap-expansion") == []
+
+
+def test_p0_dynamic_cap_env_zero_base_stays_closed_even_with_backlog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "0")
+
+    allowed, reason = reaper_lifecycle.cap_allows_reap(repo, eligible_backlog=100)
+
+    assert allowed is False
+    assert reason is not None and "daily reap cap" in reason
+    assert _cap_journal_rows(repo, "cap-expansion") == []
+
+
+def test_p0_dynamic_cap_expansion_reaps_backlog_beyond_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: base=1, two qualified worktrees -> both reaped via expansion."""
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "1")
+    worktrees = []
+    states = {}
+    for index in range(2):
+        branch = f"codex/cap-expand-{index}"
+        worktrees.append(add_worktree(repo, branch))
+        states[branch] = [{"number": 90 + index, "state": "MERGED"}]
+    patch_gh(monkeypatch, states)
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set())
+
+    for worktree in worktrees:
+        assert result_for(results, worktree).action == "removed"
+        assert not worktree.exists()
+    rows = _cap_journal_rows(repo, "cap-expansion")
+    assert rows
+    assert all(row["backlog"] == 2 for row in rows)
+
+
+def test_p0_dynamic_cap_ceiling_stops_run_in_apply_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: base=1, three qualified worktrees -> 2 reaped, 3rd blocked."""
+    repo = init_repo(tmp_path)
+    monkeypatch.setenv("LU_REAPER_MAX_REAPS_PER_DAY", "1")
+    worktrees = []
+    states = {}
+    for index in range(3):
+        branch = f"codex/cap-ceiling-{index}"
+        worktrees.append(add_worktree(repo, branch))
+        states[branch] = [{"number": 95 + index, "state": "MERGED"}]
+    patch_gh(monkeypatch, states)
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True, live_cwds=set())
+
+    actions = [result_for(results, worktree).action for worktree in worktrees]
+    assert actions.count("removed") == 2
+    blocked = [
+        result_for(results, worktree)
+        for worktree in worktrees
+        if result_for(results, worktree).action == "skipped"
+    ]
+    assert len(blocked) == 1
+    assert "daily reap cap ceiling reached (2)" in (blocked[0].reason or "")
+    assert Path(blocked[0].path).exists()


### PR DESCRIPTION
## Summary

Operator order 2026-08-14: make the merged-worktree reaper's first-class daily cap dynamic — **25/day by default, expanding occasionally**, with a hard ceiling. Continues the closed-loop reap lineage of #6478 (rescue refs unchanged).

## What changed

- `scripts/orchestration/reaper_lifecycle.py`
  - `_DEFAULT_MAX_REAPS_PER_DAY`: 10 → **25**.
  - New `_CAP_EXPANSION_MULTIPLIER = 2` — hard ceiling, **not env-configurable**, so a runaway is always stopped.
  - `cap_allows_reap(..., eligible_backlog=None)`: when the eligible backlog exceeds the remaining daily budget, the cap expands — journaled via the existing append-only journal as a `cap-expansion` event carrying `backlog`, `base`, `ceiling`, `day`, `day_count`. Blocked messages distinguish `cap reached (base)` from `cap ceiling reached (2×base)`.
  - `LU_REAPER_MAX_REAPS_PER_DAY` still overrides the base (base=0 → ceiling=0 → fully closed); `LU_REAPER_DISABLED` kill switch and `LU_REAPER_LIFT_FIRST_CLASS_CAP` policy lift unchanged.
- `scripts/orchestration/reap_worktrees.py`
  - Main loop is now two-pass: qualify first, then reap, so the backlog size is known before cap checks. Backlog counts **only clean, fully qualified candidates** from the current run — fail-closed: any doubt (unknown/invalid/negative backlog) means no expansion. `reap_success_worktree` passes no backlog → never expands.
  - **No safety proof was touched** — only how many reaps a day may pass, never what qualifies.
- `docs/runbooks/worktree-cleanup.md` — cap documentation updated.
- `tests/orchestration/test_reap_worktrees.py` — 9 new tests.

## Evidence

- `ruff check` on all changed files: **All checks passed!**
- `pytest tests/orchestration/test_reap_worktrees.py -q`: **57 passed** (48 existing + 9 new).
- New tests cover: default=25 honored; expansion grants when backlog demands (and early, before base, when backlog > remaining); no expansion when backlog fits; **ceiling never exceeded** (unit + end-to-end: base=1, 3 qualified → 2 reaped, 3rd blocked); journal records expansions with backlog size; env overrides respected (incl. base=0 stays closed even with backlog); fail-closed on unknown backlog (None/-1/str/float/bool).
- **Mutation check performed**: raising `_CAP_EXPANSION_MULTIPLIER` 2→3 makes both ceiling guard tests fail (verified), then reverted to 2 → green again.
- Full `tests/orchestration/` suite: 616 passed; 63 failed + 12 errors are **pre-existing on the clean base** (verified via `git stash` rerun: same failures without this change; none of the failing files — prompt_contracts, curriculum_readiness, thread_restart_e2e, thread_handoff, claudex_supervisor, curriculum_lifecycle_pilot — import reaper code; likely sparse-checkout/environment related).

## Out of scope / residual

- No merge, no auto-merge — driver owns review + merge.
- Pre-existing orchestration suite failures noted above are untouched by this PR.

X-Agent: kimi/infra-reaper-dynamic-cap