### PR TITLE
fix(ci): anchor pages auto-deploy eligibility to actual deployments (#6802)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   actions: read
   contents: read
+  deployments: read
 
 concurrency:
   group: "pages"
@@ -46,16 +47,41 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          runs_json="$(
+          deployments_json="$(
             curl --fail --silent --show-error --retry 3 --connect-timeout 10 --max-time 30 \
               --header "Authorization: Bearer ${GH_TOKEN}" \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/repos/${REPOSITORY}/actions/workflows/deploy-pages.yml/runs?branch=main&status=success&per_page=1"
+              "https://api.github.com/repos/${REPOSITORY}/deployments?environment=github-pages&per_page=20"
           )"
-          last_deploy_sha="$(jq --exit-status --raw-output '.workflow_runs[0].head_sha' <<< "$runs_json")"
-          git cat-file -e "${last_deploy_sha}^{commit}"
-          git merge-base --is-ancestor "$last_deploy_sha" "$GITHUB_SHA"
-          printf 'sha=%s\n' "$last_deploy_sha" >> "$GITHUB_OUTPUT"
+
+          last_deploy_sha=""
+          while IFS=$'\t' read -r dep_id dep_sha; do
+            [[ -z "$dep_id" || "$dep_id" == "null" ]] && continue
+
+            statuses_json="$(
+              curl --fail --silent --show-error --retry 3 --connect-timeout 10 --max-time 30 \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "https://api.github.com/repos/${REPOSITORY}/deployments/${dep_id}/statuses"
+            )"
+
+            has_success="$(jq -r '[.[] | select(.state == "success")] | length > 0' <<< "$statuses_json")"
+            if [[ "$has_success" == "true" ]]; then
+              if git cat-file -e "${dep_sha}^{commit}" 2>/dev/null && \
+                 git merge-base --is-ancestor "$dep_sha" "$GITHUB_SHA" 2>/dev/null; then
+                last_deploy_sha="$dep_sha"
+                break
+              fi
+            fi
+          done < <(jq -r '.[] | "\(.id)\t\(.sha)"' <<< "$deployments_json")
+
+          if [[ -n "$last_deploy_sha" ]]; then
+            echo "Resolved last deployment anchor: $last_deploy_sha"
+            printf 'sha=%s\n' "$last_deploy_sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "No prior successful deployment anchor resolvable; auto-deploy will fail closed."
+            printf 'sha=\n' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Classify all changes since that deployment
         id: classify
@@ -63,6 +89,12 @@ jobs:
           LAST_DEPLOY_SHA: ${{ steps.last-deploy.outputs.sha }}
         run: |
           set -euo pipefail
+          if [[ -z "${LAST_DEPLOY_SHA:-}" ]]; then
+            echo "auto-deploy eligibility: no_prior_deployment (fail closed)"
+            printf 'deploy=false\n' >> "$GITHUB_OUTPUT"
+            printf 'reason=no_prior_deployment\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           changed_paths="$RUNNER_TEMP/changed-paths.nul"
           git diff --no-renames --name-only --diff-filter=ACDMRT -z \
             "$LAST_DEPLOY_SHA" "$GITHUB_SHA" > "$changed_paths"

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -121,6 +121,7 @@ def test_pages_workflow_uses_fail_closed_auto_deploy_preflight() -> None:
     assert "push:\n    branches: [main]" in trigger_block
     assert "workflow_dispatch:" in trigger_block
     assert workflow["permissions"]["actions"] == "read"
+    assert workflow["permissions"]["deployments"] == "read"
 
     eligibility = workflow["jobs"]["auto-deploy-eligibility"]
     assert eligibility["if"] == "github.event_name == 'push'"
@@ -132,7 +133,7 @@ def test_pages_workflow_uses_fail_closed_auto_deploy_preflight() -> None:
     assert "outputs.deploy == 'true'" in deploy["if"]
 
     preflight = "\n".join(step.get("run", "") for step in eligibility["steps"])
-    assert "actions/workflows/deploy-pages.yml/runs" in preflight
+    assert "deployments?environment=github-pages" in preflight
     assert "git cat-file -e" in preflight
     assert "git merge-base --is-ancestor" in preflight
     assert "git diff --no-renames --name-only --diff-filter=ACDMRT -z" in preflight


### PR DESCRIPTION
Closes #6802

## Summary
Anchor the Pages auto-deploy eligibility check (`auto-deploy-eligibility` job in `.github/workflows/deploy-pages.yml`) to the last revision actually published to GitHub Pages via the GitHub Deployments API with status verification, rather than the head SHA of the last green workflow run.

## Defect & Invariant Break (#5356)
`deploy-pages.yml` previously queried:
```
/actions/workflows/deploy-pages.yml/runs?branch=main&status=success&per_page=1
```
When a push skipped its `deploy` job due to learner-content changes, the run-level conclusion remained `success`. Subsequent push runs resolved `last_deploy_sha` to that skipped run's head commit, shifting the diff window (`last_deploy_sha..GITHUB_SHA`) forward and silently dropping the uncertified learner content from the diff.

## Chosen Mechanism & Defense
- **Primary Mechanism**: GitHub Deployments API (`GET /repos/${REPOSITORY}/deployments?environment=github-pages&per_page=20`) with deployment status verification (`GET /repos/${REPOSITORY}/deployments/${dep_id}/statuses` ensuring `state == "success"`).
- **Git Validation**: Confirms the deployment SHA exists in local history (`git cat-file -e "${dep_sha}^{commit}"`) and is an ancestor of `$GITHUB_SHA` (`git merge-base --is-ancestor "$dep_sha" "$GITHUB_SHA"`).
- **Why this is optimal**:
  1. Skipped runs never execute `actions/deploy-pages` and therefore never create deployment records under `environment: github-pages`.
  2. Requires only 1 API call to list deployments and 1 call to verify status of the latest deployment (2 calls total vs N+1 calls across skipped streaks).
  3. GitHub deployment history is preserved indefinitely for the repository lifecycle, unlike Actions workflow run/job logs which expire after 90 days.

