### PR TITLE
feat(atlas): ratchet sense lint debt (#6437)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,8 +432,32 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install PyYAML jsonschema
+          .venv/bin/python -m pip install PyYAML jsonschema requests==2.34.2
           npm ci
+
+      - name: Run Word Atlas sense-lint ratchet (#6437)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          .venv/bin/python -m scripts.practice_deck.io
+          if [[ -n "$BASE_SHA" ]]; then
+            base_ref="$BASE_SHA"
+          else
+            base_ref="origin/main"
+          fi
+          deck_args=()
+          for deck in site/public/lexicon/*.json; do
+            deck_args+=(--practice-deck "$deck")
+          done
+          .venv/bin/python scripts/audit/lint_word_atlas.py \
+            --manifest site/src/data/lexicon-manifest.json \
+            "${deck_args[@]}" \
+            --base-ref "$base_ref" \
+            --baseline scripts/audit/word_atlas_lint_baseline.json \
+            --ratchet \
+            --update-baseline
+          git diff --exit-code -- scripts/audit/word_atlas_lint_baseline.json
 
       - name: Regenerate lesson schema and check drift
         run: |

--- a/scripts/audit/lint_word_atlas.py
+++ b/scripts/audit/lint_word_atlas.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Sense-first Word Atlas entry lint (#6437): LINT-001 … LINT-004 + LINT-101/102.
 
-Read-only, advisory lint over the `senses[]` array and practice bindings
+Read-only lint over the `senses[]` array and practice bindings
 documented in ``docs/runbooks/word-atlas-entry-model.md`` (§ Sense-Level
-Fields, #6437 delta). It never mutates a manifest — it only reports.
+Fields, #6437 delta). The default mode is advisory. The ``--ratchet`` mode
+blocks only findings for new or changed entries while keeping pre-existing
+findings visible and advisory.
 
 Rules implemented
 ==================
@@ -61,10 +63,11 @@ Examples
 
 Outputs
 =======
-- stdout: table of findings (rule, entry, sense, field, detail).
-- exit 0 always, unless ``--strict`` is passed and findings exist (exit 1).
-  No CI gate consumes this yet (advisory only — issue #6437 D6-7 sets the
-  residual policy before any blocking wiring).
+- stdout: table of findings (rule, entry, sense, field, detail), or a compact
+  ratchet/debt summary in ``--ratchet`` mode.
+- exit 0 by default; ``--strict`` fails on any finding, while ``--ratchet``
+  fails only on touched-entry LINT-003/004/101/102 findings or an increased
+  debt baseline.
 
 Related
 =======
@@ -76,11 +79,16 @@ Related
 from __future__ import annotations
 
 import argparse
+import gzip
+import hashlib
 import json
+import os
+import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+from urllib.request import Request, urlopen
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
@@ -93,6 +101,10 @@ from scripts.lexicon.enrich_manifest import (
 )
 
 DEFAULT_FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "atlas" / "sense_lint_sample.json"
+DEFAULT_BASELINE = PROJECT_ROOT / "scripts" / "audit" / "word_atlas_lint_baseline.json"
+MANIFEST_POINTER_PATH = "site/src/data/lexicon-manifest.pointer.json"
+PRACTICE_DECK_POINTER_PATH = "site/src/data/lexicon-practice-deck.pointer.json"
+BASELINE_SCHEMA_VERSION = 1
 
 # Allowed ``source`` values for published ``learner_en`` (LINT-004). Sourced
 # dictionary provenance plus the honest AI-minimum thin-gloss label.
@@ -175,6 +187,7 @@ LINT_004 = "LINT-004"
 LINT_101 = "LINT-101"
 LINT_102 = "LINT-102"
 IMPLEMENTED_RULE_IDS = (LINT_001, LINT_002, LINT_003, LINT_004, LINT_101, LINT_102)
+RATCHET_RULE_IDS = frozenset({LINT_003, LINT_004, LINT_101, LINT_102})
 
 # Coarse POS families for LINT-102. Only labels that map into this set can
 # produce a "clear mismatch signal"; unknown tags are left alone.
@@ -226,6 +239,129 @@ class LintFinding:
     detail: str
 
 
+@dataclass(frozen=True)
+class DebtBaselineResult:
+    current_counts: dict[str, int]
+    baseline_counts: dict[str, int] | None
+    comparison_counts: dict[str, int] | None
+    errors: tuple[str, ...]
+    updated: bool
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+
+def finding_counts(findings: list[LintFinding]) -> dict[str, int]:
+    """Count findings by every implemented rule, including zeroes."""
+    counts = {rule_id: 0 for rule_id in IMPLEMENTED_RULE_IDS}
+    for finding in findings:
+        counts[finding.rule_id] = counts.get(finding.rule_id, 0) + 1
+    return counts
+
+
+def _canonical_digest(value: object) -> str:
+    canonical = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _stable_entry_key(entry: dict[str, Any]) -> str | None:
+    for field in ("slug", "lemma"):
+        value = entry.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if value is not None and not isinstance(value, (dict, list)):
+            return str(value)
+    return None
+
+
+def _entry_digests(manifest: dict[str, Any]) -> tuple[dict[str, str], tuple[str, ...]]:
+    known: dict[str, str] = {}
+    unknown: list[str] = []
+    for entry in _entries(manifest):
+        key = _stable_entry_key(entry)
+        digest = _canonical_digest(entry)
+        if key is None:
+            unknown.append(digest)
+            continue
+        if key in known:
+            raise ValueError(f"duplicate Atlas entry identity: {key!r}")
+        known[key] = digest
+    return known, tuple(sorted(unknown))
+
+
+def _practice_entry_digests(
+    manifests: list[tuple[str, dict[str, Any]]],
+) -> dict[str, str]:
+    grouped: dict[str, list[str]] = {}
+    for source_name, manifest in manifests:
+        items = manifest.get("practice_items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            lemma = _binding_lemma(item)
+            if lemma is None:
+                continue
+            grouped.setdefault(lemma, []).append(_canonical_digest({"source": source_name, "item": item}))
+    return {key: _canonical_digest(sorted(digests)) for key, digests in grouped.items()}
+
+
+def changed_entry_keys(base_manifest: dict[str, Any], current_manifest: dict[str, Any]) -> set[str]:
+    """Return entry identities added, removed, or changed between manifests.
+
+    Entry identity is the stable ``slug``/``lemma`` value. Entries without one
+    are conservatively treated as a changed ``<unknown-entry>`` scope whenever
+    their serialized content differs, because a finding cannot be safely
+    attributed to an untouched anonymous record.
+    """
+    base, base_unknown = _entry_digests(base_manifest)
+    current, current_unknown = _entry_digests(current_manifest)
+    changed = {key for key in base.keys() | current.keys() if base.get(key) != current.get(key)}
+    if base_unknown != current_unknown:
+        changed.add("<unknown-entry>")
+
+    base_practice = _practice_entry_digests([("manifest", base_manifest)])
+    current_practice = _practice_entry_digests([("manifest", current_manifest)])
+    changed.update(
+        key
+        for key in base_practice.keys() | current_practice.keys()
+        if base_practice.get(key) != current_practice.get(key)
+    )
+    return changed
+
+
+def changed_practice_entry_keys(
+    base_decks: list[tuple[str, dict[str, Any]]],
+    current_decks: list[tuple[str, dict[str, Any]]],
+) -> set[str]:
+    """Return lemma identities whose practice cards changed between decks."""
+    base = _practice_deck_entry_digests(base_decks)
+    current = _practice_deck_entry_digests(current_decks)
+    return {key for key in base.keys() | current.keys() if base.get(key) != current.get(key)}
+
+
+def _practice_deck_entry_digests(
+    decks: list[tuple[str, dict[str, Any]]],
+) -> dict[str, str]:
+    grouped: dict[str, list[str]] = {}
+    for source_name, deck in decks:
+        for item in _practice_cards_from_deck(deck):
+            lemma = _binding_lemma(item)
+            if lemma is None:
+                continue
+            grouped.setdefault(lemma, []).append(_canonical_digest({"source": source_name, "item": item}))
+    return {key: _canonical_digest(sorted(digests)) for key, digests in grouped.items()}
+
+
+def ratchet_blocking_findings(findings: list[LintFinding], changed_entries: set[str]) -> list[LintFinding]:
+    """Return only touched-entry findings in the four ratcheted rules."""
+    return [
+        finding for finding in findings if finding.rule_id in RATCHET_RULE_IDS and finding.entry_slug in changed_entries
+    ]
+
+
 def _entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     entries = manifest.get("entries")
     if isinstance(entries, list):
@@ -254,9 +390,7 @@ def _is_truncated_text(value: object) -> bool:
     return isinstance(value, str) and value.rstrip().endswith(_ELLIPSIS_MARKERS)
 
 
-def _check_truncated_text_cutoff(
-    entry_slug: str, sense_id: str, sense: dict[str, Any]
-) -> list[LintFinding]:
+def _check_truncated_text_cutoff(entry_slug: str, sense_id: str, sense: dict[str, Any]) -> list[LintFinding]:
     if sense.get("completeness") == _HONEST_TRUNCATED_TAG:
         return []
 
@@ -292,9 +426,7 @@ def _check_truncated_text_cutoff(
     return findings
 
 
-def _check_ambiguous_bare_en(
-    entry_slug: str, sense_id: str, sense: dict[str, Any]
-) -> list[LintFinding]:
+def _check_ambiguous_bare_en(entry_slug: str, sense_id: str, sense: dict[str, Any]) -> list[LintFinding]:
     learner_en = sense.get("learner_en")
     if not isinstance(learner_en, list) or len(learner_en) != 1:
         return []
@@ -318,10 +450,7 @@ def _check_ambiguous_bare_en(
             entry_slug=entry_slug,
             sense_id=sense_id,
             field="learner_en",
-            detail=(
-                f"bare single-word EN {word!r} is a high-risk polysemy target "
-                "with no en_disambiguation"
-            ),
+            detail=(f"bare single-word EN {word!r} is a high-risk polysemy target with no en_disambiguation"),
         )
     ]
 
@@ -348,9 +477,7 @@ def _source_label(sense: dict[str, Any]) -> str | None:
     return str(source)
 
 
-def _check_unvetted_en_source(
-    entry_slug: str, sense_id: str, sense: dict[str, Any]
-) -> list[LintFinding]:
+def _check_unvetted_en_source(entry_slug: str, sense_id: str, sense: dict[str, Any]) -> list[LintFinding]:
     """LINT-004: published learner_en without a known enrich ``source`` label.
 
     Fires when ``learner_en`` is a non-empty list of non-blank strings AND
@@ -419,11 +546,7 @@ def _check_multi_sense_uk_single_en(entry: dict[str, Any]) -> list[LintFinding]:
     slug = _entry_slug(entry)
     findings: list[LintFinding] = []
 
-    senses_with_en = [
-        (sense, key)
-        for sense in senses
-        if (key := _learner_en_key(sense)) is not None
-    ]
+    senses_with_en = [(sense, key) for sense in senses if (key := _learner_en_key(sense)) is not None]
 
     if _entry_level_learner_en(entry) is not None:
         findings.append(
@@ -450,8 +573,7 @@ def _check_multi_sense_uk_single_en(entry: dict[str, Any]) -> list[LintFinding]:
                 sense_id=_sense_id(sense),
                 field="learner_en",
                 detail=(
-                    f"entry has {len(senses)} senses but only 1 publishes "
-                    "learner_en; remaining senses lack EN coverage"
+                    f"entry has {len(senses)} senses but only 1 publishes learner_en; remaining senses lack EN coverage"
                 ),
             )
         )
@@ -459,9 +581,7 @@ def _check_multi_sense_uk_single_en(entry: dict[str, Any]) -> list[LintFinding]:
         keys = {key for _sense, key in senses_with_en}
         if len(keys) == 1:
             missing_disambiguation = [
-                sense
-                for sense, _key in senses_with_en
-                if not _has_nonempty_disambiguation(sense)
+                sense for sense, _key in senses_with_en if not _has_nonempty_disambiguation(sense)
             ]
             if missing_disambiguation:
                 sense = missing_disambiguation[0]
@@ -610,10 +730,7 @@ def _check_drill_sense_id_missing(item: dict[str, Any]) -> LintFinding | None:
         entry_slug=lemma,
         sense_id="<missing-sense-id>",
         field="senseId",
-        detail=(
-            f"practice binding for lemma {lemma!r} has no senseId/sense_id "
-            "(en[0] fallback is not allowed)"
-        ),
+        detail=(f"practice binding for lemma {lemma!r} has no senseId/sense_id (en[0] fallback is not allowed)"),
     )
 
 
@@ -680,6 +797,102 @@ def lint_manifest(manifest: dict[str, Any]) -> list[LintFinding]:
     return findings
 
 
+def _validate_counts(payload: object, source: Path | str) -> dict[str, int]:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{source} must contain a JSON object")
+    if payload.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise ValueError(f"{source} has unsupported schema_version")
+    rules = payload.get("rules")
+    if not isinstance(rules, dict) or set(rules) != set(IMPLEMENTED_RULE_IDS):
+        raise ValueError(f"{source} must contain exactly one count for every implemented lint rule")
+    counts: dict[str, int] = {}
+    for rule_id in IMPLEMENTED_RULE_IDS:
+        value = rules[rule_id]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"{source} has invalid count for {rule_id}")
+        counts[rule_id] = value
+    total = payload.get("total")
+    if total != sum(counts.values()):
+        raise ValueError(f"{source} total does not equal the sum of per-rule counts")
+    return counts
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read debt baseline {path}: {exc}") from exc
+    return _validate_counts(payload, path)
+
+
+def write_baseline(path: Path, counts: dict[str, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "rules": {rule_id: counts[rule_id] for rule_id in IMPLEMENTED_RULE_IDS},
+        "total": sum(counts.values()),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def enforce_debt_baseline(
+    current_counts: dict[str, int],
+    path: Path,
+    *,
+    comparison_counts: dict[str, int] | None = None,
+    update: bool = False,
+) -> DebtBaselineResult:
+    """Enforce a non-increasing baseline and optionally write reductions.
+
+    ``comparison_counts`` is the base branch's committed baseline. It prevents
+    a PR from lowering its own baseline file without actually lowering the
+    measured debt. The current branch baseline must equal the measured counts
+    after an update, so a debt reduction is reviewable as a small tracked diff.
+    """
+    errors: list[str] = []
+    baseline_counts: dict[str, int] | None = None
+    if path.exists():
+        try:
+            baseline_counts = load_baseline(path)
+        except ValueError as exc:
+            errors.append(str(exc))
+
+    for label, reference in (
+        ("base", comparison_counts),
+        ("tracked", baseline_counts),
+    ):
+        if reference is None:
+            continue
+        increases = {
+            rule_id: (reference[rule_id], current_counts[rule_id])
+            for rule_id in IMPLEMENTED_RULE_IDS
+            if current_counts[rule_id] > reference[rule_id]
+        }
+        if increases:
+            formatted = ", ".join(f"{rule_id} {before}->{after}" for rule_id, (before, after) in increases.items())
+            errors.append(f"debt baseline increased against {label} baseline: {formatted}")
+
+    updated = False
+    if not errors and baseline_counts != current_counts:
+        if update:
+            write_baseline(path, current_counts)
+            baseline_counts = dict(current_counts)
+            updated = True
+        else:
+            errors.append(
+                "tracked debt baseline does not match measured counts; rerun with "
+                f"--update-baseline to record a decrease: {path}"
+            )
+
+    return DebtBaselineResult(
+        current_counts=dict(current_counts),
+        baseline_counts=baseline_counts,
+        comparison_counts=comparison_counts,
+        errors=tuple(errors),
+        updated=updated,
+    )
+
+
 def _load_json_object(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -696,12 +909,125 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     return _load_json_object(path)
 
 
+GIT_SCOPE_ENV_VARS = ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_WORK_TREE")
+
+
+def _git_show_json(ref: str, repository_path: str) -> dict[str, Any] | None:
+    env = os.environ.copy()
+    for name in GIT_SCOPE_ENV_VARS:
+        env.pop(name, None)
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{repository_path}"],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"git show {ref}:{repository_path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"git show {ref}:{repository_path} must contain a JSON object")
+    return payload
+
+
+def _download_release_json(pointer: dict[str, Any], *, content_hash_key: str, label: str) -> dict[str, Any]:
+    url = pointer.get("asset_url")
+    if not isinstance(url, str) or not url.startswith("https://"):
+        raise ValueError(f"{label} pointer has no valid HTTPS asset_url")
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/gzip, application/octet-stream;q=0.9, */*;q=0.1",
+            "Cache-Control": "no-cache",
+            "User-Agent": "learn-ukrainian-atlas-sense-lint/1.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=120) as response:
+            compressed = response.read()
+    except OSError as exc:
+        raise ValueError(f"failed to download {label} release asset: {exc}") from exc
+
+    expected_gzip_hash = pointer.get("gz_sha256")
+    actual_gzip_hash = hashlib.sha256(compressed).hexdigest()
+    if expected_gzip_hash != actual_gzip_hash:
+        raise ValueError(f"{label} gzip SHA-256 mismatch: expected {expected_gzip_hash}, got {actual_gzip_hash}")
+    try:
+        content = gzip.decompress(compressed)
+    except OSError as exc:
+        raise ValueError(f"{label} release asset is not valid gzip: {exc}") from exc
+
+    expected_content_hash = pointer.get(content_hash_key)
+    actual_content_hash = hashlib.sha256(content).hexdigest()
+    if expected_content_hash != actual_content_hash:
+        raise ValueError(
+            f"{label} content SHA-256 mismatch: expected {expected_content_hash}, got {actual_content_hash}"
+        )
+    try:
+        payload = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} release asset is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} release asset must contain a JSON object")
+    return payload
+
+
+def _load_base_manifest_for_ref(base_ref: str, current_manifest: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    base_pointer = _git_show_json(base_ref, MANIFEST_POINTER_PATH)
+    if base_pointer is None:
+        raise ValueError(f"{base_ref} does not contain {MANIFEST_POINTER_PATH}")
+    current_pointer = _load_json_object(PROJECT_ROOT / MANIFEST_POINTER_PATH)
+    if base_pointer.get("json_sha256") == current_pointer.get("json_sha256"):
+        return current_manifest, True
+    return (
+        _download_release_json(base_pointer, content_hash_key="json_sha256", label="Atlas manifest"),
+        False,
+    )
+
+
+def _load_base_decks_for_ref(
+    base_ref: str, current_decks: list[tuple[str, dict[str, Any]]]
+) -> tuple[list[tuple[str, dict[str, Any]]], bool]:
+    base_pointer = _git_show_json(base_ref, PRACTICE_DECK_POINTER_PATH)
+    if base_pointer is None:
+        raise ValueError(f"{base_ref} does not contain {PRACTICE_DECK_POINTER_PATH}")
+    current_pointer = _load_json_object(PROJECT_ROOT / PRACTICE_DECK_POINTER_PATH)
+    if base_pointer.get("package_sha256") == current_pointer.get("package_sha256"):
+        return current_decks, True
+
+    package = _download_release_json(
+        base_pointer,
+        content_hash_key="package_sha256",
+        label="Atlas practice deck",
+    )
+    raw_files = package.get("files")
+    if not isinstance(raw_files, list):
+        raise ValueError("base Atlas practice deck package has no files list")
+    base_decks: list[tuple[str, dict[str, Any]]] = []
+    for raw_file in raw_files:
+        if not isinstance(raw_file, dict):
+            raise ValueError("base Atlas practice deck package contains a non-object file")
+        name = raw_file.get("path")
+        content = raw_file.get("content")
+        if not isinstance(name, str) or not isinstance(content, str):
+            raise ValueError("base Atlas practice deck package file has invalid path/content")
+        try:
+            deck = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"base Atlas practice deck file {name} is not valid JSON: {exc}") from exc
+        if not isinstance(deck, dict):
+            raise ValueError(f"base Atlas practice deck file {name} must contain a JSON object")
+        base_decks.append((name, deck))
+    return base_decks, False
+
+
 def print_report(findings: list[LintFinding]) -> None:
     if not findings:
