### PR TITLE
fix(lexicon): accept attested slovnyk ukreng label abbreviations in gloss extraction (#6809)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -5965,6 +5965,56 @@ _SLOVNYK_UKRENG_PREFIX_LABELS = {
     "в",
     "спол",
     "лит",
+    # #6809: attested slovnyk.me ukreng label abbreviations that were missing
+    # here. Each blocked an otherwise-extractable English gloss in the cached
+    # 6323-slug missing-translation residual (e.g. «анчоус іхт. anchovy»,
+    # «аршин заст. arshine», «ай! виг. oh!», «дрохва орн. bustard»,
+    # «алібі невідм. юр. alibi», «інтерферон біохім. interferon»).
+    "амер",
+    "арт",
+    "архт",
+    "бакт",
+    "безос",
+    "біохім",
+    "брит",
+    "буд",
+    "бух",
+    "виг",
+    "дит",
+    "друк",
+    "ент",
+    "жив",
+    "заст",
+    "знев",
+    "ірон",
+    "іхт",
+    "карт",
+    "кін",
+    "ком",
+    "лог",
+    "літ",
+    "мисл",
+    "міф",
+    "мист",
+    "опт",
+    "орн",
+    "пестл",
+    "прикм",
+    "преф",
+    "пр",
+    "присл",
+    "рідк",
+    "сад",
+    "скороч",
+    "театр",
+    "уроч",
+    "фарм",
+    "фін",
+    "вірш",
+    "фон",
+    "фот",
+    "юр",
+    "яд",
 }
 
 
@@ -6019,6 +6069,12 @@ def _clean_ukreng_gloss(candidate: str) -> str | None:
     cleaned = re.sub(r"\(\s*(?:pl|sg|plural|singular)\.?\s*\)", " ", cleaned, flags=re.IGNORECASE)
     cleaned = re.sub(r"\s+", " ", cleaned).strip(" \t\r\n.,;:!?()[]{}«»\"“”")
     cleaned = re.sub(r"^(?:to|a|an|the)\s+", "", cleaned, flags=re.IGNORECASE)
+    # A sense boundary the chunker cannot split on (no preceding ")" before the
+    # next "2)") leaves the next sense's number glued to the gloss tail
+    # («амброзія міф. ambrosia 2) бот. ragweed» -> "ambrosia 2"). Strip a
+    # trailing standalone sense number; "vitamin B12"-style tokens keep their
+    # digits because this requires whitespace before the number.
+    cleaned = re.sub(r"\s+\d+$", "", cleaned)
     if not cleaned or not _LATIN_RE.search(cleaned) or re.search(r"[А-Яа-яЄєІіЇїҐґ]", cleaned):
         return None
     if len(cleaned.split()) > 5:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -91,8 +91,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "a33401d12412d701961df57a1775119921ddb8cb4b5f6a7ba443fde3b9a2010f"
-        "sha256": "89be0d3e3fa8b123ce987481aefd250c54d74eccb5433bfdf7bac1c366804fca"
+        "sha256": "76b662b94b5c71919aa618d0ac1656fcdc032bf7ebd620067839d3daabd7f760"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -92,6 +92,7 @@
       {
         "path": "scripts/lexicon/enrich_manifest.py",
         "sha256": "a33401d12412d701961df57a1775119921ddb8cb4b5f6a7ba443fde3b9a2010f"
+        "sha256": "89be0d3e3fa8b123ce987481aefd250c54d74eccb5433bfdf7bac1c366804fca"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -2876,6 +2876,76 @@ def test_translation_parses_slovnyk_ukreng_plural_label(monkeypatch) -> None:
     }
 
 
