### PR TITLE
test(activity-kit): expand contract tests past smoke level (#4870)

### DIFF
--- a/site/tests/unit/ActivityKit.contract.test.tsx
+++ b/site/tests/unit/ActivityKit.contract.test.tsx
@@ -10,6 +10,16 @@ import lessonFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson
 import lessonSupportFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson-support.v1.valid.fixture.json';
 import invalidLessonSupportFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson-support.v1.invalid.fixture.json';
 import { ActivityPlayer, LessonViewer } from '../../../packages/activity-kit/src';
+import {
+  Cloze as KitCloze,
+  ClozePassage as KitClozePassage,
+  MatchUp as KitMatchUp,
+  TrueFalse as KitTrueFalse,
+  TrueFalseQuestion as KitTrueFalseQuestion,
+} from '../../../packages/activity-kit/src';
+import SiteCloze, { ClozePassage as SiteClozePassage } from '@site/src/components/Cloze';
+import SiteMatchUp from '@site/src/components/MatchUp';
+import SiteTrueFalse, { TrueFalseQuestion as SiteTrueFalseQuestion } from '@site/src/components/TrueFalse';
 import type {
   ActivityEditOperation,
   LuActivityV1,
@@ -518,4 +528,97 @@ describe('lesson document v1 contract', () => {
       expect(container.querySelector('[data-testid="block-note-rent-04-multiple-choice"]')).toBeNull();
     });
   });
+});
+
+describe('golden envelope contract', () => {
+  test('pins the id pattern, level const, and provenance triple on every golden fixture', () => {
+    for (const fixture of fixtures) {
+      expect(fixture.id).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+      expect(fixture.level).toBe('b1');
+      expect(fixture.provenance.source).toEqual(expect.any(String));
+      expect(fixture.provenance.generator).toEqual(expect.any(String));
+      expect(fixture.provenance.gates).toContain('schema');
+    }
+  });
+});
+
+describe('site shim surface', () => {
+  test('re-exports the kit implementations at runtime', () => {
+    expect(SiteCloze).toBe(KitCloze);
+    expect(SiteClozePassage).toBe(KitClozePassage);
+    expect(SiteMatchUp).toBe(KitMatchUp);
+    expect(SiteTrueFalse).toBe(KitTrueFalse);
+    expect(SiteTrueFalseQuestion).toBe(KitTrueFalseQuestion);
+  });
+
+  type PropAnnotations = Record<string, { schemaDescription: boolean; ukrainianText?: string }>;
+
+  function parseInterfaceProps(source: string, interfaceName: string): PropAnnotations {
+    const body = source.match(
+      new RegExp(`export interface ${interfaceName} \\{(?<body>[\\s\\S]*?)\\n\\}`),
+    )?.groups?.body;
+    expect(body, `interface ${interfaceName} not found`).toBeDefined();
+
+    const props: PropAnnotations = {};
+    let pendingSchema = false;
+    let pendingUkrainian: string | undefined;
+    for (const line of body!.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('* @schemaDescription')) {
+        pendingSchema = true;
+      } else if (trimmed.startsWith('* @ukrainianText')) {
+        pendingUkrainian = trimmed.replace('* @ukrainianText', '').trim();
+      } else {
+        const prop = trimmed.match(/^(?<name>[a-zA-Z][a-zA-Z0-9]*)\??:/)?.groups?.name;
+        if (prop) {
+          props[prop] = { schemaDescription: pendingSchema, ukrainianText: pendingUkrainian };
+        }
+        pendingSchema = false;
+        pendingUkrainian = undefined;
+      }
+    }
+    return props;
+  }
+
+  const SHIM_PAIRS = [
+    {
+      shim: join(repoRoot, 'site/src/components/Cloze.tsx'),
+      kit: join(kitRoot, 'src/components/Cloze.tsx'),
+      interfaces: ['ClozeBlank', 'ClozePassageProps', 'ClozeProps'],
+    },
+    {
+      shim: join(repoRoot, 'site/src/components/TrueFalse.tsx'),
+      kit: join(kitRoot, 'src/components/TrueFalse.tsx'),
+      interfaces: ['TrueFalseQuestionProps', 'TrueFalseItem', 'TrueFalseProps'],
+    },
+    {
+      shim: join(repoRoot, 'site/src/components/MatchUp.tsx'),
+      kit: join(kitRoot, 'src/components/MatchUp.tsx'),
+      interfaces: ['MatchPair', 'MatchUpProps'],
+    },
+  ];
+
+  test.each(SHIM_PAIRS)(
+    '$shim mirrors the kit prop surface and annotation presence',
+    ({ shim, kit, interfaces }) => {
+      const shimSource = readFileSync(shim, 'utf8');
+      const kitSource = readFileSync(kit, 'utf8');
+
+      for (const interfaceName of interfaces) {
+        const shimProps = parseInterfaceProps(shimSource, interfaceName);
+        const kitProps = parseInterfaceProps(kitSource, interfaceName);
+
+        // Same prop names, same schemaDescription/ukrainianText annotation surface.
+        expect(shimProps).toEqual(kitProps);
+
+        // Every schema-annotated prop carries the ukrainianText tag the lesson
+        // schema generator (scripts/build/generate_lesson_schema.py) reads.
+        for (const [prop, annotations] of Object.entries(kitProps)) {
+          if (annotations.schemaDescription) {
+            expect(annotations.ukrainianText, `${interfaceName}.${prop}`).toMatch(/^(true|false)$/);
+          }
+        }
+      }
+    },
+  );
 });