-        print(
-            "No LINT-001/LINT-002/LINT-003/LINT-004/LINT-101/LINT-102 findings — "
-            "sense-first entries lint clean."
-        )
+        print("No LINT-001/LINT-002/LINT-003/LINT-004/LINT-101/LINT-102 findings — sense-first entries lint clean.")
         return
 
     rows = [
@@ -716,9 +1042,7 @@ def print_report(findings: list[LintFinding]) -> None:
         for finding in findings
     ]
     headers = ("rule", "name", "entry", "sense_id", "field", "detail")
-    widths = [
-        max(len(headers[i]), max(len(str(row[i])) for row in rows)) for i in range(len(headers))
-    ]
+    widths = [max(len(headers[i]), max(len(str(row[i])) for row in rows)) for i in range(len(headers))]
     header_line = "  ".join(h.ljust(w) for h, w in zip(headers, widths, strict=True))
     print(header_line)
     print("-" * len(header_line))
@@ -733,13 +1057,92 @@ def print_report(findings: list[LintFinding]) -> None:
     print(f"⚠️  {len(findings)} finding(s) ({summary}) — advisory, not blocking.")
 
 
-def write_report(findings: list[LintFinding], path: Path) -> None:
+def _format_finding(finding: LintFinding) -> str:
+    return (
+        f"{finding.rule_id} {finding.rule_name} {finding.entry_slug} "
+        f"{finding.sense_id} {finding.field} — {finding.detail}"
+    )
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    return ", ".join(f"{rule_id}={counts[rule_id]}" for rule_id in IMPLEMENTED_RULE_IDS)
+
+
+def print_ratchet_report(
+    findings: list[LintFinding],
+    changed_entries: set[str],
+    blocking_findings: list[LintFinding],
+    debt: DebtBaselineResult,
+) -> None:
+    """Print compact CI evidence without flooding logs with legacy debt."""
+    untouched = [finding for finding in findings if finding.entry_slug not in changed_entries]
+    touched_advisory = [
+        finding for finding in findings if finding.entry_slug in changed_entries and finding not in blocking_findings
+    ]
+    print("Word Atlas sense-lint ratchet (#6437)")
+    print(f"New/changed entry scope: {len(changed_entries)}")
+    if changed_entries and len(changed_entries) <= 12:
+        print("Changed entries: " + ", ".join(sorted(changed_entries)))
+
+    if blocking_findings:
+        print(f"::error::Blocking touched-entry findings: {len(blocking_findings)}")
+        for finding in blocking_findings[:20]:
+            print(f"::error::{_format_finding(finding)}")
+        if len(blocking_findings) > 20:
+            print(f"::error::... {len(blocking_findings) - 20} more blocking finding(s)")
+    else:
+        print("Blocking touched-entry findings: 0")
+
+    print(f"Advisory pre-existing/untouched findings: {len(untouched)}")
+    for finding in untouched[:3]:
+        print(f"[advisory pre-existing] {_format_finding(finding)}")
+    if len(untouched) > 3:
+        print(f"[advisory pre-existing] ... {len(untouched) - 3} more finding(s)")
+
+    if touched_advisory:
+        print(f"Advisory findings on changed entries (non-ratcheted rules): {len(touched_advisory)}")
+        for finding in touched_advisory[:3]:
+            print(f"[advisory changed/non-ratcheted] {_format_finding(finding)}")
+
+    baseline_label = "missing" if debt.baseline_counts is None else _format_counts(debt.baseline_counts)
+    print(f"Debt baseline: current {_format_counts(debt.current_counts)}")
+    print(f"Debt baseline tracked: {baseline_label}")
+    if debt.comparison_counts is not None:
+        print(f"Debt baseline base: {_format_counts(debt.comparison_counts)}")
+    if debt.updated:
+        print("Debt baseline updated because measured debt decreased.")
+    if debt.errors:
+        for error in debt.errors:
+            print(f"::error::{error}")
+    else:
+        print("Debt baseline gate: PASS (non-increasing)")
+
+
+def write_report(
+    findings: list[LintFinding],
+    path: Path,
+    *,
+    changed_entries: set[str] | None = None,
+    blocking_findings: list[LintFinding] | None = None,
+    debt: DebtBaselineResult | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "rule_ids": list(IMPLEMENTED_RULE_IDS),
         "finding_count": len(findings),
         "findings": [asdict(finding) for finding in findings],
     }
