### PR TITLE
fix(practice): drive dashboard tiles from session counters, not snapshot membership (#6839)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 580e55b28b1475d28a6509a62843b526d2754447bd55610681ff5bcf914160ff
+  components_sha256: 17636cd8d4f6115ac1b314ca8c00bbb1f7183b544e44cb13f165d6e3158b631d
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -3796,6 +3796,21 @@ function LexiconPracticeIsland({
         : { pendingDue: [], pendingNew: [], done: [] },
     [dailySnapshot, reviewLog],
   );
+  // #6839: the k3-stats tile row used to read straight off `dailyRows`, i.e.
+  // snapshot-membership — with ~1,371 A1 items and only 12 in the daily
+  // snapshot, a normal `Mix` session essentially never lands on a snapshot
+  // lemma, so the tiles structurally couldn't move for a typical session.
+  // Drive them off the session's own live counters instead — `dailyRows`
+  // still backs the "Words of the day" deck list below (#6786 deck labels
+  // stay snapshot-scoped), just not these three numbers.
+  const dashboardStats = useMemo(
+    () => ({
+      due: reviewsCompleted,
+      new: dailyNewCount,
+      done: reviewsCompleted + sessionNewIntroduced,
+    }),
+    [dailyNewCount, reviewsCompleted, sessionNewIntroduced],
+  );
   const stageMode: PracticeModeFilter = selection?.mode ?? mode;
   const visibleStageMode = visiblePracticeMode(stageMode);
   const stageTitleUk =
@@ -4007,15 +4022,15 @@ function LexiconPracticeIsland({
 
             <div className="k3-stats" data-testid="practice-dashboard-stats" role="group" aria-label={CHROME_STRINGS[chromeLocale]['practice.stats']}>
               <div className="k3-stat">
-                <span className="k3-stat-value">{dailyRows.pendingDue.length}</span>
+                <span className="k3-stat-value">{dashboardStats.due}</span>
                 <span className="k3-stat-label"><ChromeText k="practice.statusDue" /></span>
               </div>
               <div className="k3-stat">
-                <span className="k3-stat-value">{dailyRows.pendingNew.length}</span>
+                <span className="k3-stat-value">{dashboardStats.new}</span>
                 <span className="k3-stat-label"><ChromeText k="practice.statusNew" /></span>
               </div>
               <div className="k3-stat">
-                <span className="k3-stat-value">{dailyRows.done.length}</span>
+                <span className="k3-stat-value">{dashboardStats.done}</span>
                 <span className="k3-stat-label"><ChromeText k="practice.statusDone" /></span>
               </div>
               <div className="k3-stat">

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -5739,7 +5739,10 @@ describe('LexiconPractice', () => {
           container.querySelectorAll('[data-testid="practice-dashboard-stats"] .k3-stat-value'),
         ).map((el) => el.textContent);
 
-      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '12', '0']));
+      // #6839: tiles are now driven by the session's own live counters
+      // (dailyNewCount/reviewsCompleted/sessionNewIntroduced), not by
+      // dailySnapshot membership — nothing reviewed yet, so all three start at 0.
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '0', '0']));
 
       // Play one flashcard and rate it «Good».
       await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
@@ -5751,16 +5754,15 @@ describe('LexiconPractice', () => {
       await user.click(flashcard);
       await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!);
 
-      // Back home: the done/new tiles must reflect the rating immediately.
+      // Back home: the new/done tiles must reflect the rating immediately —
+      // dailyNewCount and sessionNewIntroduced both moved by one successful new card.
       await user.click(container.querySelector<HTMLButtonElement>('button.stage-back')!);
-      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '11', '1']));
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '1', '1']));
     });
 
-    test('#6723 deck chip and stats tiles follow the accepted level switch after going home', async () => {
+    test('#6723 deck chip follows the accepted level switch after going home', async () => {
       document.documentElement.dataset.chromeLocale = 'en';
       localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
-      // Distinct, sub-cap (<DAILY_PRACTICE_DECK_SIZE=12) counts per level so the "NEW"
-      // tile can only read 10/7 if it re-reads the CURRENT level's pool, not a stale one.
       const { fn } = mockShardFetch({ A1: 10, B1: 7 });
       vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
       const user = userEvent.setup();
@@ -5771,7 +5773,11 @@ describe('LexiconPractice', () => {
           container.querySelectorAll('[data-testid="practice-dashboard-stats"] .k3-stat-value'),
         ).map((el) => el.textContent);
 
-      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '10', '0']));
+      // #6839: the stats tiles read the session's live counters, which are
+      // level-agnostic (dailyNewCount is a per-day, not per-level, total) — no
+      // card is ever played in this test, so they stay at 0 across the switch.
+      // The deck-chip label below is the actual per-level assertion (#6786).
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '0', '0']));
 
       await user.click(await screen.findByTestId('practice-start-session'));
       await screen.findByTestId('practice-session-progress');
