### PR TITLE
fix(lexicon): bump slovnyk cache schema 3→4 to heal stale ukreng negatives (#6809)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -247,7 +247,18 @@ _SLOVNYK_BASE = "https://slovnyk.me"
 # `scripts/lexicon/migrate_slovnyk_cache_v3.py` applies the same reset directly
 # to on-disk cache files (no network needed) to purge the residue immediately
 # instead of waiting for each lemma's next live touch.
-_SLOVNYK_CACHE_SCHEMA_VERSION = 3
+# v4 (#6809, operator GO 2026-08-16): bumped because the Aug 14-15 cache run
+# wrote `ukreng: null` known-miss rows that a live slovnyk.me lookup
+# contradicts for ~57% of a 40-slug random sample -- there is no TTL/
+# re-attest path for a cached miss, so those false negatives can never
+# self-heal (#6840 fixed two extraction bugs feeding this same symptom, but
+# the stale-negative-cache root cause is separate and needs the wholesale
+# reset below). Same lever as v3: this bump makes `_slovnyk_cache()` discard
+# every non-current row (v3 `ukreng: null` included) and refetch live.
+# `scripts/lexicon/migrate_slovnyk_cache_v4.py` applies that reset directly
+# to on-disk cache files. The live 19k-slug refetch itself is a separate,
+# later drive step -- this bump only makes existing rows retryable.
+_SLOVNYK_CACHE_SCHEMA_VERSION = 4
 _OFFLINE_VALUES = {"1", "true", "yes", "on"}
 _WARNING_CLASSIFICATIONS = {"russianism", "sovietism", "surzhyk"}
 

--- a/scripts/lexicon/migrate_slovnyk_cache_v4.py
+++ b/scripts/lexicon/migrate_slovnyk_cache_v4.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Purge stale slovnyk.me cache rows predating the v4 known-miss reset.
+
+Offline replay of the #6809 zero-fill diagnosis found that ~57% of a random
+40-slug sample of cached ``ukreng: null`` rows (fetched Aug 14-15) are
+contradicted by a live slovnyk.me lookup today -- the page has a ``ukreng``
+sense, the cache just recorded a miss. ``_slovnyk_cache()`` has no TTL or
+re-attest path for a cached miss: once a lookup slug is recorded ``None`` for
+a lemma, nothing ever asks slovnyk.me again for that (lemma, slug) pair. #6840
+fixed two deterministic extraction bugs that fed this same zero-gloss symptom,
+but that only helps *future* fetches -- it cannot retroactively un-miss a
+lookup slovnyk.me was never asked to redo.
+
+``scripts/lexicon/enrich_manifest.py`` already migrates this lazily: bumping
+``_SLOVNYK_CACHE_SCHEMA_VERSION`` to 4 makes ``_slovnyk_cache()`` reset any
+non-current cache file (every v1/v2/v3 row, known-miss or not) to empty
+``lookups`` and refetch on its next touch -- same lever as the v3 precedent
+(#6524). This script applies that same reset directly to every file on disk
+right now (no network access needed -- it only drops the stale ``lookups``,
+it does not refetch), so the residue is gone immediately instead of only
+self-healing one lemma at a time as future runs happen to touch it.
+
+Idempotent: a file already at the current schema version is left untouched.
+Discards ``lookups`` wholesale per file, not selectively -- a v3 row carries
+no marker distinguishing a false-negative ``ukreng: null`` from a genuine
+miss on another slug, so this does not try to guess (no heuristics, #1).
+
+The live refetch of the ~19k-slug corpus this reset makes retryable is a
+separate, later drive step -- this script (and the schema bump) only make
+existing on-disk rows retryable; running it does not hit the network.
+
+    .venv/bin/python scripts/lexicon/migrate_slovnyk_cache_v4.py [--cache-dir PATH] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# NOTE: this pulls in `requests` (enrich_manifest is a runtime module, not the
+# minimal-deps CI freshness-gate import) -- fine for a manually-run maintenance
+# script; see migrate_source_labels.py's NOTE for the module this pattern avoids.
+from scripts.lexicon.enrich_manifest import (
+    _SLOVNYK_CACHE_SCHEMA_VERSION,
+    _default_slovnyk_cache,
+)
+
+
+def scan(cache_dir: Path) -> Counter[str]:
+    """Count cache files by migration status without modifying anything."""
+    counts: Counter[str] = Counter()
+    for path in sorted(cache_dir.glob("*.json")):
+        counts["total"] += 1
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            counts["malformed"] += 1
+            continue
+        if not isinstance(payload, dict):
+            counts["malformed"] += 1
+            continue
+        version = payload.get("schema_version")
+        if version == _SLOVNYK_CACHE_SCHEMA_VERSION:
+            counts["already_current"] += 1
+        else:
+            counts[f"stale_v{version!r}"] += 1
+            counts["stale_total"] += 1
+    return counts
+
+
+def migrate(cache_dir: Path, *, dry_run: bool) -> Counter[str]:
+    """Discard ``lookups`` in every non-current cache file; bump its schema_version.
+
+    Preserves ``lemma``/``lookup_word``/``fetched_at`` so the file is still a valid
+    (now-empty) cache entry that ``_slovnyk_cache()`` will happily refetch into on
+    its next live touch. Malformed files are left alone (not this migration's job).
+    """
+    counts: Counter[str] = Counter()
+    for path in sorted(cache_dir.glob("*.json")):
+        counts["total"] += 1
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            counts["malformed"] += 1
+            continue
+        if not isinstance(payload, dict):
+            counts["malformed"] += 1
+            continue
+        if payload.get("schema_version") == _SLOVNYK_CACHE_SCHEMA_VERSION:
+            counts["already_current"] += 1
+            continue
+
+        counts["migrated"] += 1
+        if dry_run:
+            continue
+        migrated: dict[str, Any] = {
+            "schema_version": _SLOVNYK_CACHE_SCHEMA_VERSION,
+            "lemma": payload.get("lemma", path.stem),
+            "lookup_word": payload.get("lookup_word", payload.get("lemma", path.stem)),
+            "fetched_at": payload.get("fetched_at", ""),
+            "lookups": {},
+        }
+        path.write_text(json.dumps(migrated, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return counts
+
+
+def _print_counts(label: str, counts: Counter[str]) -> None:
+    print(f"{label}:")
+    for key in sorted(counts):
+        print(f"  {key}: {counts[key]}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Override the slovnyk cache directory (defaults to the resolved SLOVNYK_CACHE path).",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
+    parser.add_argument(
+        "--scan-only",
+        action="store_true",
+        help="Only print the current schema_version distribution; write nothing.",
+    )
+    args = parser.parse_args()
+
+    cache_dir = args.cache_dir or _default_slovnyk_cache()
+    if not cache_dir.exists():
+        print(f"No cache directory at {cache_dir}; nothing to migrate.")
+        return 0
+
+    if args.scan_only:
+        _print_counts(f"scan ({cache_dir})", scan(cache_dir))
+        return 0
+
+    before = scan(cache_dir)
+    _print_counts(f"before ({cache_dir})", before)
+
+    counts = migrate(cache_dir, dry_run=args.dry_run)
+    _print_counts("dry-run result" if args.dry_run else "migrated", counts)
+
+    if not args.dry_run:
+        after = scan(cache_dir)
+        _print_counts(f"after ({cache_dir})", after)
+        if after.get("stale_total"):
+            print("FAIL: stale (non-current schema_version) rows remain after migration.", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -91,7 +91,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "d8db8c533821f69abbacf6f7e679e81501c5de208257a2d60016c46a7b52ed7e"
+        "sha256": "a33401d12412d701961df57a1775119921ddb8cb4b5f6a7ba443fde3b9a2010f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -168,6 +168,10 @@
       {
         "path": "scripts/lexicon/migrate_slovnyk_cache_v3.py",
         "sha256": "7001edca9a5f6cc7faf290376e13de2d798b17fd92182dcc2a9228aa9816193c"
+      },
+      {
+        "path": "scripts/lexicon/migrate_slovnyk_cache_v4.py",
+        "sha256": "ba5fdc11236ce2f0320a11cd5af50284a7626c48e5ed4097ee3d754e66dbb49d"
       },
       {
         "path": "scripts/lexicon/migrate_source_labels.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1637,6 +1637,46 @@ def test_slovnyk_cache_discards_v2_rows_built_with_the_corrupted_join(monkeypatc
     assert "кн и га" not in persisted["lookups"]["orthoepy"]["text"]
 
 
+def test_slovnyk_cache_discards_v3_ukreng_null_known_misses(monkeypatch, tmp_path) -> None:
+    """#6809: the v3->v4 bump exists because Aug 14-15 cached ``ukreng: null`` rows
+    are contradicted by a live slovnyk.me lookup for ~57% of a 40-slug sample --
+    there is no TTL/re-attest path for a cached miss, so a v3 row must be treated
+    as stale (same as the v1/v2 precedents) and refetched, not read as a confirmed
+    absence."""
+    monkeypatch.setattr(enrich_manifest_module, "SLOVNYK_CACHE", tmp_path)
+    monkeypatch.setattr(enrich_manifest_module, "_SLOVNYK_LOOKUP_SLUGS", ("ukreng",))
+
+    cache_path = enrich_manifest_module._slovnyk_cache_path("аршин")
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "lemma": "аршин",
+                "lookup_word": "аршин",
+                "fetched_at": "2026-08-15T00:00:00+00:00",
+                "lookups": {"ukreng": None},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_fetch(lemma: str, lookup_word: str, slug: str) -> dict[str, str]:
+        return {"dictionary_slug": slug, "text": "arshine (= 71,1 cm or 28 inches)"}
+
+    monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
+
+    cache = _slovnyk_cache("аршин")
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert cache["schema_version"] == enrich_manifest_module._SLOVNYK_CACHE_SCHEMA_VERSION
+    assert cache["lookups"]["ukreng"]["text"] == "arshine (= 71,1 cm or 28 inches)"
+    assert persisted["schema_version"] == enrich_manifest_module._SLOVNYK_CACHE_SCHEMA_VERSION
+    assert persisted["lookups"]["ukreng"]["text"] == "arshine (= 71,1 cm or 28 inches)"
+
+
 def test_read_cached_slovnyk_rows_rejects_stale_schema(monkeypatch, tmp_path) -> None:
     """#6524 P2 (codex re-verdict): ``_read_cached_slovnyk_rows`` feeds definition and
     homonym generation directly and read the cache file unconditionally, so a v2 row

--- a/tests/test_migrate_slovnyk_cache_v4.py
+++ b/tests/test_migrate_slovnyk_cache_v4.py
@@ -1,0 +1,92 @@
+"""Tests for scripts/lexicon/migrate_slovnyk_cache_v4.py (#6809)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.lexicon import enrich_manifest as enrich_manifest_module
+from scripts.lexicon.migrate_slovnyk_cache_v4 import migrate, scan
+
+
+def _write_cache(path: Path, *, schema_version: int, lookups: dict) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": schema_version,
+                "lemma": path.stem,
+                "lookup_word": path.stem,
+                "fetched_at": "2026-08-15T00:00:00+00:00",
+                "lookups": lookups,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_scan_counts_stale_v3_known_miss_rows_separately(tmp_path: Path) -> None:
+    current = enrich_manifest_module._SLOVNYK_CACHE_SCHEMA_VERSION
+    assert current == 4, "test assumes v4 is current -- update if the schema bumps again"
+
+    _write_cache(tmp_path / "аршин.json", schema_version=3, lookups={"ukreng": None})
+    _write_cache(tmp_path / "слово.json", schema_version=current, lookups={"ukreng": {"text": "word"}})
+
+    counts = scan(tmp_path)
+
+    assert counts["total"] == 2
+    assert counts["already_current"] == 1
+    assert counts["stale_v3"] == 1
+    assert counts["stale_total"] == 1
+
+
+def test_migrate_discards_v3_ukreng_null_rows_and_leaves_current_files_alone(tmp_path: Path) -> None:
+    """#6809: a v3 row with a cached ``ukreng: null`` known-miss must be discarded
+    (empty ``lookups``, bumped to the current schema version) so the lemma's next
+    live touch refetches it -- it must not be treated as a confirmed absence."""
+    current = enrich_manifest_module._SLOVNYK_CACHE_SCHEMA_VERSION
+
+    stale_path = tmp_path / "аршин.json"
+    _write_cache(stale_path, schema_version=3, lookups={"ukreng": None})
+
+    current_path = tmp_path / "слово.json"
+    _write_cache(current_path, schema_version=current, lookups={"ukreng": {"text": "word"}})
+
+    counts = migrate(tmp_path, dry_run=False)
+
+    assert counts["migrated"] == 1
+    assert counts["already_current"] == 1
+
+    migrated_payload = json.loads(stale_path.read_text(encoding="utf-8"))
+    assert migrated_payload["schema_version"] == current
+    assert migrated_payload["lookups"] == {}
+    assert migrated_payload["lemma"] == "аршин"
+
+    untouched_payload = json.loads(current_path.read_text(encoding="utf-8"))
+    assert untouched_payload["lookups"] == {"ukreng": {"text": "word"}}
+
+    assert scan(tmp_path)["stale_total"] == 0
+
+
+def test_migrate_dry_run_writes_nothing(tmp_path: Path) -> None:
+    stale_path = tmp_path / "аршин.json"
+    _write_cache(stale_path, schema_version=3, lookups={"ukreng": None})
+    before_bytes = stale_path.read_bytes()
+
+    counts = migrate(tmp_path, dry_run=True)
+
+    assert counts["migrated"] == 1
+    assert stale_path.read_bytes() == before_bytes
+
+
+def test_migrate_leaves_malformed_files_untouched(tmp_path: Path) -> None:
+    malformed_path = tmp_path / "broken.json"
+    malformed_path.write_text("not json", encoding="utf-8")
+
+    scan_counts = scan(tmp_path)
+    migrate_counts = migrate(tmp_path, dry_run=False)
+
+    assert scan_counts["malformed"] == 1
+    assert migrate_counts["malformed"] == 1
+    assert malformed_path.read_text(encoding="utf-8") == "not json"

--- a/tests/test_repair_truncated_definition_cards.py
+++ b/tests/test_repair_truncated_definition_cards.py
@@ -47,7 +47,14 @@ def _entry_with_card(lemma: str, card_id: str, definitions: list[str]) -> dict:
     }
 
 
-def _write_cache(cache_dir, lemma: str, slug: str, text: str, *, schema_version: int = 3) -> None:
+def _write_cache(
+    cache_dir,
+    lemma: str,
+    slug: str,
+    text: str,
+    *,
+    schema_version: int = enrich_manifest._SLOVNYK_CACHE_SCHEMA_VERSION,
+) -> None:
     payload = {
         "schema_version": schema_version,
         "lookups": {slug: {"text": text, "word": lemma, "source_url": f"https://slovnyk.me/dict/{slug}/{lemma}"}},


### PR DESCRIPTION
## What

Operator-GO'd follow-up (2026-08-16) to the #6809 zero-fill diagnosis, same lever as the #6524 v3 precedent: bump `_SLOVNYK_CACHE_SCHEMA_VERSION` **3→4** so `_slovnyk_cache()` discards every non-current on-disk row and refetches live.

## Why

Aug 14-15 cached `ukreng: null` rows are contradicted by a live slovnyk.me lookup for ~57% of a 40-slug random sample. The cache has no TTL/re-attest path for a known-miss — once a (lemma, slug) lookup is recorded `None`, nothing ever asks slovnyk.me again for it. #6840 (open, draft) fixed two deterministic extraction bugs feeding the same zero-gloss symptom, but that only helps future fetches; it can't retroactively un-miss a lookup that was never re-asked. This PR is scoped to the version bump + migrate script only — it does **not** touch `#6840`'s label-abbreviation whitelist.

## Changes

- `scripts/lexicon/enrich_manifest.py`: `_SLOVNYK_CACHE_SCHEMA_VERSION` 3→4, comment names the reason.
- `scripts/lexicon/migrate_slovnyk_cache_v4.py`: new, sibling of `migrate_slovnyk_cache_v3.py` — dry-run/apply, discards `lookups` on any non-current schema file, no network access.
- Tests: a v3 cache row with `ukreng: null` is discarded and refetched under v4 (`tests/test_lexicon_enrich_manifest.py`); migrate script scan/migrate/dry-run/malformed-file behavior (`tests/test_migrate_slovnyk_cache_v4.py`).
- `site/src/data/lexicon-manifest.fingerprint.json` regenerated (`scripts/pre_commit/regen_lexicon_fingerprint.py`) — required because the fingerprint hashes every `scripts/lexicon/*.py` file.

## Explicitly NOT in this PR

- No live 19k-slug refetch (that's a separate, later drive step after this **and** #6840 merge).
- No `--write` of the #6809 pointer, no `--allow-richness-regression`, #6809 stays draft.
- No changes to #6840's label whitelist.

## Evidence

```
.venv/bin/python -m pytest -q tests/test_lexicon_enrich_manifest.py tests/test_heritage_classifier.py \
  tests/test_build_slovnyk_mirror.py tests/test_migrate_slovnyk_cache_v4.py
# 223 passed
.venv/bin/ruff check scripts/lexicon/enrich_manifest.py scripts/lexicon/migrate_slovnyk_cache_v4.py \
  tests/test_lexicon_enrich_manifest.py tests/test_migrate_slovnyk_cache_v4.py
# All checks passed!
```

(`tests/test_lexicon_manifest_fingerprint.py::test_union_merge_keeps_independent_fingerprint_updates_fresh` fails identically on unmodified HEAD in this worktree — a pre-existing git-config environment issue, unrelated to this change.)

Part of #6809.

X-Agent: grok-atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)