+    if changed_entries is not None:
+        payload["changed_entry_count"] = len(changed_entries)
+        payload["changed_entries"] = sorted(changed_entries)
+    if blocking_findings is not None:
+        payload["blocking_finding_count"] = len(blocking_findings)
+        payload["blocking_findings"] = [asdict(finding) for finding in blocking_findings]
+    if debt is not None:
+        payload["debt_counts"] = debt.current_counts
+        payload["debt_baseline_counts"] = debt.baseline_counts
+        payload["debt_base_counts"] = debt.comparison_counts
+        payload["debt_baseline_errors"] = list(debt.errors)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
@@ -771,6 +1174,53 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--practice-deck-dir",
+        type=Path,
+        action="append",
+        default=None,
+        help="Scan every JSON shard in this hydrated practice-deck directory (repeatable).",
+    )
+    parser.add_argument(
+        "--base-manifest",
+        type=Path,
+        default=None,
+        help="Explicit base manifest for --ratchet; use instead of --base-ref for fixtures.",
+    )
+    parser.add_argument(
+        "--base-practice-deck",
+        type=Path,
+        action="append",
+        default=None,
+        help="Explicit base practice-deck shard for --ratchet (repeatable).",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help=(
+            "Git ref for the review base. The release pointers are compared and, when they "
+            "differ, the base manifest/deck assets are hash-verified and hydrated."
+        ),
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help=f"Tracked per-rule debt baseline JSON. Default: {DEFAULT_BASELINE}.",
+    )
+    parser.add_argument(
+        "--ratchet",
+        action="store_true",
+        help=(
+            "Block LINT-003/004/101/102 only for new or changed entries; keep untouched "
+            "findings advisory and enforce the non-increasing debt baseline."
+        ),
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Write the tracked baseline when measured debt is lower and otherwise fail closed.",
+    )
+    parser.add_argument(
         "--report",
         type=Path,
         default=None,
@@ -783,7 +1233,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit 1 when findings exist. Default is advisory (always exit 0).",
+        help="Exit 1 when any finding exists. Default is advisory unless --ratchet is used.",
     )
     return parser
 
