### PR TITLE
fix(practice): teach the synonym/antonym pair on synonym-mode misses (#6816)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b9694a35f8488680d9a7b9a033d5ab1d2a869113927ed8c262e06429796ce3c0
+  components_sha256: 580e55b28b1475d28a6509a62843b526d2754447bd55610681ff5bcf914160ff
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1222,6 +1222,38 @@ function classifyFeedbackFor(
     : { kind: 'wrong', textUk: `Неправильно. ${textUk}`, textEn: `Incorrect. ${textEn}` };
 }
 
+/**
+ * #6816: 'synonym' mode (antonym-polarity items included — the prompt already reads
+ * «Оберіть антонім/синонім до …») locked with only a red ✗/green outline — handleChoice
+ * never built teaching feedback for mode==='synonym' (isMeaningChoiceSurface excludes it,
+ * selection.classify is unset for this mode), so a miss showed the status line only.
+ * Widening isMeaningChoiceSurface to cover 'synonym' would be wrong: it would restate the
+ * unrelated word↔gloss pair (#6807) instead of the antonym/synonym relation the learner was
+ * actually asked about. Restate the attested prompt ↔ correct-option pair from
+ * `selection.synonym` instead — same deck payload the option list and prompt already render.
+ */
+function synonymFeedbackFor(
+  selection: PracticeSelection,
+  option: ChoiceOption,
+  learnerLevel: CefrLevel,
+): DrillFeedback | null {
+  const synonym = selection.synonym;
+  if (!synonym) return null;
+  const answer = synonym.options.find((candidate) => candidate.kind === 'answer');
+  if (!answer) return null;
+  const answerLabel = displayPracticeForm(answer.label, learnerLevel);
+  const isAntonym = synonym.polarity === 'antonym';
+  const textUk = isAntonym
+    ? `Антонім до «${synonym.prompt}» — «${answerLabel}».`
+    : `Синонім до «${synonym.prompt}» — «${answerLabel}».`;
+  const textEn = isAntonym
+    ? `Antonym for «${synonym.prompt}» — «${answerLabel}».`
+    : `Synonym for «${synonym.prompt}» — «${answerLabel}».`;
+  return option.correct
+    ? { kind: 'correct', textUk: `Правильно! ${textUk}`, textEn: `Correct! ${textEn}` }
+    : { kind: 'wrong', textUk: `Неправильно. ${textUk}`, textEn: `Incorrect. ${textEn}` };
+}
+
 function drillChoiceOptions(
   selection: PracticeSelection,
   showEnglishSubtitles: boolean,
@@ -3631,12 +3663,16 @@ function LexiconPracticeIsland({
     // a teaching sentence, not just a red ✗ / green outline.
     // #6801: antonym/homonym reuse the meaning-choice surface in mixed sessions —
     // teach those misses too (see isMeaningChoiceSurface).
+    // #6816: 'synonym' mode gets its own prompt↔answer teaching sentence — never routed
+    // through isMeaningChoiceSurface (see synonymFeedbackFor for why).
     const nextChoiceFeedback =
       isMeaningChoiceSurface(selection)
         ? choiceFeedbackFor(selection, option, learnerLevel)
         : selection.classify
           ? classifyFeedbackFor(selection, option, learnerLevel)
-          : null;
+          : selection.synonym
+            ? synonymFeedbackFor(selection, option, learnerLevel)
+            : null;
     setAnswerLocked(true);
     setChoiceSelectedLabel(option.label);
     if (selection.paradigm) setParadigmSelectedLabel(option.label);
@@ -4961,7 +4997,9 @@ function PracticeItem({
             testId={
               selection.mode === 'classify'
                 ? 'practice-classify-feedback'
-                : 'practice-choice-feedback'
+                : selection.mode === 'synonym'
+                  ? 'practice-synonym-feedback'
+                  : 'practice-choice-feedback'
             }
             showEnglishSubtitles={showEnglishSubtitles}
           />
@@ -5033,6 +5071,29 @@ function PracticeItem({
     );
   }
 
+  // #6816 point 2: buildStaticCandidates (srs.ts) only ever emits a mode==='synonym'
+  // selection paired with a matched PracticeSynonymItem, so `.synonym` is never absent in
+  // practice — but drillChoiceOptions/drillChoicePrompt above already treat a missing
+  // `.synonym` as "no synonym drill" (both return null), which would otherwise let a
+  // synonym-mode selection fall through to the word↔gloss meaning-choice surface below and
+  // invent an unrelated pair. Fail closed instead: never let 'synonym' mode reach the
+  // fallback meant for bare 'choice'/'antonym'/'homonym' selections.
+  if (selection.mode === 'synonym') {
+    return (
+      <div className="practice-empty-state" data-testid="practice-choice-empty">
+        <p className="lexicon-practice-muted">
+          <PracticeChromeLabel k="practice.noChoiceCards" />
+        </p>
+        <button
+          type="button"
+          className="btn btn-accent practice-empty-primary"
+          onClick={onBackToModes}
+        >
+          <PracticeChromeLabel k="practice.backToModes" />
+        </button>
+      </div>
+    );
+  }
   const options = orderedChoiceOptions(selection, deck, selection.choicePolarity, sessionSeed, learnerLevel);
   if (!options.length) {
     return (

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -4666,7 +4666,11 @@ function DrillFeedbackPanel({
   );
 }
 
-function PracticeItem({
+// #6821: exported so a unit test can drive the mode==='synonym'-without-`.synonym`
+// fail-closed branch directly — buildStaticCandidates never emits that combination
+// in practice (see the #6816 point 2 comment below), so there's no deck fixture
+// that reaches it through the full LexiconPractice tree.
+export function PracticeItem({
   selection,
   deck,
   pairs,

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -6,6 +6,7 @@ import LexiconPractice, {
   addDailyExamples,
   isEnglishLearnerGloss,
   isMeaningMcEligible,
+  PracticeItem,
 } from '@site/src/components/LexiconPractice';
 import { LexiconCustomDeckManager } from '@site/src/components/LexiconCustomDeckManager';
 import PracticeDailyDeck from '@site/src/components/PracticeDailyDeck';
@@ -24,6 +25,7 @@ import {
   clearLoadedSrsState,
   loadState,
   saveState,
+  selectNextPracticeItem,
   type PracticeDeckData,
   type DailyPracticeDeckSnapshot,
   type DailyPracticeRowState,
@@ -32,6 +34,7 @@ import {
   type PracticeLexeme,
   type PracticeMode,
   type PracticeRating,
+  type PracticeSelection,
   type ReviewLogEntry,
 } from '@site/src/lib/lexicon/srs';
 import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
@@ -886,10 +889,14 @@ function paradigmDeck(): PracticeDeckData {
 }
 
 function synonymDeck(): PracticeDeckData {
-  const entry = lexeme('kava', 'кава', 'coffee', {
-    nominative: 'кава',
-    accusative: 'каву',
-    locative: 'каві',
+  // #6821: prompt and answer must be two DIFFERENT words — a tautological
+  // «синонім до «X» — «X»» fixture doesn't exercise the prompt↔answer teaching
+  // sentence at all. «будинок»/«дім» is an attested Ukrainian synonym pair
+  // (both mean "house/building"), unlike the coffee lexeme's own name.
+  const entry = lexeme('budynok', 'будинок', 'building', {
+    nominative: 'будинок',
+    accusative: 'будинок',
+    locative: 'будинку',
   });
   return {
     deckVersion: 'test-synonym',
@@ -909,15 +916,15 @@ function synonymDeck(): PracticeDeckData {
     classify: [],
     paradigm: [],
     synonym: [{
-      synonymId: 'kava-syn',
-      lemmaId: 'kava',
-      targetLemmaId: 'kava',
+      synonymId: 'budynok-syn',
+      lemmaId: 'budynok',
+      targetLemmaId: 'dim',
       polarity: 'synonym',
-      prompt: 'кава',
-      answer: 'кава',
+      prompt: 'будинок',
+      answer: 'дім',
       options: [
-        { label: 'кава', lemmaId: 'kava', kind: 'answer' },
-        { label: 'чай', lemmaId: 'chay', kind: 'distractor' },
+        { label: 'дім', lemmaId: 'dim', kind: 'answer' },
+        { label: 'школа', lemmaId: 'shkola', kind: 'distractor' },
       ],
       source: 'fixture',
     }],
@@ -4475,7 +4482,7 @@ describe('LexiconPractice', () => {
         mode: 'synonym',
         deck: synonymDeck(),
         answer: async (user) => {
-          await user.click(screen.getByRole('button', { name: /кава/ }));
+          await user.click(screen.getByRole('button', { name: /дім/ }));
         },
       },
       {
@@ -4615,7 +4622,7 @@ describe('LexiconPractice', () => {
       { mode: 'choice', deck: sampleDeckWithOnlyMode('knyha', 'choice'), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /книга/ })); } },
       { mode: 'stress', deck: stressDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button'); const target = buttons.find((button) => button.dataset.position === '1'); expect(target).toBeDefined(); await user.click(target!); } },
       { mode: 'classify', deck: classifyDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /жіночий/ })); } },
-      { mode: 'synonym', deck: synonymDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /кава/ })); } },
+      { mode: 'synonym', deck: synonymDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /дім/ })); } },
     ])('$mode: rail is $expectRail', async ({ mode, deck, expectRail, action }) => {
       const user = userEvent.setup();
       const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode={mode as any} />);
@@ -4640,7 +4647,7 @@ describe('LexiconPractice', () => {
     test.each([
       { mode: 'classify', deck: classifyDeck(), testId: 'practice-classify', wrongName: /чоловічий/, correctName: /жіночий/ },
       { mode: 'paradigm', deck: paradigmDeck(), testId: 'practice-paradigm', wrongName: /кава/, correctName: /кави/ },
-      { mode: 'synonym', deck: synonymDeck(), testId: 'practice-synonym', wrongName: /чай/, correctName: /кава/ },
+      { mode: 'synonym', deck: synonymDeck(), testId: 'practice-synonym', wrongName: /школа/, correctName: /дім/ },
       { mode: 'paronym', deck: paronymDeck(), testId: 'practice-paronym', wrongName: /біжить/, correctName: /бігає/ },
       { mode: 'heritage', deck: heritageDeck(), testId: 'practice-heritage', wrongName: /хата/, correctName: /дім/ },
     ])('$mode: wrong pick is marked red, correct option is marked green', async ({ mode, deck, testId, wrongName, correctName }) => {
@@ -4813,11 +4820,11 @@ describe('LexiconPractice', () => {
       render(<LexiconPractice initialDeck={synonymDeck()} autoStart initialMode="synonym" />);
       const scope = within(screen.getByTestId('practice-synonym'));
 
-      await user.click(scope.getByRole('button', { name: /чай/ }));
+      await user.click(scope.getByRole('button', { name: /школа/ }));
 
       const feedback = screen.getByTestId('practice-synonym-feedback');
-      expect(feedback).toHaveTextContent('Неправильно. Синонім до «кава» — «кава».');
-      expect(feedback).toHaveTextContent('Incorrect. Synonym for «кава» — «кава».');
+      expect(feedback).toHaveTextContent('Неправильно. Синонім до «будинок» — «дім».');
+      expect(feedback).toHaveTextContent('Incorrect. Synonym for «будинок» — «дім».');
       expect(screen.queryByTestId('practice-choice-feedback')).not.toBeInTheDocument();
     });
 
@@ -4826,10 +4833,61 @@ describe('LexiconPractice', () => {
       render(<LexiconPractice initialDeck={synonymDeck()} autoStart initialMode="synonym" />);
       const scope = within(screen.getByTestId('practice-synonym'));
 
-      await user.click(scope.getByRole('button', { name: /кава/ }));
+      await user.click(scope.getByRole('button', { name: /дім/ }));
 
       const feedback = screen.getByTestId('practice-synonym-feedback');
-      expect(feedback).toHaveTextContent('Правильно! Синонім до «кава» — «кава».');
+      expect(feedback).toHaveTextContent('Правильно! Синонім до «будинок» — «дім».');
+    });
+
+    test('synonym mode: a selection without `.synonym` fails closed to practice-choice-empty and teaches nothing (#6821)', () => {
+      // buildStaticCandidates (srs.ts) never emits mode==='synonym' without a matched
+      // `.synonym` item — this state is unreachable through the deck API (see the #6816
+      // point 2 comment in LexiconPractice.tsx). Exercise the guard directly: take a real
+      // synonym selection and strip `.synonym`, the one shape the render tree must never
+      // let fall through to the word↔gloss meaning-choice surface (#6816 point 2) or invent
+      // a teaching pair from.
+      const deck = synonymDeck();
+      const base = selectNextPracticeItem(deck, { modeFilter: 'synonym', now: NOW });
+      expect(base?.mode).toBe('synonym');
+      expect(base?.synonym).toBeDefined();
+      const selection: PracticeSelection = { ...base!, synonym: undefined };
+
+      render(
+        <PracticeItem
+          selection={selection}
+          deck={deck}
+          pairs={[]}
+          sessionSeed={1}
+          answerLocked={false}
+          clozeInput=""
+          clozeFeedback={null}
+          heritageFeedback={null}
+          paronymFeedback={null}
+          choiceFeedback={null}
+          stressSelectedPosition={null}
+          paradigmSelectedLabel={null}
+          paronymSelectedLabel={null}
+          heritageSelectedLabel={null}
+          choiceSelectedLabel={null}
+          onClozeInput={() => {}}
+          onFlashcardRating={() => {}}
+          onChoice={() => {}}
+          onStressSelect={() => {}}
+          onMatchingComplete={() => {}}
+          onClozeSubmit={() => {}}
+          onHeritageActivityComplete={() => {}}
+          presentationVariants={false}
+          onBackToModes={() => {}}
+          showEnglishSubtitles={false}
+          chromeLocale="uk"
+          learnerLevel="A1"
+        />,
+      );
+
+      expect(screen.getByTestId('practice-choice-empty')).toBeInTheDocument();
+      expect(screen.queryByTestId('practice-synonym')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('practice-synonym-feedback')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Синонім до|Антонім до|Synonym for|Antonym for/)).not.toBeInTheDocument();
     });
 
     test('synonym mode, antonym-polarity: «Оберіть антонім» miss teaches the antonym pair, not a synonym pair (#6816)', async () => {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -924,6 +924,45 @@ function synonymDeck(): PracticeDeckData {
   };
 }
 
+function antonymPolaritySynonymDeck(): PracticeDeckData {
+  const entry = lexeme('svitlyi', 'світлий', 'light', {
+    nominative: 'світлий',
+    accusative: 'світлий',
+    locative: 'світлому',
+  });
+  return {
+    deckVersion: 'test-synonym-antonym-polarity',
+    level: 'A1',
+    lexemes: [entry],
+    index: [{
+      lemmaId: entry.lemmaId,
+      lemma: entry.lemma,
+      cefr: 'A1',
+      modes: ['synonym'],
+      hasCloze: false,
+      clozeIds: [],
+      newOrder: 0,
+    }],
+    cloze: [],
+    stress: [],
+    classify: [],
+    paradigm: [],
+    synonym: [{
+      synonymId: 'svitlyi-ant',
+      lemmaId: 'svitlyi',
+      targetLemmaId: 'temnyi',
+      polarity: 'antonym',
+      prompt: 'світлий',
+      answer: 'темний',
+      options: [
+        { label: 'темний', lemmaId: 'temnyi', kind: 'answer' },
+        { label: 'яскравий', lemmaId: 'yaskravyi', kind: 'distractor' },
+      ],
+      source: 'fixture',
+    }],
+  };
+}
+
 beforeEach(() => {
   localStorage.clear();
   loadState(localStorage, NOW);
@@ -4764,6 +4803,46 @@ describe('LexiconPractice', () => {
 
       const feedback = screen.getByTestId('practice-choice-feedback');
       expect(feedback).toHaveTextContent('Неправильно. «книга» = book.');
+    });
+
+    test('synonym mode: wrong pick teaches the prompt ↔ correct-option pair, not the word↔gloss pair (#6816)', async () => {
+      // Before this fix, mode==='synonym' skipped choiceFeedbackFor (mode !== 'choice'/
+      // 'antonym'/'homonym') AND classifyFeedbackFor (selection.classify unset) — handleChoice
+      // set nextChoiceFeedback to null, so a miss showed the status line only, no red panel.
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={synonymDeck()} autoStart initialMode="synonym" />);
+      const scope = within(screen.getByTestId('practice-synonym'));
+
+      await user.click(scope.getByRole('button', { name: /чай/ }));
+
+      const feedback = screen.getByTestId('practice-synonym-feedback');
+      expect(feedback).toHaveTextContent('Неправильно. Синонім до «кава» — «кава».');
+      expect(feedback).toHaveTextContent('Incorrect. Synonym for «кава» — «кава».');
+      expect(screen.queryByTestId('practice-choice-feedback')).not.toBeInTheDocument();
+    });
+
+    test('synonym mode: correct pick affirms the prompt ↔ answer pair (#6816)', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={synonymDeck()} autoStart initialMode="synonym" />);
+      const scope = within(screen.getByTestId('practice-synonym'));
+
+      await user.click(scope.getByRole('button', { name: /кава/ }));
+
+      const feedback = screen.getByTestId('practice-synonym-feedback');
+      expect(feedback).toHaveTextContent('Правильно! Синонім до «кава» — «кава».');
+    });
+
+    test('synonym mode, antonym-polarity: «Оберіть антонім» miss teaches the antonym pair, not a synonym pair (#6816)', async () => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={antonymPolaritySynonymDeck()} autoStart initialMode="synonym" />);
+      expect(screen.getByText(/^Оберіть антонім до «світлий»/)).toBeTruthy();
+      const scope = within(screen.getByTestId('practice-synonym'));
+
+      await user.click(scope.getByRole('button', { name: /яскравий/ }));
+
+      const feedback = screen.getByTestId('practice-synonym-feedback');
+      expect(feedback).toHaveTextContent('Неправильно. Антонім до «світлий» — «темний».');
+      expect(feedback).toHaveTextContent('Incorrect. Antonym for «світлий» — «темний».');
     });
 
     test('choice ("Вибір"): correct pick affirms the pairing with EN subtitle', async () => {


### PR DESCRIPTION
Closes #6816.

## What
1. Cards with `selection.synonym` («Оберіть антонім/синонім до …») now teach the attested **prompt ↔ correct-option** pair from `selection.synonym` on a miss, instead of showing no panel at all (previously `handleChoice` never built feedback for `mode==='synonym'` — `isMeaningChoiceSurface` excludes it, `selection.classify` is unset — so only the status line updated).
2. Audited whether a bare `synonym`-mode selection without `selection.synonym` can fall through to the meaning-choice surface: `buildStaticCandidates` (srs.ts) only ever emits `mode==='synonym'` paired 1:1 with a matched `PracticeSynonymItem`, so it isn't reachable today — but the render function had no guard against it. Added a fail-closed guard so a corrupted/stale selection renders the empty state instead of inventing an unrelated word↔gloss pair.

## Testing
`cd site && npx vitest run tests/unit/LexiconPractice.test.tsx` — 175/175 passing (3 new tests covering synonym-mode miss/correct feedback and antonym-polarity feedback).

`npx tsc --noEmit` / `npx eslint` — no new errors vs. baseline (verified diff against `git stash`).

X-Agent: claude/atlas-6816-antonym-teach