### PR TITLE
fix(review): normalize combining stress marks in vocabulary surface candidates (#5375)

### DIFF
--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -2003,14 +2003,34 @@ def _visible_source_lines(path: str, text: str) -> list[str]:
     return masked.splitlines()
 
 
+# Combining acute stress marks (U+0301) are pedagogical annotations, not
+# lexical identity: a stressed learner surface (м'яки́й) and its unstressed
+# ledger lemma (м'який) are the same word. Word tokens must admit the mark
+# mid-token (м'яки́й otherwise splits into м'яки + й and can never match), and
+# comparisons strip it — for candidate matching and VESUM lookup only. Stored
+# and displayed evidence always keeps the original bytes. (#5375)
+_COMBINING_STRESS_MARK = "\u0301"
+_TOKEN_WORD = "[^\\W_]+(?:\u0301+[^\\W_]*)*"
+_LEXICAL_TOKEN_PATTERN = re.compile(rf"{_TOKEN_WORD}(?:[’']{_TOKEN_WORD})*", flags=re.UNICODE)
+
+
+def _strip_combining_stress(text: str) -> str:
+    return text.replace(_COMBINING_STRESS_MARK, "")
+
+
+def _candidate_match_key(text: str) -> str:
+    """Comparison-only key for candidate resolution; never applied to evidence bytes."""
+    return _strip_combining_stress(text).casefold()
+
+
 def _lexical_tokens(value: str) -> list[str]:
     """Return Unicode word tokens without inferring any morphology."""
-    return [token.casefold() for token in re.findall(r"[^\W_]+(?:[’'][^\W_]+)*", value, flags=re.UNICODE)]
+    return [token.casefold() for token in _LEXICAL_TOKEN_PATTERN.findall(value)]
 
 
 def _contains_exact_token_sequence(value: str, phrase: str) -> bool:
-    value_tokens = _lexical_tokens(value)
-    phrase_tokens = _lexical_tokens(phrase)
+    value_tokens = [_candidate_match_key(token) for token in _lexical_tokens(value)]
+    phrase_tokens = [_candidate_match_key(token) for token in _lexical_tokens(phrase)]
     if not phrase_tokens:
         return False
     width = len(phrase_tokens)
@@ -2075,7 +2095,7 @@ def build_vocabulary_surface_candidates(
     vocabulary_material = target_materials.get("vocabulary")
     if not isinstance(vocabulary_material, Mapping):
         payload = {
-            "resolver_version": "vesum-surface-candidates.v1",
+            "resolver_version": "vesum-surface-candidates.v2",
             "vesum_status": "not_applicable",
             "lemmas": [],
         }
@@ -2093,14 +2113,13 @@ def build_vocabulary_surface_candidates(
 
     tokenized_lines: list[tuple[str, int, str, list[re.Match[str]]]] = []
     unique_tokens: set[str] = set()
-    token_pattern = re.compile(r"[^\W_]+(?:[’'][^\W_]+)*", flags=re.UNICODE)
     for path, material in learner_materials:
         for line_number, visible in enumerate(_visible_source_lines(path, target_material_text(material)), start=1):
-            matches = list(token_pattern.finditer(visible))
+            matches = list(_LEXICAL_TOKEN_PATTERN.finditer(visible))
             if not matches:
                 continue
             tokenized_lines.append((path, line_number, visible, matches))
-            unique_tokens.update(match.group(0).casefold() for match in matches)
+            unique_tokens.update(_candidate_match_key(match.group(0)) for match in matches)
 
     vesum_path = main_checkout_root(repo_root) / "data" / "vesum.db"
     vesum_status = "available"
@@ -2124,12 +2143,12 @@ def build_vocabulary_surface_candidates(
                     continue
                 surface = visible[window[0].start() : window[-1].end()]
                 surface_tokens = [match.group(0).casefold() for match in window]
-                if surface.casefold() == lemma.casefold():
+                if _candidate_match_key(surface) == _candidate_match_key(lemma):
                     verification = "exact lemma surface"
                 elif all(
                     any(
-                        str(match.get("lemma") or "").casefold() == lemma_token
-                        for match in verified.get(surface_token, [])
+                        _candidate_match_key(str(match.get("lemma") or "")) == _candidate_match_key(lemma_token)
+                        for match in verified.get(_candidate_match_key(surface_token), [])
                     )
                     for lemma_token, surface_token in zip(lemma_tokens, surface_tokens, strict=True)
                 ):
@@ -2162,7 +2181,7 @@ def build_vocabulary_surface_candidates(
             }
         )
     candidate_payload = {
-        "resolver_version": "vesum-surface-candidates.v1",
+        "resolver_version": "vesum-surface-candidates.v2",
         "vesum_status": vesum_status,
         "lemmas": lemma_entries,
     }

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -3129,6 +3129,84 @@ def test_regression_exposes_unintegrated_vocabulary_surfaces_hermetically() -> N
     }
 
 
+def test_vocabulary_candidates_match_across_combining_stress_marks() -> None:
+    """#5375: combining stress marks (U+0301) are stripped for candidate
+    matching/VESUM lookup only; candidate surfaces keep the original bytes."""
+
+    def material(path: str, text: str) -> dict:
+        return {
+            "path": path,
+            "sha256": pbr.sha256_text(text),
+            "lines": [{"line": index, "text": line} for index, line in enumerate(text.splitlines(), start=1)],
+            "trailing_newline": text.endswith("\n"),
+        }
+
+    def fake_verify(words: list[str], *, db_path: Path) -> dict[str, list[dict]]:
+        del db_path
+        lemmas = {"твердого": "твердий"}
+        return {word: ([{"lemma": lemmas[word]}] if word in lemmas else []) for word in words}
+
+    content = (
+        # Stressed learner surface for the unstressed ledger lemma.
+        "М'яки́й знак пом'якшує приголосний.\n"
+        # Stressed inflected surface for the stressed ledger lemma.
+        "Це твердого́ відмінка.\n"
+        # Lexical drift: злиття is not a form of зли́то.
+        "Ніколи не пиши злиття тут.\n"
+    )
+    vocabulary = "- lemma: м'який знак\n- lemma: тверди́й\n- lemma: зли́то\n"
+    candidates = pbr.build_vocabulary_surface_candidates(
+        {"files": {"content": "module.md", "vocabulary": "vocabulary.yaml"}},
+        {
+            "content": material("module.md", content),
+            "vocabulary": material("vocabulary.yaml", vocabulary),
+        },
+        verify_words_fn=fake_verify,
+    )
+    by_lemma = {entry["lemma"]: entry["candidates"] for entry in candidates["lemmas"]}
+
+    assert {(candidate["surface"], candidate["verification"]) for candidate in by_lemma["м'який знак"]} == {
+        ("М'яки́й знак", "exact lemma surface")
+    }
+    # Displayed/stored evidence bytes are preserved: the surface still carries U+0301.
+    assert by_lemma["м'який знак"][0]["surface"] == "М'яки́й знак"
+
+    assert {(candidate["surface"], candidate["verification"]) for candidate in by_lemma["тверди́й"]} == {
+        ("твердого́", "VESUM: тверди́й=твердого́")
+    }
+
+    assert by_lemma["зли́то"] == []
+
+
+def test_vocabulary_coverage_accepts_stressed_exact_surface() -> None:
+    """#5375: a packet-bound stressed surface with 'exact lemma surface'
+    verification passes coverage validation for the unstressed lemma."""
+    source_lookup = {"module.md": "М'яки́й знак пом'якшує приголосний.\n"}
+    coverage = {
+        "lemma": "м'який знак",
+        "status": "INTEGRATED",
+        "surface": "М'яки́й знак",
+        "verification": "exact lemma surface",
+        "evidence": [
+            {
+                "location": "module.md:1",
+                "excerpt": "М'яки́й знак пом'якшує приголосний.",
+                "supports": "The stressed learner surface is the ledger lemma.",
+            }
+        ],
+        "finding_id": None,
+    }
+    normalized = pbr._normalize_vocabulary_coverage(
+        [coverage],
+        expected_lemmas=["м'який знак"],
+        verdict="PASS",
+        findings=[],
+        source_lookup=source_lookup,
+        target_files={"content": "module.md"},
+    )
+    assert normalized[0]["surface"] == "М'яки́й знак"
+
+
 def test_vocabulary_coverage_rejects_stem_collision_and_comment_only_surface() -> None:
     source_lookup = {"module.md": "<!-- правий -->\nПравда не є поверхнею цільової леми.\n"}
     base = {


### PR DESCRIPTION
Closes #5375.

## What

The vocabulary surface resolver (`build_vocabulary_surface_candidates` in `scripts/audit/post_build_review.py`) split stressed learner tokens mid-word — U+0301 is not a `\w` word char, so `м'яки́й` tokenized as `м'яки` + `й`, the multi-token whitespace-gap check then rejected every stressed window — and compared raw bytes for exact/VESUM matching. Stressed a1/special-signs surfaces therefore missed otherwise valid forms and produced false MISSING findings in canonical post-build review.

Fix, scoped to candidate matching/VESUM lookup only:

- `_LEXICAL_TOKEN_PATTERN` admits U+0301 inside word tokens (`scripts/audit/post_build_review.py:2012-2014`).
- New comparison-only `_candidate_match_key` strips U+0301 before exact matching, VESUM lookup keys, and VESUM lemma comparison (`:2021-2023`, call sites `:2147-2155`); `_contains_exact_token_sequence` compares via the same key so packet-bound stressed surfaces pass coverage validation.
- `resolver_version` bumped `vesum-surface-candidates.v1` → `v2` (informational; nothing validates it).

**Displayed/stored evidence bytes are unchanged**: candidate `surface` slices and `VESUM:` verification strings keep the original stressed bytes (asserted in tests).

## Verification (all commands run in the dispatch worktree)

1. False-MISSING repro → match. Real a1/special-signs ledger + module + activities (from `origin/main` object store) + real VESUM DB, before/after quoted:

   ```
   # before (main): MISSING (21/29): "м'яки́й знак", 'апо́строф', "м'яки́й", 'тверди́й', ...
   # after (this PR): MISSING (3/29): 'зли́то', "здоро́в'я", 'сього́дні'
   ```
   The remaining three stems never occur in the module's learner-facing text (verified stress-insensitively over module.md + activities.yaml) — a genuine content gap, out of scope per the issue's no-content-edits constraint.

2. Regression tests added (`tests/audit/test_post_build_review.py`):
   - `test_vocabulary_candidates_match_across_combining_stress_marks` — stressed↔unstressed exact match, stressed inflected VESUM match with raw bytes preserved, lexical drift (`злиття` vs `зли́то`) still rejected.
   - `test_vocabulary_coverage_accepts_stressed_exact_surface` — packet-bound stressed surface passes coverage validation.

3. Mutation check (#M-16): with the fix stashed (`git stash push -- scripts/audit/post_build_review.py`):
   ```
   FAILED tests/audit/test_post_build_review.py::test_vocabulary_candidates_match_across_combining_stress_marks
   FAILED tests/audit/test_post_build_review.py::test_vocabulary_coverage_accepts_stressed_exact_surface
   2 failed, 202 deselected
   ```
   Both fail without the fix, pass with it.

4. `.venv/bin/pytest tests/audit/test_post_build_review.py`: `53 failed, 105 passed, 48 errors` — the failing set is byte-identical (`diff` verified) to clean `origin/main` in this sparse checkout (`curriculum/` absent; pre-existing environmental failures, not regressions). `.venv/bin/ruff check` on both changed files: all checks passed.

Sibling PR for #5374 (apostrophe glyphs) stacks on this branch.