### PR TITLE
feat(sources): add verify_stress oracle (#6515)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -16,6 +16,7 @@ with imports; rename there is a follow-up.
 Tools:
     - search_sources, search_text, search_literary, search_external, search_images, get_chunk_context
     - verify_word, verify_words, verify_lemma, vet_vocabulary (VESUM)
+    - verify_stress (stress oracle: ukrainian-word-stress trie + override layer + VESUM join)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
     - search_definitions, search_grinchenko_1907, search_esum, search_idioms, search_synonyms
     - search_slovnyk_me, search_heritage
@@ -505,6 +506,38 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["lemma"]
+            },
+        ),
+        Tool(
+            name="verify_stress",
+            description=(
+                "Stress oracle: look up the stressed form + stressed-vowel index for a Ukrainian word "
+                "from the offline ukrainian-word-stress dictionary (ULIF-derived, 2.9M word forms), with "
+                "the project's manual override layer applied and a best-effort VESUM identity join. "
+                "vowel_index is the 0-based codepoint index of the stressed vowel in the NFC-normalized "
+                "unstressed form (same convention as generate_practice_deck.py / PracticeStress.tsx). "
+                "status is 'ok' (single reading), 'ambiguous' (heteronym — pass pos/tags to disambiguate; "
+                "see each match's required_tags), 'not_found' (valid word, not in the dictionary), or "
+                "'invalid_input' (empty/multi-word/non-Cyrillic/single-syllable). Returns JSON (unlike the "
+                "prose-formatted verify_word/verify_lemma) so bake-off scoring can consume it directly."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "word": {
+                        "type": "string",
+                        "description": "Ukrainian word to check: bare lemma, inflected form, or U+0301/U+0300-marked form (e.g., 'замок', 'любов'ю', 'за́мок')"
+                    },
+                    "pos": {
+                        "type": "string",
+                        "description": "Optional POS to help disambiguate a heteronym (e.g. 'NOUN' or 'upos=NOUN')."
+                    },
+                    "tags": {
+                        "type": "string",
+                        "description": "Optional additional dictionary tags to help disambiguate, comma-separated (e.g. 'Case=Nom,Gender=Masc') — same vocabulary as each match's required_tags."
+                    },
+                },
+                "required": ["word"]
             },
         ),
         # ── Live source query tools ──────────────────────────────
@@ -1323,6 +1356,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "verify_words": lambda: handle_verify_words(arguments),
             "vet_vocabulary": lambda: handle_vet_vocabulary(arguments),
             "verify_lemma": lambda: handle_verify_lemma(arguments),
+            "verify_stress": lambda: handle_verify_stress(arguments),
             "query_wikipedia": lambda: handle_query_wikipedia(arguments),
             "query_grac": lambda: handle_query_grac(arguments),
             "query_ulif": lambda: handle_query_ulif(arguments),
@@ -1782,6 +1816,17 @@ async def handle_verify_lemma(args: dict) -> list[TextContent]:
         lines.append("")
 
     return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_verify_stress(args: dict) -> list[TextContent]:
+    word = args["word"]
+    pos = args.get("pos")
+    tags = args.get("tags")
+
+    from scripts.verification.stress import verify_stress
+    payload = await asyncio.to_thread(verify_stress, word, pos, tags)
+
+    return [TextContent(type="text", text=json.dumps(payload, indent=2, ensure_ascii=False))]
 
 
 def _lookup_wikipedia_in_db(query: str) -> dict | None:

--- a/agents_extensions/shared/rules/mcp-sources-and-dictionaries.md
+++ b/agents_extensions/shared/rules/mcp-sources-and-dictionaries.md
@@ -18,6 +18,7 @@ paths:
 ## Core tools (always use)
 - `mcp__sources__verify_word` / `mcp__sources__verify_words` / `mcp__sources__verify_lemma` — VESUM morphological dictionary (409K lemmas, 6.7M forms). Also surfaces `is_archaic` and `has_archaic_forms` metadata flags for forms tagged as historical.
 - `mcp__sources__check_modern_form` — VESUM metadata extraction to explicitly check if a word has modern codified forms vs only archaic forms.
+- `mcp__sources__verify_stress` — stress oracle: stressed form + 0-based stressed-vowel index for a word, from the offline `ukrainian-word-stress` dictionary (2.9M forms) + the project's manual override layer + a best-effort VESUM join. Returns JSON (unlike the other `verify_*` tools' prose). Pass `pos`/`tags` to disambiguate a heteronym (e.g. за́мок "castle" vs замо́к "lock").
 - `mcp__sources__search_sources` — **PREFERRED unified entry point** across textbooks, literary corpora, Wikipedia, external articles, and `ukrainian_wiki`
 - `mcp__sources__search_text` — textbook content search (23K chunks, Grades 1-11)
 - `mcp__sources__search_images` — textbook image search (14K images)

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -207,7 +207,7 @@ typing_extensions==4.16.0
 tzlocal==5.4.4
 udapi==0.5.2
 udtools==0.2.8
