### PR TITLE
feat(lexicon): make grow_lexicon_from_content crash-safe and resumable (#5214)

### DIFF
--- a/scripts/lexicon/grow_lexicon_from_content.py
+++ b/scripts/lexicon/grow_lexicon_from_content.py
@@ -9,12 +9,14 @@ Run from the repository root:
 from __future__ import annotations
 
 import argparse
-import copy
+import contextlib
 import json
+import os
 import sqlite3
 import sys
+import tempfile
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +31,7 @@ from scripts.lexicon.content_lexicon_reconciler import (
 from scripts.lexicon.lemma_normalization import strip_acute_stress
 
 DEFAULT_OUT = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates.json"
+DEFAULT_CHECKPOINT_INTERVAL = 10
 GENERATED_FROM = "content_lexicon_reconciler.missing_lemmas"
 _WARNING_CLASSIFICATIONS = {"russianism", "sovietism", "surzhyk"}
 _POS_PRIORITY = {
@@ -37,6 +40,59 @@ _POS_PRIORITY = {
     "adj": 2,
     "adv": 3,
 }
+
+
+def _write_atomically(path: Path, content: bytes) -> None:
+    """Write content to path atomically via a temporary file in path.parent."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+            tmp_name = tmp.name
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        if tmp_name:
+            with contextlib.suppress(FileNotFoundError):
+                Path(tmp_name).unlink()
+
+
+def _flush_caches() -> None:
+    """Flush any dirty in-memory fetch caches to disk."""
+    with suppress(Exception):
+        enrich_manifest._write_wiki_reference_cache()
+    with suppress(Exception):
+        enrich_manifest._write_grac_frequency_cache()
+
+
+def load_checkpoint(path: Path) -> dict[str, dict[str, Any]]:
+    """Load previously enriched entries from an existing candidates file.
+
+    Returns a mapping of lemma -> entry dict. If the file is missing, empty, or
+    corrupted, returns an empty mapping and logs a warning to stderr.
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            print(f"[grow_lexicon] Warning: checkpoint {path} is not a JSON object; starting fresh.", file=sys.stderr)
+            return {}
+        entries_by_lemma: dict[str, dict[str, Any]] = {}
+        for entry in data.get("auto_merge", []):
+            if isinstance(entry, dict) and "lemma" in entry:
+                entries_by_lemma[str(entry["lemma"])] = entry
+        for item in data.get("needs_review", []):
+            if isinstance(item, dict):
+                entry = item.get("entry")
+                if isinstance(entry, dict) and "lemma" in entry:
+                    entries_by_lemma[str(entry["lemma"])] = entry
+        return entries_by_lemma
+    except Exception as exc:
+        print(f"[grow_lexicon] Warning: could not load checkpoint from {path} ({exc}); starting fresh.", file=sys.stderr)
+        return {}
 
 
 def build_skeleton_entry(lemma: str) -> dict[str, Any]:
@@ -102,45 +158,123 @@ def build_payload(
     }
 
 
+def write_candidates(payload: dict[str, Any], out: Path = DEFAULT_OUT) -> None:
+    """Atomically write the candidates JSON payload to disk."""
+    content = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    _write_atomically(out, content)
+
+
+def write_checkpoint(
+    entries: Sequence[dict[str, Any]],
+    *,
+    total_delta: int,
+    limit: int | None,
+    out: Path = DEFAULT_OUT,
+) -> dict[str, Any]:
+    """Save an intermediate checkpoint atomically to disk."""
+    auto_merge, needs_review = split_candidates(entries)
+    payload = build_payload(
+        total_delta=total_delta,
+        processed=len(entries),
+        auto_merge=auto_merge,
+        needs_review=needs_review,
+        limit=limit,
+    )
+    write_candidates(payload, out)
+    _flush_caches()
+    return payload
+
+
 def generate_candidates(
     *,
     limit: int | None = None,
     out: Path = DEFAULT_OUT,
+    checkpoint_interval: int = DEFAULT_CHECKPOINT_INTERVAL,
+    resume: bool = True,
+    quiet: bool = False,
 ) -> dict[str, Any]:
-    """Generate, write, and return gated Atlas-entry candidates."""
+    """Generate, write, and return gated Atlas-entry candidates with checkpointing."""
     paths = discover_content_mdx_paths()
     result = reconcile_content(paths, manifest_path=LEXICON_MANIFEST_PATH)
     delta = _limited_delta(result.missing_lemmas, limit)
+    total_missing = len(result.missing_lemmas)
+    total_to_process = len(delta)
+
+    checkpointed = load_checkpoint(out) if resume and out.exists() else {}
+    resumed_count = 0
+    newly_enriched_count = 0
+
+    if not quiet:
+        print(
+            f"[grow_lexicon] Starting candidates generation: {total_to_process} delta items "
+            f"(total missing: {total_missing}, checkpointed: {len(checkpointed)}, interval: {checkpoint_interval})",
+            file=sys.stderr,
+        )
 
     entries: list[dict[str, Any]] = []
     kaikki_lookup = enrich_manifest._load_kaikki_lookup()
     with _source_connection(enrich_manifest.SOURCES_DB) as conn, _preserve_wiki_reference_cache():
         has_sum11_flags = enrich_manifest._sum11_has_flag_columns(conn)
-        for item in delta:
-            entry = build_skeleton_entry(item.lemma)
-            enrich_manifest.enrich_entry(
-                entry,
-                conn,
-                kaikki_lookup,
-                has_sum11_flags=has_sum11_flags,
-            )
-            entries.append(entry)
+        for idx, item in enumerate(delta, start=1):
+            if resume and item.lemma in checkpointed:
+                entry = checkpointed[item.lemma]
+                entries.append(entry)
+                resumed_count += 1
+                if not quiet and (
+                    idx % max(1, checkpoint_interval) == 0 or idx == total_to_process
+                ):
+                    print(
+                        f"[grow_lexicon] [{idx}/{total_to_process}] lemma='{item.lemma}' (resumed, total_resumed={resumed_count}, newly_enriched={newly_enriched_count})",
+                        file=sys.stderr,
+                    )
+            else:
+                entry = build_skeleton_entry(item.lemma)
+                enrich_manifest.enrich_entry(
+                    entry,
+                    conn,
+                    kaikki_lookup,
+                    has_sum11_flags=has_sum11_flags,
+                )
+                entries.append(entry)
+                newly_enriched_count += 1
+                if not quiet and (
+                    idx % max(1, checkpoint_interval) == 0 or idx == total_to_process
+                ):
+                    print(
+                        f"[grow_lexicon] [{idx}/{total_to_process}] lemma='{item.lemma}' (enriched, total_resumed={resumed_count}, newly_enriched={newly_enriched_count})",
+                        file=sys.stderr,
+                    )
+                if checkpoint_interval > 0 and newly_enriched_count % checkpoint_interval == 0:
+                    write_checkpoint(
+                        entries,
+                        total_delta=total_missing,
+                        limit=limit,
+                        out=out,
+                    )
+                    if not quiet:
+                        print(
+                            f"[grow_lexicon] Checkpoint saved: {len(entries)} items ({newly_enriched_count} newly enriched) -> {out}",
+                            file=sys.stderr,
+                        )
 
     auto_merge, needs_review = split_candidates(entries)
     payload = build_payload(
-        total_delta=len(result.missing_lemmas),
+        total_delta=total_missing,
         processed=len(delta),
         auto_merge=auto_merge,
         needs_review=needs_review,
         limit=limit,
     )
     write_candidates(payload, out)
+    _flush_caches()
+    if not quiet:
+        print(
+            f"[grow_lexicon] Completed: {len(entries)} items written to {out} "
+            f"({resumed_count} resumed, {newly_enriched_count} newly enriched; "
+            f"auto_merge={len(auto_merge)}, needs_review={len(needs_review)})",
+            file=sys.stderr,
+        )
     return payload
-
-
-def write_candidates(payload: dict[str, Any], out: Path = DEFAULT_OUT) -> None:
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def format_report(payload: dict[str, Any]) -> str:
@@ -165,6 +299,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"Candidate JSON output path (default: {DEFAULT_OUT.relative_to(PROJECT_ROOT)})",
     )
     parser.add_argument("--report", action="store_true", help="Print candidate bucket counts")
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=DEFAULT_CHECKPOINT_INTERVAL,
+        help=f"Periodic checkpoint interval in lemmas (default: {DEFAULT_CHECKPOINT_INTERVAL})",
+    )
+    parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Do not resume from existing candidates file, start fresh",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress stderr progress heartbeat",
+    )
     return parser
 
 