@@ -791,6 +1241,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.ratchet and not (args.base_manifest or args.base_ref):
+        parser.error("--ratchet requires --base-manifest or --base-ref")
+    if args.base_manifest and args.base_ref:
+        parser.error("--base-manifest and --base-ref are mutually exclusive")
+    if args.update_baseline and not args.ratchet:
+        parser.error("--update-baseline is only valid with --ratchet")
+    if (args.base_manifest or args.base_practice_deck) and not args.ratchet:
+        parser.error("base inputs are only valid with --ratchet")
 
     manifest_path = args.manifest
     if not manifest_path.is_absolute():
@@ -801,21 +1260,104 @@ def main(argv: list[str] | None = None) -> int:
     manifest = _load_manifest(manifest_path)
     findings = lint_manifest(manifest)
 
-    for deck_arg in args.practice_deck or []:
+    deck_paths = list(args.practice_deck or [])
+    for deck_dir_arg in args.practice_deck_dir or []:
+        deck_dir = deck_dir_arg if deck_dir_arg.is_absolute() else PROJECT_ROOT / deck_dir_arg
+        if not deck_dir.exists() or not deck_dir.is_dir():
+            parser.error(f"practice deck directory does not exist or is not a directory: {deck_dir}")
+        deck_paths.extend(sorted(deck_dir.glob("*.json")))
+    if args.practice_deck_dir and not deck_paths:
+        parser.error("practice deck directory contains no JSON shards")
+
+    current_decks: list[tuple[str, dict[str, Any]]] = []
+    for deck_arg in deck_paths:
         deck_path = deck_arg if deck_arg.is_absolute() else PROJECT_ROOT / deck_arg
         if not deck_path.exists() or not deck_path.is_file():
             parser.error(f"practice deck does not exist or is not a file: {deck_path}")
         deck = _load_json_object(deck_path)