-ukrainian_word_stress==1.1.1
+ukrainian_word_stress==2.1.0
 unlzw3==0.2.3
 urllib3==2.7.0
 uvicorn==0.48.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pymorphy3-dicts-ru
 pymorphy3-dicts-uk
 # tokenize-uk is vendored at scripts/linguistics/tokenize_uk.py (#1318).
 # Intentionally NOT a pip dep — local ABBRS extensions require it.
-ukrainian-word-stress>=1.0
+ukrainian-word-stress>=2,<3
 
 # Testing
 pytest>=9.0.3

--- a/scripts/verification/stress.py
+++ b/scripts/verification/stress.py
@@ -1,0 +1,392 @@
+"""Stress oracle: stressed form + stressed-vowel index for a Ukrainian word.
+
+Implements the design pinned on issue #6515 (design note + K3 cross-family
+review + round-2 revision — see the issue for the full rationale). Summary
+of the contract this module implements:
+
+- Source of truth: the offline `ukrainian_word_stress` trie (ULIF-derived,
+  ``ukrainian_word_stress/data/stress.trie``), looked up on-demand via
+  ``Disambiguation.Dictionary`` (no Stanza — sentence context doesn't apply
+  to isolated single-word oracle calls).
+- ``vowel_index`` uses the same convention as
+  ``scripts/audit/generate_practice_deck.py::_stress_position``: the 0-based
+  codepoint index of the stressed vowel in the NFC-normalized unstressed
+  form. That convention is what ``site/src/components/PracticeStress.tsx``
+  already consumes.
+- U+0301/U+0300 handling follows the #5375/#6832 convention: strip combining
+  stress marks for the lookup key, keep the caller's original bytes in
+  ``input``.
+- ``scripts/data/stress_overrides.yaml`` is applied as a pre-lookup patch,
+  keyed by *exact* lemma string match only (never extended to inflected
+  forms) — matching its one existing consumer,
+  ``scripts/generate_mdx/generate_ipa.py``.
+- The trie packs ambiguous readings into a private byte layout
+  (``compile_dict.py``'s ``POS_SEP``/``REC_SEP``/``accent_pos`` scheme) that
+  the package's public API (``Stressifier``, ``find_accent_positions``)
+  collapses into a single resolved answer. Enumerating separate readings —
+  required for ``status="ambiguous"`` — needs that packed layout directly.
+  Round-2 design note §3c sanctions this, gated by the version pin
+  (``requirements-lock.txt``) + the trie digest below: a package bump
+  changes the digest, which forces revalidation, and
+  ``TestStressGolden::test_zamok_golden_entry`` (tests/test_stress_oracle.py)
+  fails loudly if the packing format itself changes.
+- Some ambiguous entries have byte-identical required_tags across distinct
+  stress positions (true meaning-dependent homographs, e.g. за́мок "castle"
+  vs замо́к "lock" — both ``Number=Sing|Case=Nom|Gender=Masc|upos=NOUN``).
+  No tag combination the dictionary offers can disambiguate those further;
+  see ``unresolvable_by_tags`` in the return payload.
+- VESUM (``data/vesum.db``) and the stress dictionary are two disjoint
+  dictionaries with no shared key beyond the ``word_form`` string itself —
+  VESUM carries zero stress information. The VESUM join here is
+  intentionally conservative: it only attaches a VESUM record to a reading
+  when exactly one VESUM row is left after filtering by the reading's own
+  ``upos`` tag (when it has one); anything more ambiguous is left ``null``
+  rather than guessed.
+- Not implemented (explicitly out of scope for this PR, per the design
+  note's own framing as an optional "keep the door open" cross-check, not a
+  pinned deliverable): the ``query_ulif`` live cross-check and the mphdict
+  headword cross-check. Both are hydration/network-dependent and orthogonal
+  to correctness — the trie stays the sole source of truth.
+
+Extension beyond the pinned schema, needed for correctness: hyphenated
+compound entries (e.g. "попереково-крижовими") can carry *more than one*
+stress mark in a single trie value. The pinned schema's ``vowel_index`` stays
+a single int (the primary/lowest-index mark, for schema compatibility);
+``vowel_indices`` (plural, always present) carries the full list.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STRESS_OVERRIDES_PATH = PROJECT_ROOT / "scripts" / "data" / "stress_overrides.yaml"
+
+_STRESS_MARK_RE = re.compile("[\u0300\u0301]")  # combining grave + acute accent
+_UKRAINIAN_WORD_RE = re.compile(r"^[А-Яа-яЄєІіЇїҐґ'’ʼ-]+$")
+_UKRAINIAN_VOWELS = frozenset("аеєиіїоуюяАЕЄИІЇОУЮЯ")
+
+# UD upos (as decompressed from the trie's packed tag bytes) -> VESUM `pos`
+# column value. Best-effort, used only to narrow the VESUM join for readings
+# that carry an upos tag; an unmapped/absent upos just skips the filter.
+_UPOS_TO_VESUM_POS = {
+    "NOUN": "noun",
+    "PROPN": "noun",
+    "VERB": "verb",
+    "ADJ": "adj",
+    "ADV": "adv",
+    "NUM": "numr",
+    "ADP": "prep",
+    "CCONJ": "conj",
+    "PART": "part",
+    "INTJ": "intj",
+}
+
+
+def _strip_stress(text: str) -> str:
+    """U+0301/U+0300-stripped, NFC-normalized form (the #5375/#6832 convention)."""
+    normalized = unicodedata.normalize("NFKD", text)
+    normalized = _STRESS_MARK_RE.sub("", normalized)
+    return unicodedata.normalize("NFC", normalized)
+
+
+def _has_whitespace(text: str) -> bool:
+    return any(ch.isspace() for ch in text)
+
+
+def _count_vowels(text: str) -> int:
+    return sum(1 for ch in text if ch in _UKRAINIAN_VOWELS)
+
+
+def _stress_positions_in_marked_string(marked: str) -> tuple[str, list[int]]:
+    """Return (unstressed NFC form, [0-based codepoint vowel indices]).
+
+    Generalizes ``generate_practice_deck.py::_stress_position`` (which
+    handles exactly one mark) to any number of combining stress marks, for
+    hyphenated-compound and override-yaml inputs.
+    """
+    nfd = unicodedata.normalize("NFD", marked)
+    indices: list[int] = []
+    working: list[str] = []
+    for ch in nfd:
+        if ch in ("\u0301", "\u0300"):
+            prefix_nfc = unicodedata.normalize("NFC", "".join(working))
+            indices.append(len(prefix_nfc) - 1)
+        else:
+            working.append(ch)
+    unstressed_nfc = unicodedata.normalize("NFC", "".join(working))
+    return unstressed_nfc, indices
+
+
+@lru_cache(maxsize=1)
+def _load_overrides() -> dict[str, str]:
+    if not STRESS_OVERRIDES_PATH.exists():
+        return {}
+    with open(STRESS_OVERRIDES_PATH, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return data if isinstance(data, dict) else {}
+
+
+@lru_cache(maxsize=1)
+def _trie_path() -> Path:
+    import ukrainian_word_stress
+
+    return Path(ukrainian_word_stress.__file__).resolve().parent / "data" / "stress.trie"
+
+
+@lru_cache(maxsize=1)
+def _load_trie():
+    import marisa_trie
+
+    trie = marisa_trie.BytesTrie()
+    trie.load(str(_trie_path()))
+    return trie
+
+
+@lru_cache(maxsize=1)
+def _trie_digest() -> str:
+    digest = hashlib.sha256()
+    with open(_trie_path(), "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=1)
+def _package_version() -> str:
+    import importlib.metadata
+
+    return importlib.metadata.version("ukrainian-word-stress")
+
+
+def source_info() -> dict[str, Any]:
+    """Reproducibility envelope: package version + trie entry count + digest."""
+    trie = _load_trie()
+    return {
+        "dictionary": "ukrainian-word-stress (ULIF-derived)",
+        "package_version": _package_version(),
+        "trie_entries": len(trie),
+        "digest": _trie_digest(),
+    }
+
+
+def _trie_value(trie, word: str) -> bytes | None:
+    """Exact + case/apostrophe-variant lookup.
+
+    Mirrors ``ukrainian_word_stress.stressify_._trie_value``'s fallback
+    order. Reimplemented (rather than imported) so the hot lookup path
+    doesn't depend on a leading-underscore package-private symbol; only the
+    genuinely undocumented part — the packed-value byte layout, parsed by
+    ``_parse_dictionary_value`` below — is sanctioned private-API use.
+    """
+    if word in trie:
+        return trie[word][0]
+    candidates = [word.lower(), word.title(), word.capitalize()]
+    normalized = word.translate(str.maketrans("’ʼ`", "'''"))
+    if normalized != word:
+        candidates += [normalized, normalized.lower(), normalized.title(), normalized.capitalize()]
+    for candidate in candidates:
+        if candidate != word and candidate in trie:
+            return trie[candidate][0]
+    return None
+
+
+def _parse_dictionary_value(value: bytes) -> list[tuple[list[str], list[int]]]:
+    """Enumerate every (required_tags, accent_positions) reading packed into
+    one trie value. See the module docstring for why this needs the
+    package-private byte layout.
+    """
+    from ukrainian_word_stress.tags import TAGS, decompress_tags
+
+    pos_sep = TAGS["POS-separator"]
+    rec_sep = TAGS["Record-separator"]
+
+    if rec_sep not in value:
+        return [([], [int(b) for b in value])]
+
+    readings: list[tuple[list[str], list[int]]] = []
+    for item in value.split(rec_sep):
+        if not item:
+            continue
+        accents, _, tags = item.partition(pos_sep)
+        readings.append((decompress_tags(tags), [int(b) for b in accents]))
+    return readings
+
+
+def _apply_accents(base: str, positions: list[int]) -> str:
+    for position in sorted(positions, reverse=True):
+        base = base[:position] + "\u0301" + base[position:]
+    return base
+
+
+def _classify_invalid(clean: str) -> str | None:
+    """Return an error message if `clean` can't be stress-checked, else None.
+
+    Mirrors ``scripts/lexicon/enrich_manifest.py::_stress_word``'s guard
+    order (empty -> multi-word -> non-Cyrillic -> too-short-to-have-stress),
+    surfaced as a distinct ``invalid_input`` status per round-2 §3(d) rather
+    than being folded into ``not_found``.
+    """
+    if not clean:
+        return "empty or whitespace-only input"
+    if _has_whitespace(clean):
+        return "multi-word input (verify_stress takes a single word)"
+    if not _UKRAINIAN_WORD_RE.fullmatch(clean):
+        return "not a single Ukrainian word (non-Cyrillic or disallowed characters)"
+    if _count_vowels(clean) < 2:
+        return "single-syllable word (no stress position to mark)"
+    return None
+
+
+def _normalize_supplied_tags(pos: str | None, tags: str | list[str] | None) -> set[str]:
+    supplied: set[str] = set()
+    if pos:
+        pos_clean = pos.strip()
+        if pos_clean:
+            supplied.add(pos_clean if pos_clean.startswith("upos=") else f"upos={pos_clean.upper()}")
+    if isinstance(tags, str):
+        tags = re.split(r"[,\s]+", tags.strip())
+    if tags:
+        supplied.update(tag.strip() for tag in tags if tag and tag.strip())
+    return supplied
+
+
+def _vesum_lookup(word_form: str) -> list[dict]:
+    """Best-effort VESUM lookup; never raises (VESUM join is supplementary)."""
+    try:
+        from scripts.verification.vesum import verify_word
+
+        return verify_word(word_form)
+    except Exception:
+        return []
+
+
+def _attach_vesum(match: dict[str, Any], vesum_matches: list[dict]) -> None:
+    candidates = vesum_matches
+    upos = next((tag.split("=", 1)[1] for tag in match["required_tags"] if tag.startswith("upos=")), None)
+    vesum_pos = _UPOS_TO_VESUM_POS.get(upos) if upos else None
+    if vesum_pos:
+        filtered = [m for m in candidates if m.get("pos") == vesum_pos]
+        candidates = filtered
+    match["vesum"] = candidates[0] if len(candidates) == 1 else None
+
+
+def _apply_input_mismatch(matches: list[dict[str, Any]], word: str) -> None:
+    if not _STRESS_MARK_RE.search(unicodedata.normalize("NFD", word)):
+        return  # no stress mark in the caller's input: key stays omitted
+    _, caller_positions = _stress_positions_in_marked_string(word)
+    caller_set = set(caller_positions)
+    for match in matches:
+        match["input_mismatch"] = caller_set != set(match["vowel_indices"])
+
+
+def _build_match(unstressed_form: str, positions: list[int], required_tags: list[str], *, override_applied: bool) -> dict[str, Any]:
+    vowel_indices = sorted(p - 1 for p in positions)
+    return {
+        "stressed_form": _apply_accents(unstressed_form, positions),
+        "unstressed_form": unstressed_form,
+        "vowel_index": vowel_indices[0],
+        "vowel_indices": vowel_indices,
+        "vesum": None,
+        "required_tags": required_tags,
+        "override_applied": override_applied,
+    }
+
+
+def _readings_unresolvable_by_tags(candidates: list[dict[str, Any]]) -> bool:
+    """True if >=2 candidates share byte-identical required_tags with
+    different stress positions — a true meaning-dependent homograph the
+    dictionary's tag vocabulary can never disambiguate (round-2 §3b)."""
+    seen: dict[tuple[str, ...], set[tuple[int, ...]]] = {}
+    for match in candidates:
+        key = tuple(match["required_tags"])
+        seen.setdefault(key, set()).add(tuple(match["vowel_indices"]))
+    return any(len(positions) > 1 for positions in seen.values())
+
+
+def verify_stress(word: str, pos: str | None = None, tags: str | list[str] | None = None) -> dict[str, Any]:
+    """Look up the stress position of a Ukrainian word.
+
+    Args:
+        word: bare lemma, inflected form, or U+0301/U+0300-marked form.
+        pos: optional POS to help disambiguate a heteronym (e.g. "NOUN" or
+            "upos=NOUN").
+        tags: optional additional dictionary-native tags to help
+            disambiguate (e.g. "Case=Nom,Gender=Masc" or
+            ["Case=Nom", "Gender=Masc"]) — same vocabulary as each match's
+            own ``required_tags``.
+
+    Returns:
+        The JSON-shaped envelope documented in the module docstring / issue
+        #6515.
+    """
+    lookup_key = _strip_stress(word).strip()
+    invalid_reason = _classify_invalid(lookup_key)
+    source = source_info()
+
+    if invalid_reason is not None:
+        return {
+            "input": word,
+            "lookup_key": lookup_key,
+            "status": "invalid_input",
+            "matches": [],
+            "unresolvable_by_tags": False,
+            "source": source,
+            "error": invalid_reason,
+        }
+
+    override = _load_overrides().get(lookup_key)
+    if override:
+        unstressed_override, positions = _stress_positions_in_marked_string(override)
+        matches = [_build_match(unstressed_override, [p + 1 for p in positions], [], override_applied=True)]
+        status = "ok"
+    else:
+        trie = _load_trie()
+        value = _trie_value(trie, lookup_key)
+        if value is None:
+            return {
+                "input": word,
+                "lookup_key": lookup_key,
+                "status": "not_found",
+                "matches": [],
+                "unresolvable_by_tags": False,
+                "source": source,
+            }
+
+        readings = _parse_dictionary_value(value)
+        all_matches = [
+            _build_match(lookup_key, positions, required_tags, override_applied=False)
+            for required_tags, positions in readings
+        ]
+
+        if len(all_matches) == 1:
+            matches = all_matches
+            status = "ok"
+        else:
+            supplied = _normalize_supplied_tags(pos, tags)
+            filtered = [m for m in all_matches if supplied and set(m["required_tags"]) <= supplied]
+            candidates = filtered if filtered else all_matches
+            matches = candidates
+            status = "ok" if len(candidates) == 1 else "ambiguous"
+
+    _apply_input_mismatch(matches, word)
+
+    vesum_matches = _vesum_lookup(matches[0]["unstressed_form"]) if matches else []
+    for match in matches:
+        _attach_vesum(match, vesum_matches)
+
+    return {
+        "input": word,
+        "lookup_key": lookup_key,
+        "status": status,
+        "matches": matches,
+        "unresolvable_by_tags": status == "ambiguous" and _readings_unresolvable_by_tags(matches),
+        "source": source,
+    }

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -50,6 +50,7 @@ class TestListTools:
             "search_sources", "search_text", "search_images", "search_literary", "search_external",
             "get_full_text", "get_chunk_context", "collection_stats",
             "verify_word", "verify_source_attribution", "verify_words", "vet_vocabulary", "verify_lemma", "verify_quote", "check_modern_form",
+            "verify_stress",
             "query_wikipedia", "query_grac", "query_ulif", "query_ulif_synonyms",
             "query_ulif_antonyms", "query_ulif_phraseology",
             "query_r2u", "query_e2u", "query_sum20", "query_slovnyk_me",
@@ -175,6 +176,13 @@ class TestUlifHandlers:
             "style_guide",
         }
 
+    def test_verify_stress_schema(self, server_module):
+        tools = _run(server_module.list_tools())
+        tool = next(t for t in tools if t.name == "verify_stress")
+        assert tool.input_schema["required"] == ["word"]
+        assert "pos" in tool.input_schema["properties"]
+        assert "tags" in tool.input_schema["properties"]
+
 
 class TestCallToolDispatch:
     """Test that call_tool routes to correct handlers."""
@@ -271,6 +279,12 @@ class TestCallToolDispatch:
             mock.assert_called_once_with({"word": "звір"})
 
 
+    def test_verify_stress_dispatches(self, server_module):
+        with patch.object(server_module, "handle_verify_stress", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            _run(server_module.call_tool("verify_stress", {"word": "замок", "pos": "VERB"}))
+            mock.assert_called_once_with({"word": "замок", "pos": "VERB"})
+
     def test_handler_exception_returns_error_text(self, server_module):
         with patch.object(server_module, "handle_verify_word", new_callable=AsyncMock) as mock:
             mock.side_effect = RuntimeError("test error")
@@ -356,6 +370,29 @@ class TestVerifyWordsHandler:
             assert "Found: 1/2" in text
             assert "**стій** — FOUND" in text
             assert "**взяйте** — NOT FOUND" in text
+
+
+class TestVerifyStressHandler:
+    """Test the verify_stress handler wires args through and emits JSON (#6515)."""
+
+    def test_returns_json_envelope(self, server_module):
+        payload = {
+            "input": "замок",
+            "lookup_key": "замок",
+            "status": "ambiguous",
+            "matches": [],
+            "unresolvable_by_tags": True,
+            "source": {"dictionary": "ukrainian-word-stress (ULIF-derived)"},
+        }
+        with patch("scripts.verification.stress.verify_stress", return_value=payload) as mock:
+            result = _run(server_module.handle_verify_stress({"word": "замок"}))
+            mock.assert_called_once_with("замок", None, None)
+            assert json.loads(result[0].text) == payload
+
+    def test_passes_pos_and_tags(self, server_module):
+        with patch("scripts.verification.stress.verify_stress", return_value={}) as mock:
+            _run(server_module.handle_verify_stress({"word": "замок", "pos": "VERB", "tags": "Number=Sing"}))
+            mock.assert_called_once_with("замок", "VERB", "Number=Sing")
 
 
 @pytest.fixture

--- a/tests/test_stress_oracle.py
+++ b/tests/test_stress_oracle.py
@@ -1,0 +1,200 @@
+"""Tests for scripts/verification/stress.py — the verify_stress oracle (#6515).
+
+Covers the pinned design contract (issue #6515: design note + K3 review +
+round-2 revision):
+- любов/разом override hits (exact-lemma-only, per round-2 §4)
+- a multi-stress heteronym (замок) enumerating every reading, incl. the
+  true-homograph unresolvable_by_tags case (round-2 §3b)
+- unknown-word not_found
+- U+0301-marked input agree/disagree (input_mismatch, round-2 §3a)
+- the four invalid_input error classes (round-2 §3d)
+- a golden decode of the packed trie value for замок (round-2 §3c —
+  guards the sanctioned private-API byte-layout parsing)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from scripts.verification.stress import (
+    _load_trie,
+    _parse_dictionary_value,
+    _trie_value,
+    verify_stress,
+)
+
+STRESS = "́"
+
+
+class TestOverrides:
+    def test_lyubov_override(self):
+        result = verify_stress("любов")
+        assert result["status"] == "ok"
+        match = result["matches"][0]
+        assert match["stressed_form"] == f"любо{STRESS}в"
+        assert match["unstressed_form"] == "любов"
+        assert match["vowel_index"] == 3
+        assert match["override_applied"] is True
+        assert match["required_tags"] == []
+
+    def test_razom_override(self):
+        result = verify_stress("разом")
+        match = result["matches"][0]
+        assert match["stressed_form"] == f"ра{STRESS}зом"
+        assert match["override_applied"] is True
+
+    def test_override_is_exact_lemma_only_not_inflected_forms(self):
+        # "любові" is an inflected (dative/locative) form of "любов"; the
+        # override is keyed by the bare lemma string only (round-2 §4) — an
+        # inflected form must fall through to the raw dictionary answer,
+        # not the override.
+        result = verify_stress("любові")
+        assert all(not m["override_applied"] for m in result["matches"])
+
+
+class TestHeteronymEnumeration:
+    def test_zamok_enumerates_every_reading(self):
+        result = verify_stress("замок")
+        assert result["status"] == "ambiguous"
+        stressed_forms = {m["stressed_form"] for m in result["matches"]}
+        assert stressed_forms == {f"за{STRESS}мок", f"замо{STRESS}к"}
+        assert all(m["override_applied"] is False for m in result["matches"])
+        assert all(m["required_tags"] for m in result["matches"])
+
+    def test_zamok_true_homograph_unresolvable_by_tags(self):
+        # The "castle" and "lock" nominative-noun readings carry
+        # byte-identical required_tags — no tag combination the dictionary
+        # offers can disambiguate them (round-2 §3b).
+        result = verify_stress("замок", pos="NOUN", tags="Case=Nom,Number=Sing,Gender=Masc")
+        assert result["status"] == "ambiguous"
+        assert result["unresolvable_by_tags"] is True
+
+    def test_zamok_resolves_with_full_required_tags(self):
+        result = verify_stress("замок", pos="VERB", tags="Number=Sing")
+        assert result["status"] == "ok"
+        assert len(result["matches"]) == 1
+        assert result["matches"][0]["stressed_form"] == f"замо{STRESS}к"
+
+    def test_unresolvable_by_tags_false_for_unambiguous_word(self):
+        result = verify_stress("село")
+        assert result["status"] == "ok"
+        assert result["unresolvable_by_tags"] is False
+
+
+class TestNotFound:
+    def test_unknown_word(self):
+        # Valid Ukrainian-alphabet nonsense word, ≥2 vowels, not in the
+        # dictionary.
+        result = verify_stress("квазюрап")
+        assert result["status"] == "not_found"
+        assert result["matches"] == []
+
+
+class TestInputMismatch:
+    def test_agreeing_mark_is_false_not_omitted(self):
+        result = verify_stress(f"за{STRESS}мок")
+        agrees = [m for m in result["matches"] if m["vowel_index"] == 1]
+        assert agrees and all(m["input_mismatch"] is False for m in agrees)
+
+    def test_disagreeing_mark_is_true(self):
+        result = verify_stress(f"за{STRESS}мок")
+        disagrees = [m for m in result["matches"] if m["vowel_index"] == 3]
+        assert disagrees and all(m["input_mismatch"] is True for m in disagrees)
+
+    def test_no_mark_omits_the_key(self):
+        result = verify_stress("замок")
+        assert all("input_mismatch" not in m for m in result["matches"])
+
+    def test_grave_accent_also_counts_as_a_mark(self):
+        # U+0300 (combining grave) is the other mark #5375/#6832 normalizes.
+        result = verify_stress("за̀мок")
+        assert all("input_mismatch" in m for m in result["matches"])
+
+
+class TestInvalidInput:
+    def test_empty(self):
+        result = verify_stress("")
+        assert result["status"] == "invalid_input"
+        assert "empty" in result["error"]
+
+    def test_whitespace_only(self):
+        result = verify_stress("   ")
+        assert result["status"] == "invalid_input"
+
+    def test_multi_word(self):
+        result = verify_stress("добрий день")
+        assert result["status"] == "invalid_input"
+        assert "multi-word" in result["error"]
+
+    def test_non_cyrillic(self):
+        result = verify_stress("hello")
+        assert result["status"] == "invalid_input"
+        assert "Cyrillic" in result["error"]
+
+    def test_single_syllable(self):
+        result = verify_stress("я")
+        assert result["status"] == "invalid_input"
+        assert "single-syllable" in result["error"]
+
+    def test_invalid_input_distinct_from_not_found(self):
+        # A stray multi-word string must not be reported as "dictionary
+        # doesn't know this word" (round-2 §3d) — status differs.
+        assert verify_stress("добрий день")["status"] != verify_stress("квазюрап")["status"]
+
+
+class TestVesumJoin:
+    def test_attaches_single_unambiguous_vesum_match(self):
+        mock_matches = [{"lemma": "замокти", "pos": "verb", "tags": "verb:perf:past:m"}]
+        with patch("scripts.verification.vesum.verify_word", return_value=mock_matches):
+            result = verify_stress("замок", pos="VERB", tags="Number=Sing")
+        assert result["matches"][0]["vesum"] == mock_matches[0]
+
+    def test_null_when_vesum_join_ambiguous(self):
+        mock_matches = [
+            {"lemma": "замок", "pos": "noun", "tags": "noun:inanim:m:v_naz:xp1"},
+            {"lemma": "замок", "pos": "noun", "tags": "noun:inanim:m:v_naz:xp2"},
+        ]
+        with patch("scripts.verification.vesum.verify_word", return_value=mock_matches):
+            result = verify_stress("замок", pos="NOUN", tags="Case=Nom,Number=Sing,Gender=Masc")
+        assert all(m["vesum"] is None for m in result["matches"])
+
+    def test_vesum_join_failure_does_not_crash_the_call(self):
+        with patch("scripts.verification.vesum.verify_word", side_effect=FileNotFoundError("no db")):
+            result = verify_stress("замок")
+        assert result["status"] == "ambiguous"
+        assert all(m["vesum"] is None for m in result["matches"])
+
+
+class TestSourceInfo:
+    def test_source_envelope_present_on_every_status(self):
+        for word in ("замок", "квазюрап", "", "любов"):
+            result = verify_stress(word)
+            source = result["source"]
+            assert source["dictionary"] == "ukrainian-word-stress (ULIF-derived)"
+            assert source["trie_entries"] > 2_000_000
+            assert len(source["digest"]) == 64  # sha256 hex
+
+
+class TestStressGolden:
+    """Golden-entry test for the sanctioned packed-value decode (round-2 §3c).
+
+    Fails loudly if `ukrainian_word_stress` ever changes its trie packing
+    format — the signal round-2 mandated as the safety net for using the
+    package-private byte layout.
+    """
+
+    def test_zamok_golden_entry(self):
+        trie = _load_trie()
+        value = _trie_value(trie, "замок")
+        assert value is not None
+        readings = _parse_dictionary_value(value)
+        as_sets = sorted((tuple(sorted(tags)), tuple(positions)) for tags, positions in readings)
+        assert as_sets == sorted(
+            [
+                (tuple(sorted(["Number=Sing", "Case=Nom", "upos=NOUN", "Gender=Masc"])), (2,)),
+                (tuple(sorted(["Number=Sing", "Case=Acc", "upos=NOUN", "Gender=Masc"])), (2,)),
+                (tuple(sorted(["Number=Sing", "Case=Nom", "upos=NOUN", "Gender=Masc"])), (4,)),
+                (tuple(sorted(["Number=Sing", "Case=Acc", "upos=NOUN", "Gender=Masc"])), (4,)),
+                (tuple(sorted(["Number=Sing", "upos=VERB"])), (4,)),
+            ]
+        )


### PR DESCRIPTION
## What

New `mcp__sources__verify_stress` tool: stressed form + stressed-vowel index for a Ukrainian word, implementing the design pinned on #6515 (design note + K3 cross-family review + round-2 revision — the round-2 revision is the spec this PR implements).

## Evidence (#M-4)

- `scripts/verification/stress.py` — the oracle. Trie-decode logic (`_parse_dictionary_value`/`_apply_accents`) validated against the package's own `Stressifier` output across ~3000 sampled trie entries before writing tests (0 mismatches) — see PR conversation for the verification script.
- Golden-entry test `tests/test_stress_oracle.py::TestStressGolden::test_zamok_golden_entry` pins the exact 5-reading decode of `замок`'s packed trie value (round-2 §3c safety net).
- Live one-shot smoke through the actual MCP dispatch path (`call_tool("verify_stress", {"word": "замок"})`) — full JSON envelope confirmed, 5 enumerated readings incl. `unresolvable_by_tags: true` for the true castle/lock homograph.
- `.venv/bin/pytest tests/test_stress_oracle.py tests/test_mcp_sources_server.py -q` → **74 passed**, 3 pre-existing failures (`ModuleNotFoundError: rapidfuzz`, confirmed unrelated — reproduces identically on `git stash` of this PR's diff), 5 skipped (pre-existing VESUM-DB-dependent smoke tests).
- `.venv/bin/ruff check` clean on all changed Python files.
- Mutation-checked (#M-16): reverting the override-layer line breaks 2/3 `TestOverrides` tests; reverting the `input_mismatch` comparison breaks `test_disagreeing_mark_is_true`. Both pass again after restore, diff confirmed identical to pre-mutation.

## Contract implemented (round-2 revision, verbatim points)

- §2: `ukrainian-word-stress` pinned `requirements.txt` `>=2,<3`, `requirements-lock.txt` `==2.1.0` (was drifted `1.1.1`/`>=1.0`) + `source.digest` = sha256 of the loaded trie file.
- §3a: `input_mismatch` per-match, omitted (not `false`) when the caller's input carried no stress mark.
- §3b: `required_tags` uses the dictionary's own native `upos=*` vocabulary; `unresolvable_by_tags` flags true meaning-dependent homographs (byte-identical `required_tags` across distinct stress positions) that no tag combination can disambiguate.
- §3c: packed-value byte-layout parsing sanctioned, gated by version pin + trie digest + the golden-entry test.
- §3d: new `invalid_input` status (empty/multi-word/non-Cyrillic/single-syllable), distinct from `not_found`.
- §4: override layer applied by exact-lemma-string match only (never inflected forms) — matches `generate_ipa.py`'s existing behavior; VESUM join uses `scripts/verification/vesum.py::verify_word` (worktree-fallback already solved via `scripts/rag/config.py`, #6542).
- Registration: `Tool` + dispatch-dict + `handle_verify_stress` in `.mcp/servers/sources/server.py`, same three touch points as `verify_word`/`verify_lemma`.

## Extension beyond the pinned schema (found during implementation, documented in the module docstring)

Hyphenated compound entries (e.g. `попереково-крижовими`) can carry more than one stress mark in a single trie value (~6.9K/2.9M entries, ~0.24%) — not addressed by either design round. `vowel_index` stays a single int for schema compatibility (first/lowest mark); `vowel_indices` (always present) carries the full list so compound stress isn't silently dropped.

## Out of scope (explicit)

`query_ulif` and mphdict live/hydration-dependent cross-checks — the design note frames both as optional "keep the door open" extensions, not pinned deliverables. The trie stays the sole source of truth; nothing in this PR depends on either.

Refs #6515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