@@ -173,9 +323,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit < 0:
         parser.error("--limit must be non-negative")
+    if args.checkpoint_interval < 0:
+        parser.error("--checkpoint-interval must be non-negative")
 
     try:
-        payload = generate_candidates(limit=args.limit, out=args.out)
+        payload = generate_candidates(
+            limit=args.limit,
+            out=args.out,
+            checkpoint_interval=args.checkpoint_interval,
+            resume=not args.no_resume,
+            quiet=args.quiet,
+        )
     except FileNotFoundError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -227,20 +385,11 @@ def _vesum_pos(lemma: str) -> str | None:
 
 @contextmanager
 def _preserve_wiki_reference_cache() -> Iterator[None]:
-    path = enrich_manifest.WIKI_REFERENCE_CACHE
-    original_bytes = path.read_bytes() if path.exists() else None
-    original_data = copy.deepcopy(enrich_manifest._WIKI_REFERENCE_CACHE_DATA)
-    original_dirty = enrich_manifest._WIKI_REFERENCE_CACHE_DIRTY
+    """Maintain cache persistence across runs and flush dirty caches on exit."""
     try:
         yield
     finally:
-        if original_bytes is None:
-            path.unlink(missing_ok=True)
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(original_bytes)
-        enrich_manifest._WIKI_REFERENCE_CACHE_DATA = original_data
-        enrich_manifest._WIKI_REFERENCE_CACHE_DIRTY = original_dirty
+        _flush_caches()
 
 
 def _has_dictionary_definition(entry: dict[str, Any]) -> bool:
