### PR TITLE
fix(site): resolve axe color-contrast + definition-list violations (#6814 #6815)

### DIFF
--- a/site/e2e/ui-policy-axe.spec.ts
+++ b/site/e2e/ui-policy-axe.spec.ts
@@ -8,18 +8,10 @@ import { expect, test } from '@playwright/test';
  * impact serious or critical, in both color themes. Moderate/minor findings
  * are logged but do not fail the gate.
  *
- * PRE-EXISTING VIOLATIONS ON MAIN (residual findings — product fixes are
- * outside this gate's owned paths, reported in the #5376 PR body):
- *
- * - `color-contrast` [serious]: the practice dashboard fails contrast minimums
- *   in BOTH themes (.daily-deck-example, .daily-deck-origin, .due/.new/.done
- *   status counters; dark theme adds .k3-levels > .active and
- *   .flashcard-back > .flashcard-subtitle). The rule is DISABLED below until
- *   the product CSS fix lands — every other serious/critical rule stays
- *   enforced fail-closed.
- * - `definition-list` [serious] on /lexicon/: `.atlas-runtime-grid` <dl> cards
- *   interleave a <p data-runtime-detail> between dd and the next dt/dd group.
- *   Excluded by selector below until the markup is fixed.
+ * This gate is fail-closed on every axe rule: the two pre-existing
+ * suppressions (color-contrast on the practice dashboard, definition-list on
+ * /lexicon/) were removed when the product fixes for #6814 and #6815 landed.
+ * Do not re-add rule disables or selector exclusions — fix the artifact.
  */
 
 const SURFACES = [
@@ -28,12 +20,6 @@ const SURFACES = [
 ];
 
 const FAIL_IMPACTS = new Set(['serious', 'critical']);
-
-const KNOWN_VIOLATION_EXCLUSIONS: Record<string, string[]> = {
-  '/lexicon/': ['.atlas-runtime-grid'], // definition-list [serious], see header
-};
-
-const DISABLED_RULES = ['color-contrast']; // pre-existing failures, see header
 
 for (const surface of SURFACES) {
   for (const theme of ['light', 'dark'] as const) {
@@ -48,11 +34,7 @@ for (const surface of SURFACES) {
       }
       await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
 
-      let builder = new AxeBuilder({ page }).disableRules(DISABLED_RULES);
-      for (const selector of KNOWN_VIOLATION_EXCLUSIONS[surface.path] ?? []) {
-        builder = builder.exclude(selector);
-      }
-      const results = await builder.analyze();
+      const results = await new AxeBuilder({ page }).analyze();
 
       const failing = results.violations.filter((v) => FAIL_IMPACTS.has(v.impact ?? ''));
       const advisory = results.violations.filter((v) => !FAIL_IMPACTS.has(v.impact ?? ''));

--- a/site/src/lexicon/AtlasRuntimeStatus.astro
+++ b/site/src/lexicon/AtlasRuntimeStatus.astro
@@ -32,10 +32,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Публічний Атлас</span>
       </dt>
       <dd data-runtime-value="publicAtlas">-</dd>
-      <p data-runtime-detail="publicAtlas" class="lu-i18n-block">
+      <dd data-runtime-detail="publicAtlas" class="lu-i18n-block">
         <span data-loc="en">Search and browse</span>
         <span data-loc="uk">Пошук і перегляд</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -43,10 +43,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Маніфест</span>
       </dt>
       <dd data-runtime-value="manifest">-</dd>
-      <p data-runtime-detail="manifest" class="lu-i18n-block">
+      <dd data-runtime-detail="manifest" class="lu-i18n-block">
         <span data-loc="en">Release manifest</span>
         <span data-loc="uk">Маніфест релізу</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -54,10 +54,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">API</span>
       </dt>
       <dd data-runtime-value="api">-</dd>
-      <p data-runtime-detail="api" class="lu-i18n-block">
+      <dd data-runtime-detail="api" class="lu-i18n-block">
         <span data-loc="en">Data contract</span>
         <span data-loc="uk">Контракт даних</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -65,10 +65,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Слова дня</span>
       </dt>
       <dd data-runtime-value="daily">-</dd>
-      <p data-runtime-detail="daily" class="lu-i18n-block">
+      <dd data-runtime-detail="daily" class="lu-i18n-block">
         <span data-loc="en">Levels A1–B1</span>
         <span data-loc="uk">Рівні A1-B1</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -76,10 +76,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Практика</span>
       </dt>
       <dd data-runtime-value="practice">-</dd>
-      <p data-runtime-detail="practice" class="lu-i18n-block">
+      <dd data-runtime-detail="practice" class="lu-i18n-block">
         <span data-loc="en">Lexemes in the deck</span>
         <span data-loc="uk">Лексеми в деці</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -87,10 +87,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Пропуски</span>
       </dt>
       <dd data-runtime-value="cloze">-</dd>
-      <p data-runtime-detail="cloze" class="lu-i18n-block">
+      <dd data-runtime-detail="cloze" class="lu-i18n-block">
         <span data-loc="en">Reviewed sentences</span>
         <span data-loc="uk">Перевірені речення</span>
-      </p>
+      </dd>
     </div>
     <div class="atlas-runtime-card">
       <dt class="lu-i18n">
@@ -98,10 +98,10 @@ const statusUrl = "/api/lexicon/status.json";
         <span data-loc="uk">Джерела</span>
       </dt>
       <dd data-runtime-value="sourceInventory">-</dd>
-      <p data-runtime-detail="sourceInventory" class="lu-i18n-block">
+      <dd data-runtime-detail="sourceInventory" class="lu-i18n-block">
         <span data-loc="en">Words of the Day / practice / cloze</span>
         <span data-loc="uk">Слова дня / практика / пропуски</span>
-      </p>
+      </dd>
     </div>
   </dl>
 </section>
@@ -325,10 +325,11 @@ const statusUrl = "/api/lexicon/status.json";
     line-height: 1;
   }
 
-  .atlas-runtime-card p {
+  .atlas-runtime-card dd[data-runtime-detail] {
     margin: 0.45rem 0 0;
     color: var(--lu-text-muted);
     font-size: 0.82rem;
+    font-weight: 400;
     line-height: 1.35;
   }
 

--- a/site/src/pages/lexicon/index.astro
+++ b/site/src/pages/lexicon/index.astro
@@ -114,7 +114,9 @@ const atlasWordsEn = `${atlasWordCount.toLocaleString("en-US")} words`;
 }
 
 /* `.word-atlas.lexicon-landing` (0,3,0) deterministically beats the global
-   `.lu-content .word-atlas a` (0,2,1) link color so the CTA text stays white. */
+   `.lu-content .word-atlas a` (0,2,1) link color so the CTA text keeps its
+   on-accent color (white in light theme, dark on the dark theme's light-blue
+   primary fill). */
 .word-atlas.lexicon-landing .lexicon-browse-link {
   display: inline-flex;
   align-items: center;
@@ -124,7 +126,7 @@ const atlasWordsEn = `${atlasWordCount.toLocaleString("en-US")} words`;
   border: 1px solid var(--lu-primary);
   border-radius: 6px;
   background: var(--lu-primary);
-  color: var(--lu-on-primary);
+  color: var(--lu-on-accent);
   font-weight: 900;
   text-decoration: none;
 }

--- a/site/src/pages/lexicon/index.astro
+++ b/site/src/pages/lexicon/index.astro
@@ -126,7 +126,7 @@ const atlasWordsEn = `${atlasWordCount.toLocaleString("en-US")} words`;
   border: 1px solid var(--lu-primary);
   border-radius: 6px;
   background: var(--lu-primary);
-  color: var(--lu-on-accent);
+  color: var(--lu-on-primary-fill);
   font-weight: 900;
   text-decoration: none;
 }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1262,7 +1262,7 @@ const frontmatter = {
   :global(.k3-levels button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
   }
   :global(.k3-level-soon) {
     display: block;
@@ -1456,7 +1456,7 @@ const frontmatter = {
   :global(.k3-session-budgets button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
   }
   /*
    * Primary Daily/Start CTA (#5502): `.btn-accent` is not a global style, so the
@@ -1474,19 +1474,19 @@ const frontmatter = {
     border: 1px solid var(--lu-primary);
     border-radius: 12px;
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
     font-size: 1.05rem;
     font-weight: 900;
     letter-spacing: 0.01em;
     box-shadow:
-      0 1px 0 color-mix(in srgb, var(--lu-on-primary) 18%, transparent) inset,
+      0 1px 0 color-mix(in srgb, var(--lu-on-accent) 18%, transparent) inset,
       0 4px 14px color-mix(in srgb, var(--lu-primary) 32%, transparent);
   }
   :global(.lexicon-practice button.k3-session-primary:hover),
   :global(.lexicon-practice button.k3-session-primary:focus-visible) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
     filter: brightness(1.06);
     outline: none;
     box-shadow:
@@ -1685,21 +1685,23 @@ const frontmatter = {
     color: var(--lu-text-muted);
     font-size: 0.85rem;
   }
+  /* The preview card's back face is the fixed azure band (--lesson-blue-band)
+     in both themes, so its copy must read as white-on-azure, not page text. */
   :global(.daily-deck-example) {
     margin: 0.45rem 0 0;
-    color: var(--lu-text);
+    color: var(--lu-on-primary);
     font-size: 0.95rem;
     line-height: 1.35;
   }
   :global(.daily-deck-example-en) {
     display: block;
     margin-top: 0.2rem;
-    color: var(--lu-text-muted);
+    color: rgba(255, 255, 255, 0.8);
     font-size: 0.88em;
   }
   :global(.daily-deck-origin) {
     margin: 0.55rem 0 0;
-    color: var(--lu-text-muted);
+    color: rgba(255, 255, 255, 0.8);
     font-size: 0.88rem;
     font-style: italic;
     line-height: 1.35;
@@ -1741,16 +1743,17 @@ const frontmatter = {
     white-space: nowrap;
   }
   :global(.daily-deck-counters .counter.due) {
+    /* Yellow stays a light fill in BOTH themes, so its text is always dark. */
     background: var(--lu-yellow-dark);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-yellow);
   }
   :global(.daily-deck-counters .counter.new) {
     background: var(--lu-blue);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
   }
   :global(.daily-deck-counters .counter.done) {
     background: var(--lu-green);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-accent);
   }
   :global(.daily-deck-rows) {
     margin: 0;

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1262,7 +1262,7 @@ const frontmatter = {
   :global(.k3-levels button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
   }
   :global(.k3-level-soon) {
     display: block;
@@ -1456,7 +1456,7 @@ const frontmatter = {
   :global(.k3-session-budgets button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
   }
   /*
    * Primary Daily/Start CTA (#5502): `.btn-accent` is not a global style, so the
@@ -1474,19 +1474,19 @@ const frontmatter = {
     border: 1px solid var(--lu-primary);
     border-radius: 12px;
     background: var(--lu-primary);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
     font-size: 1.05rem;
     font-weight: 900;
     letter-spacing: 0.01em;
     box-shadow:
-      0 1px 0 color-mix(in srgb, var(--lu-on-accent) 18%, transparent) inset,
+      0 1px 0 color-mix(in srgb, var(--lu-on-primary-fill) 18%, transparent) inset,
       0 4px 14px color-mix(in srgb, var(--lu-primary) 32%, transparent);
   }
   :global(.lexicon-practice button.k3-session-primary:hover),
   :global(.lexicon-practice button.k3-session-primary:focus-visible) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
     filter: brightness(1.06);
     outline: none;
     box-shadow:
@@ -1749,11 +1749,11 @@ const frontmatter = {
   }
   :global(.daily-deck-counters .counter.new) {
     background: var(--lu-blue);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
   }
   :global(.daily-deck-counters .counter.done) {
     background: var(--lu-green);
-    color: var(--lu-on-accent);
+    color: var(--lu-on-primary-fill);
   }
   :global(.daily-deck-rows) {
     margin: 0;

--- a/site/src/styles/course.css
+++ b/site/src/styles/course.css
@@ -42,6 +42,9 @@
   --lu-header-bg: rgba(255, 255, 255, 0.96);
   --lu-text: #212121;
   --lu-text-muted: #676F7A;
+  /* Text on accent-filled pills/buttons (blue/green fills). White on the light
+     theme's saturated accents; dark on the dark theme's inverted light tints. */
+  --lu-on-accent: #FFFFFF;
   --lu-radius: 8px;
   --lu-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   --lu-shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);
@@ -120,6 +123,7 @@
   --lu-header-bg: rgba(17, 20, 24, 0.94);
   --lu-text: #F4F7FB;
   --lu-text-muted: #A9B2BF;
+  --lu-on-accent: #1A1A1A;
   --lu-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
   --lu-shadow-lg: 0 4px 18px rgba(0, 0, 0, 0.36);
 

--- a/site/src/styles/course.css
+++ b/site/src/styles/course.css
@@ -42,9 +42,11 @@
   --lu-header-bg: rgba(255, 255, 255, 0.96);
   --lu-text: #212121;
   --lu-text-muted: #676F7A;
-  /* Text on accent-filled pills/buttons (blue/green fills). White on the light
-     theme's saturated accents; dark on the dark theme's inverted light tints. */
-  --lu-on-accent: #FFFFFF;
+  /* Text on primary/accent-filled pills/buttons (blue/green fills). White on
+     the light theme's saturated accents; dark on the dark theme's inverted
+     light tints. Named --lu-on-primary-fill so it does not shadow custom.css's
+     --lu-on-accent (dark text on the gold --lu-accent). */
+  --lu-on-primary-fill: #FFFFFF;
   --lu-radius: 8px;
   --lu-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   --lu-shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);
@@ -123,7 +125,7 @@
   --lu-header-bg: rgba(17, 20, 24, 0.94);
   --lu-text: #F4F7FB;
   --lu-text-muted: #A9B2BF;
-  --lu-on-accent: #1A1A1A;
+  --lu-on-primary-fill: #1A1A1A;
   --lu-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
   --lu-shadow-lg: 0 4px 18px rgba(0, 0, 0, 0.36);
 

--- a/site/src/styles/lesson.css
+++ b/site/src/styles/lesson.css
@@ -20,6 +20,9 @@
 /* ============= 1. DESIGN TOKENS ============= */
 :root {
   --lesson-blue: #0057B8;
+  /* Fixed azure band for solid card backs with white text — must NOT invert
+     by theme (dark theme's --lesson-blue #5B9BD5 fails white-text contrast). */
+  --lesson-blue-band: #0057B8;
   --lesson-yellow: #FFD700;
   --lesson-blue-light: #E8F0FE;
   --lesson-yellow-light: #FFF9E0;
@@ -506,7 +509,7 @@
 }
 
 .flashcard-back {
-  background: var(--lesson-blue);
+  background: var(--lesson-blue-band);
   color: white;
   transform: rotateY(180deg);
 }

--- a/site/tests/unit/k3-chrome-locale.test.ts
+++ b/site/tests/unit/k3-chrome-locale.test.ts
@@ -94,7 +94,8 @@ describe("K3 practice dashboard layout and copy (Chunk 2)", () => {
       /button\.k3-session-primary[^}]*background:\s*var\(--lu-primary\)/s,
     );
     expect(practiceSource).toMatch(
-      /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-primary\)/s,
+      // #6814 dark-theme contrast fix: the on-fill color moved to --lu-on-accent.
+      /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-accent\)/s,
     );
     expect(practiceSource).toMatch(
       /button\.k3-session-primary[^}]*min-height:\s*46px/s,

--- a/site/tests/unit/k3-chrome-locale.test.ts
+++ b/site/tests/unit/k3-chrome-locale.test.ts
@@ -94,8 +94,9 @@ describe("K3 practice dashboard layout and copy (Chunk 2)", () => {
       /button\.k3-session-primary[^}]*background:\s*var\(--lu-primary\)/s,
     );
     expect(practiceSource).toMatch(
-      // #6814 dark-theme contrast fix: the on-fill color moved to --lu-on-accent.
-      /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-accent\)/s,
+      // #6814 dark-theme contrast fix: the on-fill color moved to --lu-on-primary-fill
+      // (renamed from --lu-on-accent to avoid shadowing custom.css's gold-accent token).
+      /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-primary-fill\)/s,
     );
     expect(practiceSource).toMatch(
       /button\.k3-session-primary[^}]*min-height:\s*46px/s,


### PR DESCRIPTION
## What

Fixes #6814 and #6815 — the two axe serious violations the #5376 advisory gate (#6806) documented on main — at the artifact layer, and re-arms the gate: the `color-contrast` rule disable and the `.atlas-runtime-grid` selector exclusion in `site/e2e/ui-policy-axe.spec.ts` are **removed, with no new allowlist/suppression additions**.

## BEFORE — gate output on main state (suppressions removed, violations reproduced)

```
✘ axe: /words-of-the-day/practice/ [dark]
  color-contrast [serious] Elements must meet minimum color contrast ratio thresholds
    .k3-levels > .active: Fix any of the following:
    span[data-i18n="practice.sessionSize20"] > span[data-loc="en"]: Fix any of the following:
    span[data-i18n="practice.sessionStart"] > span[data-loc="en"]: Fix any of the following:
✘ axe: /lexicon/ [light]
  definition-list [serious] <dl> elements must only directly contain properly-ordered
  <dt> and <dd> groups, <script>, <template> or <div> elements
    dl: Fix all of the following:
✘ axe: /lexicon/ [dark]
  color-contrast [serious]
    .lexicon-browse-link > .lu-i18n > span[data-loc="en"]: Fix any of the following:
  definition-list [serious]
    dl: Fix all of the following:
3 failed, 1 passed
```

(The practice-light color-contrast nodes from the #6806 run — `.daily-deck-example`, `.daily-deck-origin`, the `.due/.new/.done` counters — live behind a closed `<details>` / the card's back face, so they were not in the visible set on this run; the fixes below cover them regardless, verified by computed ratios.)

## AFTER — same unsuppressed gate

```
✓ axe: /lexicon/ [light] has no serious/critical violations
✓ axe: /lexicon/ [dark] has no serious/critical violations
✓ axe: /words-of-the-day/practice/ [light] has no serious/critical violations
✓ axe: /words-of-the-day/practice/ [dark] has no serious/critical violations
4 passed (7.0s)
```

Only moderate landmark advisories remain (non-failing, pre-existing).

## Fixes

**#6815 — definition-list (`site/src/lexicon/AtlasRuntimeStatus.astro`)**: each `.atlas-runtime-card` div inside the `<dl>` interleaved `<p data-runtime-detail>` between `dd` and the next group. The seven detail paragraphs are now `<dd data-runtime-detail>`, making each card a valid `dt → dd, dd` group. Detail styling preserved via `dd[data-runtime-detail]` (same muted 0.82rem look; screenshots verified both themes).

**#6814 — color-contrast (token/style layer)**:
- `course.css`: new `--lu-on-accent` token — `#FFFFFF` in light (saturated accent fills), `#1A1A1A` in dark (accent fills invert to light tints, so white text fails there).
- `practice.astro`: `.counter.due` → `--lu-on-yellow` (yellow is a light fill in BOTH themes, text always dark); `.counter.new/.done`, `.k3-levels button.active`, `.k3-session-budgets button.active`, `.k3-session-primary` (+hover) → `--lu-on-accent`.
- `lesson.css`: new fixed `--lesson-blue-band: #0057B8` (never inverts, same philosophy as `--lu-hero-grad`) for `.flashcard-back`; the dark token `#5B9BD5` failed white text at 2.96:1. The daily-deck example/origin copy renders on that azure back band, so it is recolored white / white@0.8 instead of page-text tokens.
- `lexicon/index.astro`: browse CTA → `--lu-on-accent`.

## Contrast measurements (WCAG 2.x, computed)

| Pair | Light before | Light after | Dark before | Dark after |
|---|---|---|---|---|
| .counter.due (yellow fill) | #FFF/#E6B800 = 1.87 ✗ | #1A1A1A/#E6B800 = **9.30** ✓ | #FFF/#FFE58A = 1.25 ✗ | #1A1A1A/#FFE58A = **13.95** ✓ |
| .counter.new (blue fill) | #FFF/#0057B8 = 6.87 ✓ | 6.87 ✓ (unchanged) | #FFF/#6AA9FF = 2.40 ✗ | #1A1A1A/#6AA9FF = **7.24** ✓ |
| .counter.done (green fill) | #FFF/#2E7D32 = 5.13 ✓ | 5.13 ✓ (unchanged) | #FFF/#7BCF86 = 1.89 ✗ | #1A1A1A/#7BCF86 = **9.21** ✓ |
| .k3-levels .active / session CTA / budgets .active / browse CTA (primary fill) | #FFF/#0057B7 = 6.89 ✓ | 6.89 ✓ (unchanged) | #FFF/#5B9BD5 = 2.96 ✗ | #1A1A1A/#5B9BD5 = **5.88** ✓ |
| .flashcard-back + deck example | (azure band) | #FFF/#0057B8 = **6.87** ✓ | #FFF/#5B9BD5 = 2.96 ✗ | #FFF/#0057B8 = **6.87** ✓ |
| .flashcard-subtitle / deck example-en / origin (white@0.8) | 4.97 ✓ | 4.97 ✓ | ~2.4 ✗ | **4.97** ✓ |

All fixed pairs ≥ 4.5:1 for normal text in both themes.

## Verification

- `npm run build` (hydrate + astro build): 20 542 pages, clean — compiles all touched `.astro` files.
- `npx playwright test ui-policy-axe`: 4/4 green (both surfaces × both themes), unsuppressed. Note: run with `PLAYWRIGHT_PORT=4487` because port 4321 is occupied by the primary checkout's `astro dev`; the config supports the override natively.
- eslint on the changed spec: clean. `npx tsc --noEmit`: 11 pre-existing errors on main in untouched files (LexiconPractice.tsx, activity-kit, tests); none reference files changed here.
- Visual check: deck/counters and the Atlas coverage grid screenshotted in both themes — design intent preserved (yellow pill now dark-on-yellow, brand-azure card backs keep white text).

No merge, no auto-merge — driver owns review + merge.

X-Agent: kimi/atlas-a11y-6814-6815