+        current_decks.append((deck_path.name, deck))
         findings.extend(lint_practice_items(_practice_cards_from_deck(deck)))
 
-    print_report(findings)
+    changed_entries: set[str] | None = None
+    blocking_findings: list[LintFinding] | None = None
+    debt: DebtBaselineResult | None = None
+    if args.ratchet:
+        try:
+            manifest_base_is_current = False
+            if args.base_manifest:
+                base_manifest_path = args.base_manifest
+                if not base_manifest_path.is_absolute():
+                    base_manifest_path = PROJECT_ROOT / base_manifest_path
+                if not base_manifest_path.exists() or not base_manifest_path.is_file():
+                    parser.error(f"base manifest does not exist or is not a file: {base_manifest_path}")
+                base_manifest = _load_manifest(base_manifest_path)
+            else:
+                base_manifest, manifest_base_is_current = _load_base_manifest_for_ref(args.base_ref, manifest)
+
+            changed_entries = set() if manifest_base_is_current else changed_entry_keys(base_manifest, manifest)
+
+            if current_decks:
+                deck_base_is_current = False
+                if args.base_practice_deck:
+                    base_decks: list[tuple[str, dict[str, Any]]] = []
+                    for base_deck_arg in args.base_practice_deck:
+                        base_deck_path = base_deck_arg if base_deck_arg.is_absolute() else PROJECT_ROOT / base_deck_arg
+                        if not base_deck_path.exists() or not base_deck_path.is_file():
+                            parser.error(f"base practice deck does not exist or is not a file: {base_deck_path}")
+                        base_decks.append((base_deck_path.name, _load_json_object(base_deck_path)))
+                elif args.base_ref:
+                    base_decks, deck_base_is_current = _load_base_decks_for_ref(args.base_ref, current_decks)
+                else:
+                    base_decks = []
+                if not deck_base_is_current and base_decks:
+                    changed_entries.update(changed_practice_entry_keys(base_decks, current_decks))
+
+            baseline_path = args.baseline
+            if not baseline_path.is_absolute():
+                baseline_path = PROJECT_ROOT / baseline_path
+            comparison_counts = None
+            if args.base_ref:
+                baseline_relative = baseline_path.resolve().relative_to(PROJECT_ROOT.resolve())
+                base_baseline_payload = _git_show_json(args.base_ref, baseline_relative.as_posix())
+                if base_baseline_payload is not None:
+                    comparison_counts = _validate_counts(
+                        base_baseline_payload,
+                        f"git show {args.base_ref}:{baseline_relative.as_posix()}",
+                    )
+            debt = enforce_debt_baseline(
+                finding_counts(findings),
+                baseline_path,
+                comparison_counts=comparison_counts,
+                update=args.update_baseline,
+            )
+            blocking_findings = ratchet_blocking_findings(findings, changed_entries)
+        except ValueError as exc:
+            parser.error(str(exc))
+
+    if args.ratchet:
+        assert changed_entries is not None
+        assert blocking_findings is not None
+        assert debt is not None
+        print_ratchet_report(findings, changed_entries, blocking_findings, debt)
+    else:
+        print_report(findings)
 
     if args.report:
         report_path = args.report if args.report.is_absolute() else PROJECT_ROOT / args.report