### Rejected Alternatives
1. **Actions Workflow Runs + Jobs API (`/actions/workflows/deploy-pages.yml/runs` + `/actions/runs/{id}/jobs`)**:
   - *Rejected because*: Workflow runs API does not expose job conclusions in the top-level list. To find the last successful `deploy` job across a streak of 15 skipped runs requires 1 run list call + 15 individual job inspection API calls (N+1 query pattern), risking rate-limiting, pagination truncation, and 90-day retention log expiry.
2. **HTTP Live-Site Marker Polling (`https://learn-ukrainian.github.io/.well-known/...`)**:
   - *Rejected because*: Relies on public CDN propagation latency, DNS resolution, and cache invalidation timing; marker filenames contain dynamic SHAs rather than fixed index pointers; breaks in isolated/firewalled runner environments.
3. **Git Tag / Marker Ref Pushed on Deploy**:
   - *Rejected because*: Requires granting `contents: write` to the deployment workflow, violating the principle of least privilege (zizmor / security baseline) and introducing push conflict failure modes.

## Handling When No Prior Actual Deployment is Resolvable
When no prior deployment anchor exists (first repository run, fresh clone, or expired history):
- `last-deploy` emits an empty `sha=`.
- `classify` detects the empty SHA, sets `deploy=false` and `reason=no_prior_deployment`, and exits 0.
- `auto-deploy-eligibility` outputs `deploy: false`.
- The `deploy` job is skipped cleanly on push.

**Why this is safe in both directions:**
- **No missed deploys**: The manual certification route (`workflow_dispatch`) is always available and bypasses the auto-deploy eligibility check entirely, creating the initial deployment anchor.
- **No pointless / uncertified deploys**: A push run never assumes a clean diff without an established baseline, preventing uncertified learner content from being deployed automatically on first runs or orphaned histories.

## Tool-Backed Verification Evidence

### 1. Proof across streak of green skipped-deploy runs on 2026-08-14
Demonstrating that run-level conclusion was `success` while `deploy` job was `skipped`:
```
Run ID        Event             Created At            Run Conclusion  deploy Job Conclusion  Head SHA
---------------------------------------------------------------------------------------------------------
31867394421   push              2026-08-15T05:37:12Z  success         skipped                00d2011144
31848636275   workflow_dispatch 2026-08-14T22:58:08Z  success         success                c5a04d9799
31848619574   push              2026-08-14T22:57:52Z  success         skipped                c5a04d9799
31848169323   push              2026-08-14T22:50:35Z  success         skipped                298c10a2d2
31845790852   push              2026-08-14T22:13:53Z  success         success                20d5249477
31845043539   push              2026-08-14T22:03:04Z  success         skipped                4d393cb522
31845026101   workflow_dispatch 2026-08-14T22:02:48Z  success         success                a8156e043a
31844612666   push              2026-08-14T21:56:57Z  success         skipped                a8156e043a
31839648081   push              2026-08-14T20:49:09Z  success         skipped                d7c6f09545
31839635905   push              2026-08-14T20:49:00Z  success         skipped                61a9d32c96
31834910060   push              2026-08-14T19:48:06Z  success         skipped                a7e104c57c
31834199593   push              2026-08-14T19:38:48Z  success         skipped                b7ac07cc08
31834045982   push              2026-08-14T19:36:46Z  success         skipped                630382431c
31832685513   push              2026-08-14T19:18:45Z  success         skipped                f0c84ca92a
31831973348   push              2026-08-14T19:09:16Z  success         skipped                3406de2159
```

GitHub Deployments API query across the same period:
```bash
gh api "repos/learn-ukrainian/learn-ukrainian.github.io/deployments?environment=github-pages&per_page=6" --jq '.[] | {id: .id, sha: .sha[0:10], created_at: .created_at}'
```
Output:
```json
{"created_at":"2026-08-14T22:58:46Z","id":5914706240,"sha":"c5a04d9799"}
{"created_at":"2026-08-14T22:14:48Z","id":5914241477,"sha":"20d5249477"}
{"created_at":"2026-08-14T22:02:50Z","id":5914109163,"sha":"a8156e043a"}
{"created_at":"2026-08-14T18:19:21Z","id":5911237990,"sha":"3ded847162"}
{"created_at":"2026-08-14T16:39:05Z","id":5909850542,"sha":"6457166afc"}
{"created_at":"2026-08-14T03:10:45Z","id":5899804978,"sha":"d1fcb64e88"}
```
All skipped runs are omitted, resolving directly to the true deployment anchors.

### 2. Actionlint & Zizmor Verification
```
$ ./scripts/audit/check_workflows.sh .github/workflows/deploy-pages.yml
→ actionlint 1.7.12 on 1 workflow file(s)
✅ actionlint: all workflow files valid

$ zizmor .github/workflows/deploy-pages.yml
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/deploy-pages.yml
No findings to report. Good job! (3 suppressed)
```

### 3. Test Suite Verification
```
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_deploy_pages_workflow.py tests/test_actionlint_workflow.py tests/test_workflow_head_concurrency.py
======================== 19 passed, 2 warnings in 0.38s ========================
```

X-Agent: agy