@@ -5780,7 +5786,7 @@ describe('LexiconPractice', () => {
       expect(await screen.findByTestId('practice-active-deck-chip')).toHaveTextContent(
         'All Words (A1)',
       );
-      expect(statValues().slice(0, 3)).toEqual(['0', '10', '0']);
+      expect(statValues().slice(0, 3)).toEqual(['0', '0', '0']);
 
       await user.click(screen.getByRole('button', { name: 'B1' }));
       await user.click(await screen.findByTestId('practice-switch-session-accept'));
@@ -5789,8 +5795,62 @@ describe('LexiconPractice', () => {
       expect(await screen.findByTestId('practice-active-deck-chip')).toHaveTextContent(
         'All Words (B1)',
       );
-      // The B1 pool's own count, not the A1 count left behind by the switch.
-      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '7', '0']));
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '0', '0']));
+    });
+
+    test('#6839 dashboard tiles move from a session that never touches the daily snapshot', async () => {
+      document.documentElement.dataset.chromeLocale = 'en';
+      localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+
+      // The gap #6751's fixture hid: that fixture made the daily-pool.json draw and
+      // the practice-index.A1 shard the SAME 12 lemmas, so session pool == snapshot
+      // pool by construction and any tile-computation bug was invisible. Here the
+      // daily snapshot is a disjoint, fully separate 12-word pool (`daily-only-*`)
+      // from the 30-word practice index (`A1-*`) — closer to production, where the
+      // 12-word snapshot is a sliver of a >1,000-word level pool. A session played
+      // against the index can structurally never touch a `daily-only-*` lemma.
+      const { fn: indexFn } = mockShardFetch({ A1: 30 });
+      const disjointDailyPool = Array.from({ length: 12 }, (_unused, i) => ({
+        lemma: `ізольоване-слово-${i}`,
+        slug: `daily-only-${i}`,
+        gloss: `daily gloss ${i}`,
+        cefr: 'A1',
+      }));
+      const fn = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('daily-pool.json')) return okJson(disjointDailyPool);
+        return indexFn(input);
+      });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice />);
+
+      const statValues = () =>
+        Array.from(
+          container.querySelectorAll('[data-testid="practice-dashboard-stats"] .k3-stat-value'),
+        ).map((el) => el.textContent);
+
+      await screen.findByTestId('practice-daily-deck');
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '0', '0']));
+
+      // Play one flashcard (drawn from the A1-* index pool) and rate it «Good».
+      // Snapshot-membership counting (deriveDailyPracticeRows over dailySnapshot)
+      // would leave every tile frozen forever, since this session can never serve
+      // one of the 12 `daily-only-*` lemmas.
+      await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+      const flashcard = await waitFor(() => {
+        const el = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
+        expect(el).toBeInTheDocument();
+        return el!;
+      });
+      const playedLemma = flashcard.textContent ?? '';
+      expect(playedLemma).not.toContain('ізольоване-слово');
+      await user.click(flashcard);
+      await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!);
+
+      await user.click(container.querySelector<HTMLButtonElement>('button.stage-back')!);
+      await waitFor(() => expect(statValues().slice(0, 3)).toEqual(['0', '1', '1']));
     });
   });
 });


### PR DESCRIPTION
## What

Implements option **(b)** from #6839 (frozen product choice — do not touch Mix selection): the `k3-stats` dashboard tile row (Due/New/Done) now reads the session's own live counters instead of daily-snapshot membership.

## Root cause

`site/src/components/LexiconPractice.tsx` computed the tiles via:
```
dailyRows.pendingDue.length / dailyRows.pendingNew.length / dailyRows.done.length
```
where `dailyRows = deriveDailyPracticeRows(dailySnapshot, null, reviewLog, new Date())` (`site/src/lib/lexicon/srs.ts:3258`) — pure snapshot-membership. With ~1,371 A1 items and only 12 in the daily snapshot, a normal `Mix` session essentially never lands on a snapshot lemma, so the tiles structurally couldn't move for a typical session.

## Fix

New source of the tile numbers, `dashboardStats` (`LexiconPractice.tsx`):
```
due:  reviewsCompleted
new:  dailyNewCount
done: reviewsCompleted + sessionNewIntroduced
```
All three were already tracked in the component. `dailyRows` still backs the "Words of the day" deck list (`PracticeDailyDeck`) — deck labels stay snapshot-scoped per #6786, only the top tile numbers changed source.

## Tests

- Updated the two `#6723` tests whose expected tile values assumed snapshot-membership counting (they now assert `['0','0','0']` pre-play, `['0','1','1']`/level-agnostic post-play).
- Added `#6839 dashboard tiles move from a session that never touches the daily snapshot`: builds a daily-snapshot pool (`daily-only-*`) that is structurally disjoint from the session's practice index (`A1-*`) — the gap #6751's fixture hid, where session pool == snapshot pool by construction. Asserts tiles move after playing a card the snapshot could never contain.
- Mutation-checked: reverting the tile JSX back to `dailyRows.pending*/done` fails the new test (confirmed locally).
- `npx vitest run tests/unit/LexiconPractice.test.tsx` — 177/177 passing.
- `npx tsc --noEmit` / `npx eslint` — no new errors introduced (pre-existing baseline errors unchanged, confirmed via stash diff).

## Non-goals

#4696 audio, #6809, pointer, `selectNextPracticeItem` ranking — untouched.

Leaves #6723/#6839 open per dispatch instructions.

X-Agent: claude-atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