-        write_report(findings, report_path)
+        write_report(
+            findings,
+            report_path,
+            changed_entries=changed_entries,
+            blocking_findings=blocking_findings,
+            debt=debt,
+        )
         print(f"Residual report written to {report_path}")
 
-    return 1 if (args.strict and findings) else 0
+    if args.strict and findings:
+        return 1
+    if args.ratchet and (blocking_findings or (debt is not None and not debt.passed)):
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/audit/word_atlas_lint_baseline.json
+++ b/scripts/audit/word_atlas_lint_baseline.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "rules": {
+    "LINT-001": 0,
+    "LINT-002": 0,
+    "LINT-003": 44550,
+    "LINT-004": 0,
+    "LINT-101": 0,
+    "LINT-102": 0
+  },
+  "total": 44550
+}

--- a/tests/test_lint_word_atlas.py
+++ b/tests/test_lint_word_atlas.py
@@ -270,9 +270,7 @@ def test_practice_deck_mode_flags_cards_without_sense_id(tmp_path: Path) -> None
         encoding="utf-8",
     )
 
-    exit_code = lint_word_atlas.main(
-        ["--manifest", str(manifest_path), "--practice-deck", str(deck_path)]
-    )
+    exit_code = lint_word_atlas.main(["--manifest", str(manifest_path), "--practice-deck", str(deck_path)])
     assert exit_code == 0
     findings = lint_word_atlas.lint_practice_items(
         [{"lemmaId": "автобус"}, {"lemmaId": "мова", "senseId": "mova_language"}]
@@ -298,9 +296,7 @@ def test_practice_deck_lexemes_shard_flags_lexeme_without_sense_id(tmp_path: Pat
         encoding="utf-8",
     )
 
-    exit_code = lint_word_atlas.main(
-        ["--manifest", str(manifest_path), "--practice-deck", str(deck_path)]
-    )
+    exit_code = lint_word_atlas.main(["--manifest", str(manifest_path), "--practice-deck", str(deck_path)])
     assert exit_code == 0
     findings = lint_word_atlas.lint_practice_items(
         lint_word_atlas._practice_cards_from_deck(json.loads(deck_path.read_text(encoding="utf-8")))
@@ -327,9 +323,7 @@ def test_report_mode_writes_json_and_stays_advisory(tmp_path: Path) -> None:
     )
     report_path = tmp_path / "residual.json"
 
-    exit_code = lint_word_atlas.main(
-        ["--manifest", str(manifest_path), "--report", str(report_path)]
-    )
+    exit_code = lint_word_atlas.main(["--manifest", str(manifest_path), "--report", str(report_path)])
 
     assert exit_code == 0  # advisory: findings exist but --strict was not passed
     payload = json.loads(report_path.read_text(encoding="utf-8"))
@@ -616,3 +610,145 @@ def test_pos_transform_mismatch_suppressed_for_unknown_sense_pos() -> None:
         ]
     }
     assert lint_word_atlas.lint_manifest(manifest) == []
