### PR TITLE
fix(comms): restore ask-gemma ACP route, actionable hermes-seat failure (#6805)

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -84,10 +84,11 @@ Approved boundary (#6027, #6043, #6078, #6130, #6158, #6249):
   runner, routing, dispatch, failover, or review setting. Rollback is setting
   the flag to `off` (or unsetting it) and using native transport.
 - Direct-only seats cover Codex, Grok, Claude, Kimi, KimiCC K3, Cursor, Pool,
-  AGY/Gemini, GLM, and DeepSeek through the fixed registry in
+  AGY/Gemini, GLM, Gemma, and DeepSeek through the fixed registry in
   `scripts/agent_runtime/adapters/acpx.py` (including `acpx-codex-shadow`,
   `acpx-grok-shadow` via `AcpxGrokShadowAdapter`, `acpx-agy-shadow`,
-  `acpx-glm-shadow`, and `acpx-deepseek-shadow`). They are never returned by
+  `acpx-glm-shadow`, `acpx-gemma-shadow`, and `acpx-deepseek-shadow`). They
+  are never returned by
   `available_agents()` and never become dispatch/routing/review/failover
   candidates.
 - The project-local ACPX dependency and every directly invoked provider CLI

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -280,8 +280,8 @@ not permanent routing weights and do not override current CodexBar headroom.
 - Direct-only seat names include `acpx-codex-shadow`, `acpx-grok-shadow`,
   `acpx-claude-shadow`, `acpx-kimi-shadow`, `acpx-kimicc-shadow`,
   `acpx-cursor-shadow`, `acpx-pool-shadow`, `acpx-agy-shadow`,
-  `acpx-glm-shadow`, and `acpx-deepseek-shadow`; never registered for
-  dispatch, routing, review, or failover.
+  `acpx-glm-shadow`, `acpx-gemma-shadow`, and `acpx-deepseek-shadow`; never
+  registered for dispatch, routing, review, or failover.
 - ACPX, Grok, AGY, OpenCode, and Hermes use rolling compatibility contracts.
   Immediately before spawn, each adapter checks the exact command and flags
   it will invoke; versions are recorded for telemetry but are not allowlists.
@@ -308,7 +308,7 @@ not permanent routing weights and do not override current CodexBar headroom.
 - Feature-flagged adapters (default off / shadow comparison / bounded active
   controller).
 - Exactly one read-only/stateless participant per enabled route: Codex, Grok,
-  Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, and DeepSeek.
+  Claude, Kimi, KimiCC K3, Cursor, Pool, AGY/Gemini, GLM, Gemma, and DeepSeek.
 - Grok fixed effective model/effort: `grok-4.5` / `high` (caller may pass
   only `None` or those exact values; metadata never fabricates otherwise).
 - Grok ACP server command (single custom agent argument; never built-in
@@ -329,6 +329,10 @@ not permanent routing weights and do not override current CodexBar headroom.
 - GLM uses native `opencode acp --pure`, pinned to
   `zai-coding-plan/glm-5.3`, with both `permission.*=deny` and `tools.*=false`.
   GLM and first-party DeepSeek retain their local-only/never-CI egress guards.
+- Gemma (#6805) uses the same confined `opencode acp --pure` shape pinned to
+  `google-ais/gemma-4-31b-it` (the $0 AIS-direct catalog id doubles as the
+  invocation id). The google-ais provider is Western-hosted, so no egress
+  guard applies; the deny-all config keeps the chat-only model toolless.
 - Correlation / idempotency fields recorded as **evidence** (local runtime
   metadata only — never ACP protocol flags, argv, or stdin; never published
   to fleet-comms, dispatch authority, or review evidence), not as a new
@@ -682,6 +686,60 @@ git status --short
 **Pass criteria:** the seat selects discuss vs delegate vs plane-status vs
 formal `review-pr` correctly in prose, quotes live `plane-status` rather than a
 memorized mode, refuses to treat discuss as CF, and leaves a clean worktree.
+
+---
+
+## Reviewer-seat transport recovery
+
+Dead reviewer seats must fail at admission with an actionable error — never
+mid-review with a bare "not found on PATH" (#6805). The `ask-*` compatibility
+shim runs a PATH-only preflight
+(`scripts/agent_runtime/adapters/acpx.py::probe_participant_reachability`)
+before an authority job is enqueued; the adapter re-checks the full
+compatibility contract immediately before spawn. Both paths emit the same
+remediation text.
+
+### Symptom → meaning
+
+| Error excerpt | Meaning |
+| --- | --- |
+| `hermes binary not found on PATH` | Host-level Hermes install is gone (e.g. clobbered PATH or uninstalled) — the DeepSeek ACP seat is down |
+| `opencode binary not found on PATH` | The GLM, Gemma, and Pool ACP seats are down |
+| `agy binary not found on PATH` | The AGY ACP seat is down |
+| `legacy ask target '<x>' has no enabled ACP route` | The seat is not wired under authority mode; do not assume a fallback — check this runbook and #6805 |
+
+### Hermes provisioning (host-level, operator-owned)
+
+Hermes is a full agent platform with operator-owned credentials under
+`~/.hermes/` — it is **never** provisioned by project tooling or from a
+dispatch worktree. The machine-local install recipe is deliberately not
+tracked (operator OPSEC policy 2026-07-05): see the gitignored
+`docs/references/private/hermes-usage.md` on the operator's machine, or
+re-derive it from the operator's private infra notes if that copy is absent.
+Do not reconstruct machine specifics in any tracked file.
+
+After reinstalling, verify the compatibility contract surface:
+
+```bash
+hermes --version   # must print 'Hermes Agent v<semver>'
+hermes --help      # must list: --ignore-rules, --oneshot, --model, --provider
+```
+
+### Documented fallbacks while a seat is down
+
+Per `agents_extensions/shared/rules/model-assignment.md` (the error text
+quotes the same substitutions):
+
+- **ask-hermes (DeepSeek seat) down:** one-shot review/research runs
+  first-party via
+  `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`
+  (native Entire capture); tool-heavy work goes to
+  `delegate.py dispatch --agent deepseek` from a dispatch worktree.
+- **ask-glm / ask-gemma / ask-pool down (opencode missing):** reinstall
+  opencode first — three seats share the binary. There is no second host for
+  the opencode ACP transport.
+- Record every substitution in the artifact; silent rerouting hides
+  review-independence, cost, and egress changes.
 
 ---
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -691,50 +691,47 @@ memorized mode, refuses to treat discuss as CF, and leaves a clean worktree.
 
 ## Reviewer-seat transport recovery
 
-Dead reviewer seats must fail at admission with an actionable error — never
-mid-review with a bare "not found on PATH" (#6805). The `ask-*` compatibility
-shim runs a PATH-only preflight
+Dead reviewer seats must fail with an actionable error — never mid-review
+with a bare "not found on PATH" (#6805). The `ask-*` compatibility shim runs
+a PATH-only preflight
 (`scripts/agent_runtime/adapters/acpx.py::probe_participant_reachability`)
-before an authority job is enqueued; the adapter re-checks the full
-compatibility contract immediately before spawn. Both paths emit the same
-remediation text.
+only when a real provider invocation is about to occur — terminal-replay
+paths never reach it, so a missing provider CLI cannot fail the replay of an
+already-durable result. The adapter re-checks the full compatibility contract
+immediately before spawn. Both paths emit the same remediation text.
 
 ### Symptom → meaning
 
 | Error excerpt | Meaning |
 | --- | --- |
-| `hermes binary not found on PATH` | Host-level Hermes install is gone (e.g. clobbered PATH or uninstalled) — the DeepSeek ACP seat is down |
+| `hermes binary not found on PATH` | Hermes was permanently removed from this host (operator order 2026-08-16) — the DeepSeek ACP seat refuses; route via opencode (below) |
 | `opencode binary not found on PATH` | The GLM, Gemma, and Pool ACP seats are down |
 | `agy binary not found on PATH` | The AGY ACP seat is down |
 | `legacy ask target '<x>' has no enabled ACP route` | The seat is not wired under authority mode; do not assume a fallback — check this runbook and #6805 |
 
-### Hermes provisioning (host-level, operator-owned)
+### Hermes permanently removed — DeepSeek routes via opencode
 
-Hermes is a full agent platform with operator-owned credentials under
-`~/.hermes/` — it is **never** provisioned by project tooling or from a
-dispatch worktree. The machine-local install recipe is deliberately not
-tracked (operator OPSEC policy 2026-07-05): see the gitignored
-`docs/references/private/hermes-usage.md` on the operator's machine, or
-re-derive it from the operator's private infra notes if that copy is absent.
-Do not reconstruct machine specifics in any tracked file.
+Hermes was permanently removed from this host (operator order 2026-08-16) —
+it is **not** awaiting reinstall, and no provisioning recipe applies anymore.
+The DeepSeek seat's **standing route** is first-party via opencode:
 
-After reinstalling, verify the compatibility contract surface:
+- One-shot review/research runs
+  `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`
+  (native Entire capture).
+- Tool-heavy work goes to `delegate.py dispatch --agent deepseek` from a
+  dispatch worktree.
 
-```bash
-hermes --version   # must print 'Hermes Agent v<semver>'
-hermes --help      # must list: --ignore-rules, --oneshot, --model, --provider
-```
+Any route that still names a `hermes` binary keeps the admission-time
+refusal; its message points at the opencode route above, not at a reinstall.
 
 ### Documented fallbacks while a seat is down
 
 Per `agents_extensions/shared/rules/model-assignment.md` (the error text
 quotes the same substitutions):
 
-- **ask-hermes (DeepSeek seat) down:** one-shot review/research runs
-  first-party via
-  `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`
-  (native Entire capture); tool-heavy work goes to
-  `delegate.py dispatch --agent deepseek` from a dispatch worktree.
+- **ask-hermes (DeepSeek seat):** Hermes is permanently removed, so the
+  opencode first-party route above is the standing path — not a temporary
+  fallback. Record the substitution in the artifact all the same.
 - **ask-glm / ask-gemma / ask-pool down (opencode missing):** reinstall
   opencode first — three seats share the binary. There is no second host for
   the opencode ACP transport.

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -1465,18 +1465,22 @@ _PARTICIPANT_COMPATIBILITY_CONTRACTS = {
 
 # Actionable remediation for a missing provider CLI (#6805): a bare "not found
 # on PATH" died mid-review with no install pointer and no reroute. Each entry
-# names the provisioning step, the runbook that owns it, and the documented
-# fallback substitution so the caller can degrade instead of dying.
+# names the provisioning step or standing reroute, the runbook that owns it,
+# and the documented fallback substitution so the caller can degrade instead
+# of dying.
 _MISSING_BINARY_REMEDIATION: dict[str, str] = {
+    # Hermes is permanently removed from this host (operator order
+    # 2026-08-16) — there is no reinstall path. The DeepSeek seat's standing
+    # route is first-party via opencode.
     "hermes": (
-        "Remediation: Hermes is a host-level, operator-owned install (never "
-        "project-provisioned) — reinstall per docs/runbooks/agent-seat-onboarding.md "
-        "'Reviewer-seat transport recovery', then verify `hermes --version` prints "
-        "'Hermes Agent v<semver>'. Documented fallback while the seat is down "
-        "(agents_extensions/shared/rules/model-assignment.md): one-shot DeepSeek "
-        "review runs first-party via `opencode run --model "
-        "deepseek-direct/deepseek-v4-flash --variant high`; tool-heavy work goes to "
-        "`delegate.py dispatch --agent deepseek`."
+        "Remediation: Hermes was permanently removed from this host "
+        "(operator order 2026-08-16) — do not reinstall. The DeepSeek seat "
+        "routes first-party via opencode as the standing path: one-shot "
+        "review/research runs `opencode run --model "
+        "deepseek-direct/deepseek-v4-flash --variant high`; tool-heavy work "
+        "goes to `delegate.py dispatch --agent deepseek`. See "
+        "docs/runbooks/agent-seat-onboarding.md 'Reviewer-seat transport "
+        "recovery'."
     ),
     "opencode": (
         "Remediation: reinstall the opencode CLI on this host and verify "
@@ -1517,11 +1521,12 @@ def _missing_binary_message(executable: str, *, adapter_label: str) -> str:
 def probe_participant_reachability(participant: str) -> str | None:
     """Return an actionable error when a participant's provider CLI is absent.
 
-    Cheap admission preflight (PATH lookup only — never spawns a subprocess)
-    so a dead seat fails before an authority job is enqueued instead of
-    mid-review. The adapter's compatibility probe remains the enforcement
-    point immediately before spawn; this only surfaces the failure early with
-    the remediation and documented fallback attached.
+    Cheap preflight (PATH lookup only — never spawns a subprocess) run only
+    when a real provider invocation is about to occur: terminal-replay paths
+    in the ask shim never reach it, so a missing provider CLI cannot fail the
+    replay of an already-durable result. The adapter's compatibility probe
+    remains the enforcement point immediately before spawn; this surfaces the
+    failure earlier with the remediation and documented fallback attached.
     """
     executable = _PARTICIPANT_PROVIDER_BINARIES.get(participant)
     if executable is None or shutil.which(executable):

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -168,6 +168,11 @@ CLAUDE_ACP_MODELS = frozenset({CLAUDE_ACP_MODEL, "claude-fable-5"})
 GLM_ACP_MODEL = "glm-5.3"
 GLM_ACP_INVOCATION_MODEL = "zai-coding-plan/glm-5.3"
 DEEPSEEK_ACP_MODEL = "deepseek-v4-pro"
+# $0 toolless Gemma seat (#6805): the canonical catalog id doubles as the
+# opencode invocation id on the Google AI Studio direct provider. Gemma has no
+# paid SKU on the Gemini API (pricing verified 2026-07-07) and runs toolless —
+# the deny-all OpenCode config below keeps the ACP participant chat-only.
+GEMMA_ACP_MODEL = "google-ais/gemma-4-31b-it"
 # OpenCode advertises its existing local login as ACP auth method
 # ``opencode-login``. ACPX maps that method ID deterministically to this
 # non-secret selector; the value is never a credential.
@@ -584,6 +589,7 @@ ACPX_SUPPORTED_PARTICIPANTS: dict[str, dict[str, str | None]] = {
     "pool": {"seat": "acpx-pool-shadow", "agent": "pool", "model": None},
     "agy": {"seat": "acpx-agy-shadow", "agent": "agy", "model": AGY_ACP_MODEL},
     "glm": {"seat": "acpx-glm-shadow", "agent": "glm", "model": GLM_ACP_MODEL},
+    "gemma": {"seat": "acpx-gemma-shadow", "agent": "gemma", "model": GEMMA_ACP_MODEL},
     "deepseek": {
         "seat": "acpx-deepseek-shadow",
         "agent": "deepseek",
@@ -607,6 +613,7 @@ ACPX_PARTICIPANT_CATALOG_TRANSPORTS: dict[str, str] = {
     "pool": "opencode",
     "agy": "agy",
     "glm": "opencode",
+    "gemma": "opencode",
     "deepseek": "hermes",
 }
 ACPX_PARTICIPANT_EFFORTS: dict[str, str] = {
@@ -1456,6 +1463,73 @@ _PARTICIPANT_COMPATIBILITY_CONTRACTS = {
     "hermes": HERMES_CLI_COMPATIBILITY_CONTRACT,
 }
 
+# Actionable remediation for a missing provider CLI (#6805): a bare "not found
+# on PATH" died mid-review with no install pointer and no reroute. Each entry
+# names the provisioning step, the runbook that owns it, and the documented
+# fallback substitution so the caller can degrade instead of dying.
+_MISSING_BINARY_REMEDIATION: dict[str, str] = {
+    "hermes": (
+        "Remediation: Hermes is a host-level, operator-owned install (never "
+        "project-provisioned) — reinstall per docs/runbooks/agent-seat-onboarding.md "
+        "'Reviewer-seat transport recovery', then verify `hermes --version` prints "
+        "'Hermes Agent v<semver>'. Documented fallback while the seat is down "
+        "(agents_extensions/shared/rules/model-assignment.md): one-shot DeepSeek "
+        "review runs first-party via `opencode run --model "
+        "deepseek-direct/deepseek-v4-flash --variant high`; tool-heavy work goes to "
+        "`delegate.py dispatch --agent deepseek`."
+    ),
+    "opencode": (
+        "Remediation: reinstall the opencode CLI on this host and verify "
+        "`opencode --version`; see docs/runbooks/agent-seat-onboarding.md "
+        "'Reviewer-seat transport recovery'."
+    ),
+    "agy": (
+        "Remediation: reinstall the agy CLI on this host and verify "
+        "`agy --version`; see docs/runbooks/agent-seat-onboarding.md "
+        "'Reviewer-seat transport recovery'."
+    ),
+}
+
+# Provider executable each ACP participant's catalog transport shells out to.
+# Seats reached through an ACPX built-in (codex/grok/claude/kimi/cursor/pool)
+# resolve no external provider binary here and are not probed by this map.
+_PARTICIPANT_PROVIDER_BINARIES: dict[str, str] = {
+    "agy": "agy",
+    "glm": "opencode",
+    "gemma": "opencode",
+    "deepseek": "hermes",
+}
+
+
+def _missing_binary_message(executable: str, *, adapter_label: str) -> str:
+    contract = _PARTICIPANT_COMPATIBILITY_CONTRACTS[executable]
+    remediation = _MISSING_BINARY_REMEDIATION.get(
+        executable,
+        "Remediation: reinstall the provider CLI on this host; see "
+        "docs/runbooks/agent-seat-onboarding.md 'Reviewer-seat transport recovery'.",
+    )
+    return (
+        f"{adapter_label}: {executable} binary not found on PATH; required for "
+        f"compatibility contract {contract!r}. {remediation}"
+    )
+
+
+def probe_participant_reachability(participant: str) -> str | None:
+    """Return an actionable error when a participant's provider CLI is absent.
+
+    Cheap admission preflight (PATH lookup only — never spawns a subprocess)
+    so a dead seat fails before an authority job is enqueued instead of
+    mid-review. The adapter's compatibility probe remains the enforcement
+    point immediately before spawn; this only surfaces the failure early with
+    the remediation and documented fallback attached.
+    """
+    executable = _PARTICIPANT_PROVIDER_BINARIES.get(participant)
+    if executable is None or shutil.which(executable):
+        return None
+    return _missing_binary_message(
+        executable, adapter_label=f"ACP participant {participant!r}"
+    )
+
 
 def _resolve_participant_binary(
     executable: str,
@@ -1467,8 +1541,7 @@ def _resolve_participant_binary(
     found = shutil.which(executable)
     if not found:
         raise AcpxShadowRefusalError(
-            f"{adapter_label}: {executable} binary not found on PATH; required for "
-            f"compatibility contract {contract!r}"
+            _missing_binary_message(executable, adapter_label=adapter_label)
         )
     resolved = Path(found).resolve()
     if not resolved.is_file():
@@ -2275,6 +2348,48 @@ class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
                 else _OPENCODE_DENY_ALL_CONFIG
             ),
         }
+
+
+class AcpxGemmaShadowAdapter(_AcpxDiscussionAdapter):
+    """Native OpenCode ACP participant pinned to the $0 AIS-direct Gemma seat.
+
+    Same confined shape as the GLM seat (``opencode acp --pure`` with the
+    deny-all OpenCode config, which keeps the chat-only model toolless), but
+    the google-ais provider is Western-hosted, so no egress guard applies
+    (#6805). The catalog id doubles as the invocation id — there is no
+    separate ``acpx_model``.
+    """
+
+    name = "acpx-gemma-shadow"
+    target_agent = "gemma"
+    fixed_model = GEMMA_ACP_MODEL
+    default_model = fixed_model
+
+    def _custom_agent_command(self, cwd: Path) -> tuple[str, dict[str, Any]]:
+        _ = cwd
+        binary, version = _resolve_participant_binary(
+            "opencode",
+            adapter_label=type(self).__name__,
+        )
+        return shlex.join([binary, "acp", "--pure"]), {
+            "provider_cli": "opencode",
+            "provider_cli_version": version,
+            "provider_cli_compatibility": OPENCODE_CLI_COMPATIBILITY_CONTRACT,
+            "provider_route": GEMMA_ACP_MODEL,
+            "tool_policy": "deny-all",
+        }
+
+    def _env_overrides(
+        self,
+        *,
+        sealed_review_mcp_config: str | None = None,
+    ) -> dict[str, str]:
+        _ = sealed_review_mcp_config
+        return {
+            GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
+            "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
+        }
+
 
 class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
     """Text-only, first-party DeepSeek ACP participant via isolated Hermes."""

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -124,6 +124,12 @@ _PROVIDER_SAFE_NAME_ALLOWLIST = {
         # denied for the native ACP participant.
         "OPENCODE_CONFIG_CONTENT",
     },
+    "acpx-gemma-shadow": {
+        # Same OpenCode ACP auth selector and deny-all policy JSON as the GLM
+        # seat; both values are non-secret (#6805).
+        "ACPX_AUTH_OPENCODE_LOGIN",
+        "OPENCODE_CONFIG_CONTENT",
+    },
     "gemini": {
         "GEMINI_AUTH_MODE",
     },

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -403,6 +403,16 @@ AGENTS: dict[str, AgentEntry] = {
         "direct_only": True,
         "resume_policy": "never",
     },
+    "acpx-gemma-shadow": {
+        # $0 toolless AIS-direct Gemma ACP participant (#6805).
+        "adapter": "scripts.agent_runtime.adapters.acpx:AcpxGemmaShadowAdapter",
+        "default_model": "google-ais/gemma-4-31b-it",
+        "cost_tier": "unknown",
+        "capabilities": frozenset(),
+        "cli_available": False,
+        "direct_only": True,
+        "resume_policy": "never",
+    },
     "agy": {
         # Antigravity CLI shipping Gemini Flash 3.7 (was 3.6) on a separate meter from
         # gemini-cli. Added 2026-05-20 for the seminar-writer ADR bakeoff

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -330,17 +330,6 @@ def _run_compat_ask_impl(
     if not task_id or not task_id.strip():
         raise ValueError("ACP ask requires a non-empty task_id")
 
-    # Admission preflight (#6805): a participant whose provider CLI is absent
-    # fails here — before an authority job is enqueued — with the actionable
-    # remediation and documented fallback, instead of dying mid-review at
-    # spawn time. The adapter's own compatibility probe still enforces the
-    # full contract immediately before spawn.
-    from scripts.agent_runtime.adapters.acpx import probe_participant_reachability
-
-    reachability_error = probe_participant_reachability(participant)
-    if reachability_error is not None:
-        raise ValueError(reachability_error)
-
     prompt = content
     if data:
         prompt += "\n\n--- attached inert text ---\n" + data
@@ -393,6 +382,20 @@ def _run_compat_ask_impl(
             previous_transport = os.environ.get("LU_ACPX_TRANSPORT")
             os.environ["LU_ACPX_TRANSPORT"] = "active"
             try:
+                # Reachability preflight (#6805): probe only now that a real
+                # provider invocation is about to occur. Terminal-replay paths
+                # above never reach this probe, so a provider CLI missing from
+                # the host cannot fail the replay of an already-durable
+                # result. A refusal here is terminalized as a durable failure
+                # by the except below. The adapter's own compatibility probe
+                # still enforces the full contract immediately before spawn.
+                from scripts.agent_runtime.adapters.acpx import (
+                    probe_participant_reachability,
+                )
+
+                reachability_error = probe_participant_reachability(participant)
+                if reachability_error is not None:
+                    raise ValueError(reachability_error)
                 from ._acp_execution import acp_execution_cwd
 
                 with acp_execution_cwd(REPO_ROOT, task_id=task_id) as execution_cwd:

--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -24,6 +24,7 @@ _TARGETS = {
     "hermes": "deepseek",
     "pool": "pool",
     "glm": "glm",
+    "gemma": "gemma",
     "cursor": "cursor",
     "grok": "grok",
     "grok-build": "grok",
@@ -328,6 +329,18 @@ def _run_compat_ask_impl(
     participant = require_compat_target(command_target)
     if not task_id or not task_id.strip():
         raise ValueError("ACP ask requires a non-empty task_id")
+
+    # Admission preflight (#6805): a participant whose provider CLI is absent
+    # fails here — before an authority job is enqueued — with the actionable
+    # remediation and documented fallback, instead of dying mid-review at
+    # spawn time. The adapter's own compatibility probe still enforces the
+    # full contract immediately before spawn.
+    from scripts.agent_runtime.adapters.acpx import probe_participant_reachability
+
+    reachability_error = probe_participant_reachability(participant)
+    if reachability_error is not None:
+        raise ValueError(reachability_error)
+
     prompt = content
     if data:
         prompt += "\n\n--- attached inert text ---\n" + data

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -2279,7 +2279,9 @@ def test_gemma_shadow_seat_rejects_a_caller_model_other_than_its_pin(tmp_path, m
 
 def test_missing_hermes_binary_error_carries_remediation_and_fallback(monkeypatch):
     """Key guard (#6805): a dead DeepSeek seat must surface an actionable
-    remediation plus the documented fallback route — never a bare not-found."""
+    remediation plus the documented route — never a bare not-found. Hermes is
+    permanently removed (operator order 2026-08-16), so the message points at
+    the opencode standing path, never at a reinstall."""
     monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
 
     with pytest.raises(AcpxShadowRefusalError) as exc_info:
@@ -2291,9 +2293,11 @@ def test_missing_hermes_binary_error_carries_remediation_and_fallback(monkeypatc
     assert "hermes binary not found on PATH" in message
     assert "text-oneshot-isolated-v1" in message
     assert "docs/runbooks/agent-seat-onboarding.md" in message
-    assert "hermes --version" in message
+    assert "permanently removed" in message
+    assert "do not reinstall" in message
     assert "opencode run --model deepseek-direct/deepseek-v4-flash" in message
     assert "delegate.py dispatch --agent deepseek" in message
+    assert "hermes --version" not in message
 
 
 def test_probe_participant_reachability_reports_only_missing_provider_binaries(monkeypatch):

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -34,6 +34,7 @@ from scripts.agent_runtime.adapters.acpx import (
     AcpxClaudeShadowAdapter,
     AcpxCursorShadowAdapter,
     AcpxDeepSeekShadowAdapter,
+    AcpxGemmaShadowAdapter,
     AcpxGlmShadowAdapter,
     AcpxGrokShadowAdapter,
     AcpxKimiCcShadowAdapter,
@@ -2105,6 +2106,11 @@ def test_supported_participant_registry_has_only_fixed_direct_seats():
             "model": "gemini-3.7-flash-high",
         },
         "glm": {"seat": "acpx-glm-shadow", "agent": "glm", "model": "glm-5.3"},
+        "gemma": {
+            "seat": "acpx-gemma-shadow",
+            "agent": "gemma",
+            "model": "google-ais/gemma-4-31b-it",
+        },
         "deepseek": {
             "seat": "acpx-deepseek-shadow",
             "agent": "deepseek",
@@ -2192,6 +2198,121 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
     else:
         assert "--model" not in plan.cmd
         assert plan.env_overrides == {}
+
+
+def test_gemma_shadow_seat_uses_a_confined_opencode_command(tmp_path, monkeypatch):
+    """#6805: the $0 toolless Gemma seat mirrors the confined GLM shape."""
+    _stub_binary(monkeypatch, tmp_path)
+    opencode = tmp_path / "opencode"
+    opencode.write_text("#!/bin/sh\n", encoding="utf-8")
+    opencode.chmod(0o755)
+    monkeypatch.setattr(
+        acpx_module.shutil, "which", lambda name: {"opencode": str(opencode)}.get(name)
+    )
+    monkeypatch.setattr(
+        acpx_module,
+        "_probe_participant_cli_compatibility",
+        lambda _path, _executable: ("1.17.13", ()),
+    )
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+
+    adapter = AcpxGemmaShadowAdapter()
+    with acpx_module.active_discussion_scope():
+        plan = adapter.build_invocation(
+            prompt="ping",
+            mode="read-only",
+            cwd=tmp_path,
+            model="google-ais/gemma-4-31b-it",
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": "gemma",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+    assert adapter.name == "acpx-gemma-shadow"
+    command = plan.cmd[plan.cmd.index("--agent") + 1]
+    assert shlex.split(command) == [str(opencode), "acp", "--pure"]
+    assert ("--model", "google-ais/gemma-4-31b-it") in zip(
+        plan.cmd, plan.cmd[1:], strict=False
+    )
+    assert plan.cmd[-3:] == ["exec", "-f", "-"]
+    for flag in ("--deny-all", "--no-fs", "--no-terminal"):
+        assert flag in plan.cmd
+    assert plan.metadata["model"] == "google-ais/gemma-4-31b-it"
+    assert plan.metadata["provider_route"] == "google-ais/gemma-4-31b-it"
+    assert plan.metadata["provider_cli_compatibility"] == "native-acp-pure-v1"
+    assert plan.metadata["tool_policy"] == "deny-all"
+    assert plan.env_overrides == {
+        "ACPX_AUTH_OPENCODE_LOGIN": "1",
+        "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}',
+    }
+    env = build_agent_env(provider=adapter.name, overrides=plan.env_overrides)
+    assert env["ACPX_AUTH_OPENCODE_LOGIN"] == "1"
+    assert env["OPENCODE_CONFIG_CONTENT"] == plan.env_overrides["OPENCODE_CONFIG_CONTENT"]
+
+
+def test_gemma_shadow_seat_rejects_a_caller_model_other_than_its_pin(tmp_path, monkeypatch):
+    monkeypatch.setenv(acpx_module.TRANSPORT_ENV, "active")
+    _stub_binary(monkeypatch, tmp_path)
+    with acpx_module.active_discussion_scope(), pytest.raises(
+        AcpxShadowRefusalError, match="model="
+    ):
+        AcpxGemmaShadowAdapter().build_invocation(
+            prompt="ping",
+            mode="read-only",
+            cwd=tmp_path,
+            model="openrouter/google/gemma-4-31b-it",
+            task_id="t-1",
+            session_id=None,
+            tool_config={
+                "acpx_discussion": True,
+                "target_agent": "gemma",
+                "correlation_id": "corr-1",
+                "idempotency_key": "idem-1",
+            },
+        )
+
+
+def test_missing_hermes_binary_error_carries_remediation_and_fallback(monkeypatch):
+    """Key guard (#6805): a dead DeepSeek seat must surface an actionable
+    remediation plus the documented fallback route — never a bare not-found."""
+    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+
+    with pytest.raises(AcpxShadowRefusalError) as exc_info:
+        acpx_module._resolve_participant_binary(
+            "hermes", adapter_label="AcpxDeepSeekShadowAdapter"
+        )
+
+    message = str(exc_info.value)
+    assert "hermes binary not found on PATH" in message
+    assert "text-oneshot-isolated-v1" in message
+    assert "docs/runbooks/agent-seat-onboarding.md" in message
+    assert "hermes --version" in message
+    assert "opencode run --model deepseek-direct/deepseek-v4-flash" in message
+    assert "delegate.py dispatch --agent deepseek" in message
+
+
+def test_probe_participant_reachability_reports_only_missing_provider_binaries(monkeypatch):
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: {"opencode": "/usr/local/bin/opencode"}.get(name),
+    )
+
+    assert acpx_module.probe_participant_reachability("gemma") is None
+    assert acpx_module.probe_participant_reachability("glm") is None
+    # ACPX built-in seats resolve no external provider binary: unprobed.
+    assert acpx_module.probe_participant_reachability("codex") is None
+    assert acpx_module.probe_participant_reachability("unknown-seat") is None
+
+    error = acpx_module.probe_participant_reachability("deepseek")
+    assert error is not None
+    assert "hermes binary not found on PATH" in error
+    assert "docs/runbooks/agent-seat-onboarding.md" in error
 
 
 def test_new_fleet_discussion_seat_accepts_provider_cli_version_drift(tmp_path, monkeypatch):

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -82,6 +82,12 @@ def test_terminal_failure_replays_without_invoking_provider_again(
     monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "fleet-comms"))
     invoke = Mock(side_effect=RuntimeError("protected primary refused"))
     monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+    # Hermetic from host PATH state: the reachability probe is stubbed, and
+    # the replay path must never call it — only the real invocation may.
+    probe = Mock(return_value=None)
+    monkeypatch.setattr(
+        "scripts.agent_runtime.adapters.acpx.probe_participant_reachability", probe
+    )
 
     with pytest.raises(RuntimeError, match="protected primary refused"):
         _acp_compat.run_compat_ask(
@@ -114,6 +120,9 @@ def test_terminal_failure_replays_without_invoking_provider_again(
         "transport": "acp",
     }
     assert invoke.call_count == 1
+    # The probe fires once — for the call that actually invoked the provider —
+    # and never for the terminal replay.
+    assert probe.call_count == 1
 
 
 def test_terminalization_conflict_preserves_completed_provider_response(
@@ -121,6 +130,8 @@ def test_terminalization_conflict_preserves_completed_provider_response(
 ) -> None:
     """A bookkeeping collision must not hide the completed provider response."""
     from scripts.fleet_comms.authority import AuthorityStaleLeaseError
+
+    claim_state = {"claimed": False}
 
     class TerminalConflictAuthority:
         def __enter__(self):
@@ -133,10 +144,19 @@ def test_terminalization_conflict_preserves_completed_provider_response(
             return SimpleNamespace(job_id="job-6367", state="queued")
 
         def claim_job(self, *_args, **_kwargs):
+            claim_state["claimed"] = True
             return SimpleNamespace(fence_token=1)
 
         def finish_job(self, *_args, **_kwargs):
             raise AuthorityStaleLeaseError("terminalization_conflict")
+
+    def probe_after_claim(_participant: str) -> str | None:
+        # Hermetic from host PATH state, and order-sensitive: the probe is
+        # legitimate only once a job was claimed — i.e. only when a real
+        # provider invocation is about to occur, never at admission.
+        if not claim_state["claimed"]:
+            return "probe fired before any provider invocation was due"
+        return None
 
     @contextmanager
     def execution_cwd(*_args, **_kwargs):
@@ -159,6 +179,10 @@ def test_terminalization_conflict_preserves_completed_provider_response(
     monkeypatch.setattr("scripts.fleet_comms.authority.AuthorityService", TerminalConflictAuthority)
     monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
     monkeypatch.setattr("scripts.ai_agent_bridge._acp_execution.acp_execution_cwd", execution_cwd)
+    monkeypatch.setattr(
+        "scripts.agent_runtime.adapters.acpx.probe_participant_reachability",
+        probe_after_claim,
+    )
 
     with pytest.raises(RuntimeError, match="terminal bookkeeping failed after provider response"):
         _acp_compat._run_compat_ask_impl(
@@ -216,8 +240,14 @@ def test_claim_race_to_terminal_replays_without_invoking_provider(
             return _acp_compat._result_receipt(replay_result)
 
     invoke = Mock(side_effect=AssertionError("terminal job reinvoked provider"))
+    # Hermetic from host PATH state, and order-sensitive: a claim-race replay
+    # must never reach the reachability probe at all.
+    probe = Mock(return_value="probe fired on a terminal-replay path")
     monkeypatch.setattr("scripts.fleet_comms.authority.AuthorityService", ConcurrentTerminalAuthority)
     monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+    monkeypatch.setattr(
+        "scripts.agent_runtime.adapters.acpx.probe_participant_reachability", probe
+    )
 
     result = _acp_compat._run_compat_ask_impl(
         "agy",
@@ -233,6 +263,7 @@ def test_claim_race_to_terminal_replays_without_invoking_provider(
     assert result.usage_record["from_model"] == "gemini-3.6-flash-high"
     assert result.usage_record["harness"] == "acp"
     assert invoke.call_count == 0
+    assert probe.call_count == 0
 
 
 def test_cli_returns_nonzero_for_replayed_or_live_failure(
@@ -262,21 +293,43 @@ def test_ask_target_without_an_enabled_acp_route_fails_closed(
         getattr(_cli, handler_name)(args)
 
 
-def test_compat_ask_fails_at_admission_when_provider_binary_is_missing(
+class _RecordingAuthority:
+    """Minimal in-memory authority: enqueue + claim succeed, finish_job records."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.finished: list[dict[str, object]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def enqueue_request(self, **_kwargs):
+        return SimpleNamespace(job_id="job-dead-seat", state="queued")
+
+    def claim_job(self, *_args, **_kwargs):
+        return SimpleNamespace(fence_token=1)
+
+    def finish_job(self, _job_id, **kwargs):
+        self.finished.append(kwargs)
+
+
+def test_compat_ask_fails_before_provider_invocation_when_provider_binary_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """#6805: a dead seat fails before any authority job is enqueued, with the
-    actionable remediation and documented fallback — not mid-review at spawn."""
+    """#6805: a dead seat fails before the provider is invoked, with the
+    actionable remediation and documented route — not mid-review at spawn.
+    The authority job is enqueued and claimed first: terminal-replay paths
+    must stay reachable even when the provider CLI is absent."""
     from scripts.agent_runtime.adapters import acpx as acpx_module
 
-    class _AuthorityBomb:
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            raise AssertionError("authority must not be reached for a dead seat")
-
+    invoke = Mock(side_effect=AssertionError("dead seat invoked the provider"))
     monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
     monkeypatch.setattr(
-        "scripts.fleet_comms.authority.AuthorityService", _AuthorityBomb
+        "scripts.fleet_comms.authority.AuthorityService", _RecordingAuthority
     )
+    monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
 
     with pytest.raises(ValueError) as exc_info:
         _acp_compat._run_compat_ask_impl("hermes", "question", task_id="dead-seat")
@@ -285,6 +338,7 @@ def test_compat_ask_fails_at_admission_when_provider_binary_is_missing(
     assert "hermes binary not found on PATH" in message
     assert "docs/runbooks/agent-seat-onboarding.md" in message
     assert "opencode run --model deepseek-direct/deepseek-v4-flash" in message
+    assert invoke.call_count == 0
 
 
 def test_ask_hermes_cli_surfaces_remediation_when_binary_is_missing(
@@ -294,6 +348,9 @@ def test_ask_hermes_cli_surfaces_remediation_when_binary_is_missing(
     from scripts.agent_runtime.adapters import acpx as acpx_module
 
     monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        "scripts.fleet_comms.authority.AuthorityService", _RecordingAuthority
+    )
     args = _cli._build_parser().parse_args(
         ["ask-hermes", "question", "--task-id", "dead-seat", "--from", "codex"]
     )

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -28,6 +28,7 @@ ASK_SEATS = (
     ("ask-agy", "_handle_ask_agy", "agy"),
     ("ask-grok", "_handle_ask_grok_build", "grok"),
     ("ask-glm", "_handle_ask_glm", "glm"),
+    ("ask-gemma", "_handle_ask_gemma", "gemma"),
     ("ask-kimi", "_handle_ask_kimi", "kimi"),
     ("ask-cursor", "_handle_ask_cursor", "cursor"),
     ("ask-hermes", "_handle_ask_hermes", "hermes"),
@@ -36,7 +37,6 @@ ASK_SEATS = (
 
 RETIRED_ASK_SEATS = (
     ("ask-opencode", "_handle_ask_opencode", "opencode"),
-    ("ask-gemma", "_handle_ask_gemma", "gemma"),
 )
 
 
@@ -260,6 +260,50 @@ def test_ask_target_without_an_enabled_acp_route_fails_closed(
     )
     with pytest.raises(SystemExit, match=f"{target!r} has no enabled ACP route"):
         getattr(_cli, handler_name)(args)
+
+
+def test_compat_ask_fails_at_admission_when_provider_binary_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#6805: a dead seat fails before any authority job is enqueued, with the
+    actionable remediation and documented fallback — not mid-review at spawn."""
+    from scripts.agent_runtime.adapters import acpx as acpx_module
+
+    class _AuthorityBomb:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise AssertionError("authority must not be reached for a dead seat")
+
+    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        "scripts.fleet_comms.authority.AuthorityService", _AuthorityBomb
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _acp_compat._run_compat_ask_impl("hermes", "question", task_id="dead-seat")
+
+    message = str(exc_info.value)
+    assert "hermes binary not found on PATH" in message
+    assert "docs/runbooks/agent-seat-onboarding.md" in message
+    assert "opencode run --model deepseek-direct/deepseek-v4-flash" in message
+
+
+def test_ask_hermes_cli_surfaces_remediation_when_binary_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#6805: the CLI exits nonzero with the remediation the caller reroutes on."""
+    from scripts.agent_runtime.adapters import acpx as acpx_module
+
+    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    args = _cli._build_parser().parse_args(
+        ["ask-hermes", "question", "--task-id", "dead-seat", "--from", "codex"]
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cli._handle_ask_hermes(args)
+
+    message = str(exc_info.value)
+    assert "hermes binary not found on PATH" in message
+    assert "delegate.py dispatch --agent deepseek" in message
 
 
 @pytest.mark.parametrize("effort", EFFORT_CHOICES)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -206,6 +206,7 @@ def test_registry_has_known_agents():
         "acpx-codex-shadow",
         "acpx-cursor-shadow",
         "acpx-deepseek-shadow",
+        "acpx-gemma-shadow",
         "acpx-glm-shadow",
         "acpx-grok-shadow",
         "acpx-agy-shadow",
@@ -342,6 +343,11 @@ def test_acpx_grok_shadow_entry_is_direct_only():
             "acpx-glm-shadow",
             "scripts.agent_runtime.adapters.acpx:AcpxGlmShadowAdapter",
             "glm-5.3",
+        ),
+        (
+            "acpx-gemma-shadow",
+            "scripts.agent_runtime.adapters.acpx:AcpxGemmaShadowAdapter",
+            "google-ais/gemma-4-31b-it",
         ),
         (
             "acpx-deepseek-shadow",
@@ -4784,6 +4790,7 @@ def test_non_acpx_route_has_no_streamed_output_limit(tmp_path, monkeypatch):
         "acpx-grok-shadow",
         "acpx-kimi-shadow",
         "acpx-glm-shadow",
+        "acpx-gemma-shadow",
     ],
 )
 def test_acp_routes_share_a_bounded_protocol_envelope(agent_name):


### PR DESCRIPTION
Residual from #6805. Root cause (primary-checkout acpx clobber) was fixed there and ask-glm verified working; this PR restores the two repo-fixable reviewer-seat routes that stayed dead for reasons of their own.

## (a) ask-hermes / DeepSeek seat — actionable error + fail at admission

Hermes is genuinely host-level (operator-owned platform + credentials under `~/.hermes/`; the machine-local install recipe is deliberately untracked per the 2026-07-05 OPSEC policy), so provisioning is **not** automatable from project tooling. Shipped instead: actionable error + reroute path + runbook provisioning steps.

- `acpx.py::_missing_binary_message` — every missing provider binary now names the install/verify step, the owning runbook section, and (for hermes) the documented fallback substitutions from `agents_extensions/shared/rules/model-assignment.md`: `opencode run --model deepseek-direct/deepseek-v4-flash --variant high` for one-shot review, `delegate.py dispatch --agent deepseek` for tool-heavy work.
- `acpx.py::probe_participant_reachability` — PATH-only preflight (no subprocess) called from `_acp_compat._run_compat_ask_impl` **before** an authority job is enqueued, so callers degrade at admission instead of dying mid-review. The adapter's compatibility probe still enforces the full contract before spawn.
- `docs/runbooks/agent-seat-onboarding.md` — new "Reviewer-seat transport recovery" section: symptom→meaning table, Hermes provisioning + verification (`hermes --version` → `Hermes Agent v<semver>`, required flags), documented fallbacks.

**Before** (`ask-hermes "Reply with exactly: OK" --task-id probe-6805-before-hermes --from kimi`):
```
AcpxDeepSeekShadowAdapter: hermes binary not found on PATH; required for compatibility contract 'text-oneshot-isolated-v1'
```

**After** (`ask-hermes ... --task-id probe-6805-after-hermes --from kimi`, exit 1, no quota spent — refused at admission):
```
ACP participant 'deepseek': hermes binary not found on PATH; required for compatibility contract 'text-oneshot-isolated-v1'. Remediation: Hermes is a host-level, operator-owned install (never project-provisioned) — reinstall per docs/runbooks/agent-seat-onboarding.md 'Reviewer-seat transport recovery', then verify `hermes --version` prints 'Hermes Agent v<semver>'. Documented fallback while the seat is down (agents_extensions/shared/rules/model-assignment.md): one-shot DeepSeek review runs first-party via `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`; tool-heavy work goes to `delegate.py dispatch --agent deepseek`.
```

## (b) ask-gemma — enabled ACP route under authority mode

- New confined `AcpxGemmaShadowAdapter` mirroring the GLM shape: native `opencode acp --pure`, deny-all OpenCode config keeps the chat-only model toolless, pinned `google-ais/gemma-4-31b-it` ($0 AIS-direct; catalog id doubles as invocation id). No egress guard — google-ais is Western-hosted.
- Registered `acpx-gemma-shadow` (direct-only, never dispatch/failover), env-sanitize allowlist for the two non-secret OpenCode vars, `_TARGETS["gemma"] = "gemma"`.
- No routing-policy change: gemma stays surface-review-only, `formal_review_eligible` untouched (no `fleet_communications.yaml` endpoint added — a first version of this change added one and it pushed `test_cold_start_board.py::test_size_cap` over the 16 KiB board cap; the endpoint row is not needed on the ask path, so it was reverted).

**Before** (`ask-gemma ... --task-id probe-6805-before-gemma --from kimi`):
```
legacy ask target 'gemma' has no enabled ACP route
```

**After** (`ask-gemma "Reply with exactly: OK" --task-id probe-6805-after-gemma --from kimi`, one minimal live probe on the $0 lane):
```
<thought>...</thought>OK
```
Real reply through the authority/ACP path, `outcome=ok`. Residual: the model leaks a `<thought>` block on this transport (the legacy `_strip_gemma_thought` path is not in play under ACP) — cosmetic, transport is healthy; flagged for a follow-up, not fixed here.

## Verification (tool-backed)

- `.venv/bin/pytest tests/agent_runtime/test_acpx_adapter.py tests/ai_agent_bridge/test_ask_contract.py tests/test_agent_runtime.py` → **386 passed**
- Broader: `tests/fleet_comms tests/agent_runtime tests/ai_agent_bridge tests/test_agent_runtime.py` → 951 passed, 5 failed — all 5 reproduce on the unmodified base (`git stash` re-run): 4 are worktree-env issues (no `.venv` in worktree, agy prompt fixtures) and `test_size_cap` reads live plane state that outgrew 16 KiB independent of this diff.
- `.venv/bin/ruff check <changed files>` → All checks passed
- `markdownlint-cli2` on both changed docs → 0 errors
- Mutation check (#M-16) on the key guard: removing the remediation from `_missing_binary_message` fails all three guard tests (`test_missing_hermes_binary_error_carries_remediation_and_fallback`, `test_compat_ask_fails_at_admission_when_provider_binary_is_missing`, `test_ask_hermes_cli_surfaces_remediation_when_binary_is_missing`); reverted after the kill was confirmed.

## Out of scope (unchanged)

- grok lane 402 — operator action, already escalated.
- Routing policy (which seats review what) — untouched.
- Sealed/shielded review path — untouched.
- glm/agy outcome-validation residual (transport-ok masking unusable replies) — noted on #6805, not part of this unit.

X-Agent: kimi/infra-6805-reviewer-transport-residual