@@ -283,3 +432,4 @@ def _heritage_review_reasons(status: dict[str, Any]) -> list[str]:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -135,7 +135,7 @@
       },
       {
         "path": "scripts/lexicon/grow_lexicon_from_content.py",
-        "sha256": "3ebbbc8c379784a5c10b261a72a10c895a1f4308027ce3c85e49dabf0de347fb"
+        "sha256": "4ffc2ba63f72f01843fc09204fb1fe7ad3f50a989c30e47fe9fefd9dc92bf487"
       },
       {
         "path": "scripts/lexicon/heritage_calque_wave.py",

--- a/tests/test_grow_lexicon_from_content.py
+++ b/tests/test_grow_lexicon_from_content.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import sqlite3
-from contextlib import nullcontext
+from contextlib import nullcontext, suppress
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -170,22 +170,249 @@ def test_generate_candidates_writes_expected_json_shape(tmp_path, monkeypatch) -
     assert written["needs_review"][0]["reason"] == "missing dictionary definition"
 
 
-def test_wiki_reference_cache_is_preserved(tmp_path, monkeypatch) -> None:
+def test_wiki_reference_cache_persists_across_runs(tmp_path, monkeypatch) -> None:
     cache = tmp_path / "wiki_reference.json"
-    original = '{"старий": null}\n'
-    cache.write_text(original, encoding="utf-8")
+    cache.write_text('{"старий": null}\n', encoding="utf-8")
     monkeypatch.setattr(grow.enrich_manifest, "WIKI_REFERENCE_CACHE", cache)
-    monkeypatch.setattr(grow.enrich_manifest, "_WIKI_REFERENCE_CACHE_DATA", {"старий": None})
-    monkeypatch.setattr(grow.enrich_manifest, "_WIKI_REFERENCE_CACHE_DIRTY", False)
+    monkeypatch.setattr(grow.enrich_manifest, "_WIKI_REFERENCE_CACHE_DATA", {"старий": None, "новий": {"title": "Новий"}})
+    monkeypatch.setattr(grow.enrich_manifest, "_WIKI_REFERENCE_CACHE_DIRTY", True)
 
     with grow._preserve_wiki_reference_cache():
-        cache.write_text('{"новий": null}\n', encoding="utf-8")
-        grow.enrich_manifest._WIKI_REFERENCE_CACHE_DATA = {"новий": None}
-        grow.enrich_manifest._WIKI_REFERENCE_CACHE_DIRTY = True
+        pass
 
-    assert cache.read_text(encoding="utf-8") == original
-    assert grow.enrich_manifest._WIKI_REFERENCE_CACHE_DATA == {"старий": None}
+    saved = json.loads(cache.read_text(encoding="utf-8"))
+    assert "новий" in saved
+    assert saved["новий"]["title"] == "Новий"
     assert grow.enrich_manifest._WIKI_REFERENCE_CACHE_DIRTY is False
+
+
+def test_load_checkpoint_handles_missing_corrupt_and_valid_payloads(tmp_path) -> None:
+    non_existent = tmp_path / "non_existent.json"
+    assert grow.load_checkpoint(non_existent) == {}
+
+    corrupted = tmp_path / "corrupted.json"
+    corrupted.write_text("{not-valid-json", encoding="utf-8")
+    assert grow.load_checkpoint(corrupted) == {}
+
+    not_dict = tmp_path / "not_dict.json"
+    not_dict.write_text("[\"item1\", \"item2\"]", encoding="utf-8")
+    assert grow.load_checkpoint(not_dict) == {}
+
+    valid = tmp_path / "valid.json"
+    valid_payload = {
+        "auto_merge": [{"lemma": "сонце", "pos": "noun"}],
+        "needs_review": [{"entry": {"lemma": "зірка", "pos": "noun"}, "reason": "missing dictionary definition"}],
+    }
+    valid.write_text(json.dumps(valid_payload), encoding="utf-8")
+    loaded = grow.load_checkpoint(valid)
+    assert len(loaded) == 2
+    assert loaded["сонце"]["lemma"] == "сонце"
+    assert loaded["зірка"]["lemma"] == "зірка"
+
+
+def test_write_candidates_is_atomic_and_does_not_corrupt_on_failure(tmp_path, monkeypatch) -> None:
+    out = tmp_path / "target.json"
+    initial_content = '{"initial": "safe"}\n'
+    out.write_text(initial_content, encoding="utf-8")
+
+    def failing_fsync(fd):
+        raise OSError("Simulated disk error during fsync")
+
+    monkeypatch.setattr(grow.os, "fsync", failing_fsync)
+
+    with suppress(OSError):
+        grow.write_candidates({"updated": "data"}, out=out)
+
+    # The original file must remain intact and uncorrupted
+    assert out.read_text(encoding="utf-8") == initial_content
+
+
+def test_kill_and_resume_preserves_completed_work_and_avoids_refetching(tmp_path, monkeypatch) -> None:
+    missing = (
+        LemmaExample("авто", "авто", tmp_path / "a.mdx"),
+        LemmaExample("мама", "мама", tmp_path / "b.mdx"),
+        LemmaExample("сонце", "сонце", tmp_path / "c.mdx"),
+        LemmaExample("книга", "книга", tmp_path / "d.mdx"),
+    )
+    result = SimpleNamespace(missing_lemmas=missing)
+    out = tmp_path / "grow_candidates.json"
+
+    monkeypatch.setattr(grow, "discover_content_mdx_paths", lambda: [tmp_path / "a.mdx"])
+    monkeypatch.setattr(grow, "reconcile_content", lambda paths, *, manifest_path: result)
+    monkeypatch.setattr(grow, "_source_connection", lambda path: nullcontext(object()))
+    monkeypatch.setattr(grow.enrich_manifest, "_load_kaikki_lookup", lambda: {})
+    monkeypatch.setattr(grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
+    monkeypatch.setattr(grow, "build_skeleton_entry", lambda lemma: {"lemma": lemma, "pos": "noun"})
+
+    enriched_lemmas: list[str] = []
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
+        lemma = entry["lemma"]
+        enriched_lemmas.append(lemma)
+        entry["heritage_status"] = {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+        }
+        entry["enrichment"] = {
+            "meaning": {
+                "definitions": [f"definition for {lemma}"],
+                "source": "fixture",
+            }
+        }
+        # Simulate a crash on the 3rd lemma after the 2-item checkpoint has been written
+        if lemma == "сонце" and not hasattr(fake_enrich_entry, "run2"):
+            raise KeyboardInterrupt("Simulated mid-run interruption")
+        return True
+
+    monkeypatch.setattr(grow.enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    # --- Run 1: Interrupted mid-way ---
+    with suppress(KeyboardInterrupt):
+        grow.generate_candidates(limit=4, out=out, checkpoint_interval=2, resume=True, quiet=True)
+
+    # In run 1, "авто" and "мама" completed and "сонце" was interrupted
+    assert enriched_lemmas == ["авто", "мама", "сонце"]
+    # Checkpoint must have been saved at checkpoint_interval=2 containing "авто" and "мама"
+    assert out.exists()
+    checkpoint_payload = json.loads(out.read_text(encoding="utf-8"))
+    assert checkpoint_payload["counts"]["processed"] == 2
+    assert [e["lemma"] for e in checkpoint_payload["auto_merge"]] == ["авто", "мама"]
+
+    # --- Run 2: Resumed ---
+    fake_enrich_entry.run2 = True  # type: ignore[attr-defined]
+    run2_enriched: list[str] = []
+
+    def fake_enrich_entry_run2(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
+        lemma = entry["lemma"]
+        run2_enriched.append(lemma)
+        entry["heritage_status"] = {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+        }
+        entry["enrichment"] = {
+            "meaning": {
+                "definitions": [f"definition for {lemma}"],
+                "source": "fixture",
+            }
+        }
+        return True
+
+    monkeypatch.setattr(grow.enrich_manifest, "enrich_entry", fake_enrich_entry_run2)
+
+    payload2 = grow.generate_candidates(limit=4, out=out, checkpoint_interval=2, resume=True, quiet=True)
+
+    # Verify that run 2 ONLY enriched "сонце" and "книга", NOT "авто" or "мама"!
+    assert run2_enriched == ["сонце", "книга"]
+    assert payload2["counts"]["processed"] == 4
+    assert [e["lemma"] for e in payload2["auto_merge"]] == ["авто", "мама", "сонце", "книга"]
+
+
+def test_no_resume_flag_starts_fresh_and_reenriches_all(tmp_path, monkeypatch) -> None:
+    missing = (
+        LemmaExample("авто", "авто", tmp_path / "a.mdx"),
+        LemmaExample("мама", "мама", tmp_path / "b.mdx"),
+    )
+    result = SimpleNamespace(missing_lemmas=missing)
+    out = tmp_path / "grow_candidates.json"
+
+    # Pre-seed checkpoint
+    preseeded_payload = {
+        "generated_from": grow.GENERATED_FROM,
+        "counts": {"total_delta": 2, "processed": 1, "auto_merge": 1, "needs_review": 0},
+        "limit": 2,
+        "auto_merge": [{"lemma": "авто", "pos": "noun", "enrichment": {"meaning": {"definitions": ["car"]}}}],
+        "needs_review": [],
+    }
+    out.write_text(json.dumps(preseeded_payload), encoding="utf-8")
+
+    monkeypatch.setattr(grow, "discover_content_mdx_paths", lambda: [tmp_path / "a.mdx"])
+    monkeypatch.setattr(grow, "reconcile_content", lambda paths, *, manifest_path: result)
+    monkeypatch.setattr(grow, "_source_connection", lambda path: nullcontext(object()))
+    monkeypatch.setattr(grow.enrich_manifest, "_load_kaikki_lookup", lambda: {})
+    monkeypatch.setattr(grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
+    monkeypatch.setattr(grow, "build_skeleton_entry", lambda lemma: {"lemma": lemma, "pos": "noun"})
+
+    enriched_lemmas: list[str] = []
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
+        lemma = entry["lemma"]
+        enriched_lemmas.append(lemma)
+        entry["heritage_status"] = {"classification": "standard", "is_russianism": False, "russian_shadow": False}
+        entry["enrichment"] = {"meaning": {"definitions": [f"def {lemma}"]}}
+        return True
+
+    monkeypatch.setattr(grow.enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    payload = grow.generate_candidates(limit=2, out=out, resume=False, quiet=True)
+    # Both lemmas should have been re-enriched because resume=False
+    assert enriched_lemmas == ["авто", "мама"]
+    assert payload["counts"]["processed"] == 2
+
+
+def test_checkpoint_interval_saves_periodically(tmp_path, monkeypatch) -> None:
+    missing = tuple(LemmaExample(f"w{i}", f"w{i}", tmp_path / "a.mdx") for i in range(10))
+    result = SimpleNamespace(missing_lemmas=missing)
+    out = tmp_path / "grow_candidates.json"
+
+    monkeypatch.setattr(grow, "discover_content_mdx_paths", lambda: [tmp_path / "a.mdx"])
+    monkeypatch.setattr(grow, "reconcile_content", lambda paths, *, manifest_path: result)
+    monkeypatch.setattr(grow, "_source_connection", lambda path: nullcontext(object()))
+    monkeypatch.setattr(grow.enrich_manifest, "_load_kaikki_lookup", lambda: {})
+    monkeypatch.setattr(grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
+    monkeypatch.setattr(grow, "build_skeleton_entry", lambda lemma: {"lemma": lemma, "pos": "noun"})
+
+    checkpoints: list[int] = []
+    real_write_checkpoint = grow.write_checkpoint
+
+    def tracking_write_checkpoint(entries, *, total_delta, limit, out):
+        checkpoints.append(len(entries))
+        return real_write_checkpoint(entries, total_delta=total_delta, limit=limit, out=out)
+
+    monkeypatch.setattr(grow, "write_checkpoint", tracking_write_checkpoint)
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
+        entry["heritage_status"] = {"classification": "standard", "is_russianism": False, "russian_shadow": False}
+        entry["enrichment"] = {"meaning": {"definitions": [f"def {entry['lemma']}"]}}
+        return True
+
+    monkeypatch.setattr(grow.enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    payload = grow.generate_candidates(limit=10, out=out, checkpoint_interval=3, quiet=True)
+
+    # With 10 items and interval=3, checkpoints should be triggered at 3, 6, and 9 items
+    assert checkpoints == [3, 6, 9]
+    assert payload["counts"]["processed"] == 10
+    # Final file has all 10 items
+    assert len(json.loads(out.read_text(encoding="utf-8"))["auto_merge"]) == 10
+
+
+def test_cli_parsing_and_main(tmp_path, monkeypatch, capsys) -> None:
+    out = tmp_path / "out.json"
+    called_kwargs: dict[str, object] = {}
+
+    def fake_generate_candidates(**kwargs):
+        called_kwargs.update(kwargs)
+        return {
+            "counts": {"total_delta": 5, "processed": 5, "auto_merge": 3, "needs_review": 2},
+            "auto_merge": [],
+            "needs_review": [],
+        }
+
+    monkeypatch.setattr(grow, "generate_candidates", fake_generate_candidates)
+
+    exit_code = grow.main(["--limit", "5", "--out", str(out), "--checkpoint-interval", "2", "--no-resume", "--report", "--quiet"])
+    assert exit_code == 0
+    assert called_kwargs["limit"] == 5
+    assert called_kwargs["out"] == out
+    assert called_kwargs["checkpoint_interval"] == 2
+    assert called_kwargs["resume"] is False
+    assert called_kwargs["quiet"] is True
+
+    captured = capsys.readouterr()
+    assert "total_delta: 5" in captured.out
+    assert "processed: 5" in captured.out
 
 
 def test_enrich_entry_exists_and_enrich_delegates_to_it() -> None:


### PR DESCRIPTION
## Summary
Closes #5214.

Previously, 11+ hour runs of `grow_lexicon_from_content` lost all accumulated progress if interrupted (single terminal write), and fetch caches were reverted on exit in `_preserve_wiki_reference_cache()`, forcing restarts to re-fetch from zero.

This PR makes candidate growth durable and resumable:
1. **Periodic atomic checkpointing**: Intermediate candidate payloads are saved every `--checkpoint-interval` (default 10) lemmas using atomic tempfile replace (`_write_atomically`), so a crash during write never corrupts previous checkpoints.
2. **Crash-safe resume**: On startup, `grow_lexicon_from_content` loads existing checkpointed entries from `--out` and reuses them without re-calling `enrich_entry` for already-processed lemmas.
3. **Persistent fetch caching**: Removes the `finally` cache reversion so newly fetched Wikipedia, Slovnyk, and GRAC cache entries persist on disk across runs.
4. **Progress visibility**: Added informative stderr progress logging with heartbeat updates every checkpoint interval.
5. **Rejected alternative**: Considered using an append-only JSONL sidecar / SQLite checkpoint database, but rejected it because it introduces secondary file drift, requires an extra compaction step, and complicates downstream consumers (`promote_grow_candidates.py`, `triage_needs_review.py`, CI workflows) which already expect the canonical JSON schema at `--out`. By writing the canonical payload atomically at each interval, `--out` remains 100% valid and self-contained at any point during or after a run.

## Verification
- Kill-resume test: verified on a multi-lemma fixture that an interrupted run saves checkpointed entries and the resumed run skips already-processed lemmas.
- Atomic write test: verified that simulated write failures do not corrupt existing checkpoint files.
- Mutation checks: verified that disabling checkpoint loading or using direct non-atomic writes fails guard tests.
- All test suites green: `pytest tests/test_grow_lexicon_from_content.py tests/test_grow_lexicon_from_sources.py tests/test_grow_lexicon_from_lemmas.py tests/test_promote_grow_candidates.py`
- Linter clean: `ruff check scripts/lexicon/grow_lexicon_from_content.py tests/test_grow_lexicon_from_content.py`