### PR TITLE
fix(api): load bridge via scripts.ai_agent_bridge only (#6812)

### DIFF
--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -200,10 +200,15 @@ def _maybe_run_delivery_expiry_sweep() -> None:
 
 def _run_delivery_expiry_sweep(message_db: "os.PathLike[str]") -> None:
     try:
-        from ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
-        from ai_agent_bridge import _db as _ch_db  # noqa: PLC0415 — optional broker bridge
+        # Canonical identity only (#6812): this module already imports
+        # `scripts.*` at module level, so the repo root is always on sys.path
+        # wherever this sweep runs. A bare `ai_agent_bridge` import here loads
+        # a second sys.modules identity — and on the sweep's background thread
+        # it did so at racy, xdist-order-dependent times.
+        from scripts.ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
+        from scripts.ai_agent_bridge import _db as _ch_db  # noqa: PLC0415 — optional broker bridge
     except Exception:
-        logger.exception("bridge delivery-expiry sweep: ai_agent_bridge not importable")
+        logger.exception("bridge delivery-expiry sweep: scripts.ai_agent_bridge not importable")
         return
 
     # `_db.get_db()` reads its own module-level DB_PATH, bound once from
@@ -1377,7 +1382,7 @@ async def get_channel_endpoint(name: str):
     context_preview = ""
     context_sha = ""
     try:
-        from ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
+        from scripts.ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — canonical identity (#6812)
 
         ctx_path = _ch.channel_context_path(name)
         if ctx_path.exists():

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -59,11 +59,12 @@ OPTIONAL_MODULES = [
     "fitz",
     "rag.poc_pair_page",
     "rag.query",
-    "ai_agent_bridge",
-    "ai_agent_bridge._channels",
-    "ai_agent_bridge._db",
+    # Bridge modules use the canonical `scripts.` identity only (#6812):
+    # preloading the bare `ai_agent_bridge` name would create a second,
+    # divergent sys.modules identity in the long-lived API process.
     "scripts.ai_agent_bridge",
     "scripts.ai_agent_bridge._channels",
+    "scripts.ai_agent_bridge._db",
 ]
 
 DYNAMIC_LOADERS = {

--- a/tests/ai_agent_bridge/test_module_identity.py
+++ b/tests/ai_agent_bridge/test_module_identity.py
@@ -7,6 +7,11 @@ state, so ``monkeypatch`` on one identity never affected the other.
 
 These tests fail if any test file reintroduces a non-canonical bridge import
 or quoted module target, or if the bare identity is loaded at runtime.
+
+``scripts/api/`` is scanned too: the Monitor API boots inside the test process
+(FastAPI lifespan preload, comms sweep background thread), and bare-identity
+imports there were the runtime loaders that made this guard flaky under
+pytest-xdist (#6838 red on an unrelated CSS change).
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ import sys
 from pathlib import Path
 
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _TESTS_ROOT.parent
 _SELF = Path(__file__).resolve()
 
 # Match the bare identity as a module path segment, not a substring (#M-16):
@@ -27,22 +33,30 @@ _NONCANONICAL_PATTERNS = {
     "quoted module target": re.compile(r"""['"]ai_agent_bridge\."""),
 }
 
+# Static scan roots: the test suite plus the in-process API package. The rest
+# of scripts/ deliberately keeps blessed bare fallbacks for direct-script
+# production runs (``__main__`` script mode, agent_runtime adapters), which a
+# blanket scan would flag; scripts/api/ never runs that way — it imports
+# ``scripts.*`` at module level, so the repo root is always on sys.path.
+_SCAN_ROOTS = (_TESTS_ROOT, _REPO_ROOT / "scripts" / "api")
 
-def _iter_test_files():
-    for path in sorted(_TESTS_ROOT.rglob("*.py")):
-        if path.resolve() != _SELF:
-            yield path
+
+def _iter_scanned_files():
+    for root in _SCAN_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            if path.resolve() != _SELF:
+                yield path
 
 
 def test_no_noncanonical_bridge_imports_in_test_suite() -> None:
-    """No test file may reference the bare ``ai_agent_bridge`` identity."""
+    """No scanned file may reference the bare ``ai_agent_bridge`` identity."""
     violations: list[str] = []
-    for path in _iter_test_files():
+    for path in _iter_scanned_files():
         text = path.read_text(encoding="utf-8")
         for kind, pattern in _NONCANONICAL_PATTERNS.items():
             for match in pattern.finditer(text):
                 line = text.count("\n", 0, match.start()) + 1
-                violations.append(f"{path.relative_to(_TESTS_ROOT.parent)}:{line}: {kind}: {match.group()!r}")
+                violations.append(f"{path.relative_to(_REPO_ROOT)}:{line}: {kind}: {match.group()!r}")
     assert not violations, (
         "Non-canonical `ai_agent_bridge` module identity found; use `scripts.ai_agent_bridge` "
         "everywhere (#6812):\n" + "\n".join(violations)
@@ -51,7 +65,9 @@ def test_no_noncanonical_bridge_imports_in_test_suite() -> None:
 
 def test_bare_bridge_identity_not_loaded() -> None:
     """The bare identity must never occupy a second ``sys.modules`` entry."""
+    bare = sys.modules.get("ai_agent_bridge")
     assert "ai_agent_bridge" not in sys.modules, (
         "The bare `ai_agent_bridge` module identity is loaded alongside "
-        "`scripts.ai_agent_bridge`; module-level state would diverge (#6812)."
+        "`scripts.ai_agent_bridge`; module-level state would diverge (#6812). "
+        f"Loaded from: {getattr(bare, '__file__', '<unknown>')}"
     )


### PR DESCRIPTION
## Summary
Root cause of the xdist flake that blocked #6838/#6840/#6841/#6843: `scripts/api/preload.py` and `comms_router.py` imported the bare `ai_agent_bridge` identity. The Monitor API boots inside pytest, so those imports created a second `sys.modules` entry depending on shard order.

Scan `scripts/api/` in `test_module_identity.py`. Do not weaken the single-identity contract.

Finalized in the existing `kimi/atlas-6812-identity-flake` worktree after the worker hit hard_timeout mid full-suite. Targeted tests: 46 passed. No new worktree.

X-Agent: grok-atlas