### PR TITLE
refactor(practice): extract shard hydration and ZNO overlay (#6761)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: a672999559bbb5c8b11b165699c63d5fae34f72d36c7cbc22ba0c8a689a98879
+  components_sha256: 8a4dd429a9c73c0fbd115dd89c6ee4517514dd89f38acddab3a3cda26ffd0dba
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -108,8 +108,16 @@ import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken
 import { usablePracticeSentenceEnglish } from '../lib/lexicon/practice-sentence-en';
 import { selectHeritagePracticePresentation } from '../lib/lexicon/practice-activity-adapters';
 import { searchShardForQuery, type SearchRow, type SearchShardManifest } from '../lib/lexicon/search';
+import {
+  appendDrillFields,
+  concatDrillFields,
+  fetchPracticeDrillFields,
+  getShardJson,
+  isMissingShard,
+} from '../lib/lexicon/practice-shard-fetch';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
-import ZnoPractice, { ZNO_PRACTICE_DECKS, type ZnoPracticeDeck } from './ZnoPractice';
+import ZnoPractice, { ZNO_PRACTICE_DECKS } from './ZnoPractice';
+import { useZnoPracticeOverlay, ZNO_MODE_META } from './useZnoPracticeOverlay';
 
 
 /**
@@ -664,61 +672,6 @@ const MODE_META: Record<
     step: 'Питома лексика',
     stepEn: 'Native vocabulary',
     accent: 'teal',
-  },
-};
-
-const ZNO_MODE_META: Record<
-  ZnoPracticeDeck['deckId'],
-  {
-    description: string;
-    descriptionEn: string;
-    accent: 'blue' | 'teal' | 'purple' | 'orange';
-  }
-> = {
-  'zno-stress': {
-    description: 'Тренуйте наголос на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Practise stress placement with official ZNO and NMT items.',
-    accent: 'teal',
-  },
-  'zno-paronym': {
-    description: 'Розрізняйте пароніми на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Distinguish paronyms with official ZNO and NMT items.',
-    accent: 'purple',
-  },
-  'zno-lexical-norm': {
-    description: 'Закріплюйте лексичну норму на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Reinforce lexical norms with official ZNO and NMT items.',
-    accent: 'orange',
-  },
-  'zno-morphological-norm': {
-    description: 'Закріплюйте морфологічну норму на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Reinforce morphological norms with official ZNO and NMT items.',
-    accent: 'purple',
-  },
-  'zno-syntactic-norm': {
-    description: 'Закріплюйте синтаксичну норму на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Reinforce syntactic norms with official ZNO and NMT items.',
-    accent: 'teal',
-  },
-  'zno-orthography': {
-    description: 'Тренуйте орфографію на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Practise orthography with official ZNO and NMT items.',
-    accent: 'blue',
-  },
-  'zno-morphology': {
-    description: 'Закріплюйте морфологію на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Reinforce morphology with official ZNO and NMT items.',
-    accent: 'purple',
-  },
-  'zno-syntax': {
-    description: 'Тренуйте синтаксис і розділові знаки на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Practise syntax and punctuation with official ZNO and NMT items.',
-    accent: 'teal',
-  },
-  'zno-phonetics': {
-    description: 'Тренуйте фонетику на офіційних завданнях ЗНО та НМТ.',
-    descriptionEn: 'Practise phonetics with official ZNO and NMT items.',
-    accent: 'orange',
   },
 };
 
@@ -1868,45 +1821,6 @@ function DigitChoiceShortcuts({
   return null;
 }
 
-/** Deduped fetch for practice and Atlas JSON by URL. Concurrent or repeated callers share the promise. */
-async function getShardJson<T>(url: string, cache: Map<string, Promise<unknown>>): Promise<T> {
-  let p = cache.get(url) as Promise<T> | undefined;
-  if (!p) {
-    p = fetch(url).then((res) => {
-      if (!res.ok) {
-        // Tag the HTTP status so callers can tell an unpublished shard (404,
-        // soft-skippable) from a real load fault (network / server error).
-        const err = new Error(`Shard fetch failed: ${url}`) as Error & { status?: number };
-        err.status = res.status;
-        throw err;
-      }
-      return res.json() as Promise<T>;
-    });
-    // On failure allow retry next time
-    p = p.catch((err) => {
-      cache.delete(url);
-      throw err;
-    });
-    cache.set(url, p);
-  }
-  return p;
-}
-
-/**
- * Optional drill-kind shards (and some Atlas search fallbacks) are unpublished
- * per level/type: HTTP 404 means "not shipped", so callers may treat that as an
- * empty payload. Network faults and 5xx must not be rewritten as empty decks
- * (#6768) — rethrow so the Practice load-error path can surface.
- */
-function isMissingShard(reason: unknown): boolean {
-  return (reason as { status?: number } | null)?.status === 404;
-}
-
-function softSkipUnpublishedDrillShard(reason: unknown): Record<string, never> {
-  if (isMissingShard(reason)) return {};
-  throw reason;
-}
-
 export default function LexiconPractice(props: LexiconPracticeProps) {
   return (
     <PracticeErrorBoundary>
@@ -2115,8 +2029,12 @@ function LexiconPracticeIsland({
     return () => clearTimeout(timeoutId);
   }, []);
   const [hoveredMode, setHoveredMode] = useState<VisiblePracticeModeFilter | null>(null);
-  const [hoveredZnoDeckId, setHoveredZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
-  const [activeZnoDeckId, setActiveZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
+  const {
+    hoveredZnoDeckId,
+    setHoveredZnoDeckId,
+    setActiveZnoDeckId,
+    activeZnoDeck,
+  } = useZnoPracticeOverlay();
   const [publishedLevels] = useState<Set<CefrLevel>>(
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
   );
@@ -2171,10 +2089,6 @@ function LexiconPracticeIsland({
     const title = customSets.find((s) => s.id === selectedDeckFilter)?.title;
     return title ? { uk: title, en: title } : null;
   }, [selectedDeckFilter, customSets]);
-  const activeZnoDeck = useMemo(
-    () => ZNO_PRACTICE_DECKS.find((candidate) => candidate.deckId === activeZnoDeckId) ?? null,
-    [activeZnoDeckId],
-  );
   const modeDetail = hoveredZnoDeckId
     ? ZNO_MODE_META[hoveredZnoDeckId]
     : MODE_META[hoveredMode ?? 'mixed'];
@@ -2978,33 +2892,12 @@ function LexiconPracticeIsland({
         // them, e.g. initialMode=cloze or mixed). Other drill shards are background.
         // This also defers drill-kind shards for basic modes (flashcards etc) until a
         // drill mode surfaces (optional path kept clean).
-        const drillUrls = [
-          `${shardBaseUrl}/practice-cloze.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-stress.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-classify.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-paradigm.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-synonym.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-paronym.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-heritage.${targetLevel}.json`,
-          `${shardBaseUrl}/practice-antonym.${targetLevel}.json`,
-        ];
-        const drillResults = await Promise.all(
-          drillUrls.map((u) =>
-            getShardJson<any>(u, shardJsonCacheRef.current).catch(softSkipUnpublishedDrillShard),
-          ),
+        const drillFields = await fetchPracticeDrillFields(
+          shardBaseUrl,
+          targetLevel,
+          shardJsonCacheRef.current,
         );
-        const [clozeR, stressR, classifyR, paradigmR, synonymR, paronymR, heritageR, antonymR] = drillResults;
-        nextDeck = {
-          ...nextDeck!,
-          cloze: [...(nextDeck!.cloze ?? []), ...((clozeR as { cloze?: PracticeClozeItem[] }).cloze ?? [])],
-          stress: [...(nextDeck!.stress ?? []), ...((stressR as { stress?: any[] }).stress ?? [])],
-          classify: [...(nextDeck!.classify ?? []), ...((classifyR as { classify?: any[] }).classify ?? [])],
-          paradigm: [...(nextDeck!.paradigm ?? []), ...((paradigmR as { paradigm?: any[] }).paradigm ?? [])],
-          synonym: [...(nextDeck!.synonym ?? []), ...((synonymR as { synonym?: any[] }).synonym ?? [])],
-          paronym: [...(nextDeck!.paronym ?? []), ...((paronymR as { paronym?: any[] }).paronym ?? [])],
-          heritage: [...(nextDeck!.heritage ?? []), ...((heritageR as { heritage?: any[] }).heritage ?? [])],
-          antonym: [...(nextDeck!.antonym ?? []), ...((antonymR as { antonym?: any[] }).antonym ?? [])],
-        };
+        nextDeck = appendDrillFields(nextDeck!, drillFields);
 
         // Merge teacher deck pre-generated cloze items if active
         if (deckFilter === 'virtual_teacher_lesson') {
@@ -3049,48 +2942,14 @@ function LexiconPracticeIsland({
             const bgId = deckRequestId.current;
             try {
               const otherDrillBatches = await Promise.all(
-                otherLevels.map(async (lv) => {
-                  const urls = [
-                    `${shardBaseUrl}/practice-cloze.${lv}.json`,
-                    `${shardBaseUrl}/practice-stress.${lv}.json`,
-                    `${shardBaseUrl}/practice-classify.${lv}.json`,
-                    `${shardBaseUrl}/practice-paradigm.${lv}.json`,
-                    `${shardBaseUrl}/practice-synonym.${lv}.json`,
-                    `${shardBaseUrl}/practice-paronym.${lv}.json`,
-                    `${shardBaseUrl}/practice-heritage.${lv}.json`,
-                    `${shardBaseUrl}/practice-antonym.${lv}.json`,
-                  ];
-                  const rs = await Promise.all(
-                    urls.map((u) =>
-                      getShardJson<any>(u, shardJsonCacheRef.current).catch(softSkipUnpublishedDrillShard),
-                    ),
-                  );
-                  return {
-                    cloze: (rs[0] as { cloze?: PracticeClozeItem[] }).cloze ?? [],
-                    stress: (rs[1] as { stress?: any[] }).stress ?? [],
-                    classify: (rs[2] as { classify?: any[] }).classify ?? [],
-                    paradigm: (rs[3] as { paradigm?: any[] }).paradigm ?? [],
-                    synonym: (rs[4] as { synonym?: any[] }).synonym ?? [],
-                    paronym: (rs[5] as { paronym?: any[] }).paronym ?? [],
-                    heritage: (rs[6] as { heritage?: any[] }).heritage ?? [],
-                    antonym: (rs[7] as { antonym?: any[] }).antonym ?? [],
-                  };
-                }),
+                otherLevels.map((lv) =>
+                  fetchPracticeDrillFields(shardBaseUrl, lv, shardJsonCacheRef.current),
+                ),
               );
               if (deckRequestId.current !== bgId) return;
               setDeck((prev) => {
                 if (!prev) return prev;
-                return {
-                  ...prev,
-                  cloze: [...(prev.cloze ?? []), ...otherDrillBatches.flatMap((b) => b.cloze)],
-                  stress: [...(prev.stress ?? []), ...otherDrillBatches.flatMap((b) => b.stress)],
-                  classify: [...(prev.classify ?? []), ...otherDrillBatches.flatMap((b) => b.classify)],
-                  paradigm: [...(prev.paradigm ?? []), ...otherDrillBatches.flatMap((b) => b.paradigm)],
-                  synonym: [...(prev.synonym ?? []), ...otherDrillBatches.flatMap((b) => b.synonym)],
-                  paronym: [...(prev.paronym ?? []), ...otherDrillBatches.flatMap((b) => b.paronym)],
-                  heritage: [...(prev.heritage ?? []), ...otherDrillBatches.flatMap((b) => b.heritage)],
-                  antonym: [...(prev.antonym ?? []), ...otherDrillBatches.flatMap((b) => b.antonym)],
-                };
+                return appendDrillFields(prev, concatDrillFields(otherDrillBatches));
               });
             } catch {
               // Selected-level drills already committed; skip broken background

--- a/site/src/components/useZnoPracticeOverlay.ts
+++ b/site/src/components/useZnoPracticeOverlay.ts
@@ -1,0 +1,73 @@
+import { useMemo, useState } from 'react';
+import { ZNO_PRACTICE_DECKS, type ZnoPracticeDeck } from './ZnoPractice';
+
+export type ZnoModeMeta = {
+  description: string;
+  descriptionEn: string;
+  accent: 'blue' | 'teal' | 'purple' | 'orange';
+};
+
+export const ZNO_MODE_META: Record<ZnoPracticeDeck['deckId'], ZnoModeMeta> = {
+  'zno-stress': {
+    description: 'Тренуйте наголос на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Practise stress placement with official ZNO and NMT items.',
+    accent: 'teal',
+  },
+  'zno-paronym': {
+    description: 'Розрізняйте пароніми на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Distinguish paronyms with official ZNO and NMT items.',
+    accent: 'purple',
+  },
+  'zno-lexical-norm': {
+    description: 'Закріплюйте лексичну норму на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Reinforce lexical norms with official ZNO and NMT items.',
+    accent: 'orange',
+  },
+  'zno-morphological-norm': {
+    description: 'Закріплюйте морфологічну норму на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Reinforce morphological norms with official ZNO and NMT items.',
+    accent: 'purple',
+  },
+  'zno-syntactic-norm': {
+    description: 'Закріплюйте синтаксичну норму на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Reinforce syntactic norms with official ZNO and NMT items.',
+    accent: 'teal',
+  },
+  'zno-orthography': {
+    description: 'Тренуйте орфографію на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Practise orthography with official ZNO and NMT items.',
+    accent: 'blue',
+  },
+  'zno-morphology': {
+    description: 'Закріплюйте морфологію на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Reinforce morphology with official ZNO and NMT items.',
+    accent: 'purple',
+  },
+  'zno-syntax': {
+    description: 'Тренуйте синтаксис і розділові знаки на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Practise syntax and punctuation with official ZNO and NMT items.',
+    accent: 'teal',
+  },
+  'zno-phonetics': {
+    description: 'Тренуйте фонетику на офіційних завданнях ЗНО та НМТ.',
+    descriptionEn: 'Practise phonetics with official ZNO and NMT items.',
+    accent: 'orange',
+  },
+};
+
+/** Hover/active ZNO deck overlay for the Practice hub (UI stays in LexiconPractice). */
+export function useZnoPracticeOverlay() {
+  const [hoveredZnoDeckId, setHoveredZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
+  const [activeZnoDeckId, setActiveZnoDeckId] = useState<ZnoPracticeDeck['deckId'] | null>(null);
+  const activeZnoDeck = useMemo(
+    () => ZNO_PRACTICE_DECKS.find((candidate) => candidate.deckId === activeZnoDeckId) ?? null,
+    [activeZnoDeckId],
+  );
+  return {
+    hoveredZnoDeckId,
+    setHoveredZnoDeckId,
+    activeZnoDeckId,
+    setActiveZnoDeckId,
+    activeZnoDeck,
+  };
+}

--- a/site/src/lib/lexicon/practice-shard-fetch.ts
+++ b/site/src/lib/lexicon/practice-shard-fetch.ts
@@ -1,0 +1,148 @@
+/**
+ * Deduped practice/Atlas JSON fetch plus optional drill-kind hydration.
+ *
+ * HTTP 404 on a drill shard means "not published for this level" and may be
+ * treated as an empty payload. Network faults and 5xx must surface (#6768).
+ */
+
+import type {
+  PracticeAntonymItem,
+  PracticeClassifyItem,
+  PracticeClozeItem,
+  PracticeDeckData,
+  PracticeHeritageItem,
+  PracticeParadigmItem,
+  PracticeParonymItem,
+  PracticeStressItem,
+  PracticeSynonymItem,
+} from "./srs";
+
+export type ShardJsonCache = Map<string, Promise<unknown>>;
+
+export const PRACTICE_DRILL_KINDS = [
+  "cloze",
+  "stress",
+  "classify",
+  "paradigm",
+  "synonym",
+  "paronym",
+  "heritage",
+  "antonym",
+] as const;
+
+export type PracticeDrillKind = (typeof PRACTICE_DRILL_KINDS)[number];
+
+export type PracticeDrillFields = {
+  cloze: PracticeClozeItem[];
+  stress: PracticeStressItem[];
+  classify: PracticeClassifyItem[];
+  paradigm: PracticeParadigmItem[];
+  synonym: PracticeSynonymItem[];
+  paronym: PracticeParonymItem[];
+  heritage: PracticeHeritageItem[];
+  antonym: PracticeAntonymItem[];
+};
+
+/** Deduped fetch for practice and Atlas JSON by URL. Concurrent or repeated callers share the promise. */
+export async function getShardJson<T>(url: string, cache: ShardJsonCache): Promise<T> {
+  let p = cache.get(url) as Promise<T> | undefined;
+  if (!p) {
+    p = fetch(url).then((res) => {
+      if (!res.ok) {
+        // Tag the HTTP status so callers can tell an unpublished shard (404,
+        // soft-skippable) from a real load fault (network / server error).
+        const err = new Error(`Shard fetch failed: ${url}`) as Error & { status?: number };
+        err.status = res.status;
+        throw err;
+      }
+      return res.json() as Promise<T>;
+    });
+    // On failure allow retry next time
+    p = p.catch((err) => {
+      cache.delete(url);
+      throw err;
+    });
+    cache.set(url, p);
+  }
+  return p;
+}
+
+/**
+ * Optional drill-kind shards (and some Atlas search fallbacks) are unpublished
+ * per level/type: HTTP 404 means "not shipped", so callers may treat that as an
+ * empty payload. Network faults and 5xx must not be rewritten as empty decks
+ * (#6768) — rethrow so the Practice load-error path can surface.
+ */
+export function isMissingShard(reason: unknown): boolean {
+  return (reason as { status?: number } | null)?.status === 404;
+}
+
+export function softSkipUnpublishedDrillShard(reason: unknown): Record<string, never> {
+  if (isMissingShard(reason)) return {};
+  throw reason;
+}
+
+export function practiceDrillShardUrls(shardBaseUrl: string, level: string): string[] {
+  return PRACTICE_DRILL_KINDS.map((kind) => `${shardBaseUrl}/practice-${kind}.${level}.json`);
+}
+
+function itemsFromShard<T>(payload: unknown, key: PracticeDrillKind): T[] {
+  return ((payload as Record<string, T[] | undefined> | null)?.[key] ?? []) as T[];
+}
+
+export function drillFieldsFromShardResults(results: readonly unknown[]): PracticeDrillFields {
+  return {
+    cloze: itemsFromShard<PracticeClozeItem>(results[0], "cloze"),
+    stress: itemsFromShard<PracticeStressItem>(results[1], "stress"),
+    classify: itemsFromShard<PracticeClassifyItem>(results[2], "classify"),
+    paradigm: itemsFromShard<PracticeParadigmItem>(results[3], "paradigm"),
+    synonym: itemsFromShard<PracticeSynonymItem>(results[4], "synonym"),
+    paronym: itemsFromShard<PracticeParonymItem>(results[5], "paronym"),
+    heritage: itemsFromShard<PracticeHeritageItem>(results[6], "heritage"),
+    antonym: itemsFromShard<PracticeAntonymItem>(results[7], "antonym"),
+  };
+}
+
+export async function fetchPracticeDrillFields(
+  shardBaseUrl: string,
+  level: string,
+  cache: ShardJsonCache,
+): Promise<PracticeDrillFields> {
+  const results = await Promise.all(
+    practiceDrillShardUrls(shardBaseUrl, level).map((url) =>
+      getShardJson<unknown>(url, cache).catch(softSkipUnpublishedDrillShard),
+    ),
+  );
+  return drillFieldsFromShardResults(results);
+}
+
+export function concatDrillFields(batches: readonly PracticeDrillFields[]): PracticeDrillFields {
+  return {
+    cloze: batches.flatMap((batch) => batch.cloze),
+    stress: batches.flatMap((batch) => batch.stress),
+    classify: batches.flatMap((batch) => batch.classify),
+    paradigm: batches.flatMap((batch) => batch.paradigm),
+    synonym: batches.flatMap((batch) => batch.synonym),
+    paronym: batches.flatMap((batch) => batch.paronym),
+    heritage: batches.flatMap((batch) => batch.heritage),
+    antonym: batches.flatMap((batch) => batch.antonym),
+  };
+}
+
+type DeckWithAntonym = PracticeDeckData & { antonym?: PracticeAntonymItem[] };
+
+export function appendDrillFields(deck: PracticeDeckData, fields: PracticeDrillFields): PracticeDeckData {
+  const withAntonym = deck as DeckWithAntonym;
+  const merged: DeckWithAntonym = {
+    ...deck,
+    cloze: [...(deck.cloze ?? []), ...fields.cloze],
+    stress: [...(deck.stress ?? []), ...fields.stress],
+    classify: [...(deck.classify ?? []), ...fields.classify],
+    paradigm: [...(deck.paradigm ?? []), ...fields.paradigm],
+    synonym: [...(deck.synonym ?? []), ...fields.synonym],
+    paronym: [...(deck.paronym ?? []), ...fields.paronym],
+    heritage: [...(deck.heritage ?? []), ...fields.heritage],
+    antonym: [...(withAntonym.antonym ?? []), ...fields.antonym],
+  };
+  return merged;
+}

--- a/site/tests/unit/practice-shard-fetch.test.ts
+++ b/site/tests/unit/practice-shard-fetch.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  appendDrillFields,
+  concatDrillFields,
+  fetchPracticeDrillFields,
+  getShardJson,
+  isMissingShard,
+  practiceDrillShardUrls,
+  softSkipUnpublishedDrillShard,
+  type PracticeDrillFields,
+} from "@site/src/lib/lexicon/practice-shard-fetch";
+import type { PracticeDeckData } from "@site/src/lib/lexicon/srs";
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const emptyFields: PracticeDrillFields = {
+  cloze: [],
+  stress: [],
+  classify: [],
+  paradigm: [],
+  synonym: [],
+  paronym: [],
+  heritage: [],
+  antonym: [],
+};
+
+describe("practice-shard-fetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("getShardJson tags HTTP status and evicts a failed URL from the cache", async () => {
+    const cache = new Map<string, Promise<unknown>>();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(500))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getShardJson("/lexicon/practice-synonym.A1.json", cache)).rejects.toMatchObject({
+      status: 500,
+    });
+    expect(cache.size).toBe(0);
+
+    await expect(getShardJson("/lexicon/practice-synonym.A1.json", cache)).resolves.toEqual({
+      ok: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("getShardJson shares one in-flight promise for the same URL", async () => {
+    let resolveResponse: ((value: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveResponse = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const cache = new Map<string, Promise<unknown>>();
+
+    const first = getShardJson("/lexicon/practice-index.A1.json", cache);
+    const second = getShardJson("/lexicon/practice-index.A1.json", cache);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveResponse!(jsonResponse(200, { items: [] }));
+    await expect(Promise.all([first, second])).resolves.toEqual([{ items: [] }, { items: [] }]);
+  });
+
+  test("soft-skip unpublished drills (404) and rethrow other faults (#6768)", () => {
+    const missing = Object.assign(new Error("missing"), { status: 404 });
+    const server = Object.assign(new Error("server"), { status: 500 });
+    expect(isMissingShard(missing)).toBe(true);
+    expect(isMissingShard(server)).toBe(false);
+    expect(softSkipUnpublishedDrillShard(missing)).toEqual({});
+    expect(() => softSkipUnpublishedDrillShard(server)).toThrow(server);
+    expect(() => softSkipUnpublishedDrillShard(new TypeError("Failed to fetch"))).toThrow(
+      TypeError,
+    );
+  });
+
+  test("practiceDrillShardUrls keeps the published kind order under /lexicon", () => {
+    expect(practiceDrillShardUrls("/lexicon", "A1")).toEqual([
+      "/lexicon/practice-cloze.A1.json",
+      "/lexicon/practice-stress.A1.json",
+      "/lexicon/practice-classify.A1.json",
+      "/lexicon/practice-paradigm.A1.json",
+      "/lexicon/practice-synonym.A1.json",
+      "/lexicon/practice-paronym.A1.json",
+      "/lexicon/practice-heritage.A1.json",
+      "/lexicon/practice-antonym.A1.json",
+    ]);
+  });
+
+  test("fetchPracticeDrillFields soft-skips 404 kinds and surfaces 5xx (#6768)", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("practice-cloze.A1.json")) {
+        return jsonResponse(200, { cloze: [{ clozeId: "c1" }] });
+      }
+      if (url.includes("practice-synonym.A1.json")) return jsonResponse(500);
+      return jsonResponse(404);
+    });
+
+    await expect(fetchPracticeDrillFields("/lexicon", "A1", new Map())).rejects.toMatchObject({
+      status: 500,
+    });
+
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("practice-cloze.A1.json")) {
+        return jsonResponse(200, { cloze: [{ clozeId: "c1" }] });
+      }
+      return jsonResponse(404);
+    });
+
+    await expect(fetchPracticeDrillFields("/lexicon", "A1", new Map())).resolves.toEqual({
+      ...emptyFields,
+      cloze: [{ clozeId: "c1" }],
+    });
+  });
+
+  test("appendDrillFields concatenates selected-level then background batches", () => {
+    const cloze = (clozeId: string) => ({ clozeId }) as PracticeDrillFields["cloze"][number];
+    const deck = {
+      deckVersion: "v1",
+      level: "A1",
+      index: [],
+      lexemes: [],
+      cloze: [cloze("core")],
+    } as PracticeDeckData;
+    const merged = appendDrillFields(
+      deck,
+      concatDrillFields([
+        { ...emptyFields, cloze: [cloze("a1")] },
+        { ...emptyFields, cloze: [cloze("a2")] },
+      ]),
+    );
+    expect(merged.cloze.map((item) => item.clozeId)).toEqual(["core", "a1", "a2"]);
+  });
+});

--- a/site/tests/unit/useZnoPracticeOverlay.test.ts
+++ b/site/tests/unit/useZnoPracticeOverlay.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { ZNO_PRACTICE_DECKS } from "@site/src/components/ZnoPractice";
+import { useZnoPracticeOverlay, ZNO_MODE_META } from "@site/src/components/useZnoPracticeOverlay";
+
+describe("useZnoPracticeOverlay", () => {
+  test("resolves the published ZNO deck catalog by deckId", () => {
+    const { result } = renderHook(() => useZnoPracticeOverlay());
+    expect(result.current.activeZnoDeck).toBeNull();
+
+    act(() => {
+      result.current.setActiveZnoDeckId("zno-stress");
+    });
+    expect(result.current.activeZnoDeck).toBe(
+      ZNO_PRACTICE_DECKS.find((deck) => deck.deckId === "zno-stress"),
+    );
+    expect(result.current.activeZnoDeck?.items.length).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.setActiveZnoDeckId(null);
+    });
+    expect(result.current.activeZnoDeck).toBeNull();
+  });
+
+  test("keeps one overlay meta entry per published ZNO deck", () => {
+    const deckIds = ZNO_PRACTICE_DECKS.map((deck) => deck.deckId);
+    expect(Object.keys(ZNO_MODE_META).sort()).toEqual([...deckIds].sort());
+    for (const deck of ZNO_PRACTICE_DECKS) {
+      expect(ZNO_MODE_META[deck.deckId].description.length).toBeGreaterThan(0);
+      expect(ZNO_MODE_META[deck.deckId].descriptionEn.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extract two independent state machines out of `LexiconPracticeIsland` so drill-shard hydration and the ZNO overlay are no longer defined only inside the ~5k-line Practice island. Learner UI, session identity keys, `shardBaseUrl` default `/lexicon`, and published ZNO decks are unchanged.

## Changes

- Move `getShardJson`, 404-vs-5xx skip (`#6768`), and drill-kind URL/merge into `site/src/lib/lexicon/practice-shard-fetch.ts`.
- Move ZNO hover/active deck state and overlay copy into `useZnoPracticeOverlay` next to `ZnoPractice`.
- Add unit tests for cache/evict, 404 soft-skip vs 5xx, drill URL order, and ZNO catalog identity.
- Refresh `docs/lesson-schema.yaml` `components_sha256` after the `LexiconPractice.tsx` edit.

## Testing

- [x] `npx vitest run tests/unit/LexiconPractice.test.tsx tests/unit/practice-session.test.ts tests/unit/lexicon-srs.test.ts tests/unit/practice-shard-fetch.test.ts tests/unit/useZnoPracticeOverlay.test.ts` (251 passed)
- [ ] Modules pass audit (`scripts/audit_module.py`)
- [ ] Website builds without errors (`cd site && npm run build`)
- [ ] Ukrainian text reviewed for naturalness

## Related Issues

Closes #6761

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-444ff947-e9bb-47d4-af71-f129d8dc91e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-444ff947-e9bb-47d4-af71-f129d8dc91e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

