### PR TITLE
test(bridge): standardize on scripts.ai_agent_bridge identity (#6812)

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -171,7 +171,10 @@ class DeepSeekAdapter:
         rate_limited = bool(_RATE_LIMIT_RE.search(f"{stderr or ''}\n{stdout or ''}"))
         text = _extract_text_from_stdout(stdout)
 
-        from ai_agent_bridge._opencode import read_opencode_turn_status
+        try:
+            from scripts.ai_agent_bridge._opencode import read_opencode_turn_status
+        except ModuleNotFoundError:  # pragma: no cover - direct-script runs with only scripts/ on sys.path
+            from ai_agent_bridge._opencode import read_opencode_turn_status
 
         cwd = plan.cwd if plan is not None else None
         turn_status = read_opencode_turn_status(stdout, cwd=cwd)

--- a/scripts/agent_runtime/adapters/glm.py
+++ b/scripts/agent_runtime/adapters/glm.py
@@ -165,7 +165,10 @@ class GlmAdapter:
         rate_limited = bool(_RATE_LIMIT_RE.search(f"{stderr or ''}\n{stdout or ''}"))
         text = _extract_text_from_stdout(stdout)
 
-        from ai_agent_bridge._opencode import read_opencode_turn_status
+        try:
+            from scripts.ai_agent_bridge._opencode import read_opencode_turn_status
+        except ModuleNotFoundError:  # pragma: no cover - direct-script runs with only scripts/ on sys.path
+            from ai_agent_bridge._opencode import read_opencode_turn_status
 
         cwd = plan.cwd if plan is not None else None
         turn_status = read_opencode_turn_status(stdout, cwd=cwd)

--- a/scripts/ai_agent_bridge/_ui_agy.py
+++ b/scripts/ai_agent_bridge/_ui_agy.py
@@ -46,7 +46,10 @@ result's `thread_id` is then parsed from the agy log file.
 
 ## Usage from Python
 
-    from scripts.ai_agent_bridge._ui_agy import send
+From outside the package (tests, tools), import `send` from the module
+`scripts.ai_agent_bridge._ui_agy`; from inside the package, siblings use
+the relative form (`from ._ui_agy import send`):
+
     result = send(thread_id="48fd721e-...", message="ping", cwd=Path("/tmp"))
     print(result["final_message"])
 """

--- a/scripts/ai_agent_bridge/_ui_agy.py
+++ b/scripts/ai_agent_bridge/_ui_agy.py
@@ -46,7 +46,7 @@ result's `thread_id` is then parsed from the agy log file.
 
 ## Usage from Python
 
-    from ai_agent_bridge._ui_agy import send
+    from scripts.ai_agent_bridge._ui_agy import send
     result = send(thread_id="48fd721e-...", message="ping", cwd=Path("/tmp"))
     print(result["final_message"])
 """

--- a/scripts/ai_agent_bridge/_ui_codex.py
+++ b/scripts/ai_agent_bridge/_ui_codex.py
@@ -39,7 +39,7 @@ Observed behavior:
 
 ## Usage from Python
 
-    from ai_agent_bridge._ui_codex import send
+    from scripts.ai_agent_bridge._ui_codex import send
     result = send(thread_id="019e6063-...", message="ping", cwd=Path("/tmp"))
     print(result["final_message"])
 """

--- a/scripts/ai_agent_bridge/_ui_codex.py
+++ b/scripts/ai_agent_bridge/_ui_codex.py
@@ -39,7 +39,10 @@ Observed behavior:
 
 ## Usage from Python
 
-    from scripts.ai_agent_bridge._ui_codex import send
+From outside the package (tests, tools), import `send` from the module
+`scripts.ai_agent_bridge._ui_codex`; from inside the package, siblings use
+the relative form (`from ._ui_codex import send`):
+
     result = send(thread_id="019e6063-...", message="ping", cwd=Path("/tmp"))
     print(result["final_message"])
 """

--- a/scripts/tools/agent_watcher.py
+++ b/scripts/tools/agent_watcher.py
@@ -39,8 +39,10 @@ from pathlib import Path
 
 import yaml
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from ai_agent_bridge._env import build_agent_env
+# Canonical module identity (#6812): repo root on sys.path, never the bare
+# ``ai_agent_bridge`` identity (a second sys.modules entry with divergent state).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+from scripts.ai_agent_bridge._env import build_agent_env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -9,8 +9,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.adapters.claude import ClaudeAdapter
-from ai_agent_bridge import _channels, _channels_cli, _cli, _db
-from ai_agent_bridge._acp_compat import _discussion_failure_metadata, _failure_metadata
+
+from scripts.ai_agent_bridge import _channels, _channels_cli, _cli, _db
+from scripts.ai_agent_bridge._acp_compat import _discussion_failure_metadata, _failure_metadata
 
 
 def _clear_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -34,7 +35,7 @@ def test_discuss_round_four_prompt_preserves_root_and_all_thread_replies(
     """
     # Patch both bindings — ``_db`` imports DB_PATH from ``_config`` by
     # name, so they are independent (#5247 xdist leak class).
-    from ai_agent_bridge import _config
+    from scripts.ai_agent_bridge import _config
 
     db_path = tmp_path / "bridge.db"
     monkeypatch.setattr(_config, "DB_PATH", db_path)
@@ -170,7 +171,7 @@ def test_ask_codex_infers_from_claude_agent_name(
         captured["from_llm"] = kwargs["source"]
         return SimpleNamespace(ok=True, response="ok", transport_outcome="ok")
 
-    monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
+    monkeypatch.setattr("scripts.ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
     parser = _cli._build_parser()
     args = parser.parse_args(["ask-codex", "hello", "--task-id", "task-1"])
 
@@ -202,7 +203,7 @@ def test_ask_gemini_shim_routes_to_agy_with_mapped_model(
         captured.update(target=target, content=content, **kwargs)
         return SimpleNamespace(ok=True, response="ok", transport_outcome="ok")
 
-    monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
+    monkeypatch.setattr("scripts.ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
     parser = _cli._build_parser()
     args = parser.parse_args(
         [

--- a/tests/ai_agent_bridge/test_agy_model_selection.py
+++ b/tests/ai_agent_bridge/test_agy_model_selection.py
@@ -18,9 +18,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.result import Result
-from ai_agent_bridge._agy import _extract_target_model, process_for_agy
-from ai_agent_bridge._config import REPO_ROOT
-from ai_agent_bridge._review_worktree import (
+
+from scripts.ai_agent_bridge._agy import _extract_target_model, process_for_agy
+from scripts.ai_agent_bridge._config import REPO_ROOT
+from scripts.ai_agent_bridge._review_worktree import (
     ProvisionedReviewWorktree,
     ReviewIsolationEvidenceBinder,
 )
@@ -69,10 +70,10 @@ def test_agy_bridge_records_unsandboxed_repo_read_mode(monkeypatch):
     }
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr("ai_agent_bridge._agy._fetch_agy_message", lambda _id: msg)
-    monkeypatch.setattr("ai_agent_bridge._agy.acknowledge", lambda _id: None)
-    monkeypatch.setattr("ai_agent_bridge._agy.send_message", lambda **_kwargs: 9)
-    monkeypatch.setattr("ai_agent_bridge._agy.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy._fetch_agy_message", lambda _id: msg)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.acknowledge", lambda _id: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.send_message", lambda **_kwargs: 9)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.record_ask_reply", lambda *_args: None)
 
     def fake_invoke(*_args, **kwargs):
         captured.update(kwargs)
@@ -91,7 +92,7 @@ def test_agy_bridge_records_unsandboxed_repo_read_mode(monkeypatch):
             usage_record={},
         )
 
-    monkeypatch.setattr("ai_agent_bridge._agy.agent_runner.invoke", fake_invoke)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.agent_runner.invoke", fake_invoke)
 
     assert process_for_agy(8, stdout_only=True) == "reply"
     assert captured["mode"] == "danger"
@@ -135,18 +136,18 @@ def test_agy_branch_review_fails_closed_until_native_isolation_exists(monkeypatc
     def fake_checkout(*_args, **_kwargs):
         yield checkout
 
-    monkeypatch.setattr("ai_agent_bridge._agy._fetch_agy_message", lambda _id: msg)
-    monkeypatch.setattr("ai_agent_bridge._agy.provision_review_worktree", fake_checkout)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy._fetch_agy_message", lambda _id: msg)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.provision_review_worktree", fake_checkout)
     monkeypatch.setattr(
         ProvisionedReviewWorktree,
         "review_prompt_evidence",
         lambda self, engine: "\nSEALED_DOSSIER",
     )
-    monkeypatch.setattr("ai_agent_bridge._agy.acknowledge", lambda _id: None)
-    monkeypatch.setattr("ai_agent_bridge._agy.send_message", lambda **_kwargs: 10)
-    monkeypatch.setattr("ai_agent_bridge._agy.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.acknowledge", lambda _id: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.record_ask_reply", lambda *_args: None)
     monkeypatch.setattr(
-        "ai_agent_bridge._agy.agent_runner.invoke",
+        "scripts.ai_agent_bridge._agy.agent_runner.invoke",
         lambda *args, **kwargs: (
             captured.update({"prompt": args[1], **kwargs})
             or Result(

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -13,8 +13,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from ai_agent_bridge import _acp_compat, _cli
-from ai_agent_bridge._ask_contract import (
+from scripts.ai_agent_bridge import _acp_compat, _cli
+from scripts.ai_agent_bridge._ask_contract import (
     EFFORT_CHOICES,
     failed_response_provenance,
     resolve_model_selection,
@@ -158,7 +158,7 @@ def test_terminalization_conflict_preserves_completed_provider_response(
     output_path = tmp_path / "response.txt"
     monkeypatch.setattr("scripts.fleet_comms.authority.AuthorityService", TerminalConflictAuthority)
     monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
-    monkeypatch.setattr("ai_agent_bridge._acp_execution.acp_execution_cwd", execution_cwd)
+    monkeypatch.setattr("scripts.ai_agent_bridge._acp_execution.acp_execution_cwd", execution_cwd)
 
     with pytest.raises(RuntimeError, match="terminal bookkeeping failed after provider response"):
         _acp_compat._run_compat_ask_impl(
@@ -417,9 +417,9 @@ def test_acp_failed_result_receipt_serializes_none_effort_as_unapplied() -> None
 
 def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> None:
     """Native grok ask prompt includes NATIVE_ASK_TOOL_CONTRACT when not review-provisioned; absent on review-provisioned, reverted builders, and full drivers (#5893)."""
-    from ai_agent_bridge._ask_contract import NATIVE_ASK_TOOL_CONTRACT
-    from ai_agent_bridge._grok_build import _build_grok_build_prompt
-    from ai_agent_bridge._prompts import (
+    from scripts.ai_agent_bridge._ask_contract import NATIVE_ASK_TOOL_CONTRACT
+    from scripts.ai_agent_bridge._grok_build import _build_grok_build_prompt
+    from scripts.ai_agent_bridge._prompts import (
         _build_full_execution_prompt,
         build_agy_prompt,
         build_claude_prompt,

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -11,20 +11,20 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from ai_agent_bridge import _ask_lifecycle as lifecycle
-from ai_agent_bridge._agy import ask_agy
-from ai_agent_bridge._cli import _build_parser
-from ai_agent_bridge._db import get_db, init_db
-from ai_agent_bridge._messaging import send_message
+from scripts.ai_agent_bridge import _ask_lifecycle as lifecycle
+from scripts.ai_agent_bridge._agy import ask_agy
+from scripts.ai_agent_bridge._cli import _build_parser
+from scripts.ai_agent_bridge._db import get_db, init_db
+from scripts.ai_agent_bridge._messaging import send_message
 
 
 @pytest.fixture
 def bridge_db(tmp_path, monkeypatch):
     db_path = tmp_path / "messages.db"
-    monkeypatch.setattr("ai_agent_bridge._config.DB_PATH", db_path)
-    monkeypatch.setattr("ai_agent_bridge._db.DB_PATH", db_path)
+    monkeypatch.setattr("scripts.ai_agent_bridge._config.DB_PATH", db_path)
+    monkeypatch.setattr("scripts.ai_agent_bridge._db.DB_PATH", db_path)
     monkeypatch.setattr(lifecycle, "PID_DIR", tmp_path / "pids")
-    monkeypatch.setattr("ai_agent_bridge._broker.PID_DIR", tmp_path / "pids")
+    monkeypatch.setattr("scripts.ai_agent_bridge._broker.PID_DIR", tmp_path / "pids")
     conn = init_db()
     conn.close()
     return db_path
@@ -55,7 +55,7 @@ def _status(message_id: int) -> str:
 
 def test_background_ask_sends_immediately_and_mocks_detached_spawn(bridge_db, monkeypatch):
     spawn = Mock(return_value=4321)
-    monkeypatch.setattr("ai_agent_bridge._agy.launch_background_ask", spawn)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.launch_background_ask", spawn)
 
     message_id = ask_agy("Read one file", task_id="task-4837", background=True)
 
@@ -75,7 +75,7 @@ def test_background_ask_sends_immediately_and_mocks_detached_spawn(bridge_db, mo
 def test_background_branch_review_agy_refuses_sealed_cf(bridge_db, monkeypatch):
     """AGY sealed formal review is fail-closed before send (#5553 / #5555)."""
     spawn = Mock(return_value=4321)
-    monkeypatch.setattr("ai_agent_bridge._agy.launch_background_ask", spawn)
+    monkeypatch.setattr("scripts.ai_agent_bridge._agy.launch_background_ask", spawn)
 
     with pytest.raises(ValueError, match="agy_isolated_review_unsupported"):
         ask_agy(
@@ -430,9 +430,9 @@ def test_ask_reply_remains_unacked_for_requester(bridge_db, monkeypatch):
         model="claude-sonnet-5",
         effort=None,
     )
-    monkeypatch.setattr("ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
+    monkeypatch.setattr("scripts.ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
 
-    from ai_agent_bridge._claude import process_for_claude
+    from scripts.ai_agent_bridge._claude import process_for_claude
 
     process_for_claude(ask_id)
 
@@ -473,7 +473,7 @@ def test_background_ask_reply_remains_unacked_for_requester(bridge_db, monkeypat
         model="claude-sonnet-5",
         effort=None,
     )
-    monkeypatch.setattr("ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
+    monkeypatch.setattr("scripts.ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
     monkeypatch.setattr(lifecycle, "_background_options", lambda *_args: {})
 
     lifecycle.process_background_ask(ask_id, "claude")
@@ -767,7 +767,7 @@ def test_atomic_retry_claim_prevents_concurrent_refire(bridge_db, monkeypatch, t
 
 def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypatch, tmp_path):
     """A native Grok turn ending in permission_cancelled auto-retries once with refusal reason (#5893)."""
-    from ai_agent_bridge import _grok_build
+    from scripts.ai_agent_bridge import _grok_build
 
     monkeypatch.setattr(_grok_build, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
@@ -813,8 +813,8 @@ def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypat
 
 def test_cancel_and_retell_composes_with_watchdog_within_bound(bridge_db, monkeypatch, tmp_path):
     """Total automatic re-fires for one ask never exceed MAX_TOTAL_ASK_RETRIES = 2 (#5893)."""
-    from ai_agent_bridge import _grok_build
-    from ai_agent_bridge._ask_contract import MAX_TOTAL_ASK_RETRIES
+    from scripts.ai_agent_bridge import _grok_build
+    from scripts.ai_agent_bridge._ask_contract import MAX_TOTAL_ASK_RETRIES
 
     assert MAX_TOTAL_ASK_RETRIES == 2
 
@@ -838,10 +838,10 @@ def test_cancel_and_retell_composes_with_watchdog_within_bound(bridge_db, monkey
 
 def test_asks_cli_watchdog_flag(bridge_db, monkeypatch, capsys):
     """asks --watchdog executes watchdog and lists asks."""
-    from ai_agent_bridge import _cli
+    from scripts.ai_agent_bridge import _cli
 
     watchdog_mock = Mock(return_value=[])
-    monkeypatch.setattr("ai_agent_bridge._ask_lifecycle.run_ask_watchdog", watchdog_mock)
+    monkeypatch.setattr("scripts.ai_agent_bridge._ask_lifecycle.run_ask_watchdog", watchdog_mock)
 
     args = _cli._build_parser().parse_args(["asks", "--watchdog"])
     _cli._dispatch_command(args)

--- a/tests/ai_agent_bridge/test_ask_worker_startup.py
+++ b/tests/ai_agent_bridge/test_ask_worker_startup.py
@@ -22,7 +22,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from ai_agent_bridge import _ask_lifecycle as lifecycle
+from scripts.ai_agent_bridge import _ask_lifecycle as lifecycle
 
 
 class _FakeProc:

--- a/tests/ai_agent_bridge/test_claude_review_worktree.py
+++ b/tests/ai_agent_bridge/test_claude_review_worktree.py
@@ -8,8 +8,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.result import Result
-from ai_agent_bridge import _claude
-from ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
+
+from scripts.ai_agent_bridge import _claude
+from scripts.ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
 def test_claude_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):

--- a/tests/ai_agent_bridge/test_hermes_review_isolation.py
+++ b/tests/ai_agent_bridge/test_hermes_review_isolation.py
@@ -8,8 +8,9 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from ai_agent_bridge import _hermes as hermes
-from ai_agent_bridge import _review_safety as safety
+
+from scripts.ai_agent_bridge import _hermes as hermes
+from scripts.ai_agent_bridge import _review_safety as safety
 
 
 @pytest.fixture()

--- a/tests/ai_agent_bridge/test_inbox_watch.py
+++ b/tests/ai_agent_bridge/test_inbox_watch.py
@@ -11,14 +11,14 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from ai_agent_bridge import _db, _inbox_watch, _messaging
+from scripts.ai_agent_bridge import _db, _inbox_watch, _messaging
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path: Path):
     """Create an isolated broker database with the current messages schema."""
     db_path = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_path), patch("ai_agent_bridge._db.DB_PATH", db_path):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_path), patch("scripts.ai_agent_bridge._db.DB_PATH", db_path):
         _db.init_db().close()
         yield db_path
 
@@ -159,7 +159,7 @@ def test_cursor_does_not_advance_when_stdout_flush_fails(isolate_db: Path):
 
 def test_inbox_watcher_tick_invokes_ask_watchdog(isolate_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """The persistent inbox watcher loop invokes run_ask_watchdog on each tick (#5893)."""
-    watchdog_mock = patch("ai_agent_bridge._ask_lifecycle.run_ask_watchdog").start()
+    watchdog_mock = patch("scripts.ai_agent_bridge._ask_lifecycle.run_ask_watchdog").start()
     try:
         _inbox_watch.run_watcher(
             "grok",
@@ -175,7 +175,7 @@ def test_inbox_watcher_tick_invokes_ask_watchdog(isolate_db: Path, tmp_path: Pat
 
 def test_inbox_watcher_watchdog_failure_warns_and_continues(isolate_db: Path, tmp_path: Path, capsys: pytest.CaptureFixture):
     """A raising ask watchdog emits a stderr warning and does not crash the watcher loop (#5893)."""
-    watchdog_mock = patch("ai_agent_bridge._ask_lifecycle.run_ask_watchdog", side_effect=RuntimeError("watchdog exploded")).start()
+    watchdog_mock = patch("scripts.ai_agent_bridge._ask_lifecycle.run_ask_watchdog", side_effect=RuntimeError("watchdog exploded")).start()
     try:
         cursor = _inbox_watch.run_watcher(
             "grok",

--- a/tests/ai_agent_bridge/test_module_identity.py
+++ b/tests/ai_agent_bridge/test_module_identity.py
@@ -1,0 +1,57 @@
+"""Guard: the bridge package must load under a single module identity (#6812).
+
+The canonical identity is ``scripts.ai_agent_bridge`` (repo root is on
+``sys.path`` via ``tests/conftest.py``). The bare ``ai_agent_bridge`` identity
+used to load as a second ``sys.modules`` entry with independent module-level
+state, so ``monkeypatch`` on one identity never affected the other.
+
+These tests fail if any test file reintroduces a non-canonical bridge import
+or quoted module target, or if the bare identity is loaded at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+_SELF = Path(__file__).resolve()
+
+# Match the bare identity as a module path segment, not a substring (#M-16):
+# ``from ai_agent_bridge`` / ``import ai_agent_bridge._db`` are non-canonical,
+# while ``scripts.ai_agent_bridge`` (the canonical form) never matches because
+# the segment must directly follow ``from``/``import`` or an opening quote.
+_NONCANONICAL_PATTERNS = {
+    "import statement": re.compile(r"^\s*(?:from|import)\s+ai_agent_bridge(?:[\s.]|$)", re.M),
+    "quoted module target": re.compile(r"""['"]ai_agent_bridge\."""),
+}
+
+
+def _iter_test_files():
+    for path in sorted(_TESTS_ROOT.rglob("*.py")):
+        if path.resolve() != _SELF:
+            yield path
+
+
+def test_no_noncanonical_bridge_imports_in_test_suite() -> None:
+    """No test file may reference the bare ``ai_agent_bridge`` identity."""
+    violations: list[str] = []
+    for path in _iter_test_files():
+        text = path.read_text(encoding="utf-8")
+        for kind, pattern in _NONCANONICAL_PATTERNS.items():
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                violations.append(f"{path.relative_to(_TESTS_ROOT.parent)}:{line}: {kind}: {match.group()!r}")
+    assert not violations, (
+        "Non-canonical `ai_agent_bridge` module identity found; use `scripts.ai_agent_bridge` "
+        "everywhere (#6812):\n" + "\n".join(violations)
+    )
+
+
+def test_bare_bridge_identity_not_loaded() -> None:
+    """The bare identity must never occupy a second ``sys.modules`` entry."""
+    assert "ai_agent_bridge" not in sys.modules, (
+        "The bare `ai_agent_bridge` module identity is loaded alongside "
+        "`scripts.ai_agent_bridge`; module-level state would diverge (#6812)."
+    )

--- a/tests/ai_agent_bridge/test_review_ask_caps.py
+++ b/tests/ai_agent_bridge/test_review_ask_caps.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from ai_agent_bridge import _claude, _codex, _hermes, _opencode
-from ai_agent_bridge import _review_safety as safety
+
+from scripts.ai_agent_bridge import _claude, _codex, _hermes, _opencode
+from scripts.ai_agent_bridge import _review_safety as safety
 
 
 @pytest.mark.parametrize(

--- a/tests/ai_agent_bridge/test_review_deep_pointer_only.py
+++ b/tests/ai_agent_bridge/test_review_deep_pointer_only.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from ai_agent_bridge._dispatch_wrappers import (
+from scripts.ai_agent_bridge._dispatch_wrappers import (
     _list_review_path_names,
     _write_review_deep_path_prompt,
     _write_review_deep_pr_prompt,
@@ -38,7 +38,7 @@ def test_pr_prompt_is_pointer_only(tmp_path: Path) -> None:
         "files": [{"path": "a.py", "additions": 1, "deletions": 0}],
     }
     with patch(
-        "ai_agent_bridge._dispatch_wrappers._run_json_command",
+        "scripts.ai_agent_bridge._dispatch_wrappers._run_json_command",
         return_value=fake,
     ):
         out = _write_review_deep_pr_prompt("1", tmp_path)

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -15,8 +15,9 @@ from agent_runtime.adapters.acpx import (
     AcpxGlmShadowAdapter,
     _confinement_prefix_argv,
 )
-from ai_agent_bridge import _review_pr as review_pr
-from ai_agent_bridge._review_safety import ReviewSafetyError
+
+from scripts.ai_agent_bridge import _review_pr as review_pr
+from scripts.ai_agent_bridge._review_safety import ReviewSafetyError
 
 
 def _invalid_response_args() -> Namespace:
@@ -53,8 +54,8 @@ def _run_invalid_response_lifecycle(
 ) -> tuple[int, list[str], object]:
     """Run one invalid response through the bridge with a real formal-job store."""
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations
     from scripts.fleet_comms.artifacts import ArtifactStore
@@ -408,7 +409,7 @@ def test_build_review_pr_prompt_injects_ground_truth_block() -> None:
 
 def test_build_review_pr_prompt_large_path_inventory_stays_under_cap() -> None:
     """Large three-dot inventories must stay pointer-budgeted (≤ 4 KiB)."""
-    from ai_agent_bridge._review_safety import MAX_REVIEW_REQUEST_BYTES
+    from scripts.ai_agent_bridge._review_safety import MAX_REVIEW_REQUEST_BYTES
     from scripts.fleet_comms.review_ground_truth import (
         format_ground_truth_brief,
         inventory_from_path_status,
@@ -603,7 +604,7 @@ def test_acpx_parser_preserves_sealed_tool_coverage_trace() -> None:
 
 
 def test_acpx_parser_normalizes_grok_use_tool_to_sealed_operation(tmp_path: Path) -> None:
-    from ai_agent_bridge._review_worktree import verify_clean_review_evidence_reads
+    from scripts.ai_agent_bridge._review_worktree import verify_clean_review_evidence_reads
 
     bundle = tmp_path / ".review-bundle"
     bundle.mkdir()

--- a/tests/ai_agent_bridge/test_review_pr_lifecycle.py
+++ b/tests/ai_agent_bridge/test_review_pr_lifecycle.py
@@ -7,7 +7,8 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
-from ai_agent_bridge import _review_pr
+
+from scripts.ai_agent_bridge import _review_pr
 
 
 def _args(
@@ -93,8 +94,8 @@ def test_completed_replay_requires_the_original_authorization_envelope() -> None
 
 def test_completed_exact_head_replays_without_provider_call(monkeypatch, capsys, tmp_path) -> None:
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.api import state_router
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations
@@ -200,8 +201,8 @@ def test_completed_exact_head_replays_without_provider_call(monkeypatch, capsys,
 
 def test_active_exact_head_exits_before_reservation_or_provider_call(monkeypatch, capsys, tmp_path) -> None:
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.api import state_router
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations
@@ -273,8 +274,8 @@ def test_failed_explicit_review_without_result_invalid_prior_retries_in_place(
     prior_failure: str | None,
 ) -> None:
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.api import state_router
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations
@@ -366,8 +367,8 @@ def test_refused_substitution_makes_no_provider_call_or_claim(
     refusal: str,
 ) -> None:
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.api import state_router
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations
@@ -453,8 +454,8 @@ def test_expired_reservation_after_successful_substitution_never_reaches_provide
     tmp_path,
 ) -> None:
     from agent_runtime import runner
-    from ai_agent_bridge import _review_worktree
 
+    from scripts.ai_agent_bridge import _review_worktree
     from scripts.api import state_router
     from scripts.fleet_comms import authority as authority_module
     from scripts.fleet_comms import routing_reservations

--- a/tests/ai_agent_bridge/test_review_pr_required.py
+++ b/tests/ai_agent_bridge/test_review_pr_required.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from ai_agent_bridge import _review_safety as safety
+
+from scripts.ai_agent_bridge import _review_safety as safety
 
 
 def test_looks_like_pr_cf_review_detects_github_pr_url() -> None:

--- a/tests/ai_agent_bridge/test_review_verdict.py
+++ b/tests/ai_agent_bridge/test_review_verdict.py
@@ -6,8 +6,9 @@ import json
 import subprocess
 
 import pytest
-from ai_agent_bridge import _review_verdict as publisher
-from ai_agent_bridge._review_safety import ReviewSafetyError
+
+from scripts.ai_agent_bridge import _review_verdict as publisher
+from scripts.ai_agent_bridge._review_safety import ReviewSafetyError
 
 
 def _approved_evidence() -> dict[str, object]:

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -15,13 +15,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from ai_agent_bridge import _agy, _claude, _cli, _codex, _grok_build
-from ai_agent_bridge import _review_worktree as review_worktree
-
 from scripts.agent_runtime.adapters.acpx import (
     AcpxShadowRefusalError,
     _validate_sealed_review_mcp_config,
 )
+from scripts.ai_agent_bridge import _agy, _claude, _cli, _codex, _grok_build
+from scripts.ai_agent_bridge import _review_worktree as review_worktree
 from scripts.review.isolation import create_review_temp_root
 from scripts.review.snapshot import (
     ReviewSnapshot,

--- a/tests/ai_agent_bridge/test_verify_review.py
+++ b/tests/ai_agent_bridge/test_verify_review.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from ai_agent_bridge import _channels, _inbox, _prompts
-from ai_agent_bridge._inbox import _ClaimedDelivery, _ClaimedThread
+from scripts.ai_agent_bridge import _channels, _inbox, _prompts
+from scripts.ai_agent_bridge._inbox import _ClaimedDelivery, _ClaimedThread
 
 
 def test_review_protocol_is_loaded_at_call_time(tmp_path, monkeypatch):

--- a/tests/test_ab_channel_watch.py
+++ b/tests/test_ab_channel_watch.py
@@ -13,8 +13,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.result import Result
-from ai_agent_bridge import _channels, _cli, _db, _inbox
-from ai_agent_bridge._channels_watch import (
+
+from scripts.ai_agent_bridge import _channels, _cli, _db, _inbox
+from scripts.ai_agent_bridge._channels_watch import (
     emit_delivery_delivered,
     emit_reply_complete,
     emit_reply_started,
@@ -26,8 +27,8 @@ from ai_agent_bridge._channels_watch import (
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path):
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), \
-         patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), \
+         patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()
         yield db_file
 
@@ -137,7 +138,7 @@ def test_channel_watch_auto_migrates_missing_table():
     assert events[0]["event"] == "reply_started"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_emits_watch_events_with_heartbeat(mock_invoke, monkeypatch):
     thread = _make_thread("claude")
     thread_id = str(thread["thread_id"])

--- a/tests/test_ab_dispatch_wrappers.py
+++ b/tests/test_ab_dispatch_wrappers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge import _dispatch_wrappers as wrappers
+from scripts.ai_agent_bridge import _dispatch_wrappers as wrappers
 
 
 def _option(command: list[str], name: str) -> str:

--- a/tests/test_ab_gemini_session_link.py
+++ b/tests/test_ab_gemini_session_link.py
@@ -12,14 +12,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.errors import AgentTimeoutError
-from ai_agent_bridge import _channels, _db, _gemini_session_link, _inbox
+
+from scripts.ai_agent_bridge import _channels, _db, _gemini_session_link, _inbox
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path):
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
-        "ai_agent_bridge._db.DB_PATH", db_file
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "scripts.ai_agent_bridge._db.DB_PATH", db_file
     ):
         _db.init_db()
         yield
@@ -190,7 +191,7 @@ def test_find_session_recovery_prefers_brief_match_when_windows_overlap(tmp_path
     assert recovery.text == "right reply"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_timeout_recovers_session_reply(mock_invoke, tmp_path):
     thread = _make_thread("gemini", body="please review this carefully")
     started_at = datetime.now(UTC)
@@ -210,7 +211,7 @@ def test_run_inbox_gemini_timeout_recovers_session_reply(mock_invoke, tmp_path):
     )
     mock_invoke.side_effect = AgentTimeoutError("gemini", 900)
 
-    with patch("ai_agent_bridge._gemini_session_link._GEMINI_TMP_ROOT", tmp_path):
+    with patch("scripts.ai_agent_bridge._gemini_session_link._GEMINI_TMP_ROOT", tmp_path):
         summary = _inbox.run_inbox("gemini")
 
     row = _delivery_row(str(thread["message_id"]))
@@ -225,12 +226,12 @@ def test_run_inbox_gemini_timeout_recovers_session_reply(mock_invoke, tmp_path):
     assert "Recovered from session file." in messages[-1]["body"]
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_timeout_without_session_keeps_delivery_pending(mock_invoke, tmp_path):
     thread = _make_thread("gemini", body="please review this carefully")
     mock_invoke.side_effect = AgentTimeoutError("gemini", 900)
 
-    with patch("ai_agent_bridge._gemini_session_link._GEMINI_TMP_ROOT", tmp_path):
+    with patch("scripts.ai_agent_bridge._gemini_session_link._GEMINI_TMP_ROOT", tmp_path):
         summary = _inbox.run_inbox("gemini")
 
     row = _delivery_row(str(thread["message_id"]))

--- a/tests/test_ab_orphan_recovery.py
+++ b/tests/test_ab_orphan_recovery.py
@@ -11,8 +11,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.errors import AgentTimeoutError
-from ai_agent_bridge import _channels, _db, _inbox
-from ai_agent_bridge._orphan_recovery import (
+
+from scripts.ai_agent_bridge import _channels, _db, _inbox
+from scripts.ai_agent_bridge._orphan_recovery import (
     RecoveryCandidate,
     RecoveryResult,
     recover_orphan_commit,
@@ -110,7 +111,7 @@ def test_recover_orphan_commit_rejects_when_ruff_fails(tmp_path: Path):
     repo = _init_repo(tmp_path)
     (repo / "scripts" / "task.py").write_text("print('bad')\n", encoding="utf-8")
 
-    with patch("ai_agent_bridge._orphan_recovery._run_ruff", return_value=False):
+    with patch("scripts.ai_agent_bridge._orphan_recovery._run_ruff", return_value=False):
         result = recover_orphan_commit(
             _candidate("Touch scripts/task.py"),
             repo_root=repo,
@@ -141,16 +142,16 @@ def test_recover_orphan_commit_rejects_when_pre_commit_blocks(tmp_path: Path):
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path: Path):
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
-        "ai_agent_bridge._db.DB_PATH", db_file
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "scripts.ai_agent_bridge._db.DB_PATH", db_file
     ):
         _db.init_db()
         yield
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 @patch(
-    "ai_agent_bridge._inbox._maybe_recover_orphan_commit",
+    "scripts.ai_agent_bridge._inbox._maybe_recover_orphan_commit",
     return_value=RecoveryResult(commit_sha="abc123", reason=None),
 )
 def test_run_inbox_timeout_recovery_marks_delivery_delivered(

--- a/tests/test_ab_reconcile.py
+++ b/tests/test_ab_reconcile.py
@@ -10,14 +10,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.result import Result
-from ai_agent_bridge import _channels, _cli, _db, _inbox, _reconcile
+
+from scripts.ai_agent_bridge import _channels, _cli, _db, _inbox, _reconcile
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path):
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
-        "ai_agent_bridge._db.DB_PATH", db_file
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "scripts.ai_agent_bridge._db.DB_PATH", db_file
     ):
         _db.init_db()
         yield
@@ -80,7 +81,7 @@ def test_reconcile_dry_run_prints_worker_disappeared_without_applying(capsys, mo
         lease_until=(datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
     )
 
-    with patch("ai_agent_bridge._reconcile._has_active_worker", return_value=False):
+    with patch("scripts.ai_agent_bridge._reconcile._has_active_worker", return_value=False):
         exit_code = _run_cli(["reconcile", "--dry-run"])
 
     assert exit_code == 0
@@ -124,7 +125,7 @@ def test_reconcile_marks_workspace_write_delivery_delivered_when_recovery_commit
     delivery_id = post["delivery_ids"][0]
     _set_delivery(delivery_id, status="processing")
 
-    with patch("ai_agent_bridge._reconcile._find_timeout_recovery_commit", return_value="abc123"):
+    with patch("scripts.ai_agent_bridge._reconcile._find_timeout_recovery_commit", return_value="abc123"):
         changes = _reconcile.reconcile_deliveries()
 
     assert changes[0].error == "reconcile:git-commit-found:abc123"
@@ -134,8 +135,8 @@ def test_reconcile_marks_workspace_write_delivery_delivered_when_recovery_commit
     assert row["delivered_at"] is not None
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
-@patch("ai_agent_bridge._inbox.reconcile_deliveries")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.reconcile_deliveries")
 def test_run_inbox_calls_reconcile_at_end(mock_reconcile, mock_invoke):
     _channels.create_channel("reviews")
     _channels.post("reviews", "user", "hello", to_agents=["claude"], auto_snapshot=False)

--- a/tests/test_agent_env.py
+++ b/tests/test_agent_env.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge._env import build_agent_env, is_secret_env_key
+from scripts.ai_agent_bridge._env import build_agent_env, is_secret_env_key
 
 
 def test_is_secret_env_key_matches_common_secret_names():

--- a/tests/test_agy_integration.py
+++ b/tests/test_agy_integration.py
@@ -73,7 +73,7 @@ def _isolate_bridge_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     siblings — inherits isolation without reintroducing the leak.
     """
     _ensure_scripts_path()
-    from ai_agent_bridge import _config, _db
+    from scripts.ai_agent_bridge import _config, _db
 
     db_path = tmp_path / "bridge.db"
     monkeypatch.setattr(_config, "DB_PATH", db_path)
@@ -89,7 +89,7 @@ def _isolate_bridge_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 def discuss_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub channel I/O for discuss tests; relies on ``_isolate_bridge_db_path``."""
     _ensure_scripts_path()
-    from ai_agent_bridge import _channels
+    from scripts.ai_agent_bridge import _channels
 
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
     monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
@@ -146,7 +146,7 @@ def test_ab_channels_valid_agents_includes_agy():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels
+    from scripts.ai_agent_bridge import _channels
 
     importlib.reload(_channels)
     assert "agy" in _channels.VALID_AGENTS
@@ -157,7 +157,7 @@ def test_ab_channels_cli_marks_agy_cli_available():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels_cli
+    from scripts.ai_agent_bridge import _channels_cli
 
     assert _channels_cli._cli_available_agent("agy") is True
 
@@ -165,7 +165,7 @@ def test_ab_channels_cli_marks_agy_cli_available():
 def test_ab_discuss_accepts_agy_in_multi_participant_list(discuss_bridge, monkeypatch):
     """ACP discussion accepts Agy as one member of a bounded participant set."""
     _ensure_scripts_path()
-    from ai_agent_bridge import _channels_cli
+    from scripts.ai_agent_bridge import _channels_cli
 
     observed: dict[str, object] = {}
 
@@ -197,7 +197,7 @@ def test_ab_discuss_accepts_agy_in_multi_participant_list(discuss_bridge, monkey
 def test_ab_discuss_passes_registered_agy_model_pin(discuss_bridge, monkeypatch):
     """The registered Agy ACP model pin reaches the durable controller."""
     _ensure_scripts_path()
-    from ai_agent_bridge import _channels_cli
+    from scripts.ai_agent_bridge import _channels_cli
 
     observed: dict[str, object] = {}
 

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -13,15 +13,15 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge import _channels, _db
+from scripts.ai_agent_bridge import _channels, _db
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path):
     """Ensure every test runs against a clean, isolated SQLite database."""
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), \
-         patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), \
+         patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()
         yield db_file
 
@@ -1600,7 +1600,7 @@ def test_add_column_racesafe_swallows_duplicate_and_reraises_others(tmp_path):
     must re-raise. (review-4897 F1 — concurrent migration race.)"""
     import sqlite3
 
-    from ai_agent_bridge._db import _add_column_racesafe
+    from scripts.ai_agent_bridge._db import _add_column_racesafe
 
     conn = sqlite3.connect(str(tmp_path / "race.db"))
     conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")

--- a/tests/test_bridge_inbox.py
+++ b/tests/test_bridge_inbox.py
@@ -12,15 +12,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.errors import RateLimitedError
 from agent_runtime.result import Result
-from ai_agent_bridge import _channels, _db, _inbox
 from batch_gemini_config import FLASH_LITE_MODEL, FLASH_MODEL, PRO_MODEL
+
+from scripts.ai_agent_bridge import _channels, _db, _inbox
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(tmp_path):
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), \
-         patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), \
+         patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()
         yield db_file
 
@@ -105,7 +106,7 @@ def _ok_result(
     )
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_single_thread_single_delivery(mock_invoke):
     thread = _make_thread("claude", count=1)
     mock_invoke.return_value = _ok_result("claude")
@@ -126,7 +127,7 @@ def test_run_inbox_single_thread_single_delivery(mock_invoke):
     assert messages[-1]["parent_id"] == thread[0]["message_id"]
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_codex_cold_call_persists_runtime_session(mock_invoke):
     thread = _make_thread("codex", count=1)
     mock_invoke.return_value = _ok_result(
@@ -142,7 +143,7 @@ def test_run_inbox_codex_cold_call_persists_runtime_session(mock_invoke):
     assert _inbox._get_session_id(task_id, "codex") == "codex-session-one"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_codex_same_thread_resumes_with_unseen_only_prompt(mock_invoke):
     thread = _make_thread("codex", count=1)
     mock_invoke.return_value = _ok_result(
@@ -173,7 +174,7 @@ def test_run_inbox_codex_same_thread_resumes_with_unseen_only_prompt(mock_invoke
     assert str(follow_up["message_id"]) not in prompt
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_codex_sessions_are_isolated_by_thread(mock_invoke):
     first = _make_thread("codex", channel="first", count=1)
     second = _make_thread("codex", channel="second", count=1)
@@ -194,7 +195,7 @@ def test_run_inbox_codex_sessions_are_isolated_by_thread(mock_invoke):
     assert _inbox._get_session_id(second_task_id, "codex") == "second-session"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_failed_codex_result_does_not_overwrite_session(mock_invoke):
     thread = _make_thread("codex", count=1)
     task_id = _inbox._thread_session_key("topic", str(thread[0]["thread_id"]))
@@ -214,7 +215,7 @@ def test_run_inbox_failed_codex_result_does_not_overwrite_session(mock_invoke):
     assert _inbox._get_session_id(task_id, "codex") == "existing-session"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_single_thread_three_deliveries_coalesces(mock_invoke):
     thread = _make_thread("claude", count=3)
     mock_invoke.return_value = _ok_result("claude")
@@ -233,7 +234,7 @@ def test_run_inbox_single_thread_three_deliveries_coalesces(mock_invoke):
     assert messages[-1]["parent_id"] == thread[-1]["message_id"]
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_two_threads_invokes_twice(mock_invoke):
     first = _make_thread("claude", channel="topic", count=1)
     second = _make_thread("claude", channel="topic", count=1)
@@ -248,7 +249,7 @@ def test_run_inbox_two_threads_invokes_twice(mock_invoke):
     assert _delivery_rows(str(second[0]["message_id"]))[0]["status"] == "delivered"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_thread_tool_error_fails_only_that_thread(mock_invoke):
     first = _make_thread("claude", count=1)
     second = _make_thread("claude", count=1)
@@ -267,7 +268,7 @@ def test_run_inbox_thread_tool_error_fails_only_that_thread(mock_invoke):
     assert second_row["status"] == "delivered"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_rate_limit_releases_and_aborts(mock_invoke):
     first = _make_thread("claude", count=1)
     second = _make_thread("claude", count=1)
@@ -293,7 +294,7 @@ def test_run_inbox_rate_limit_releases_and_aborts(mock_invoke):
     assert second_row["status"] == "pending"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_until_idle_false_stops_after_one_thread(mock_invoke):
     first = _make_thread("claude", count=1)
     second = _make_thread("claude", count=1)
@@ -308,13 +309,13 @@ def test_run_inbox_until_idle_false_stops_after_one_thread(mock_invoke):
     assert _delivery_rows(str(second[0]["message_id"]))[0]["status"] == "pending"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_stop_after_seconds_checks_between_groups(mock_invoke):
     first = _make_thread("claude", count=1)
     second = _make_thread("claude", count=1)
     mock_invoke.return_value = _ok_result("claude")
 
-    with patch("ai_agent_bridge._inbox.time.monotonic", side_effect=[0.0, 5.0]):
+    with patch("scripts.ai_agent_bridge._inbox.time.monotonic", side_effect=[0.0, 5.0]):
         summary = _inbox.run_inbox("claude", stop_after_seconds=1)
 
     assert summary.threads_processed == 1
@@ -323,7 +324,7 @@ def test_run_inbox_stop_after_seconds_checks_between_groups(mock_invoke):
     assert _delivery_rows(str(second[0]["message_id"]))[0]["status"] == "pending"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_max_messages_caps_deliveries(mock_invoke):
     first = _make_thread("claude", count=1)
     second = _make_thread("claude", count=2)
@@ -341,7 +342,7 @@ def test_run_inbox_max_messages_caps_deliveries(mock_invoke):
     assert all(row["status"] == "pending" for row in second_rows)
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_max_messages_soft_cap_first_thread(mock_invoke):
     """Regression: Gemini c2-review r1 BLOCKER — queue deadlock.
 
@@ -367,7 +368,7 @@ def test_run_inbox_max_messages_soft_cap_first_thread(mock_invoke):
         assert _delivery_rows(str(message["message_id"]))[0]["status"] == "delivered"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_429_falls_back_pro_to_flash_and_persists_model(mock_invoke):
     thread = _make_thread("gemini", count=1)
     message_id = str(thread[0]["message_id"])
@@ -401,7 +402,7 @@ def test_run_inbox_gemini_429_falls_back_pro_to_flash_and_persists_model(mock_in
     )
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_passes_auth_mode_to_runtime(mock_invoke):
     thread = _make_thread("gemini", count=1)
     _set_delivery_model(str(thread[0]["message_id"]), PRO_MODEL)
@@ -416,7 +417,7 @@ def test_run_inbox_gemini_passes_auth_mode_to_runtime(mock_invoke):
     }
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_429_falls_back_flash_to_flash_lite(mock_invoke):
     thread = _make_thread("gemini", count=1)
     message_id = str(thread[0]["message_id"])
@@ -445,7 +446,7 @@ def test_run_inbox_gemini_429_falls_back_flash_to_flash_lite(mock_invoke):
     assert messages[-1]["body"] == "bridge reply"
 
 
-@patch("ai_agent_bridge._inbox.runtime_invoke")
+@patch("scripts.ai_agent_bridge._inbox.runtime_invoke")
 def test_run_inbox_gemini_429_exhausts_cascade_and_fails(mock_invoke):
     thread = _make_thread("gemini", count=1)
     message_id = str(thread[0]["message_id"])

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -12,7 +12,8 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.result import Result
-from ai_agent_bridge import _acp_compat, _channels, _channels_cli, _cli, _db
+
+from scripts.ai_agent_bridge import _acp_compat, _channels, _channels_cli, _cli, _db
 
 
 def test_post_preflight_warns_for_large_body():
@@ -66,7 +67,7 @@ def isolate_db(tmp_path, monkeypatch):
     # historical writer behavior. Production authority mode refuses writers.
     monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "shadow")
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()
         yield db_file
 
@@ -182,9 +183,9 @@ def _delivery_detail(delivery_id: str) -> sqlite3.Row:
 
 
 def _install_fake_inbox_module(monkeypatch, run_inbox) -> None:
-    fake_inbox_module = ModuleType("ai_agent_bridge._inbox")
+    fake_inbox_module = ModuleType("scripts.ai_agent_bridge._inbox")
     fake_inbox_module.run_inbox = run_inbox
-    monkeypatch.setitem(sys.modules, "ai_agent_bridge._inbox", fake_inbox_module)
+    monkeypatch.setitem(sys.modules, "scripts.ai_agent_bridge._inbox", fake_inbox_module)
 
 
 def _reply_deliveries() -> list[sqlite3.Row]:

--- a/tests/test_bridge_set_session.py
+++ b/tests/test_bridge_set_session.py
@@ -15,7 +15,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge._db import (
+from scripts.ai_agent_bridge._db import (
     _session_column,
     get_session,
     init_db,
@@ -27,7 +27,7 @@ from ai_agent_bridge._db import (
 def bridge_db(tmp_path):
     """Use a temporary broker DB so tests never touch the real one."""
     db_path = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._db.DB_PATH", db_path):
+    with patch("scripts.ai_agent_bridge._db.DB_PATH", db_path):
         conn = init_db()
         conn.close()
         yield db_path
@@ -63,7 +63,7 @@ def test_set_session_noop_for_grok_build_does_not_raise(bridge_db):
 
 def test_set_session_noop_is_zero_touch(bridge_db):
     """A no-op must not even create a sessions row for the task."""
-    from ai_agent_bridge._db import get_db
+    from scripts.ai_agent_bridge._db import get_db
 
     set_session("task-zero", "grok-build", "sess-x")
     conn = get_db()

--- a/tests/test_bridge_wave2_cli.py
+++ b/tests/test_bridge_wave2_cli.py
@@ -16,7 +16,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge import _channels, _cli, _db, _messaging
+from scripts.ai_agent_bridge import _channels, _cli, _db, _messaging
 
 
 @pytest.fixture(autouse=True)
@@ -25,7 +25,7 @@ def isolate_db(tmp_path, monkeypatch):
     # Authority-mode retirement is covered in test_bridge_inbox_cli.py.
     monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "shadow")
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db()
         yield db_file
 

--- a/tests/test_citation_check.py
+++ b/tests/test_citation_check.py
@@ -29,7 +29,7 @@ _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
-from ai_agent_bridge import _citation_check as cc
+from scripts.ai_agent_bridge import _citation_check as cc
 
 # ─────────────────────────────────────────────────────────────────────
 # Detection
@@ -436,7 +436,7 @@ def _isolated_db(tmp_path, monkeypatch):
     own DB without touching the real broker. Cleared automatically
     when ``tmp_path`` is removed at end of the test.
     """
-    from ai_agent_bridge import _config, _db
+    from scripts.ai_agent_bridge import _config, _db
     db_path = tmp_path / "messages.db"
     monkeypatch.setattr(_config, "DB_PATH", db_path)
     monkeypatch.setattr(_db, "DB_PATH", db_path)
@@ -455,7 +455,7 @@ def test_channels_post_annotates_unverified_citation(monkeypatch, tmp_path):
     """End-to-end: posting a message with a fabricated citation results
     in the body (as persisted) carrying the CITATION-UNVERIFIED marker.
     """
-    from ai_agent_bridge import _channels, _citation_check
+    from scripts.ai_agent_bridge import _channels, _citation_check
 
     fake = _FakeSourcesDB(style_guide={})  # no AD entries
     monkeypatch.setattr(_citation_check, "_try_load_sources_db", lambda: fake)
@@ -488,7 +488,7 @@ def test_channels_post_annotates_unverified_citation(monkeypatch, tmp_path):
 
 
 def test_channels_post_skips_verification_when_disabled(monkeypatch, tmp_path):
-    from ai_agent_bridge import _channels, _citation_check
+    from scripts.ai_agent_bridge import _channels, _citation_check
 
     fake = _FakeSourcesDB(style_guide={})
     monkeypatch.setattr(_citation_check, "_try_load_sources_db", lambda: fake)
@@ -514,7 +514,7 @@ def test_channels_post_skips_verification_when_disabled(monkeypatch, tmp_path):
 
 
 def test_channels_post_skips_verification_for_system_kinds(monkeypatch, tmp_path):
-    from ai_agent_bridge import _channels, _citation_check
+    from scripts.ai_agent_bridge import _channels, _citation_check
 
     fake = _FakeSourcesDB(style_guide={})
     monkeypatch.setattr(_citation_check, "_try_load_sources_db", lambda: fake)

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -23,17 +23,18 @@ from agent_runtime.adapters.codex import CodexAdapter
 from agent_runtime.errors import AgentStalledError, RateLimitedError
 from agent_runtime.result import Result
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
-from ai_agent_bridge._cli import _dispatch_command, _handle_ask_codex
-from ai_agent_bridge._codex import (
+
+from scripts.ai_agent_bridge._cli import _dispatch_command, _handle_ask_codex
+from scripts.ai_agent_bridge._codex import (
     _codex_bridge_runtime_mode,
     _reported_codex_effort,
     _resolve_codex_bridge_timeout,
     ask_codex_chain,
     process_for_codex,
 )
-from ai_agent_bridge._db import get_db, init_db
-from ai_agent_bridge._messaging import detect_sender, send_message
-from ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
+from scripts.ai_agent_bridge._db import get_db, init_db
+from scripts.ai_agent_bridge._messaging import detect_sender, send_message
+from scripts.ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
 @pytest.fixture(autouse=True)
@@ -49,7 +50,7 @@ def _isolate_usage_log(tmp_path):
 def bridge_db(tmp_path):
     """Use a temporary broker DB for bridge tests."""
     db_path = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._db.DB_PATH", db_path):
+    with patch("scripts.ai_agent_bridge._db.DB_PATH", db_path):
         conn = init_db()
         conn.close()
         yield db_path
@@ -103,7 +104,7 @@ def test_detect_sender_codex():
     }
     with (
         patch.dict(os.environ, {**env, "CODEX_SESSION": "1"}, clear=True),
-        patch("ai_agent_bridge._messaging.Path.exists", return_value=False),
+        patch("scripts.ai_agent_bridge._messaging.Path.exists", return_value=False),
     ):
         assert detect_sender() == "codex"
 
@@ -137,7 +138,7 @@ def test_handle_ask_codex_reads_stdin(monkeypatch):
         captured.update(args=args, kwargs=kwargs)
         return SimpleNamespace(ok=True)
 
-    monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
+    monkeypatch.setattr("scripts.ai_agent_bridge._acp_compat.run_compat_ask", fake_compat)
     with patch("sys.stdin", io.StringIO("stdin prompt")):
         _handle_ask_codex(args)
     assert captured["args"] == ("codex", "stdin prompt")
@@ -211,7 +212,7 @@ def test_ask_codex_chain_dispatches_issues_sequentially(monkeypatch):
         monkeypatch.delenv(variable, raising=False)
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/tmp/project")
 
-    with patch("ai_agent_bridge._codex.ask_codex", side_effect=[11, 12]) as ask_codex_mock:
+    with patch("scripts.ai_agent_bridge._codex.ask_codex", side_effect=[11, 12]) as ask_codex_mock:
         message_ids = ask_codex_chain(
             "Fix {issue_ref} via {task_id}",
             ["1177", "#1178", "issue-1177"],
@@ -234,7 +235,7 @@ def test_ask_codex_chain_dispatches_issues_sequentially(monkeypatch):
 
 
 def test_ask_codex_chain_prefixes_issue_context_without_placeholders():
-    with patch("ai_agent_bridge._codex.ask_codex", return_value=11) as ask_codex_mock:
+    with patch("scripts.ai_agent_bridge._codex.ask_codex", return_value=11) as ask_codex_mock:
         ask_codex_chain("Review and fix the issue.", ["1177"])
 
     assert ask_codex_mock.call_args.args[0] == ("GitHub issue #1177 (issue-1177).\n\nReview and fix the issue.")
@@ -266,13 +267,13 @@ def test_codex_bridge_runtime_mode_invalid_mode_falls_back_read_only():
         assert _codex_bridge_runtime_mode() == "read-only"
 
 
-@patch("ai_agent_bridge._codex.acknowledge")
-@patch("ai_agent_bridge._codex.send_message", return_value=99)
-@patch("ai_agent_bridge._codex.set_session")
-@patch("ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
-@patch("ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
+@patch("scripts.ai_agent_bridge._codex.acknowledge")
+@patch("scripts.ai_agent_bridge._codex.send_message", return_value=99)
+@patch("scripts.ai_agent_bridge._codex.set_session")
+@patch("scripts.ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
+@patch("scripts.ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
 @patch(
-    "ai_agent_bridge._codex._fetch_codex_message",
+    "scripts.ai_agent_bridge._codex._fetch_codex_message",
     return_value={
         "id": 7,
         "task_id": "issue-1177",
@@ -342,13 +343,13 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
     mock_acknowledge.assert_called_once_with(7)
 
 
-@patch("ai_agent_bridge._codex.acknowledge")
-@patch("ai_agent_bridge._codex.send_message", return_value=100)
-@patch("ai_agent_bridge._codex.set_session")
-@patch("ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
-@patch("ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
+@patch("scripts.ai_agent_bridge._codex.acknowledge")
+@patch("scripts.ai_agent_bridge._codex.send_message", return_value=100)
+@patch("scripts.ai_agent_bridge._codex.set_session")
+@patch("scripts.ai_agent_bridge._codex.get_session", return_value={"codex": "session-existing"})
+@patch("scripts.ai_agent_bridge._codex.build_codex_prompt", return_value="bridge prompt")
 @patch(
-    "ai_agent_bridge._codex._fetch_codex_message",
+    "scripts.ai_agent_bridge._codex._fetch_codex_message",
     return_value={
         "id": 8,
         "task_id": "issue-1178",
@@ -445,14 +446,14 @@ def test_process_for_codex_cold_starts_without_stored_session(monkeypatch):
         returncode=0,
         usage_record={},
     )
-    monkeypatch.setattr("ai_agent_bridge._codex._fetch_codex_message", lambda _message_id: message)
-    monkeypatch.setattr("ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": None})
-    monkeypatch.setattr("ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
-    monkeypatch.setattr("ai_agent_bridge._codex.build_codex_prompt", lambda *_args, **_kwargs: "bridge prompt")
-    monkeypatch.setattr("ai_agent_bridge._codex.agent_runner.invoke", lambda *_args, **kwargs: captured.update(kwargs) or result)
-    monkeypatch.setattr("ai_agent_bridge._codex.send_message", lambda **_kwargs: 11)
-    monkeypatch.setattr("ai_agent_bridge._codex.acknowledge", lambda *_args: None)
-    monkeypatch.setattr("ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex._fetch_codex_message", lambda _message_id: message)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": None})
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.build_codex_prompt", lambda *_args, **_kwargs: "bridge prompt")
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.agent_runner.invoke", lambda *_args, **kwargs: captured.update(kwargs) or result)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.send_message", lambda **_kwargs: 11)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.acknowledge", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
 
     process_for_codex(10)
 
@@ -620,7 +621,7 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
         yield checkout
 
     monkeypatch.setattr(
-        "ai_agent_bridge._codex._fetch_codex_message",
+        "scripts.ai_agent_bridge._codex._fetch_codex_message",
         lambda _id: {
             "id": 9,
             "task_id": "branch-review",
@@ -631,9 +632,9 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
             "data": json.dumps({"review_target": {"branch": "feature/review"}}),
         },
     )
-    monkeypatch.setattr("ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
-    monkeypatch.setattr("ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": "session-existing"})
-    monkeypatch.setattr("ai_agent_bridge._codex.provision_review_worktree", fake_checkout)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.get_session", lambda _task_id: {"codex": "session-existing"})
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.provision_review_worktree", fake_checkout)
     monkeypatch.setattr(
         ProvisionedReviewWorktree,
         "review_prompt_evidence",
@@ -649,12 +650,12 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
         "bind_review_result",
         lambda self, result, engine: None,
     )
-    monkeypatch.setattr("ai_agent_bridge._codex.acknowledge", lambda *_args: None)
-    monkeypatch.setattr("ai_agent_bridge._codex.send_message", lambda **_kwargs: 10)
-    monkeypatch.setattr("ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
-    monkeypatch.setattr("ai_agent_bridge._codex.set_session", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.acknowledge", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr("scripts.ai_agent_bridge._codex.set_session", lambda *_args: None)
     monkeypatch.setattr(
-        "ai_agent_bridge._codex.agent_runner.invoke",
+        "scripts.ai_agent_bridge._codex.agent_runner.invoke",
         lambda *args, **kwargs: (
             captured.update({"prompt": args[1], **kwargs})
             or Result(
@@ -694,11 +695,11 @@ def test_process_for_codex_short_circuits_when_no_headroom(bridge_db):
 
     with (
         patch(
-            "ai_agent_bridge._codex.has_codex_headroom",
+            "scripts.ai_agent_bridge._codex.has_codex_headroom",
             return_value=(False, "rate_limited 30s ago"),
         ),
         patch(
-            "ai_agent_bridge._codex.build_codex_prompt",
+            "scripts.ai_agent_bridge._codex.build_codex_prompt",
         ) as mock_prompt,
         patch(
             "agent_runtime.runner.invoke",
@@ -734,11 +735,11 @@ def test_rate_limit_error_defers_message(bridge_db):
 
     with (
         patch(
-            "ai_agent_bridge._codex.has_codex_headroom",
+            "scripts.ai_agent_bridge._codex.has_codex_headroom",
             return_value=(True, ""),
         ),
         patch(
-            "ai_agent_bridge._codex.build_codex_prompt",
+            "scripts.ai_agent_bridge._codex.build_codex_prompt",
             return_value="bridge prompt",
         ),
         patch(
@@ -771,11 +772,11 @@ def test_other_errors_still_ack_inbound(bridge_db):
 
     with (
         patch(
-            "ai_agent_bridge._codex.has_codex_headroom",
+            "scripts.ai_agent_bridge._codex.has_codex_headroom",
             return_value=(True, ""),
         ),
         patch(
-            "ai_agent_bridge._codex.build_codex_prompt",
+            "scripts.ai_agent_bridge._codex.build_codex_prompt",
             return_value="bridge prompt",
         ),
         patch(

--- a/tests/test_codex_report.py
+++ b/tests/test_codex_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from ai_agent_bridge._codex_report import (
+from scripts.ai_agent_bridge._codex_report import (
     CodexReport,
     parse_codex_report,
     validate_codex_report,

--- a/tests/test_comms_router_expiry_sweep.py
+++ b/tests/test_comms_router_expiry_sweep.py
@@ -21,10 +21,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge import _channels
-from ai_agent_bridge import _config as ab_config
-from ai_agent_bridge import _db as ab_db
-
+from scripts.ai_agent_bridge import _channels
+from scripts.ai_agent_bridge import _config as ab_config
+from scripts.ai_agent_bridge import _db as ab_db
 from scripts.api import comms_router
 from scripts.api.state_helpers import cache_invalidate
 

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -240,7 +240,7 @@ class TestWarnLongHandoff:
     """Test _warn_long_handoff."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _warn_long_handoff
+        from scripts.ai_agent_bridge._gemini import _warn_long_handoff
 
         return _warn_long_handoff
 
@@ -251,13 +251,13 @@ class TestWarnLongHandoff:
 
     def test_long_handoff_with_issue_warns(self, capsys):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._extract_issue_number", return_value=123):
+        with patch("scripts.ai_agent_bridge._gemini._extract_issue_number", return_value=123):
             f("x" * 600, "handoff", "issue-123")
             assert "WARNING" in capsys.readouterr().out
 
     def test_long_handoff_no_issue_no_warning(self, capsys):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._extract_issue_number", return_value=None):
+        with patch("scripts.ai_agent_bridge._gemini._extract_issue_number", return_value=None):
             f("x" * 600, "handoff", None)
             assert "WARNING" not in capsys.readouterr().out
 
@@ -271,38 +271,38 @@ class TestHandleGeminiError:
     """Test _handle_gemini_error."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _handle_gemini_error
+        from scripts.ai_agent_bridge._gemini import _handle_gemini_error
 
         return _handle_gemini_error
 
     def test_model_error_returns_stop(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value="Model not found"):
+        with patch("scripts.ai_agent_bridge._gemini._detect_model_error", return_value="Model not found"):
             result = f("model not found", "test-model", 0, 5, 30)
             assert result == "stop"
 
     @patch("time.sleep")
     def test_rate_limit_returns_retry(self, mock_sleep):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None):
+        with patch("scripts.ai_agent_bridge._gemini._detect_model_error", return_value=None):
             result = f("exhausted your capacity", "test-model", 0, 5, 30)
             assert result == "retry"
 
     def test_rate_limit_last_attempt_returns_stop(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None):
+        with patch("scripts.ai_agent_bridge._gemini._detect_model_error", return_value=None):
             result = f("429 error", "test-model", 4, 5, 30)
             assert result == "stop"
 
     def test_quota_returns_retry(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None), patch("time.sleep"):
+        with patch("scripts.ai_agent_bridge._gemini._detect_model_error", return_value=None), patch("time.sleep"):
             result = f("quota exceeded", "test-model", 0, 5, 30)
             assert result == "retry"
 
     def test_unknown_error_returns_continue(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None):
+        with patch("scripts.ai_agent_bridge._gemini._detect_model_error", return_value=None):
             result = f("some random error", "test-model", 0, 5, 30)
             assert result == "continue"
 
@@ -311,7 +311,7 @@ class TestExtractAndPrint:
     """Test _extract_and_print."""
 
     def test_extract_with_tags(self, capsys):
-        from ai_agent_bridge._gemini import _extract_and_print
+        from scripts.ai_agent_bridge._gemini import _extract_and_print
 
         # Call with no matching tags - should still work without crashing
         _extract_and_print("some response text", [])
@@ -324,11 +324,11 @@ class TestExtractAndPrint:
             extract_delimited=MagicMock(return_value=None),
         )
         with patch.dict("sys.modules", {"gemini_output": mock_gemini_output}):
-            if "ai_agent_bridge._gemini" in sys.modules:
+            if "scripts.ai_agent_bridge._gemini" in sys.modules:
                 import importlib
 
-                importlib.reload(sys.modules["ai_agent_bridge._gemini"])
-            from ai_agent_bridge._gemini import _extract_and_print
+                importlib.reload(sys.modules["scripts.ai_agent_bridge._gemini"])
+            from scripts.ai_agent_bridge._gemini import _extract_and_print
 
             _extract_and_print("some response", [])
             out = capsys.readouterr().out
@@ -339,7 +339,7 @@ class TestPrintCompletionStatus:
     """Test _print_completion_status."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _print_completion_status
+        from scripts.ai_agent_bridge._gemini import _print_completion_status
 
         return _print_completion_status
 
@@ -370,7 +370,7 @@ class TestRouteGeminiResponse:
     """Test _route_gemini_response."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _route_gemini_response
+        from scripts.ai_agent_bridge._gemini import _route_gemini_response
 
         return _route_gemini_response
 
@@ -385,8 +385,8 @@ class TestRouteGeminiResponse:
         f = self._import()
         msg = {"task_id": "test-task"}
         with (
-            patch("ai_agent_bridge._gemini.send_message", return_value=42) as sm,
-            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.send_message", return_value=42) as sm,
+            patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
         ):
             f(msg, 1, "model", "response", True, None, False)
             sm.assert_called_once()
@@ -396,9 +396,9 @@ class TestRouteGeminiResponse:
         f = self._import()
         msg = {"task_id": "test-task"}
         with (
-            patch("ai_agent_bridge._gemini.send_message", return_value=42),
-            patch("ai_agent_bridge._gemini.acknowledge"),
-            patch("ai_agent_bridge._gemini._post_review_to_github") as gh,
+            patch("scripts.ai_agent_bridge._gemini.send_message", return_value=42),
+            patch("scripts.ai_agent_bridge._gemini.acknowledge"),
+            patch("scripts.ai_agent_bridge._gemini._post_review_to_github") as gh,
         ):
             f(msg, 1, "model", "response", False, None, False)
             gh.assert_called_once()
@@ -407,9 +407,9 @@ class TestRouteGeminiResponse:
         f = self._import()
         msg = {"task_id": "test-task"}
         with (
-            patch("ai_agent_bridge._gemini.send_message", return_value=42),
-            patch("ai_agent_bridge._gemini.acknowledge"),
-            patch("ai_agent_bridge._gemini._post_review_to_github") as gh,
+            patch("scripts.ai_agent_bridge._gemini.send_message", return_value=42),
+            patch("scripts.ai_agent_bridge._gemini.acknowledge"),
+            patch("scripts.ai_agent_bridge._gemini._post_review_to_github") as gh,
         ):
             f(msg, 1, "model", "response", False, None, True)
             gh.assert_not_called()
@@ -419,7 +419,7 @@ class TestSendGeminiError:
     """Test _send_gemini_error."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _send_gemini_error
+        from scripts.ai_agent_bridge._gemini import _send_gemini_error
 
         return _send_gemini_error
 
@@ -427,8 +427,8 @@ class TestSendGeminiError:
         f = self._import()
         msg = {"task_id": "test-task"}
         with (
-            patch("ai_agent_bridge._gemini.send_message", return_value=99) as sm,
-            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.send_message", return_value=99) as sm,
+            patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
         ):
             f(msg, 42)
             sm.assert_called_once()
@@ -437,7 +437,7 @@ class TestSendGeminiError:
     def test_exception_suppressed(self):
         f = self._import()
         msg = {"task_id": "test-task"}
-        with patch("ai_agent_bridge._gemini.send_message", side_effect=Exception("boom")):
+        with patch("scripts.ai_agent_bridge._gemini.send_message", side_effect=Exception("boom")):
             f(msg, 42)  # Should not raise
 
 
@@ -445,15 +445,15 @@ class TestSendGeminiMessage:
     """Test _send_gemini_message."""
 
     def _import(self):
-        from ai_agent_bridge._gemini import _send_gemini_message
+        from scripts.ai_agent_bridge._gemini import _send_gemini_message
 
         return _send_gemini_message
 
     def test_output_path_mode(self):
         f = self._import()
         with (
-            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=10) as st,
-            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.send_to_gemini", return_value=10) as st,
+            patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
         ):
             result = f("content", "task-1", "query", None, None, None, "model", False, "/out")
             assert result == 10
@@ -462,8 +462,8 @@ class TestSendGeminiMessage:
     def test_stdout_only_mode(self):
         f = self._import()
         with (
-            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=11),
-            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.send_to_gemini", return_value=11),
+            patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
         ):
             result = f("content", "task-1", "query", None, None, None, "model", True, None)
             assert result == 11
@@ -472,8 +472,8 @@ class TestSendGeminiMessage:
     def test_normal_mode(self):
         f = self._import()
         with (
-            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=12),
-            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.send_to_gemini", return_value=12),
+            patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
         ):
             result = f("content", "task-1", "query", None, None, None, "model", False, None)
             assert result == 12
@@ -484,7 +484,7 @@ class TestDetectModelError:
     """Test _detect_model_error from _model.py."""
 
     def _import(self):
-        from ai_agent_bridge._model import _detect_model_error
+        from scripts.ai_agent_bridge._model import _detect_model_error
 
         return _detect_model_error
 

--- a/tests/test_cursor_integration.py
+++ b/tests/test_cursor_integration.py
@@ -56,7 +56,7 @@ def test_ab_channels_valid_agents_includes_cursor():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels
+    from scripts.ai_agent_bridge import _channels
 
     importlib.reload(_channels)
     assert "cursor" in _channels.VALID_AGENTS
@@ -72,7 +72,7 @@ def test_ab_channels_cli_marks_cursor_cli_available():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels_cli
+    from scripts.ai_agent_bridge import _channels_cli
 
     assert _channels_cli._cli_available_agent("cursor") is True
 

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -11,18 +11,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.errors import RateLimitedError
 from agent_runtime.result import Result
-from ai_agent_bridge._cli import _handle_ask_gemini
-from ai_agent_bridge._db import get_db, init_db
-from ai_agent_bridge._gemini import _run_gemini_sync
-from ai_agent_bridge._messaging import send_message
 from batch_gemini_config import FALLBACK_MODEL, PRO_MODEL
+
+from scripts.ai_agent_bridge._cli import _handle_ask_gemini
+from scripts.ai_agent_bridge._db import get_db, init_db
+from scripts.ai_agent_bridge._gemini import _run_gemini_sync
+from scripts.ai_agent_bridge._messaging import send_message
 
 
 @pytest.fixture
 def bridge_db(tmp_path):
     db_path = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_path), \
-         patch("ai_agent_bridge._db.DB_PATH", db_path):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_path), \
+         patch("scripts.ai_agent_bridge._db.DB_PATH", db_path):
         conn = init_db()
         conn.close()
         yield db_path
@@ -41,9 +42,9 @@ def _message_to_model(message_id: int) -> str | None:
         conn.close()
 
 
-@patch("ai_agent_bridge._gemini._route_gemini_response")
-@patch("ai_agent_bridge._gemini.acknowledge")
-@patch("ai_agent_bridge._gemini.runtime_invoke")
+@patch("scripts.ai_agent_bridge._gemini._route_gemini_response")
+@patch("scripts.ai_agent_bridge._gemini.acknowledge")
+@patch("scripts.ai_agent_bridge._gemini.runtime_invoke")
 def test_run_gemini_sync_429_retries_same_model_then_falls_back_to_auto(
     mock_invoke,
     mock_acknowledge,
@@ -88,10 +89,10 @@ def test_run_gemini_sync_429_retries_same_model_then_falls_back_to_auto(
         ),
     ]
 
-    with patch("ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("ai_agent_bridge._gemini._write_pid_file"), \
-         patch("ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("ai_agent_bridge._gemini.atexit.register"):
+    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
+         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
         response = _run_gemini_sync(
             msg,
             message_id,
@@ -114,9 +115,9 @@ def test_run_gemini_sync_429_retries_same_model_then_falls_back_to_auto(
     mock_acknowledge.assert_called_once_with(message_id, quiet=True)
 
 
-@patch("ai_agent_bridge._gemini._route_gemini_response")
-@patch("ai_agent_bridge._gemini.acknowledge")
-@patch("ai_agent_bridge._gemini.runtime_invoke")
+@patch("scripts.ai_agent_bridge._gemini._route_gemini_response")
+@patch("scripts.ai_agent_bridge._gemini.acknowledge")
+@patch("scripts.ai_agent_bridge._gemini.runtime_invoke")
 def test_run_gemini_sync_passes_auth_mode_to_runtime(
     mock_invoke,
     _mock_acknowledge,
@@ -156,10 +157,10 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
         usage_record={},
     )
 
-    with patch("ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("ai_agent_bridge._gemini._write_pid_file"), \
-         patch("ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("ai_agent_bridge._gemini.atexit.register"):
+    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
+         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
         _run_gemini_sync(
             msg,
             message_id,
@@ -188,9 +189,9 @@ def _ok_result() -> Result:
     "allow_write, expected_mode",
     [(False, "read-only"), (True, "workspace-write")],
 )
-@patch("ai_agent_bridge._gemini._route_gemini_response")
-@patch("ai_agent_bridge._gemini.acknowledge")
-@patch("ai_agent_bridge._gemini.runtime_invoke")
+@patch("scripts.ai_agent_bridge._gemini._route_gemini_response")
+@patch("scripts.ai_agent_bridge._gemini.acknowledge")
+@patch("scripts.ai_agent_bridge._gemini.runtime_invoke")
 def test_run_gemini_sync_derives_runtime_mode_from_allow_write(
     mock_invoke, _ack, _route, bridge_db, allow_write, expected_mode,
 ):
@@ -205,10 +206,10 @@ def test_run_gemini_sync_derives_runtime_mode_from_allow_write(
            "to": "gemini", "type": "query", "content": "x", "data": None}
     mock_invoke.return_value = _ok_result()
 
-    with patch("ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("ai_agent_bridge._gemini._write_pid_file"), \
-         patch("ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("ai_agent_bridge._gemini.atexit.register"):
+    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
+         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
+         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
         _run_gemini_sync(
             msg, message_id, PRO_MODEL, "bridge prompt", no_timeout=False,
             stdout_only=True, output_path=None, allow_write=allow_write,
@@ -227,7 +228,7 @@ def test_handle_ask_gemini_routes_to_agy(monkeypatch):
         captured["kwargs"] = kwargs
         return SimpleNamespace(ok=True)
 
-    monkeypatch.setattr("ai_agent_bridge._acp_compat.run_compat_ask", _fake_ask_agy)
+    monkeypatch.setattr("scripts.ai_agent_bridge._acp_compat.run_compat_ask", _fake_ask_agy)
 
     class _Args:
         content = "hello"

--- a/tests/test_grok_integration.py
+++ b/tests/test_grok_integration.py
@@ -71,7 +71,7 @@ def test_ab_channels_valid_agents_includes_grok_seats():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels
+    from scripts.ai_agent_bridge import _channels
 
     importlib.reload(_channels)
     for name in ("grok", "grok-build", "grok-hermes"):
@@ -83,7 +83,7 @@ def test_ab_channels_cli_marks_grok_cli_available():
     scripts_dir = str(_REPO_ROOT / "scripts")
     if scripts_dir not in sys.path:
         sys.path.insert(0, scripts_dir)
-    from ai_agent_bridge import _channels_cli
+    from scripts.ai_agent_bridge import _channels_cli
 
     assert _channels_cli._cli_available_agent("grok") is True
     assert _channels_cli._cli_available_agent("grok-build") is True

--- a/tests/test_grok_seat_identity.py
+++ b/tests/test_grok_seat_identity.py
@@ -62,7 +62,7 @@ def test_tool_config_canonical_order_prefers_native_over_hermes_prefix():
 
 
 def test_grok_agent_env_autodetect_returns_canonical(monkeypatch):
-    from ai_agent_bridge import _cli
+    from scripts.ai_agent_bridge import _cli
 
     monkeypatch.delenv("SESSION_HANDOFF_AGENT", raising=False)
     monkeypatch.delenv("CLAUDE_AGENT_NAME", raising=False)
@@ -75,7 +75,7 @@ def test_grok_agent_env_autodetect_returns_canonical(monkeypatch):
 
 
 def test_grok_agent_non_sentinel_does_not_false_positive(monkeypatch):
-    from ai_agent_bridge import _cli
+    from scripts.ai_agent_bridge import _cli
 
     for key in (
         "SESSION_HANDOFF_AGENT",

--- a/tests/test_live_driver_message_consumption.py
+++ b/tests/test_live_driver_message_consumption.py
@@ -11,7 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from ai_agent_bridge import _ask_lifecycle, _cli, _db, _messaging
+from scripts.ai_agent_bridge import _ask_lifecycle, _cli, _db, _messaging
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DRIVE_EPIC_SKILL = PROJECT_ROOT / "agents_extensions/shared/skills/drive-epic/SKILL.md"
@@ -21,7 +21,7 @@ DRIVE_EPIC_SKILL = PROJECT_ROOT / "agents_extensions/shared/skills/drive-epic/SK
 def isolate_db(tmp_path: Path):
     """Keep legacy-message rows isolated for each consumption-state test."""
     db_file = tmp_path / "messages.db"
-    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_file), patch("scripts.ai_agent_bridge._db.DB_PATH", db_file):
         _db.init_db().close()
         yield db_file
 
@@ -73,7 +73,7 @@ def test_legacy_messages_migrate_live_driver_consumption_columns(tmp_path: Path)
     finally:
         conn.close()
 
-    with patch("ai_agent_bridge._config.DB_PATH", legacy_db), patch("ai_agent_bridge._db.DB_PATH", legacy_db):
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", legacy_db), patch("scripts.ai_agent_bridge._db.DB_PATH", legacy_db):
         migrated = _db.get_db()
         try:
             columns = {row[1] for row in migrated.execute("PRAGMA table_info(messages)").fetchall()}

--- a/tests/test_monitor_client_sdk.py
+++ b/tests/test_monitor_client_sdk.py
@@ -20,12 +20,11 @@ from fastapi.testclient import TestClient
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
-from ai_agent_bridge import _monitor_cache as cache
-from ai_agent_bridge import monitor_client
-
 import scripts.api.main as api_main
 import scripts.api.rules_router as rules_router
 import scripts.api.session_router as session_router
+from scripts.ai_agent_bridge import _monitor_cache as cache
+from scripts.ai_agent_bridge import monitor_client
 
 client = TestClient(api_main.app, raise_server_exceptions=False)
 

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -114,7 +114,7 @@ def test_agy_bridge_prompt_injects_contract_digest() -> None:
     import sys
 
     sys.path.insert(0, str(REPO / "scripts"))
-    from ai_agent_bridge._prompts import build_agy_prompt
+    from scripts.ai_agent_bridge._prompts import build_agy_prompt
 
     out = build_agy_prompt({"from": "claude", "task_id": "t", "type": "query", "content": "x", "data": None})
     assert "operator-expectations.md" in out
@@ -148,7 +148,7 @@ def test_agy_bridge_prompt_permits_narrow_repo_reads_but_forbids_writes() -> Non
     import sys
 
     sys.path.insert(0, str(REPO / "scripts"))
-    from ai_agent_bridge._prompts import build_agy_prompt
+    from scripts.ai_agent_bridge._prompts import build_agy_prompt
 
     out = build_agy_prompt({"from": "claude", "task_id": "t", "type": "query", "content": "x", "data": None})
     assert "MAY read the specific repository file(s)" in out

--- a/tests/test_secret_redactor.py
+++ b/tests/test_secret_redactor.py
@@ -28,7 +28,7 @@ def msg_db(tmp_path):
     def _fresh_conn():
         return sqlite3.connect(str(db_path))
 
-    with patch("ai_agent_bridge._messaging.get_db", side_effect=_fresh_conn):
+    with patch("scripts.ai_agent_bridge._messaging.get_db", side_effect=_fresh_conn):
         yield db_path
 
 
@@ -270,7 +270,7 @@ def test_redact_text_handles_quoted_and_spaced_assignments():
 
 
 def test_github_comment_redacts_body_before_subprocess():
-    from ai_agent_bridge._github import _gh_comment
+    from scripts.ai_agent_bridge._github import _gh_comment
 
     mock_result = MagicMock()
     mock_result.returncode = 0
@@ -286,7 +286,7 @@ def test_github_comment_redacts_body_before_subprocess():
 
 
 def test_send_message_redacts_content_and_data(msg_db):
-    from ai_agent_bridge._messaging import send_message
+    from scripts.ai_agent_bridge._messaging import send_message
 
     with patch("subprocess.run"):
         msg_id = send_message(
@@ -315,7 +315,7 @@ def test_send_message_redacts_content_and_data(msg_db):
 
 
 def test_read_message_redacts_existing_unredacted_rows(msg_db):
-    from ai_agent_bridge._messaging import read_message
+    from scripts.ai_agent_bridge._messaging import read_message
 
     conn = sqlite3.connect(str(msg_db))
     conn.execute(

--- a/tests/test_worktree_brief.py
+++ b/tests/test_worktree_brief.py
@@ -10,14 +10,14 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from ai_agent_bridge._worktree_brief import write_worktree_brief
+from scripts.ai_agent_bridge._worktree_brief import write_worktree_brief
 
 
 def test_write_worktree_brief_writes_expected_yaml(tmp_path):
     fixed_now = datetime(2026, 4, 12, 9, 30, 0, tzinfo=UTC)
 
-    with patch("ai_agent_bridge._worktree_brief._run_git") as run_git_mock, patch(
-        "ai_agent_bridge._worktree_brief._utcnow", return_value=fixed_now
+    with patch("scripts.ai_agent_bridge._worktree_brief._run_git") as run_git_mock, patch(
+        "scripts.ai_agent_bridge._worktree_brief._utcnow", return_value=fixed_now
     ):
         run_git_mock.side_effect = [
             "abc123def456",
@@ -41,7 +41,7 @@ def test_write_worktree_brief_writes_expected_yaml(tmp_path):
 
 
 def test_write_worktree_brief_calculates_divergence_from_git_commands(tmp_path):
-    with patch("ai_agent_bridge._worktree_brief._run_git") as run_git_mock:
+    with patch("scripts.ai_agent_bridge._worktree_brief._run_git") as run_git_mock:
         run_git_mock.side_effect = [
             "deadbeef",
             "7 3",


### PR DESCRIPTION
Closes #6812.

## What
- Rewrote bare `ai_agent_bridge` imports to the canonical `scripts.ai_agent_bridge` identity in 42 test files, so the bridge package loads under a single `sys.modules` entry (repo root is already on `sys.path` via `tests/conftest.py`). Previously both identities loaded as separate `sys.modules` entries with independent module-level state, so `monkeypatch` on one identity never affected the other.
- Added `tests/ai_agent_bridge/test_module_identity.py` — a reintroduction guard that fails if any test file reintroduces a bare import statement or quoted module target, or if the bare identity is loaded at runtime.

## Evidence
- **Guard passes on swept tree:** `pytest tests/ai_agent_bridge/test_module_identity.py -q` → `2 passed in 0.40s`
- **Mutation check (#M-16):** throwaway `tests/test_m16_throwaway.py` containing `import ai_agent_bridge._db` and `"ai_agent_bridge._review_pr"` → guard FAILED with both violations reported:
  ```
  tests/test_m16_throwaway.py:1: import statement: 'import ai_agent_bridge.'
  tests/test_m16_throwaway.py:3: quoted module target: '"ai_agent_bridge.'
  ```
  Throwaway removed; guard green again (`2 passed in 0.40s`).
- **Full suite:** `pytest tests/ai_agent_bridge/ -q` → `1 failed, 345 passed in 22.18s`. The single failure (`test_sealed_acp_config_is_parent_owned_and_snapshot_pinned`, `sealed_acp_python_missing:<worktree>/.venv/bin/python`) is **pre-existing and environmental**: it also fails on the unmodified tree (verified via `git stash`), because the dispatch contract forbids creating a `.venv` inside the worktree. Not caused by this sweep.
- **Ruff:** `ruff check <changed files>` → `All checks passed!`
- **Grep-proof (zero bare imports in test suite):**
  ```
  $ grep -rnE '^\s*(from|import)\s+ai_agent_bridge([\s.]|$)' tests/ --include='*.py'
  (no output, exit 1)
  $ grep -rn "['\"]ai_agent_bridge\." tests/ --include='*.py'
  (no output, exit 1)
  ```

## Out of scope
- `scripts/tools/agent_watcher.py:43` still uses the bare form; it runs as a tool with its own `sys.path` primer and is outside the test-suite identity scope of #6812.
- Deleting the ~340 inline `sys.path.insert` primers (mentioned in #6812 as a follow-up) is not included here.

X-Agent: kimi