+
+
+def _ratchet_base_manifest() -> dict:
+    return {
+        "entries": [
+            {
+                "slug": "untouched-entry",
+                "practice_bindings": [{"mode": "classify"}],
+            },
+            {
+                "slug": "changed-entry",
+                "senses": [
+                    {
+                        "id": "changed-sense",
+                        "learner_en": ["glyph"],
+                        "source": "sum20_vetted",
+                    }
+                ],
+            },
+        ]
+    }
+
+
+def _ratchet_current_manifest() -> dict:
+    manifest = _ratchet_base_manifest()
+    manifest["entries"][1]["senses"][0].pop("source")
+    return manifest
+
+
+def test_changed_entry_keys_keep_untouched_entry_out_of_ratchet_scope() -> None:
+    changed = lint_word_atlas.changed_entry_keys(_ratchet_base_manifest(), _ratchet_current_manifest())
+    assert changed == {"changed-entry"}
+
+
+def test_ratchet_blocks_changed_finding_and_keeps_untouched_finding_advisory() -> None:
+    findings = lint_word_atlas.lint_manifest(_ratchet_current_manifest())
+    changed = lint_word_atlas.changed_entry_keys(_ratchet_base_manifest(), _ratchet_current_manifest())
+
+    blocking = lint_word_atlas.ratchet_blocking_findings(findings, changed)
+    assert [(finding.rule_id, finding.entry_slug) for finding in blocking] == [("LINT-004", "changed-entry")]
+    untouched = [finding for finding in findings if finding.entry_slug not in changed]
+    assert [(finding.rule_id, finding.entry_slug) for finding in untouched] == [("LINT-003", "untouched-entry")]
+
+
+def test_ratchet_cli_emits_two_sided_evidence_and_blocks_changed_entry(tmp_path: Path, capsys) -> None:
+    base_path = tmp_path / "base.json"
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    base_path.write_text(json.dumps(_ratchet_base_manifest()), encoding="utf-8")
+    current_path.write_text(json.dumps(_ratchet_current_manifest()), encoding="utf-8")
+    lint_word_atlas.write_baseline(
+        baseline_path,
+        {
+            "LINT-001": 0,
+            "LINT-002": 0,
+            "LINT-003": 1,
+            "LINT-004": 1,
+            "LINT-101": 0,
+            "LINT-102": 0,
+        },
+    )
+
+    exit_code = lint_word_atlas.main(
+        [
+            "--manifest",
+            str(current_path),
+            "--base-manifest",
+            str(base_path),
+            "--baseline",
+            str(baseline_path),
+            "--ratchet",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Blocking touched-entry findings: 1" in output
+    assert "LINT-004 UNVETTED_EN_SOURCE changed-entry" in output
+    assert "Advisory pre-existing/untouched findings: 1" in output
+    assert "[advisory pre-existing] LINT-003 DRILL_SENSE_ID_MISSING untouched-entry" in output
+
+
+def test_debt_baseline_equal_passes_increase_fails_and_decrease_updates(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_counts = {
+        "LINT-001": 0,
+        "LINT-002": 0,
+        "LINT-003": 4,
+        "LINT-004": 2,
+        "LINT-101": 1,
+        "LINT-102": 0,
+    }
+    lint_word_atlas.write_baseline(baseline_path, baseline_counts)
+
+    equal = lint_word_atlas.enforce_debt_baseline(baseline_counts, baseline_path)
+    assert equal.passed
+
+    increased_counts = dict(baseline_counts, **{"LINT-003": 5})
+    increased = lint_word_atlas.enforce_debt_baseline(
+        increased_counts,
+        baseline_path,
+        comparison_counts=baseline_counts,
+        update=True,
+    )
+    assert not increased.passed
+    assert "LINT-003 4->5" in " ".join(increased.errors)
+    assert lint_word_atlas.load_baseline(baseline_path) == baseline_counts
+
+    decreased_counts = dict(baseline_counts, **{"LINT-003": 3})
+    decreased = lint_word_atlas.enforce_debt_baseline(
+        decreased_counts,
+        baseline_path,
+        comparison_counts=baseline_counts,
+        update=True,
+    )
+    assert decreased.passed
+    assert decreased.updated
+    assert lint_word_atlas.load_baseline(baseline_path) == decreased_counts
+
+
+def test_practice_deck_entry_changes_are_scoped_by_lemma() -> None:
+    base = [("practice-cloze.A1.json", {"cloze": [{"lemmaId": "old", "senseId": "s"}]})]
+    current = [
+        (
+            "practice-cloze.A1.json",
+            {"cloze": [{"lemmaId": "old", "senseId": "new"}, {"lemmaId": "new"}]},
+        )
+    ]
+    assert lint_word_atlas.changed_practice_entry_keys(base, current) == {"old", "new"}
+
+
+def test_ci_workflow_runs_ratchet_and_requires_committed_baseline() -> None:
+    workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert workflow.count("Run Word Atlas sense-lint ratchet (#6437)") == 1
+    assert '--base-ref "$base_ref"' in workflow
+    assert "github.event.merge_group.base_sha" in workflow
+    assert "--ratchet" in workflow
+    assert "--update-baseline" in workflow
+    assert "git diff --exit-code -- scripts/audit/word_atlas_lint_baseline.json" in workflow
+    assert workflow.index("Run Word Atlas sense-lint ratchet (#6437)") > workflow.index(
+        "Install contract-check dependencies"
+    )


### PR DESCRIPTION
## Summary

Implements the advisor-decided #6437 D6–7 sense-lint ratchet:

- LINT-003/004/101/102 block only findings attached to new or changed Atlas entries/practice lemmas.
- Findings on untouched entries remain visible and advisory.
- Adds a tracked per-rule debt baseline that fails on increases and updates only after measured decreases.
- Keeps the existing ~8,450 ellipsis glosses untouched; no bulk rewrite.
- Reuses the merged lint/source plumbing from [PR #6676](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6676), [PR #6684](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6684), and [PR #6693](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/6693).

## Evidence preamble

Synthetic touched-entry violation fails while an untouched pre-existing violation remains advisory:

```
New/changed entry scope: 1
::error::Blocking touched-entry findings: 1
::error::LINT-004 UNVETTED_EN_SOURCE changed-entry changed-sense source — published learner_en with unvetted source (missing)
Advisory pre-existing/untouched findings: 1
[advisory pre-existing] LINT-003 DRILL_SENSE_ID_MISSING untouched-entry <missing-sense-id> senseId
Debt baseline gate: PASS (non-increasing)
two_sided_exit=1
```

Debt-baseline behavior:

```
::error::debt baseline increased against tracked baseline: LINT-003 0->1
debt_increase_exit=1
debt_equal_exit=0
Debt baseline updated because measured debt decreased.
debt_decrease_exit=0
```

Mutation check: removing the `finding.entry_slug in changed_entries` guard made `test_ratchet_blocks_changed_finding_and_keeps_untouched_finding_advisory` fail; the failure showed the untouched LINT-003 entering the blocking set. The guard was restored and the full focused suite passed.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_lint_word_atlas.py -q` — 41 passed.
- Ruff check and format check — passed.
- CI workflow YAML parse — passed.
- Hydrated production manifest plus all 55 practice-deck shards against `origin/main`:
  - changed-entry scope: 0
  - blocking findings: 0
  - advisory pre-existing findings: 44,550 (`LINT-003`)
  - debt baseline: current equals tracked; PASS (non-increasing)

No merge or auto-merge requested; driver owns review and merge.