--- a/site/tests/unit/ActivityKit.player.test.tsx
+++ b/site/tests/unit/ActivityKit.player.test.tsx
@@ -1,0 +1,528 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import fixtures from '../../../packages/activity-kit/src/fixtures/lu.activity.v1.fixtures.json';
+import {
+  ActivityPlayer,
+  Cloze,
+  ClozePassage,
+  MatchUp,
+  TrueFalseQuestion,
+} from '../../../packages/activity-kit/src';
+import type { LuActivityV1 } from '../../../packages/activity-kit/src';
+
+// Mirrors packages/activity-kit MatchUp MISSHAKE_TIMEOUT_MS (wrong-pair reset).
+const MISSHAKE_TIMEOUT_MS = 240;
+
+const trueFalseFixture = fixtures.find((fixture) => fixture.type === 'true-false');
+const clozeFixture = fixtures.find((fixture) => fixture.type === 'cloze');
+const matchUpFixture = fixtures.find((fixture) => fixture.type === 'match-up');
+
+function rightColumn(container: HTMLElement): HTMLElement {
+  const column = container.querySelector('[data-activity="match-right-column"]');
+  if (!column) throw new Error('match-right-column not found');
+  return column as HTMLElement;
+}
+
+function rightTileByText(container: HTMLElement, text: string): HTMLElement {
+  return within(rightColumn(container)).getByRole('button', { name: text });
+}
+
+function leftTileByText(container: HTMLElement, text: string): HTMLElement {
+  const column = container.querySelector('[data-activity="match-left-column"]');
+  if (!column) throw new Error('match-left-column not found');
+  return within(column as HTMLElement).getByRole('button', { name: text });
+}
+
+function allTiles(container: HTMLElement): HTMLElement[] {
+  return [
+    ...within(
+      container.querySelector('[data-activity="match-left-column"]') as HTMLElement,
+    ).getAllByRole('button'),
+    ...within(rightColumn(container)).getAllByRole('button'),
+  ];
+}
+
+function fillCloze(container: HTMLElement, blankIndex: number, value: string) {
+  const select = container.querySelector(`select[data-blank-index="${blankIndex}"]`);
+  if (!select) throw new Error(`cloze select for blank ${blankIndex} not found`);
+  fireEvent.change(select, { target: { value } });
+}
+
+describe('player contract: envelope rendering and completion events', () => {
+  test('renders the activity title as the region label and heading', () => {
+    render(<ActivityPlayer activity={clozeFixture as LuActivityV1} isUkrainian />);
+
+    expect(screen.getByRole('region', { name: 'Читання в контексті' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Читання в контексті' })).toBeInTheDocument();
+  });
+
+  test('falls back to the activity type as title when the envelope omits one', () => {
+    const untitled = structuredClone(clozeFixture) as unknown as LuActivityV1;
+    delete (untitled as Partial<LuActivityV1>).title;
+
+    render(<ActivityPlayer activity={untitled} isUkrainian />);
+
+    expect(screen.getByRole('region', { name: 'cloze' })).toBeInTheDocument();
+  });
+
+  test('emits a typed completion event for cloze after a full submission', () => {
+    const onComplete = vi.fn();
+    const { container } = render(
+      <ActivityPlayer activity={clozeFixture as LuActivityV1} onComplete={onComplete} isUkrainian />,
+    );
+
+    fillCloze(container, 1, 'допомагає');
+    fireEvent.click(screen.getByRole('button', { name: 'Перевірити' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      activityId: 'golden-cloze',
+      activityType: 'cloze',
+    });
+  });
+
+  test('emits a typed completion event for match-up once every pair is connected', () => {
+    const onComplete = vi.fn();
+    const { container } = render(
+      <ActivityPlayer activity={matchUpFixture as LuActivityV1} onComplete={onComplete} isUkrainian />,
+    );
+
+    expect(onComplete).not.toHaveBeenCalled();
+
+    fireEvent.click(leftTileByText(container, 'пояснення'));
+    fireEvent.click(rightTileByText(container, 'додатковий коментар'));
+    expect(onComplete).not.toHaveBeenCalled();
+
+    fireEvent.click(leftTileByText(container, 'відповідь'));
+    fireEvent.click(rightTileByText(container, 'реакція на запитання'));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      activityId: 'golden-match-up',
+      activityType: 'match-up',
+    });
+  });
+});
+
+describe('player contract: payload mapping and answer_key separation', () => {
+  test('maps cloze payload blank ids onto select data-blank-index markers', () => {
+    const activity = structuredClone(clozeFixture) as unknown as LuActivityV1;
+    activity.id = 'deep-map-cloze';
+    activity.payload = {
+      type: 'cloze',
+      instruction: 'Виберіть слова.',
+      text: 'Перше [___:2] і друге [___:5].',
+      blanks: [
+        { id: 2, answer: 'альфа', options: ['альфа', 'бета'] },
+        { id: 5, answer: 'гамма', options: ['гамма', 'дельта'] },
+      ],
+    };
+
+    const { container } = render(<ActivityPlayer activity={activity} isUkrainian />);
+
+    const selects = [...container.querySelectorAll('select[data-blank-index]')];
+    expect(selects.map((select) => select.getAttribute('data-blank-index'))).toEqual(['2', '5']);
+
+    // Grading keys each selection to its mapped blank index, not to option order.
+    fillCloze(container, 2, 'бета');
+    fillCloze(container, 5, 'гамма');
+    fireEvent.click(screen.getByRole('button', { name: 'Перевірити' }));
+
+    const feedback = container.querySelector('[data-activity="cloze-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('false');
+  });
+
+  test('grades true-false from the payload, never from answer_key', () => {
+    const corrupted = structuredClone(trueFalseFixture) as unknown as LuActivityV1;
+    (corrupted.answer_key as { items: Array<{ correct: boolean }> }).items[0].correct = false;
+
+    const { container } = render(<ActivityPlayer activity={corrupted} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'True' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    const feedback = container.querySelector('[data-activity="tf-row-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+  });
+
+  test('grades cloze from the payload, never from answer_key', () => {
+    const corrupted = structuredClone(clozeFixture) as unknown as LuActivityV1;
+    (corrupted.answer_key as { blanks: Array<{ answer: string }> }).blanks[0].answer = 'заважає';
+
+    const { container } = render(<ActivityPlayer activity={corrupted} />);
+
+    fillCloze(container, 1, 'допомагає');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    const feedback = container.querySelector('[data-activity="cloze-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+  });
+});
+
+describe('player contract: content rendering', () => {
+  test('renders true-false instruction, statement, and feedback explanation', () => {
+    const { container } = render(
+      <ActivityPlayer activity={trueFalseFixture as LuActivityV1} isUkrainian />,
+    );
+
+    expect(screen.getByText('Прочитайте твердження й оберіть правильну відповідь.')).toBeInTheDocument();
+    expect(screen.getByText('Це навчальне твердження позначено як правдиве.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Правда' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Перевірити' }));
+
+    const feedback = container.querySelector('[data-activity="tf-row-feedback"]');
+    expect(feedback?.textContent).toContain('У ключі для цього твердження вказано «правда».');
+  });
+
+  test('renders cloze instruction and passage text around each blank select', () => {
+    const { container } = render(
+      <ActivityPlayer activity={clozeFixture as LuActivityV1} isUkrainian />,
+    );
+
+    expect(screen.getByText('Виберіть слова, що доповнюють речення.')).toBeInTheDocument();
+
+    const passage = container.querySelector('[data-activity="cloze-passage"] p');
+    expect(passage?.textContent).toContain('Уважне читання');
+    expect(passage?.textContent).toContain('зрозуміти зміст речення.');
+    expect(container.querySelectorAll('select[data-activity="cloze-blank"]')).toHaveLength(1);
+  });
+
+  test('renders match-up instruction and every pair text on the board', () => {
+    render(<ActivityPlayer activity={matchUpFixture as LuActivityV1} isUkrainian />);
+
+    expect(screen.getByText("З'єднайте поняття з відповідним описом.")).toBeInTheDocument();
+    for (const text of ['пояснення', 'відповідь', 'додатковий коментар', 'реакція на запитання']) {
+      expect(screen.getByRole('button', { name: text })).toBeInTheDocument();
+    }
+  });
+});
+
+describe('ClozePassage in isolation', () => {
+  const blanks = [
+    { index: 1, answer: 'сонце', options: ['сонце', 'місяць'] },
+    { index: 2, answer: 'зірки', options: ['зірки', 'хмари'] },
+  ];
+
+  test('keeps the submit button disabled until every blank is filled', () => {
+    const { container } = render(<ClozePassage text="На небі [___:1] і [___:2]." blanks={blanks} />);
+
+    const submit = screen.getByRole('button', { name: 'Check Answers' });
+    expect(submit).toBeDisabled();
+
+    fillCloze(container, 1, 'сонце');
+    expect(submit).toBeDisabled();
+
+    fillCloze(container, 2, 'зірки');
+    expect(submit).toBeEnabled();
+  });
+
+  test('flags wrong selections and lists the correct answers on submit', () => {
+    const { container } = render(<ClozePassage text="На небі [___:1] і [___:2]." blanks={blanks} />);
+
+    fillCloze(container, 1, 'місяць');
+    fillCloze(container, 2, 'зірки');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    const feedback = container.querySelector('[data-activity="cloze-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('false');
+    expect(feedback?.textContent).toContain('✗ Some answers are incorrect. Correct answers:');
+    expect(feedback?.textContent).toContain('сонце');
+    expect(feedback?.textContent).toContain('зірки');
+
+    const [firstBlank, secondBlank] = [
+      ...container.querySelectorAll('select[data-activity="cloze-blank"]'),
+    ];
+    expect(firstBlank.className).toContain('incorrect');
+    expect(secondBlank.className).toContain('correct');
+    expect(firstBlank).toBeDisabled();
+  });
+
+  test('reset clears selections and feedback so the passage can be retried', () => {
+    const { container } = render(<ClozePassage text="На небі [___:1] і [___:2]." blanks={blanks} />);
+
+    fillCloze(container, 1, 'місяць');
+    fillCloze(container, 2, 'хмари');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+    expect(container.querySelector('[data-activity="cloze-feedback"]')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+
+    expect(container.querySelector('[data-activity="cloze-feedback"]')).not.toBeInTheDocument();
+    const selects = [...container.querySelectorAll('select[data-activity="cloze-blank"]')];
+    for (const select of selects) {
+      expect(select).toBeEnabled();
+      expect((select as HTMLSelectElement).value).toBe('');
+    }
+    expect(screen.getByRole('button', { name: 'Check Answers' })).toBeDisabled();
+  });
+
+  test('fires onComplete exactly once per submission', () => {
+    const onComplete = vi.fn();
+    const { container } = render(
+      <ClozePassage text="На небі [___:1] і [___:2]." blanks={blanks} onComplete={onComplete} />,
+    );
+
+    fillCloze(container, 1, 'сонце');
+    fillCloze(container, 2, 'зірки');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    fillCloze(container, 1, 'сонце');
+    fillCloze(container, 2, 'зірки');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('TrueFalseQuestion in isolation', () => {
+  test('shows correct feedback with the explanation after the right answer', () => {
+    const { container } = render(
+      <TrueFalseQuestion
+        statement="Київ — столиця України."
+        isTrue
+        explanation="Київ є столицею з 1918 року."
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'True' }));
+
+    const feedback = container.querySelector('[data-activity="tf-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+    expect(feedback?.textContent).toContain('✓ Correct!');
+    expect(feedback?.textContent).toContain('Київ є столицею з 1918 року.');
+  });
+
+  test('reports the true/false verdict on a wrong answer and locks the buttons', () => {
+    const { container } = render(
+      <TrueFalseQuestion statement="Львів — столиця України." isTrue={false} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'True' }));
+
+    const feedback = container.querySelector('[data-activity="tf-feedback"]');
+    expect(feedback?.getAttribute('data-correct')).toBe('false');
+    expect(feedback?.textContent).toContain('✗ The statement is false.');
+    expect(screen.getByRole('button', { name: 'True' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'False' })).toBeDisabled();
+  });
+});
+
+describe('MatchUp onMatch in isolation', () => {
+  const pairs = [
+    { left: 'кіт', right: 'няв' },
+    { left: 'пес', right: 'гав' },
+    { left: 'корова', right: 'му' },
+  ];
+
+  test('rates a clean match good and reports a correct completion', () => {
+    const onMatch = vi.fn();
+    const onComplete = vi.fn();
+    const { container } = render(
+      <MatchUp pairs={pairs} onMatch={onMatch} onComplete={onComplete} />,
+    );
+
+    fireEvent.click(leftTileByText(container, 'кіт'));
+    fireEvent.click(rightTileByText(container, 'няв'));
+
+    expect(onMatch).toHaveBeenCalledTimes(1);
+    expect(onMatch).toHaveBeenCalledWith(0, 'good');
+
+    fireEvent.click(leftTileByText(container, 'пес'));
+    fireEvent.click(rightTileByText(container, 'гав'));
+    fireEvent.click(leftTileByText(container, 'корова'));
+    fireEvent.click(rightTileByText(container, 'му'));
+
+    expect(onMatch).toHaveBeenCalledTimes(3);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(true);
+
+    const feedback = container.querySelector('[data-activity="match-feedback"]');
+    expect(feedback).toBeInTheDocument();
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+    for (const tile of allTiles(container)) {
+      expect(tile.getAttribute('data-matched')).toBe('true');
+    }
+  });
+
+  test('rates a match hard after one miss and again after two misses', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const onMatch = vi.fn();
+      const onComplete = vi.fn();
+      const { container } = render(
+        <MatchUp pairs={pairs} onMatch={onMatch} onComplete={onComplete} />,
+      );
+
+      // Pair 1: two misses against still-unmatched right tiles → 'again'.
+      fireEvent.click(leftTileByText(container, 'пес'));
+      fireEvent.click(rightTileByText(container, 'му'));
+      act(() => {
+        vi.advanceTimersByTime(MISSHAKE_TIMEOUT_MS);
+      });
+      fireEvent.click(leftTileByText(container, 'пес'));
+      fireEvent.click(rightTileByText(container, 'няв'));
+      act(() => {
+        vi.advanceTimersByTime(MISSHAKE_TIMEOUT_MS);
+      });
+      fireEvent.click(leftTileByText(container, 'пес'));
+      fireEvent.click(rightTileByText(container, 'гав'));
+      expect(onMatch).toHaveBeenCalledWith(1, 'again');
+
+      // Pair 0: one miss before matching → 'hard'.
+      fireEvent.click(leftTileByText(container, 'кіт'));
+      fireEvent.click(rightTileByText(container, 'му'));
+      act(() => {
+        vi.advanceTimersByTime(MISSHAKE_TIMEOUT_MS);
+      });
+      fireEvent.click(leftTileByText(container, 'кіт'));
+      fireEvent.click(rightTileByText(container, 'няв'));
+      expect(onMatch).toHaveBeenCalledWith(0, 'hard');
+
+      fireEvent.click(leftTileByText(container, 'корова'));
+      fireEvent.click(rightTileByText(container, 'му'));
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('attributes ratings to the original pair index despite the shuffled right column', () => {
+    const onMatch = vi.fn();
+    const { container } = render(<MatchUp pairs={pairs} onMatch={onMatch} />);
+
+    fireEvent.click(leftTileByText(container, 'корова'));
+    fireEvent.click(rightTileByText(container, 'му'));
+
+    expect(onMatch).toHaveBeenCalledWith(2, 'good');
+  });
+});
+
+describe('Cloze legacy passage contract', () => {
+  const legacyPassage = [
+    'Учні [___:1] уважно.',
+    '',
+    '1. читають | пишуть',
+    '   > [!answer] читають',
+  ].join('\n');
+
+  test('parses legacy embedded options from the passage and grades the marked answer', () => {
+    const onComplete = vi.fn();
+    const { container } = render(
+      <Cloze passage={legacyPassage} onComplete={onComplete} isUkrainian />,
+    );
+
+    // The option block is stripped from the rendered passage text; the blank
+    // marker is replaced by the select, so only the surrounding text nodes remain.
+    const passage = container.querySelector('[data-activity="cloze-passage"] p');
+    expect(passage?.firstChild?.textContent).toBe('Учні ');
+    expect(passage?.lastChild?.textContent).toBe(' уважно.');
+    expect(passage?.textContent).not.toContain('[!answer]');
+    expect(passage?.textContent).not.toContain('1. читають');
+
+    const select = container.querySelector('select[data-blank-index="1"]');
+    expect(select).toBeInTheDocument();
+    const optionValues = [...(select as HTMLSelectElement).options].map((option) => option.value);
+    expect(new Set(optionValues)).toEqual(new Set(['', 'читають', 'пишуть']));
+
+    fireEvent.change(select!, { target: { value: 'читають' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Перевірити' }));
+
+    const feedback = container.querySelector('[data-activity="cloze-feedback"]');
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('provided blanks take precedence over embedded-option parsing', () => {
+    const { container } = render(
+      <Cloze
+        passage={legacyPassage}
+        blanks={[{ index: 1, answer: 'пишуть', options: ['пишуть', 'читають'] }]}
+      />,
+    );
+
+    // With explicit blanks the passage is used verbatim, including the option block.
+    const select = container.querySelector('select[data-blank-index="1"]');
+    fireEvent.change(select!, { target: { value: 'пишуть' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+
+    const feedback = container.querySelector('[data-activity="cloze-feedback"]');
+    expect(feedback?.getAttribute('data-correct')).toBe('true');
+  });
+
+  test('falls back to children when no passage is provided', () => {
+    const { container } = render(
+      <Cloze isUkrainian>
+        <p data-testid="legacy-child">вкладений вміст</p>
+      </Cloze>,
+    );
+
+    expect(screen.getByTestId('legacy-child')).toBeInTheDocument();
+    expect(container.querySelector('[data-activity="cloze-passage"]')).not.toBeInTheDocument();
+  });
+});
+
+describe('isUkrainian label and feedback switching', () => {
+  test('switches cloze header, buttons, and feedback between Ukrainian and English', () => {
+    const blanks = [{ index: 1, answer: 'сонце', options: ['сонце', 'місяць'] }];
+
+    const ukrainian = render(
+      <ClozePassage text="На небі [___:1]." blanks={blanks} isUkrainian />,
+    );
+    expect(screen.getByRole('button', { name: 'Перевірити' })).toBeInTheDocument();
+    fillCloze(ukrainian.container, 1, 'місяць');
+    fireEvent.click(screen.getByRole('button', { name: 'Перевірити' }));
+    expect(
+      ukrainian.container.querySelector('[data-activity="cloze-feedback"]')?.textContent,
+    ).toContain('✗ Деякі відповіді неправильні. Правильні відповіді:');
+    expect(screen.getByRole('button', { name: 'Спробувати знову' })).toBeInTheDocument();
+    ukrainian.unmount();
+
+    const english = render(<ClozePassage text="На небі [___:1]." blanks={blanks} />);
+    expect(screen.getByRole('button', { name: 'Check Answers' })).toBeInTheDocument();
+    fillCloze(english.container, 1, 'сонце');
+    fireEvent.click(screen.getByRole('button', { name: 'Check Answers' }));
+    expect(
+      english.container.querySelector('[data-activity="cloze-feedback"]')?.textContent,
+    ).toContain('✓ All answers are correct!');
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+  });
+
+  test('switches TrueFalseQuestion labels and verdict language', () => {
+    const ukrainian = render(
+      <TrueFalseQuestion statement="Два плюс два — чотири." isTrue isUkrainian />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Неправда' }));
+    expect(
+      ukrainian.container.querySelector('[data-activity="tf-feedback"]')?.textContent,
+    ).toContain('✗ Це твердження правдиве.');
+    ukrainian.unmount();
+
+    const english = render(<TrueFalseQuestion statement="Два плюс два — чотири." isTrue />);
+    fireEvent.click(screen.getByRole('button', { name: 'False' }));
+    expect(
+      english.container.querySelector('[data-activity="tf-feedback"]')?.textContent,
+    ).toContain('✗ The statement is true.');
+  });
+
+  test('switches the match-up header between Ukrainian-only and bilingual', () => {
+    const ukrainian = render(<MatchUp pairs={[{ left: 'а', right: '1' }]} isUkrainian />);
+    expect(ukrainian.container.textContent).toContain('Знайдіть пару');
+    expect(ukrainian.container.textContent).not.toContain('Match Up');
+    ukrainian.unmount();
+
+    const english = render(<MatchUp pairs={[{ left: 'а', right: '1' }]} />);
+    expect(english.container.textContent).toContain('Знайдіть пару');
+    expect(english.container.textContent).toContain('Match Up');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the #4867 grok-review follow-up: `ActivityKit.contract.test.tsx` was smoke-level. This PR adds 31 named tests (25 in the new sibling `ActivityKit.player.test.tsx`, 6 in the contract file) pinning every untested contract surface the issue enumerates. No production code changed.

## Issue bullet → test mapping

| #4870 bullet | Test(s) |
|---|---|
| `onComplete` for cloze and match-up | `emits a typed completion event for cloze after a full submission`; `emits a typed completion event for match-up once every pair is connected`; `fires onComplete exactly once per submission` (ClozePassage) |
| `ClozePassage` / `TrueFalseQuestion` / MatchUp `onMatch` in isolation | describe blocks `ClozePassage in isolation` (4 tests), `TrueFalseQuestion in isolation` (2), `MatchUp onMatch in isolation` (3) |
| Cloze legacy embedded-options parsing + `children` fallback | `parses legacy embedded options from the passage and grades the marked answer`; `provided blanks take precedence over embedded-option parsing`; `falls back to children when no passage is provided` |
| Content rendering assertions | `renders true-false instruction, statement, and feedback explanation`; `renders cloze instruction and passage text around each blank select`; `renders match-up instruction and every pair text on the board` |
| `isUkrainian` label/feedback switching | `switches cloze header, buttons, and feedback between Ukrainian and English`; `switches TrueFalseQuestion labels and verdict language`; `switches the match-up header between Ukrainian-only and bilingual` |
| Full interactions (wrong answers, resets, partial selections, all-matched, rating logic) | `flags wrong selections and lists the correct answers on submit`; `reset clears selections and feedback so the passage can be retried`; `keeps the submit button disabled until every blank is filled`; `rates a clean match good and reports a correct completion` (asserts all tiles `data-matched` + feedback); `rates a match hard after one miss and again after two misses`; `reports the true/false verdict on a wrong answer and locks the buttons` |
| `answer_key` vs payload distinction | `grades true-false from the payload, never from answer_key`; `grades cloze from the payload, never from answer_key` (both corrupt `answer_key` and assert grading is unchanged) |
| Envelope fields (provenance, level const, id in events, title rendering) | `pins the id pattern, level const, and provenance triple on every golden fixture`; `renders the activity title as the region label and heading`; `falls back to the activity type as title when the envelope omits one`; id pinned via the two completion-event tests |
| Deep mapping correctness (cloze `id` → `index`) | `maps cloze payload blank ids onto select data-blank-index markers` (non-contiguous ids 2 and 5, plus grading keyed by mapped index) |
| Shim re-export/type surface + annotation presence | `re-exports the kit implementations at runtime` (`toBe` identity for all five shim exports); `$shim mirrors the kit prop surface and annotation presence` (per-interface prop + `@schemaDescription`/`@ukrainianText` parity between `site/src/components/*.tsx` shims and kit sources) |

## Mutation checks (#M-16)

Three highest-value new tests verified by breaking the behavior in `packages/activity-kit/src/ActivityPlayer.tsx` (each reverted after the run; final `git status` on `packages/` is clean):

1. `isTrue: correct` → `isTrue: !correct` → `grades true-false from the payload, never from answer_key` fails (`data-correct` expected `"true"`, received `"false"`).
2. `index: id` → `index: 0` → `maps cloze payload blank ids onto select data-blank-index markers` fails (no `select[data-blank-index="2"/"5"]` rendered).
3. `activityId: activity.id ?? activity.type` → `activityId: activity.type` → both typed-completion-event tests fail. Example run:

```
 ❯ tests/unit/ActivityKit.player.test.tsx:100:24
    99|     expect(onComplete).toHaveBeenCalledTimes(1);
   100|     expect(onComplete).toHaveBeenCalledWith({
       |                        ^
   101|       activityId: 'golden-match-up',
   102|       activityType: 'match-up',

 Test Files  1 failed (1)
      Tests  2 failed | 23 skipped (25)
```

## Verification

- `npm test` (site suite, incl. built-output): **73 + 2 files, 1107 + 7 tests passed, 0 failed** (`PYTHON`/`LU_ACTIVITY_KIT_PYTHON` pointed at the shared interpreter per worktree contract).
- `npx eslint site/tests/unit/ActivityKit.contract.test.tsx site/tests/unit/ActivityKit.player.test.tsx --quiet`: clean (exit 0).
- Post-revert re-run of both touched files: 101/101 passed.

No product defect was exposed, so per the brief no production component was modified.

X-Agent: kimi/infra-4870-contract-tests-r2