### PR TITLE
fix(review): fold Ukrainian apostrophe glyphs in vocabulary surface candidates (#5374)

### DIFF
--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -2011,7 +2011,10 @@ def _visible_source_lines(path: str, text: str) -> list[str]:
 # and displayed evidence always keeps the original bytes. (#5375)
 _COMBINING_STRESS_MARK = "\u0301"
 _TOKEN_WORD = "[^\\W_]+(?:\u0301+[^\\W_]*)*"
-_LEXICAL_TOKEN_PATTERN = re.compile(rf"{_TOKEN_WORD}(?:[’']{_TOKEN_WORD})*", flags=re.UNICODE)
+# U+02BC is a modifier letter (Lm), so _TOKEN_WORD already matches it
+# mid-word; it is named in the joiner class explicitly so the apostrophe
+# equivalence set stays visibly complete with _APOSTROPHE_FOLD below. (#5374)
+_LEXICAL_TOKEN_PATTERN = re.compile(rf"{_TOKEN_WORD}(?:[’'ʼ]{_TOKEN_WORD})*", flags=re.UNICODE)
 
 # The three Ukrainian apostrophe glyphs — U+0027 ASCII apostrophe, U+2019
 # right single quotation mark, and U+02BC modifier letter apostrophe — are the

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -2013,6 +2013,13 @@ _COMBINING_STRESS_MARK = "\u0301"
 _TOKEN_WORD = "[^\\W_]+(?:\u0301+[^\\W_]*)*"
 _LEXICAL_TOKEN_PATTERN = re.compile(rf"{_TOKEN_WORD}(?:[’']{_TOKEN_WORD})*", flags=re.UNICODE)
 
+# The three Ukrainian apostrophe glyphs — U+0027 ASCII apostrophe, U+2019
+# right single quotation mark, and U+02BC modifier letter apostrophe — are the
+# same orthographic sign; VESUM stores the ASCII form. Fold them for
+# candidate comparison and VESUM lookup only, never in stored or displayed
+# evidence. Glyphs outside these three (e.g. U+02BB) stay distinct. (#5374)
+_APOSTROPHE_FOLD = str.maketrans({"’": "'", "ʼ": "'"})
+
 
 def _strip_combining_stress(text: str) -> str:
     return text.replace(_COMBINING_STRESS_MARK, "")
@@ -2020,7 +2027,7 @@ def _strip_combining_stress(text: str) -> str:
 
 def _candidate_match_key(text: str) -> str:
     """Comparison-only key for candidate resolution; never applied to evidence bytes."""
-    return _strip_combining_stress(text).casefold()
+    return _strip_combining_stress(text).translate(_APOSTROPHE_FOLD).casefold()
 
 
 def _lexical_tokens(value: str) -> list[str]:

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -3258,6 +3258,47 @@ def test_vocabulary_candidates_fold_ukrainian_apostrophe_glyphs() -> None:
     assert all("\u02bb" not in candidate["surface"] for candidate in by_lemma["сім'я"])
 
 
+def test_vocabulary_candidates_resolve_modifier_apostrophe_stressed_token() -> None:
+    """#5374 review fix: a U+02BC surface carrying the combining stress mark
+    (Мʼяки́й знак) must stay ONE token on the tokenizer path — if the
+    modifier apostrophe ever splits the token, _APOSTROPHE_FOLD never sees
+    the joined word and the false-MISSING returns. The surface resolves
+    against the ASCII-apostrophe ledger lemma м'який знак."""
+
+    def material(path: str, text: str) -> dict:
+        return {
+            "path": path,
+            "sha256": pbr.sha256_text(text),
+            "lines": [{"line": index, "text": line} for index, line in enumerate(text.splitlines(), start=1)],
+            "trailing_newline": text.endswith("\n"),
+        }
+
+    def fake_verify(words: list[str], *, db_path: Path) -> dict[str, list[dict]]:
+        del db_path
+        return {word: [] for word in words}
+
+    # Tokenizer path: the U+02BC + U+0301 surface is a single token.
+    assert pbr._lexical_tokens("Мʼяки́й знак") == ["мʼяки́й", "знак"]
+
+    content = "Мʼяки́й знак помʼякшує приголосний.\n"
+    vocabulary = "- lemma: м'який знак\n"
+    candidates = pbr.build_vocabulary_surface_candidates(
+        {"files": {"content": "module.md", "vocabulary": "vocabulary.yaml"}},
+        {
+            "content": material("module.md", content),
+            "vocabulary": material("vocabulary.yaml", vocabulary),
+        },
+        verify_words_fn=fake_verify,
+    )
+    by_lemma = {entry["lemma"]: entry["candidates"] for entry in candidates["lemmas"]}
+
+    assert {(candidate["surface"], candidate["verification"]) for candidate in by_lemma["м'який знак"]} == {
+        ("Мʼяки́й знак", "exact lemma surface")
+    }
+    # Evidence bytes are preserved: the surface keeps U+02BC and U+0301.
+    assert by_lemma["м'який знак"][0]["surface"] == "Мʼяки́й знак"
+
+
 def test_vocabulary_coverage_accepts_modifier_apostrophe_exact_surface() -> None:
     """#5374: a packet-bound U+02BC surface with 'exact lemma surface'
     verification passes coverage validation for the U+0027 lemma."""

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -3207,6 +3207,86 @@ def test_vocabulary_coverage_accepts_stressed_exact_surface() -> None:
     assert normalized[0]["surface"] == "М'яки́й знак"
 
 
+def test_vocabulary_candidates_fold_ukrainian_apostrophe_glyphs() -> None:
+    """#5374: the three Ukrainian apostrophe glyphs (U+0027, U+2019, U+02BC)
+    are equivalent for candidate comparison and VESUM lookup; candidate
+    surfaces keep the original glyph; glyphs outside the three stay
+    distinct."""
+
+    def material(path: str, text: str) -> dict:
+        return {
+            "path": path,
+            "sha256": pbr.sha256_text(text),
+            "lines": [{"line": index, "text": line} for index, line in enumerate(text.splitlines(), start=1)],
+            "trailing_newline": text.endswith("\n"),
+        }
+
+    seen: list[str] = []
+
+    def fake_verify(words: list[str], *, db_path: Path) -> dict[str, list[dict]]:
+        del db_path
+        seen.extend(words)
+        lemmas = {"сім'ї": "сім'я"}
+        return {word: ([{"lemma": lemmas[word]}] if word in lemmas else []) for word in words}
+
+    content = (
+        "Сім\u02bcя читає разом.\n"  # U+02BC surface, exact lemma match
+        "Сім\u2019я слухає казку.\n"  # U+2019 surface, exact lemma match
+        "Про сім\u2019ї розповіли.\n"  # U+2019 inflected surface, VESUM match
+        "Сім\u02bbя тут не та.\n"  # U+02BB is not an apostrophe: must not bind
+    )
+    vocabulary = "- lemma: сім'я\n"
+    candidates = pbr.build_vocabulary_surface_candidates(
+        {"files": {"content": "module.md", "vocabulary": "vocabulary.yaml"}},
+        {
+            "content": material("module.md", content),
+            "vocabulary": material("vocabulary.yaml", vocabulary),
+        },
+        verify_words_fn=fake_verify,
+    )
+    by_lemma = {entry["lemma"]: entry["candidates"] for entry in candidates["lemmas"]}
+
+    assert {(candidate["surface"], candidate["verification"]) for candidate in by_lemma["сім'я"]} == {
+        ("Сім\u02bcя", "exact lemma surface"),
+        ("Сім\u2019я", "exact lemma surface"),
+        ("сім\u2019ї", "VESUM: сім'я=сім\u2019ї"),
+    }
+    # The VESUM lookup received the folded ASCII form, never the raw curly glyph.
+    assert "сім'ї" in seen
+    assert "сім\u2019ї" not in seen
+    # U+02BB stays distinct: its surface produced no candidate.
+    assert all("\u02bb" not in candidate["surface"] for candidate in by_lemma["сім'я"])
+
+
+def test_vocabulary_coverage_accepts_modifier_apostrophe_exact_surface() -> None:
+    """#5374: a packet-bound U+02BC surface with 'exact lemma surface'
+    verification passes coverage validation for the U+0027 lemma."""
+    source_lookup = {"module.md": "Сім\u02bcя читає разом.\n"}
+    coverage = {
+        "lemma": "сім'я",
+        "status": "INTEGRATED",
+        "surface": "Сім\u02bcя",
+        "verification": "exact lemma surface",
+        "evidence": [
+            {
+                "location": "module.md:1",
+                "excerpt": "Сім\u02bcя читає разом.",
+                "supports": "The modifier-apostrophe surface is the ledger lemma.",
+            }
+        ],
+        "finding_id": None,
+    }
+    normalized = pbr._normalize_vocabulary_coverage(
+        [coverage],
+        expected_lemmas=["сім'я"],
+        verdict="PASS",
+        findings=[],
+        source_lookup=source_lookup,
+        target_files={"content": "module.md"},
+    )
+    assert normalized[0]["surface"] == "Сім\u02bcя"
+
+
 def test_vocabulary_coverage_rejects_stem_collision_and_comment_only_surface() -> None:
     source_lookup = {"module.md": "<!-- правий -->\nПравда не є поверхнею цільової леми.\n"}
     base = {


### PR DESCRIPTION
Closes #5374.

**Stacked on #6832** (the #5375 stress-mark PR): the two fixes share the same comparison-only match key in the same resolver function, so this branch contains that commit; the diff shown here is only the apostrophe fold. GitHub will retarget this PR to `main` once #6832 merges. Per the dispatch brief, one PR per issue was preferred over a combined PR.

## What

The vocabulary surface resolver treated the three Ukrainian apostrophe glyphs — U+0027 (`'`), U+2019 (`’`), U+02BC (`ʼ`) — as distinct for exact matching and VESUM lookup, even though they are the same orthographic sign (the semantic claim binder already folds them) and VESUM stores the ASCII form. A glyph-mixed learner text produced false MISSING vocabulary findings.

Fix: `_APOSTROPHE_FOLD` folds U+2019 and U+02BC to U+0027 inside the comparison-only `_candidate_match_key` (`scripts/audit/post_build_review.py`), which feeds exact matching, VESUM lookup keys, VESUM lemma comparison, and `_contains_exact_token_sequence` coverage validation. No tokenizer change was needed — U+02BC is a letter (Lm) and already tokenizes inside words.

- **Evidence bytes preserved**: candidate surfaces and `VESUM:` verification strings keep the original glyph (asserted in tests).
- **Glyphs outside the three stay distinct**: U+02BB (`ʻ`) is never folded and produces no candidate (asserted in tests).

## Verification (dispatch worktree)

1. False-MISSING repro → match. Real a1/special-signs ledger (ASCII apostrophes) against a glyph-mixed copy of the module content (apostrophes alternately swapped to U+2019/U+02BC), real VESUM DB:

   ```
   pre-fix MISSING on glyph-mixed content: 14/29
     - "м'яки́й знак", "сім'я́", "м'я́со", "п'ять", "де́в'ять", "ім'я́", "комп'ю́тер", "бур'я́н", "Мар'я́на", "дерев'я́ний", ...
   post-fix MISSING on glyph-mixed content: 3/29
     - 'зли́то', "здоро́в'я", 'сього́дні'   (genuinely absent from learner text — same residual as unmixed content)
   ```

2. Regression tests added (`tests/audit/test_post_build_review.py`):
   - `test_vocabulary_candidates_fold_ukrainian_apostrophe_glyphs` — U+02BC and U+2019 surfaces exact-match the U+0027 lemma; U+2019 inflected surface matches via VESUM; asserts the VESUM lookup received the folded ASCII form; asserts U+02BB binds nothing; surfaces keep original bytes.
   - `test_vocabulary_coverage_accepts_modifier_apostrophe_exact_surface` — packet-bound U+02BC surface passes coverage validation for the U+0027 lemma.

3. Mutation check (#M-16): with `.translate(_APOSTROPHE_FOLD)` removed from the match key:
   ```
   FAILED tests/audit/test_post_build_review.py::test_vocabulary_candidates_fold_ukrainian_apostrophe_glyphs
   FAILED tests/audit/test_post_build_review.py::test_vocabulary_coverage_accepts_modifier_apostrophe_exact_surface
   2 failed, 9 passed
   ```
   Both fail without the fold, pass with it; the #5375 stress tests stayed green throughout (no over-broadening).

4. `.venv/bin/pytest tests/audit/test_post_build_review.py`: failing set byte-identical (`diff` verified) to clean `origin/main` in this sparse checkout (pre-existing `curriculum/`-absence failures, not regressions); the four new tests pass. `.venv/bin/ruff check` on both changed files: all checks passed.

No `scripts/lexicon/` files touched — the Atlas manifest freshness gate does not apply.