+def test_slovnyk_ukreng_glosses_accept_missing_domain_labels() -> None:
+    """#6809: attested label abbreviations must not mask extractable glosses.
+
+    Each row quotes a cached slovnyk.me ukreng article from the 6323-slug
+    missing-translation residual whose gloss extraction returned [] only
+    because the leading label abbreviation was absent from
+    ``_SLOVNYK_UKRENG_PREFIX_LABELS``.
+    """
+    attested = [
+        ("анчоус", "анчоус іхт. anchovy Джерело: Українсько-англійський словник на Slovnyk.me", ["anchovy"]),
+        ("аршин", "аршин заст. arshine (= 71,1 cm or 28 inches)", ["arshine"]),
+        ("ай", "ай! виг. oh! Джерело: Українсько-англійський словник на Slovnyk.me", ["oh"]),
+        ("дрохва", "дрохва орн. bustard", ["bustard"]),
+        ("алібі", "алібі невідм. юр. alibi встановити чиєсь алібі — to establish smb's alibi", ["alibi"]),
+        ("інтерферон", "інтерферон біохім. interferon", ["interferon"]),
+        ("сфінкс", "сфінкс міф., перен. sphinx", ["sphinx"]),
+        ("бурлеск", "бурлеск літ. burlesque", ["burlesque"]),
+        ("готика", "готика архт. Gothic", ["Gothic"]),
+        (
+            "антракт",
+            "антракт 1) театр. intermission; брит. interval 2) муз. entr'acte, interlude "
+            "Джерело: Українсько-англійський словник на Slovnyk.me",
+            ["intermission", "interval"],
+        ),
+        ("ампір", "ампір мист. (стиль) Empire style", ["Empire style"]),
+        ("спатоньки", "спатоньки дит. hushaby", ["hushaby"]),
+        ("нетто", "нетто ком. net нетто-вага — net weight", ["net"]),
+        ("анапест", "анапест вірш. anapaest", ["anapaest"]),
+        ("задньоязиковий", "задньоязиковий фон. velar, back", ["velar", "back"]),
+        ("нуклон", "нуклон яд. фіз. nucleon", ["nucleon"]),
+        ("еліксир", "еліксир фарм. elixir", ["elixir"]),
+        ("вібріон", "вібріон бакт. vibrio", ["vibrio"]),
+        ("мариніст", "мариніст жив. painter of seascapes, marine painter", ["painter of seascapes", "marine painter"]),
+        ("бонна", "бонна заст. nursery governess", ["nursery governess"]),
+    ]
+    for lemma, text, expected in attested:
+        row = {
+            "dictionary_slug": "ukreng",
+            "word": lemma,
+            "text": text,
+        }
+        assert enrich_manifest_module._slovnyk_ukreng_glosses(row, lemma) == expected, lemma
+
+
+def test_slovnyk_ukreng_glosses_strip_trailing_sense_number() -> None:
+    """A gloss must not carry the next sense's number («ambrosia 2»)."""
+    row = {
+        "dictionary_slug": "ukreng",
+        "word": "амброзія",
+        "text": "амброзія міф. ambrosia 2) бот. ragweed Джерело: Українсько-англійський словник на Slovnyk.me",
+    }
+    assert enrich_manifest_module._slovnyk_ukreng_glosses(row, "амброзія") == ["ambrosia"]
+
+    automatics = {
+        "dictionary_slug": "ukreng",
+        "word": "автоматика",
+        "text": (
+            "автоматика 1) (галузь науки і техніки) automatics; "
+            "2) (обладнання) automatic machinery, automatic equipment, automation "
+            "Джерело: Українсько-англійський словник на Slovnyk.me"
+        ),
+    }
+    assert enrich_manifest_module._slovnyk_ukreng_glosses(automatics, "автоматика") == [
+        "automatics",
+        "automatic machinery",
+        "automatic equipment",
+        "automation",
+    ]
+
+
 def test_fill_learner_english_anchor_from_cached_ukreng() -> None:
     cache = {
         "lookups": {


### PR DESCRIPTION
## What

Draft follow-up from the #6809 zero-fill diagnosis (read-only dispatch). Two deterministic extraction defects in `_slovnyk_ukreng_glosses` (`scripts/lexicon/enrich_manifest.py`, one file):

1. **Missing label abbreviations.** ~45 attested slovnyk.me ukreng label abbreviations (`виг`, `заст`, `орн`, `іхт`, `міф`, `літ`, `архт`, `друк`, `театр`, `біохім`, `юр`, `вірш`, …) were absent from `_SLOVNYK_UKRENG_PREFIX_LABELS`, so `_ukreng_prefix_is_label` rejected every sense carrying them:
   - «анчоус **іхт.** anchovy» → `[]`
   - «аршин **заст.** arshine (= 71,1 cm or 28 inches)» → `[]`
   - «ай! **виг.** oh!» → `[]`
   - «дрохва **орн.** bustard» → `[]`
   - «алібі **невідм. юр.** alibi» → `[]` (`юр` blocked it; `невідм` was already whitelisted)
2. **Trailing sense number.** Where a sense boundary has no `)`-predecessor for the chunker's split (`ambrosia 2) бот. ragweed`), the next sense's number survived inside the gloss (`"ambrosia 2"`, `"automatics 2"`). `_clean_ukreng_gloss` now strips a trailing standalone number (`\s+\d+$`, so `vitamin B12`-style tokens are untouched).

## Evidence

- Offline replay against the cached 6323-slug #6809 residual: **135 of the 260 cached-article-but-zero-gloss entries fill with this change alone** (no network). Examples: ай→oh, алібі→alibi, ампір→Empire style, анапест→anapaest, анчоус→anchovy, аршин→arshine, антракт→intermission/interval.
- Freshly fetched pages parse cleanly with the fix: амортизація→amortization, depreciation; автоматика→automatics; інтерферон→interferon; абстрагуватися→abstract away.
- Tests: 2 new tests (20 attested label rows quoted from the cache corpus + trailing-sense-number cases); full `tests/test_lexicon_enrich_manifest.py`, `tests/test_reenrich_thin_manifest_entries.py` and 3 adjacent suites pass (257 passed). `ruff check scripts/` clean; fingerprint sidecar regenerated via `scripts/pre_commit/regen_lexicon_fingerprint.py`.

## Not in scope (reported on #6809, needs operator decision)

- The **stale negative cache** (the primary zero-fill cause): cached `ukreng: null` rows from Aug 14–15 are contradicted by today's live slovnyk.me for ~57% of a 40-slug random sample; `_slovnyk_cache()` has no TTL/re-attest path for known-misses, so "live" runs can never heal them. Fixing that is a policy decision (schema bump to force wholesale refetch, per the v3 precedent), not a one-file bug fix.

Part of #6809.