### PR TITLE
feat(work): browser-local dual-source Work projection (P3)

### DIFF
--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -517,13 +517,20 @@ button, input, select { font: inherit; }
       if (row.remote_id !== item.remote_id) return { ok: false, code: 'schema_mismatch' };
     }
 
-    const terminal = new Set(['unavailable', 'permission_denied', 'timeout']);
+    // Terminal section statuses admit neither counts nor items (degraded included).
+    const terminal = new Set(['unavailable', 'permission_denied', 'timeout', 'degraded']);
     const issuesStatus = source.sections.issues.status;
     const prsStatus = source.sections.prs.status;
-    const expectedIssueSection = terminal.has(issuesStatus) ? 0 : issueCount;
-    const expectedPrSection = terminal.has(prsStatus) ? 0 : prCount;
-    if (source.sections.issues.count !== expectedIssueSection) return { ok: false, code: 'schema_mismatch' };
-    if (source.sections.prs.count !== expectedPrSection) return { ok: false, code: 'schema_mismatch' };
+    if (terminal.has(issuesStatus)) {
+      if (source.sections.issues.count !== 0 || issueCount !== 0) return { ok: false, code: 'schema_mismatch' };
+    } else if (source.sections.issues.count !== issueCount) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (terminal.has(prsStatus)) {
+      if (source.sections.prs.count !== 0 || prCount !== 0) return { ok: false, code: 'schema_mismatch' };
+    } else if (source.sections.prs.count !== prCount) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
     if (den.issues_open !== source.sections.issues.count) return { ok: false, code: 'schema_mismatch' };
     if (den.prs_open !== source.sections.prs.count) return { ok: false, code: 'schema_mismatch' };
 
@@ -757,7 +764,7 @@ button, input, select { font: inherit; }
 
   function renderDetail(item) {
     if (!item) {
-      els.detail.className = 'detail empty';
+      els.detail.classList.add('empty');
       els.detail.textContent = 'Select a row to inspect ownership, evidence, and the safe next action.';
       return;
     }
@@ -770,7 +777,7 @@ button, input, select { font: inherit; }
       a.domain + ': age=' + (a.age_s == null ? '—' : a.age_s + 's') + (a.stale ? ' stale' : '')
     ).join(' · ');
     const rels = (item.relationships || []).map((r) => r.type + ' → ' + r.target_id).join('; ') || 'none';
-    els.detail.className = 'detail';
+    els.detail.classList.remove('empty');
     els.detail.innerHTML =
       '<h4>' + escapeHtml(item.title || item.work_id) + '</h4>' +
       '<div class="row-meta">' +
@@ -839,7 +846,6 @@ button, input, select { font: inherit; }
 
     if (els.source) {
       const currentSource = els.source.value;
-      const sourceOptions = ['public-monitor', 'private-local-adapter'].filter((s) => sourcesPresent.has(s) || s === PUBLIC_SOURCE_ID);
       // Only list private source after an admitted private payload contributed items or source.
       const hasPrivate = sources.some((s) => s && s.source_id === PRIVATE_SOURCE_ID && s.status !== 'unavailable') || sourcesPresent.has(PRIVATE_SOURCE_ID);
       const opts = ['<option value="">All sources</option>', '<option value="public-monitor">public-monitor</option>'];
@@ -864,25 +870,41 @@ button, input, select { font: inherit; }
       referrerPolicy: 'no-referrer',
     };
     if (controller) init.signal = controller.signal;
+    const aborted = function (err) {
+      return (err && err.name === 'AbortError')
+        || (controller && controller.signal && controller.signal.aborted);
+    };
+    // Keep the abort timer active through status checks and full JSON body parse.
+    // Clear only once in the terminal finalization path so a stalled body still
+    // respects the private five-second budget.
     return fetch(url, init).then(async (res) => {
-      if (timer) clearTimeout(timer);
       if (!res.ok) {
+        // Prefer timeout when the abort budget fired mid-flight.
+        if (aborted(null)) {
+          const err = new Error('timeout');
+          err.code = 'timeout';
+          throw err;
+        }
         const err = new Error('http_error');
         err.code = 'unreachable';
         throw err;
       }
-      let body;
       try {
-        body = await res.json();
-      } catch (_e) {
+        return await res.json();
+      } catch (parseErr) {
+        // Abort during body read must be typed timeout (never raw / schema_mismatch).
+        if (aborted(parseErr)) {
+          const err = new Error('timeout');
+          err.code = 'timeout';
+          throw err;
+        }
         const err = new Error('parse_error');
         err.code = 'schema_mismatch';
         throw err;
       }
-      return body;
     }).catch((err) => {
-      if (timer) clearTimeout(timer);
-      if (err && err.name === 'AbortError') {
+      if (aborted(err) || (err && err.code === 'timeout')) {
+        if (err && err.code === 'timeout') throw err;
         const e = new Error('timeout');
         e.code = 'timeout';
         throw e;
@@ -891,6 +913,11 @@ button, input, select { font: inherit; }
       const e = new Error('unreachable');
       e.code = 'unreachable';
       throw e;
+    }).finally(() => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
     });
   }
 

--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -28,7 +28,7 @@ button, input, select { font: inherit; }
 .signal-card { align-self: end; background: var(--bg2); border: 1px solid var(--border); border-left: 4px solid var(--accent); padding: 14px 16px; }
 .signal-card strong { display: block; font-family: Charter, Georgia, serif; font-size: 18px; margin-bottom: 4px; }
 .signal-card p { color: var(--text3); font-size: 12px; margin: 0; line-height: 1.4; }
-.filter-strip { background: var(--bg2); border: 1px solid var(--border); display: grid; gap: 10px; grid-template-columns: repeat(5, minmax(0, 1fr)) auto; margin: 18px 0; padding: 12px; }
+.filter-strip { background: var(--bg2); border: 1px solid var(--border); display: grid; gap: 10px; grid-template-columns: repeat(6, minmax(0, 1fr)) auto; margin: 18px 0; padding: 12px; }
 .field { display: grid; gap: 4px; min-width: 0; }
 .field label { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .field select, .field input { border: 1px solid var(--border); border-radius: 3px; min-width: 0; padding: 7px 8px; background: var(--bg); color: var(--text); }
@@ -122,11 +122,11 @@ button, input, select { font: inherit; }
     <div>
       <div class="eyebrow">Evidence rail · public foundation</div>
       <h2 id="work-title">What needs attention now.</h2>
-      <p>GitHub issues and PRs remain the source of truth. This surface projects open public work with stream membership, dispatch/review summaries, health, and a safe next action. The private source is an optional local adapter and stays unavailable until configured in the browser — never via the public server.</p>
+      <p>GitHub issues and PRs remain the source of truth. This surface projects open public work with stream membership, dispatch/review summaries, health, and a safe next action. The browser fetches the public Monitor projection and, independently, a fixed loopback private adapter. The public server never proxies private data.</p>
     </div>
     <aside class="signal-card" aria-label="Foundation status">
       <strong id="foundation-label">FOUNDATION_COMPLETE</strong>
-      <p id="foundation-copy">No mutations. No dispatch buttons. Private data is never fetched by this page from a public proxy.</p>
+      <p id="foundation-copy">No mutations. Dual-source browser merge only. Private adapter is loopback-only and optional.</p>
     </aside>
   </section>
 
@@ -183,9 +183,16 @@ button, input, select { font: inherit; }
       </select>
     </div>
     <div class="field">
+      <label for="filter-source">Source</label>
+      <select id="filter-source">
+        <option value="">All sources</option>
+        <option value="public-monitor">public-monitor</option>
+      </select>
+    </div>
+    <div class="field">
       <label for="filter-repo">Repository</label>
       <select id="filter-repo">
-        <option value="">All public</option>
+        <option value="">All repositories</option>
       </select>
     </div>
     <div class="filter-actions">
@@ -224,12 +231,37 @@ button, input, select { font: inherit; }
 <script>
 (function () {
   const ALLOWED_FILTER_KEYS = new Set(['health', 'kind', 'lifecycle', 'orphan', 'repository_id', 'source_id']);
+  const PUBLIC_SINGLETON_REPO = 'learn-ukrainian/learn-ukrainian.github.io';
+  const PUBLIC_PROJECTION_URL = '/api/work/v1/projection';
+  // Fixed constant — never configurable, never persisted, never rendered into shareable state.
+  const PRIVATE_PROJECTION_URL = 'http://127.0.0.1:8766/v1/projection';
+  const PRIVATE_SCHEMA_DIGEST = '89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde';
+  const PUBLIC_SCHEMA_COMMIT = 'f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d';
+  const PRIVATE_SOURCE_ID = 'private-local-adapter';
+  const PUBLIC_SOURCE_ID = 'public-monitor';
+  const PRIVATE_TIMEOUT_MS = 5000;
+  const HEALTH_ORDER = { OFF_TRACK: 0, AT_RISK: 1, UNKNOWN: 2, ON_TRACK: 3 };
+  const ADAPTER_STATUS = new Set(['ok', 'degraded', 'unavailable', 'permission_denied', 'timeout', 'truncated']);
+  const PRIVATE_ROOT_KEYS = ['schema_version','generated_at','cache_age_s','budget','sources','items','attention','denominator','capabilities','foundation_status'];
+  const PRIVATE_SOURCE_KEYS = ['source_id','status','freshness','capabilities','truncation','sections'];
+  const PRIVATE_ITEM_KEYS = ['work_id','source_id','repository_id','resource_kind','remote_id','title','lifecycle','labels','assignees','urls','timestamps','projections','relationships','health','attention_rank','safe_next_action','authority','omissions'];
+  const PRIVATE_ATTENTION_KEYS = ['work_id','attention_rank','health','safe_next_action','title','resource_kind','repository_id','remote_id'];
+  const PRIVATE_DENOM_KEYS = ['issues_open','prs_open','streams_complete','class4','omissions'];
+  const PRIVATE_CAP_KEYS = ['mutation','private_source'];
+  const PRIVATE_PS_KEYS = ['source_id','available','schema_version','schema_digest_sha256','public_schema_commit','endpoint','capabilities','redaction','reason_if_unavailable'];
+  const REPO_RE = /^[a-z0-9][a-z0-9_.-]{0,99}\/[a-z0-9][a-z0-9_.-]{0,99}$/;
+  const REMOTE_ID_RE = /^[1-9][0-9]*$/;
+  const RFC3339_Z_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
   const state = {
     projection: null,
+    merged: null,
     itemsById: new Map(),
     attention: [],
     selectedId: null,
     selectedIndex: -1,
+    privateStatusText: 'Checking capability…',
+    publicStatusOverride: null,
   };
 
   const els = {
@@ -244,6 +276,7 @@ button, input, select { font: inherit; }
     kind: document.getElementById('filter-kind'),
     lifecycle: document.getElementById('filter-lifecycle'),
     orphan: document.getElementById('filter-orphan'),
+    source: document.getElementById('filter-source'),
     repo: document.getElementById('filter-repo'),
     cmd: document.getElementById('cmd'),
     cmdInput: document.getElementById('cmd-input'),
@@ -260,12 +293,353 @@ button, input, select { font: inherit; }
     els.error.textContent = msg;
   }
 
+  function isObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function exactKeys(obj, keys) {
+    const actual = Object.keys(obj).sort();
+    const expected = keys.slice().sort();
+    if (actual.length !== expected.length) return false;
+    for (let i = 0; i < actual.length; i += 1) {
+      if (actual[i] !== expected[i]) return false;
+    }
+    return true;
+  }
+
+  function isFiniteNonNegativeNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 && !Object.is(value, -0);
+  }
+
+  function isNonNegInt(value) {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0 && !Object.is(value, -0);
+  }
+
+  function deepEqual(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  function admitPublicDocument(doc) {
+    if (!isObject(doc)) return { ok: false, code: 'schema_mismatch' };
+    if (doc.schema_version !== 'work-projection.v1') return { ok: false, code: 'schema_mismatch' };
+    if (doc.foundation_status !== 'FOUNDATION_COMPLETE') return { ok: false, code: 'schema_mismatch' };
+    if (!isObject(doc.capabilities) || doc.capabilities.mutation !== false) return { ok: false, code: 'schema_mismatch' };
+    if (!Array.isArray(doc.sources) || !Array.isArray(doc.items) || !Array.isArray(doc.attention)) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isFiniteNonNegativeNumber(doc.cache_age_s)) return { ok: false, code: 'schema_mismatch' };
+    const ids = new Set();
+    for (const item of doc.items) {
+      if (!isObject(item) || typeof item.work_id !== 'string' || !item.work_id) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      if (ids.has(item.work_id)) return { ok: false, code: 'schema_mismatch' };
+      ids.add(item.work_id);
+    }
+    return { ok: true, doc: doc };
+  }
+
+  function admitPrivateDocument(doc) {
+    if (!isObject(doc) || !exactKeys(doc, PRIVATE_ROOT_KEYS)) return { ok: false, code: 'schema_mismatch' };
+    if (doc.schema_version !== 'work-projection.v1') return { ok: false, code: 'schema_mismatch' };
+    if (doc.foundation_status !== 'FOUNDATION_COMPLETE') return { ok: false, code: 'schema_mismatch' };
+    if (typeof doc.generated_at !== 'string' || !RFC3339_Z_RE.test(doc.generated_at)) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isFiniteNonNegativeNumber(doc.cache_age_s)) return { ok: false, code: 'schema_mismatch' };
+    if (!isObject(doc.budget) || !exactKeys(doc.budget, ['warm_target_s', 'timeout_s'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (doc.budget.warm_target_s !== 2 || doc.budget.timeout_s !== 5) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!Array.isArray(doc.sources) || !Array.isArray(doc.items) || !Array.isArray(doc.attention)) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isObject(doc.denominator) || !exactKeys(doc.denominator, PRIVATE_DENOM_KEYS)) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isObject(doc.capabilities) || !exactKeys(doc.capabilities, PRIVATE_CAP_KEYS)) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (doc.capabilities.mutation !== false) return { ok: false, code: 'schema_mismatch' };
+    const ps = doc.capabilities.private_source;
+    if (!isObject(ps) || !exactKeys(ps, PRIVATE_PS_KEYS)) return { ok: false, code: 'schema_mismatch' };
+    if (ps.source_id !== PRIVATE_SOURCE_ID) return { ok: false, code: 'schema_mismatch' };
+    if (ps.available !== true) return { ok: false, code: 'schema_mismatch' };
+    if (ps.schema_version !== 'work-projection.v1') return { ok: false, code: 'schema_mismatch' };
+    if (ps.schema_digest_sha256 !== PRIVATE_SCHEMA_DIGEST) return { ok: false, code: 'schema_mismatch' };
+    if (ps.public_schema_commit !== PUBLIC_SCHEMA_COMMIT) return { ok: false, code: 'schema_mismatch' };
+    if (ps.endpoint !== PRIVATE_PROJECTION_URL) return { ok: false, code: 'schema_mismatch' };
+    if (!Array.isArray(ps.capabilities) || ps.capabilities.length !== 3) return { ok: false, code: 'schema_mismatch' };
+    if (ps.capabilities[0] !== 'projection' || ps.capabilities[1] !== 'capabilities' || ps.capabilities[2] !== 'health') {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (ps.redaction !== 'strict-metadata-only') return { ok: false, code: 'schema_mismatch' };
+    if (ps.reason_if_unavailable !== null) return { ok: false, code: 'schema_mismatch' };
+
+    if (doc.sources.length !== 1) return { ok: false, code: 'schema_mismatch' };
+    const source = doc.sources[0];
+    if (!isObject(source) || !exactKeys(source, PRIVATE_SOURCE_KEYS)) return { ok: false, code: 'schema_mismatch' };
+    if (source.source_id !== PRIVATE_SOURCE_ID) return { ok: false, code: 'schema_mismatch' };
+    if (!ADAPTER_STATUS.has(source.status)) return { ok: false, code: 'schema_mismatch' };
+    if (!isObject(source.freshness) || !exactKeys(source.freshness, ['observed_at', 'age_s'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!(source.freshness.observed_at === null || (typeof source.freshness.observed_at === 'string' && RFC3339_Z_RE.test(source.freshness.observed_at)))) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!(source.freshness.age_s === null || isFiniteNonNegativeNumber(source.freshness.age_s))) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isObject(source.capabilities) || !exactKeys(source.capabilities, ['mutation', 'private_fields'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (source.capabilities.mutation !== false || source.capabilities.private_fields !== false) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isObject(source.truncation) || !exactKeys(source.truncation, ['issues', 'prs', 'limit'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (typeof source.truncation.issues !== 'boolean' || typeof source.truncation.prs !== 'boolean' || source.truncation.limit !== 1000) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!isObject(source.sections) || !exactKeys(source.sections, ['issues', 'prs'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    for (const sectionName of ['issues', 'prs']) {
+      const section = source.sections[sectionName];
+      if (!isObject(section) || !exactKeys(section, ['status', 'count'])) return { ok: false, code: 'schema_mismatch' };
+      if (!ADAPTER_STATUS.has(section.status)) return { ok: false, code: 'schema_mismatch' };
+      if (!isNonNegInt(section.count)) return { ok: false, code: 'schema_mismatch' };
+    }
+
+    const den = doc.denominator;
+    if (!isNonNegInt(den.issues_open) || !isNonNegInt(den.prs_open)) return { ok: false, code: 'schema_mismatch' };
+    if (typeof den.streams_complete !== 'boolean') return { ok: false, code: 'schema_mismatch' };
+    if (!isObject(den.class4) || !exactKeys(den.class4, ['delegate_active', 'delegate_tasks', 'fleet_reviews'])) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (den.class4.delegate_active !== false || den.class4.delegate_tasks !== false || den.class4.fleet_reviews !== false) {
+      return { ok: false, code: 'schema_mismatch' };
+    }
+    if (!Array.isArray(den.omissions) || den.omissions.length !== 0) return { ok: false, code: 'schema_mismatch' };
+
+    const ids = new Set();
+    let issueCount = 0;
+    let prCount = 0;
+    const itemsById = new Map();
+    for (const item of doc.items) {
+      if (!isObject(item) || !exactKeys(item, PRIVATE_ITEM_KEYS)) return { ok: false, code: 'schema_mismatch' };
+      if (item.source_id !== PRIVATE_SOURCE_ID) return { ok: false, code: 'schema_mismatch' };
+      if (typeof item.repository_id !== 'string' || !REPO_RE.test(item.repository_id)) return { ok: false, code: 'schema_mismatch' };
+      if (item.resource_kind !== 'issue' && item.resource_kind !== 'pr') return { ok: false, code: 'schema_mismatch' };
+      if (typeof item.remote_id !== 'string' || !REMOTE_ID_RE.test(item.remote_id)) return { ok: false, code: 'schema_mismatch' };
+      const expectedId = 'wp1:' + PRIVATE_SOURCE_ID + ':' + item.repository_id + ':' + item.resource_kind + ':' + item.remote_id;
+      if (item.work_id !== expectedId) return { ok: false, code: 'schema_mismatch' };
+      if (ids.has(item.work_id)) return { ok: false, code: 'schema_mismatch' };
+      ids.add(item.work_id);
+      const expectedTitle = 'private-' + item.resource_kind + '-' + item.remote_id;
+      if (item.title !== expectedTitle) return { ok: false, code: 'schema_mismatch' };
+      if (item.resource_kind === 'issue') {
+        if (item.lifecycle !== 'open') return { ok: false, code: 'schema_mismatch' };
+        issueCount += 1;
+      } else {
+        if (item.lifecycle !== 'open' && item.lifecycle !== 'draft') return { ok: false, code: 'schema_mismatch' };
+        prCount += 1;
+      }
+      if (!Array.isArray(item.labels) || item.labels.length !== 0) return { ok: false, code: 'schema_mismatch' };
+      if (!Array.isArray(item.assignees) || item.assignees.length !== 0) return { ok: false, code: 'schema_mismatch' };
+      if (!isObject(item.urls) || !exactKeys(item.urls, ['html']) || item.urls.html !== null) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      if (!isObject(item.timestamps) || !exactKeys(item.timestamps, ['created_at', 'updated_at'])) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      for (const tsKey of ['created_at', 'updated_at']) {
+        const ts = item.timestamps[tsKey];
+        if (!(ts === null || (typeof ts === 'string' && RFC3339_Z_RE.test(ts)))) {
+          return { ok: false, code: 'schema_mismatch' };
+        }
+      }
+      if (!isObject(item.projections) || !exactKeys(item.projections, ['stream', 'dispatch', 'review', 'verification'])) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      for (const pKey of ['stream', 'dispatch', 'review', 'verification']) {
+        if (!isObject(item.projections[pKey]) || Object.keys(item.projections[pKey]).length !== 0) {
+          return { ok: false, code: 'schema_mismatch' };
+        }
+      }
+      if (!Array.isArray(item.relationships) || item.relationships.length !== 0) return { ok: false, code: 'schema_mismatch' };
+      if (item.health !== 'UNKNOWN') return { ok: false, code: 'schema_mismatch' };
+      if (!isNonNegInt(item.attention_rank)) return { ok: false, code: 'schema_mismatch' };
+      if (!isObject(item.safe_next_action) || !exactKeys(item.safe_next_action, ['code', 'reason_codes'])) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      if (item.safe_next_action.code !== 'INSPECT_UNKNOWN') return { ok: false, code: 'schema_mismatch' };
+      if (!Array.isArray(item.safe_next_action.reason_codes) || item.safe_next_action.reason_codes.length !== 2) {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      if (item.safe_next_action.reason_codes[0] !== 'private_metadata_redacted' || item.safe_next_action.reason_codes[1] !== 'no_private_authority_evidence') {
+        return { ok: false, code: 'schema_mismatch' };
+      }
+      if (!Array.isArray(item.authority) || item.authority.length !== 0) return { ok: false, code: 'schema_mismatch' };
+      if (!Array.isArray(item.omissions) || item.omissions.length !== 3) return { ok: false, code: 'schema_mismatch' };
+      const expectedOmissions = [
+        { class: 'private_content', reason: 'redacted' },
+        { class: 'stream_authority', reason: 'not_collected' },
+        { class: 'review_authority', reason: 'not_collected' },
+      ];
+      for (let i = 0; i < 3; i += 1) {
+        const om = item.omissions[i];
+        if (!isObject(om) || !exactKeys(om, ['class', 'reason'])) return { ok: false, code: 'schema_mismatch' };
+        if (om.class !== expectedOmissions[i].class || om.reason !== expectedOmissions[i].reason) {
+          return { ok: false, code: 'schema_mismatch' };
+        }
+      }
+      itemsById.set(item.work_id, item);
+    }
+
+    if (doc.attention.length !== doc.items.length) return { ok: false, code: 'schema_mismatch' };
+    const attentionIds = new Set();
+    for (const row of doc.attention) {
+      if (!isObject(row) || !exactKeys(row, PRIVATE_ATTENTION_KEYS)) return { ok: false, code: 'schema_mismatch' };
+      const item = itemsById.get(row.work_id);
+      if (!item) return { ok: false, code: 'schema_mismatch' };
+      if (attentionIds.has(row.work_id)) return { ok: false, code: 'schema_mismatch' };
+      attentionIds.add(row.work_id);
+      if (row.attention_rank !== item.attention_rank) return { ok: false, code: 'schema_mismatch' };
+      if (row.health !== item.health) return { ok: false, code: 'schema_mismatch' };
+      if (!deepEqual(row.safe_next_action, item.safe_next_action)) return { ok: false, code: 'schema_mismatch' };
+      if (row.title !== item.title) return { ok: false, code: 'schema_mismatch' };
+      if (row.resource_kind !== item.resource_kind) return { ok: false, code: 'schema_mismatch' };
+      if (row.repository_id !== item.repository_id) return { ok: false, code: 'schema_mismatch' };
+      if (row.remote_id !== item.remote_id) return { ok: false, code: 'schema_mismatch' };
+    }
+
+    const terminal = new Set(['unavailable', 'permission_denied', 'timeout']);
+    const issuesStatus = source.sections.issues.status;
+    const prsStatus = source.sections.prs.status;
+    const expectedIssueSection = terminal.has(issuesStatus) ? 0 : issueCount;
+    const expectedPrSection = terminal.has(prsStatus) ? 0 : prCount;
+    if (source.sections.issues.count !== expectedIssueSection) return { ok: false, code: 'schema_mismatch' };
+    if (source.sections.prs.count !== expectedPrSection) return { ok: false, code: 'schema_mismatch' };
+    if (den.issues_open !== source.sections.issues.count) return { ok: false, code: 'schema_mismatch' };
+    if (den.prs_open !== source.sections.prs.count) return { ok: false, code: 'schema_mismatch' };
+
+    return { ok: true, doc: doc, sourceStatus: source.status };
+  }
+
+  function attentionRowFromItem(item) {
+    return {
+      work_id: item.work_id,
+      attention_rank: item.attention_rank,
+      health: item.health,
+      safe_next_action: item.safe_next_action,
+      title: item.title,
+      resource_kind: item.resource_kind,
+      repository_id: item.repository_id,
+      remote_id: item.remote_id,
+    };
+  }
+
+  function denseAttention(items) {
+    const ranked = items.slice().sort((a, b) => {
+      const ha = HEALTH_ORDER[a.health] != null ? HEALTH_ORDER[a.health] : 99;
+      const hb = HEALTH_ORDER[b.health] != null ? HEALTH_ORDER[b.health] : 99;
+      if (ha !== hb) return ha - hb;
+      const ra = typeof a._orig_rank === 'number' ? a._orig_rank : a.attention_rank;
+      const rb = typeof b._orig_rank === 'number' ? b._orig_rank : b.attention_rank;
+      if (ra !== rb) return ra - rb;
+      if (a.source_id < b.source_id) return -1;
+      if (a.source_id > b.source_id) return 1;
+      if (a.work_id < b.work_id) return -1;
+      if (a.work_id > b.work_id) return 1;
+      return 0;
+    });
+    ranked.forEach((item, index) => {
+      item.attention_rank = index;
+      delete item._orig_rank;
+    });
+    return ranked.map(attentionRowFromItem);
+  }
+
+  function mergeProjections(publicDoc, privateDoc) {
+    const publicIds = new Set((publicDoc.items || []).map((i) => i.work_id));
+    for (const item of privateDoc.items || []) {
+      if (publicIds.has(item.work_id)) {
+        return { ok: false, code: 'identity_collision' };
+      }
+    }
+
+    const sources = (publicDoc.sources || []).map((s) => {
+      if (s && s.source_id === PRIVATE_SOURCE_ID) {
+        return privateDoc.sources[0];
+      }
+      return s;
+    });
+    if (!sources.some((s) => s && s.source_id === PRIVATE_SOURCE_ID)) {
+      sources.push(privateDoc.sources[0]);
+    }
+
+    const publicItems = (publicDoc.items || []).map((item) => {
+      const copy = Object.assign({}, item);
+      copy._orig_rank = item.attention_rank;
+      return copy;
+    });
+    const privateItems = (privateDoc.items || []).map((item) => {
+      const copy = Object.assign({}, item);
+      copy._orig_rank = item.attention_rank;
+      return copy;
+    });
+    const items = publicItems.concat(privateItems);
+    const attention = denseAttention(items);
+
+    const pubDen = publicDoc.denominator || {};
+    const privDen = privateDoc.denominator || {};
+    const omissions = [];
+    for (const om of (pubDen.omissions || [])) {
+      if (om && om.class === 'private_adapter' && om.reason === 'not_configured') continue;
+      omissions.push(om);
+    }
+    for (const om of (privDen.omissions || [])) omissions.push(om);
+
+    const merged = {
+      schema_version: publicDoc.schema_version,
+      generated_at: publicDoc.generated_at,
+      cache_age_s: Math.max(publicDoc.cache_age_s, privateDoc.cache_age_s),
+      budget: publicDoc.budget,
+      sources: sources,
+      items: items,
+      attention: attention,
+      denominator: {
+        issues_open: (pubDen.issues_open || 0) + (privDen.issues_open || 0),
+        prs_open: (pubDen.prs_open || 0) + (privDen.prs_open || 0),
+        streams_complete: !!(pubDen.streams_complete && privDen.streams_complete),
+        class4: pubDen.class4 || { delegate_active: false, delegate_tasks: false, fleet_reviews: false },
+        omissions: omissions,
+      },
+      capabilities: {
+        mutation: false,
+        private_source: privateDoc.capabilities.private_source,
+      },
+      foundation_status: 'FOUNDATION_COMPLETE',
+    };
+    return { ok: true, doc: merged };
+  }
+
   function readFiltersFromUrl() {
     const params = new URLSearchParams(window.location.search);
     const out = {};
     for (const [key, value] of params.entries()) {
       if (!ALLOWED_FILTER_KEYS.has(key)) continue;
       if (!value || value.length > 64) continue;
+      if (key === 'repository_id' && value !== PUBLIC_SINGLETON_REPO) continue;
+      if (key === 'source_id' && value !== PUBLIC_SOURCE_ID) continue;
+      if (key === 'health' && !['OFF_TRACK', 'AT_RISK', 'UNKNOWN', 'ON_TRACK'].includes(value)) continue;
+      if (key === 'kind' && !['issue', 'pr', 'task', 'review'].includes(value)) continue;
+      if (key === 'lifecycle' && !['open', 'draft', 'running', 'failed'].includes(value)) continue;
+      if (key === 'orphan' && value !== 'true' && value !== 'false') continue;
       out[key] = value;
     }
     return out;
@@ -276,6 +650,7 @@ button, input, select { font: inherit; }
     els.kind.value = filters.kind || '';
     els.lifecycle.value = filters.lifecycle || '';
     els.orphan.value = filters.orphan || '';
+    if (els.source) els.source.value = filters.source_id || '';
     els.repo.value = filters.repository_id || '';
   }
 
@@ -285,30 +660,51 @@ button, input, select { font: inherit; }
     if (els.kind.value) filters.kind = els.kind.value;
     if (els.lifecycle.value) filters.lifecycle = els.lifecycle.value;
     if (els.orphan.value) filters.orphan = els.orphan.value;
+    if (els.source && els.source.value) filters.source_id = els.source.value;
     if (els.repo.value) filters.repository_id = els.repo.value;
     return filters;
   }
 
-  function writeFiltersToUrl(filters) {
-    const params = new URLSearchParams();
+  function shareableFilters(filters) {
+    const out = {};
     Object.keys(filters).sort().forEach((key) => {
       if (!ALLOWED_FILTER_KEYS.has(key)) return;
       const value = String(filters[key]);
       if (!value || value.length > 64) return;
-      // Free text and private endpoint values are rejected client-side.
       if (key === 'endpoint' || key === 'q' || key === 'private_endpoint') return;
-      params.set(key, value);
+      if (key === 'repository_id' && value !== PUBLIC_SINGLETON_REPO) return;
+      if (key === 'source_id' && value !== PUBLIC_SOURCE_ID) return;
+      out[key] = value;
     });
+    return out;
+  }
+
+  function writeFiltersToUrl(filters) {
+    const safe = shareableFilters(filters);
+    const params = new URLSearchParams();
+    Object.keys(safe).sort().forEach((key) => params.set(key, safe[key]));
     const qs = params.toString();
-    const next = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    const next = qs ? (window.location.pathname + '?' + qs) : window.location.pathname;
     window.history.replaceState({}, '', next);
   }
 
-  function queryString(filters) {
-    const params = new URLSearchParams();
-    Object.entries(filters).forEach(([k, v]) => params.set(k, v));
-    const qs = params.toString();
-    return qs ? `?${qs}` : '';
+  function applyLocalFilters(projection, filters) {
+    if (!projection) return { items: [], attention: [] };
+    const items = (projection.items || []).filter((item) => {
+      if (filters.health && item.health !== filters.health) return false;
+      if (filters.kind && item.resource_kind !== filters.kind) return false;
+      if (filters.lifecycle && item.lifecycle !== filters.lifecycle) return false;
+      if (filters.repository_id && item.repository_id !== filters.repository_id) return false;
+      if (filters.source_id && item.source_id !== filters.source_id) return false;
+      if (filters.orphan === 'true' || filters.orphan === 'false') {
+        const orphan = !!(item.flags && item.flags.orphan);
+        if (String(orphan) !== filters.orphan) return false;
+      }
+      return true;
+    });
+    const idSet = new Set(items.map((i) => i.work_id));
+    const attention = (projection.attention || []).filter((row) => idSet.has(row.work_id));
+    return { items: items, attention: attention };
   }
 
   function railClasses(item) {
@@ -330,25 +726,29 @@ button, input, select { font: inherit; }
   function renderList() {
     const attention = state.attention;
     if (!attention.length) {
-      els.list.innerHTML = '<div class="empty">No attention items for the current public-safe filters. Sources may be empty or degraded — check the source strip.</div>';
+      if (!state.merged) {
+        els.list.innerHTML = '<div class="empty">No source projection is available. Retry refresh.</div>';
+      } else {
+        els.list.innerHTML = '<div class="empty">No attention items for the current public-safe filters. Sources may be empty or degraded — check the source strip.</div>';
+      }
       return;
     }
     els.list.innerHTML = attention.map((row, index) => {
       const item = state.itemsById.get(row.work_id) || row;
       const rail = railClasses(item);
       const selected = row.work_id === state.selectedId;
-      return `<div class="work-row" role="option" tabindex="-1" data-id="${escapeAttr(row.work_id)}" data-index="${index}" aria-selected="${selected ? 'true' : 'false'}">
-        <div class="rail" aria-hidden="true">${rail.map((c) => `<i class="${c}"></i>`).join('')}</div>
-        <div class="row-main">
-          <div class="row-title">${escapeHtml(item.title || row.title || row.work_id)}</div>
-          <div class="row-meta">
-            <span class="mono">${escapeHtml(item.repository_id || row.repository_id || '')}</span>
-            <span class="pill">${escapeHtml(item.resource_kind || row.resource_kind || '')} #${escapeHtml(String(item.remote_id || row.remote_id || ''))}</span>
-            <span class="pill ${escapeAttr(item.health || row.health || 'UNKNOWN')}">${escapeHtml(item.health || row.health || 'UNKNOWN')}</span>
-          </div>
-        </div>
-        <div class="row-side mono">${escapeHtml((item.safe_next_action && item.safe_next_action.code) || (row.safe_next_action && row.safe_next_action.code) || '')}</div>
-      </div>`;
+      return '<div class="work-row" role="option" tabindex="-1" data-id="' + escapeAttr(row.work_id) + '" data-index="' + index + '" aria-selected="' + (selected ? 'true' : 'false') + '">' +
+        '<div class="rail" aria-hidden="true">' + rail.map((c) => '<i class="' + c + '"></i>').join('') + '</div>' +
+        '<div class="row-main">' +
+          '<div class="row-title">' + escapeHtml(item.title || row.title || row.work_id) + '</div>' +
+          '<div class="row-meta">' +
+            '<span class="mono">' + escapeHtml(item.repository_id || row.repository_id || '') + '</span>' +
+            '<span class="pill">' + escapeHtml(item.resource_kind || row.resource_kind || '') + ' #' + escapeHtml(String(item.remote_id || row.remote_id || '')) + '</span>' +
+            '<span class="pill ' + escapeAttr(item.health || row.health || 'UNKNOWN') + '">' + escapeHtml(item.health || row.health || 'UNKNOWN') + '</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="row-side mono">' + escapeHtml((item.safe_next_action && item.safe_next_action.code) || (row.safe_next_action && row.safe_next_action.code) || '') + '</div>' +
+      '</div>';
     }).join('');
     els.list.querySelectorAll('.work-row').forEach((node) => {
       node.addEventListener('click', () => selectIndex(Number(node.dataset.index)));
@@ -361,35 +761,36 @@ button, input, select { font: inherit; }
       els.detail.textContent = 'Select a row to inspect ownership, evidence, and the safe next action.';
       return;
     }
-    const stream = item.projections.stream || {};
-    const dispatch = item.projections.dispatch || {};
-    const review = item.projections.review || {};
-    const verification = item.projections.verification || {};
+    const stream = (item.projections && item.projections.stream) || {};
+    const dispatch = (item.projections && item.projections.dispatch) || {};
+    const review = (item.projections && item.projections.review) || {};
+    const verification = (item.projections && item.projections.verification) || {};
     const action = item.safe_next_action || {};
     const authorities = (item.authority || []).map((a) =>
-      `${a.domain}: age=${a.age_s == null ? '—' : a.age_s + 's'}${a.stale ? ' stale' : ''}`
+      a.domain + ': age=' + (a.age_s == null ? '—' : a.age_s + 's') + (a.stale ? ' stale' : '')
     ).join(' · ');
-    const rels = (item.relationships || []).map((r) => `${r.type} → ${r.target_id}`).join('; ') || 'none';
+    const rels = (item.relationships || []).map((r) => r.type + ' → ' + r.target_id).join('; ') || 'none';
     els.detail.className = 'detail';
-    els.detail.innerHTML = `
-      <h4>${escapeHtml(item.title || item.work_id)}</h4>
-      <div class="row-meta">
-        <span class="pill ${escapeAttr(item.health)}">${escapeHtml(item.health)}</span>
-        <span class="pill">${escapeHtml(item.resource_kind)} #${escapeHtml(item.remote_id)}</span>
-        <span class="mono">${escapeHtml(item.repository_id)}</span>
-      </div>
-      <dl>
-        <div><dt>Work id</dt><dd class="mono">${escapeHtml(item.work_id)}</dd></div>
-        <div><dt>Lifecycle</dt><dd>${escapeHtml(item.lifecycle || '—')}</dd></div>
-        <div><dt>Stream</dt><dd>${escapeHtml(stream.status || '—')}${(stream.streams && stream.streams.length) ? ' · ' + escapeHtml(stream.streams.join(', ')) : ''}</dd></div>
-        <div><dt>Dispatch</dt><dd>${escapeHtml((dispatch.task_ids || []).join(', ') || 'none')} ${(dispatch.statuses || []).map(escapeHtml).join(', ')}</dd></div>
-        <div><dt>Review</dt><dd>${escapeHtml(review.review_decision || (review.states || []).join(', ') || 'none')}${review.sealed_verdict_available ? ' · sealed available' : ''}</dd></div>
-        <div><dt>Verification</dt><dd>${escapeHtml(verification.ci_state || verification.state || '—')}</dd></div>
-        <div><dt>Relationships</dt><dd class="mono">${escapeHtml(rels)}</dd></div>
-        <div><dt>Authority / freshness</dt><dd>${escapeHtml(authorities || '—')}</dd></div>
-        <div><dt>Safe next action</dt><dd><strong>${escapeHtml(action.code || 'NONE')}</strong> · ${(action.reason_codes || []).map(escapeHtml).join(', ')}</dd></div>
-        <div><dt>URL</dt><dd>${item.urls && item.urls.html ? `<a href="${escapeAttr(item.urls.html)}" target="_blank" rel="noopener">${escapeHtml(item.urls.html)}</a>` : '—'}</dd></div>
-      </dl>`;
+    els.detail.innerHTML =
+      '<h4>' + escapeHtml(item.title || item.work_id) + '</h4>' +
+      '<div class="row-meta">' +
+        '<span class="pill ' + escapeAttr(item.health) + '">' + escapeHtml(item.health) + '</span>' +
+        '<span class="pill">' + escapeHtml(item.resource_kind) + ' #' + escapeHtml(item.remote_id) + '</span>' +
+        '<span class="mono">' + escapeHtml(item.repository_id) + '</span>' +
+      '</div>' +
+      '<dl>' +
+        '<div><dt>Work id</dt><dd class="mono">' + escapeHtml(item.work_id) + '</dd></div>' +
+        '<div><dt>Source</dt><dd class="mono">' + escapeHtml(item.source_id || '') + '</dd></div>' +
+        '<div><dt>Lifecycle</dt><dd>' + escapeHtml(item.lifecycle || '—') + '</dd></div>' +
+        '<div><dt>Stream</dt><dd>' + escapeHtml(stream.status || '—') + ((stream.streams && stream.streams.length) ? ' · ' + escapeHtml(stream.streams.join(', ')) : '') + '</dd></div>' +
+        '<div><dt>Dispatch</dt><dd>' + escapeHtml((dispatch.task_ids || []).join(', ') || 'none') + ' ' + (dispatch.statuses || []).map(escapeHtml).join(', ') + '</dd></div>' +
+        '<div><dt>Review</dt><dd>' + escapeHtml(review.review_decision || (review.states || []).join(', ') || 'none') + (review.sealed_verdict_available ? ' · sealed available' : '') + '</dd></div>' +
+        '<div><dt>Verification</dt><dd>' + escapeHtml(verification.ci_state || verification.state || '—') + '</dd></div>' +
+        '<div><dt>Relationships</dt><dd class="mono">' + escapeHtml(rels) + '</dd></div>' +
+        '<div><dt>Authority / freshness</dt><dd>' + escapeHtml(authorities || '—') + '</dd></div>' +
+        '<div><dt>Safe next action</dt><dd><strong>' + escapeHtml(action.code || 'NONE') + '</strong> · ' + (action.reason_codes || []).map(escapeHtml).join(', ') + '</dd></div>' +
+        '<div><dt>URL</dt><dd>' + (item.urls && item.urls.html ? ('<a href="' + escapeAttr(item.urls.html) + '" target="_blank" rel="noopener">' + escapeHtml(item.urls.html) + '</a>') : '—') + '</dd></div>' +
+      '</dl>';
   }
 
   function selectIndex(index) {
@@ -399,72 +800,254 @@ button, input, select { font: inherit; }
     state.selectedId = state.attention[clamped].work_id;
     renderList();
     renderDetail(state.itemsById.get(state.selectedId));
-    const node = els.list.querySelector(`.work-row[data-index="${clamped}"]`);
+    const node = els.list.querySelector('.work-row[data-index="' + clamped + '"]');
     if (node) node.focus({ preventScroll: false });
   }
 
-  function renderSources(projection) {
-    const sources = projection.sources || [];
-    const pub = sources.find((s) => s.source_id === 'public-monitor') || {};
-    const priv = sources.find((s) => s.source_id === 'private-local-adapter') || {};
-    const den = projection.denominator || {};
-    els.publicMeta.textContent = [
-      `status=${pub.status || '—'}`,
-      `cache_age_s=${projection.cache_age_s ?? '—'}`,
-      `issues=${den.issues_open ?? '—'}`,
-      `prs=${den.prs_open ?? '—'}`,
-      `streams=${den.streams_complete ? 'complete' : 'incomplete'}`,
-      `class4 d1=${den.class4 && den.class4.delegate_active} d2=${den.class4 && den.class4.delegate_tasks} r1=${den.class4 && den.class4.fleet_reviews}`,
-    ].join(' · ');
-    const cap = (projection.capabilities && projection.capabilities.private_source) || {};
-    els.privateMeta.textContent = priv.available
-      ? `status=${priv.status}`
-      : `unavailable · ${cap.reason_if_unavailable || priv.reason || 'not_configured'} (public server never proxies private data)`;
-    els.foundation.textContent = projection.foundation_status || 'FOUNDATION_COMPLETE';
-    els.attentionMeta.textContent = `${(projection.attention || []).length} ranked · cache ${projection.cache_age_s ?? 0}s`;
+  function renderSources(projection, privateMetaText, publicStatusOverride) {
+    const sources = (projection && projection.sources) || [];
+    const pub = sources.find((s) => s.source_id === PUBLIC_SOURCE_ID) || {};
+    const den = (projection && projection.denominator) || {};
+    const pubStatus = publicStatusOverride || pub.status || '—';
+    if (projection) {
+      els.publicMeta.textContent = [
+        'status=' + pubStatus,
+        'cache_age_s=' + (projection.cache_age_s ?? '—'),
+        'issues=' + (den.issues_open ?? '—'),
+        'prs=' + (den.prs_open ?? '—'),
+        'streams=' + (den.streams_complete ? 'complete' : 'incomplete'),
+        'class4 d1=' + (den.class4 && den.class4.delegate_active) + ' d2=' + (den.class4 && den.class4.delegate_tasks) + ' r1=' + (den.class4 && den.class4.fleet_reviews),
+      ].join(' · ');
+      els.foundation.textContent = projection.foundation_status || 'FOUNDATION_COMPLETE';
+      els.attentionMeta.textContent = ((projection.attention || []).length) + ' ranked · cache ' + (projection.cache_age_s ?? 0) + 's';
+    } else if (publicStatusOverride) {
+      els.publicMeta.textContent = 'status=' + publicStatusOverride;
+    }
+
+    els.privateMeta.textContent = privateMetaText;
 
     const repos = new Set();
-    (projection.items || []).forEach((item) => {
+    const sourcesPresent = new Set();
+    ((projection && projection.items) || []).forEach((item) => {
       if (item.repository_id) repos.add(item.repository_id);
+      if (item.source_id) sourcesPresent.add(item.source_id);
     });
-    const current = els.repo.value;
-    els.repo.innerHTML = '<option value="">All public</option>' +
-      Array.from(repos).sort().map((r) => `<option value="${escapeAttr(r)}">${escapeHtml(r)}</option>`).join('');
-    if (current) els.repo.value = current;
+    const currentRepo = els.repo.value;
+    els.repo.innerHTML = '<option value="">All repositories</option>' +
+      Array.from(repos).sort().map((r) => '<option value="' + escapeAttr(r) + '">' + escapeHtml(r) + '</option>').join('');
+    if (currentRepo) els.repo.value = currentRepo;
+
+    if (els.source) {
+      const currentSource = els.source.value;
+      const sourceOptions = ['public-monitor', 'private-local-adapter'].filter((s) => sourcesPresent.has(s) || s === PUBLIC_SOURCE_ID);
+      // Only list private source after an admitted private payload contributed items or source.
+      const hasPrivate = sources.some((s) => s && s.source_id === PRIVATE_SOURCE_ID && s.status !== 'unavailable') || sourcesPresent.has(PRIVATE_SOURCE_ID);
+      const opts = ['<option value="">All sources</option>', '<option value="public-monitor">public-monitor</option>'];
+      if (hasPrivate) opts.push('<option value="private-local-adapter">private-local-adapter</option>');
+      els.source.innerHTML = opts.join('');
+      if (currentSource) els.source.value = currentSource;
+    }
+  }
+
+  function fetchJson(url, options) {
+    const opts = options || {};
+    const controller = opts.timeoutMs ? new AbortController() : null;
+    let timer = null;
+    if (controller) {
+      timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+    }
+    const init = {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      credentials: 'omit',
+      cache: 'no-store',
+      referrerPolicy: 'no-referrer',
+    };
+    if (controller) init.signal = controller.signal;
+    return fetch(url, init).then(async (res) => {
+      if (timer) clearTimeout(timer);
+      if (!res.ok) {
+        const err = new Error('http_error');
+        err.code = 'unreachable';
+        throw err;
+      }
+      let body;
+      try {
+        body = await res.json();
+      } catch (_e) {
+        const err = new Error('parse_error');
+        err.code = 'schema_mismatch';
+        throw err;
+      }
+      return body;
+    }).catch((err) => {
+      if (timer) clearTimeout(timer);
+      if (err && err.name === 'AbortError') {
+        const e = new Error('timeout');
+        e.code = 'timeout';
+        throw e;
+      }
+      if (err && err.code) throw err;
+      const e = new Error('unreachable');
+      e.code = 'unreachable';
+      throw e;
+    });
+  }
+
+  function classifyPublicFailure(err) {
+    return err && err.code === 'schema_mismatch' ? 'schema_mismatch' : 'unreachable';
+  }
+
+  function classifyPrivateFailure(err) {
+    if (!err) return 'unreachable';
+    if (err.code === 'timeout') return 'timeout';
+    if (err.code === 'schema_mismatch') return 'schema_mismatch';
+    if (err.code === 'identity_collision') return 'identity_collision';
+    return 'unreachable';
+  }
+
+  function privateMetaFromCode(code, admittedStatus) {
+    if (admittedStatus) return 'status=' + admittedStatus;
+    if (code === 'timeout') return 'unavailable · timeout';
+    if (code === 'schema_mismatch') return 'unavailable · schema_mismatch';
+    if (code === 'identity_collision') return 'unavailable · identity_collision';
+    return 'unavailable · unreachable';
+  }
+
+  function installView(projection) {
+    state.merged = projection;
+    state.projection = projection;
+    const filters = controlsToFilters();
+    writeFiltersToUrl(filters);
+    const filtered = applyLocalFilters(projection, filters);
+    state.itemsById = new Map(filtered.items.map((i) => [i.work_id, i]));
+    state.attention = filtered.attention;
+    if (state.selectedId && state.itemsById.has(state.selectedId)) {
+      state.selectedIndex = state.attention.findIndex((a) => a.work_id === state.selectedId);
+    } else if (state.attention.length) {
+      state.selectedIndex = 0;
+      state.selectedId = state.attention[0].work_id;
+    } else {
+      state.selectedIndex = -1;
+      state.selectedId = null;
+    }
+    renderSources(projection, state.privateStatusText, state.publicStatusOverride);
+    renderList();
+    renderDetail(state.selectedId ? state.itemsById.get(state.selectedId) : null);
   }
 
   async function loadProjection(opts) {
-    const filters = controlsToFilters();
-    writeFiltersToUrl(filters);
     showError('');
-    const qs = queryString(filters);
-    const finalUrl = `/api/work/v1/projection${qs}${opts && opts.fresh ? (qs ? '&' : '?') + 'fresh=true' : ''}`;
-    try {
-      const res = await fetch(finalUrl, { headers: { Accept: 'application/json' } });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body.detail && body.detail.message) || body.detail || `HTTP ${res.status}`);
-      }
-      const projection = await res.json();
-      state.projection = projection;
-      state.itemsById = new Map((projection.items || []).map((i) => [i.work_id, i]));
-      state.attention = projection.attention || [];
-      renderSources(projection);
-      if (state.selectedId && state.itemsById.has(state.selectedId)) {
-        state.selectedIndex = state.attention.findIndex((a) => a.work_id === state.selectedId);
-      } else if (state.attention.length) {
-        state.selectedIndex = 0;
-        state.selectedId = state.attention[0].work_id;
-      } else {
-        state.selectedIndex = -1;
-        state.selectedId = null;
-      }
-      renderList();
-      renderDetail(state.selectedId ? state.itemsById.get(state.selectedId) : null);
-    } catch (err) {
-      showError(`Work projection unavailable: ${err.message || err}`);
-      els.list.innerHTML = '<div class="empty">Projection failed. Public sources may still be healthy independently — retry refresh.</div>';
+    state.publicStatusOverride = null;
+    const publicUrl = (opts && opts.fresh)
+      ? (PUBLIC_PROJECTION_URL + '?fresh=true')
+      : PUBLIC_PROJECTION_URL;
+
+    const publicPromise = fetchJson(publicUrl);
+    const privatePromise = fetchJson(PRIVATE_PROJECTION_URL, { timeoutMs: PRIVATE_TIMEOUT_MS });
+    const settled = await Promise.allSettled([publicPromise, privatePromise]);
+    const publicSettled = settled[0];
+    const privateSettled = settled[1];
+
+    let publicDoc = null;
+    let publicFail = null;
+    if (publicSettled.status === 'fulfilled') {
+      const admitted = admitPublicDocument(publicSettled.value);
+      if (admitted.ok) publicDoc = admitted.doc;
+      else publicFail = 'schema_mismatch';
+    } else {
+      publicFail = classifyPublicFailure(publicSettled.reason);
     }
+
+    let privateDoc = null;
+    let privateFail = null;
+    let privateAdmittedStatus = null;
+    if (privateSettled.status === 'fulfilled') {
+      const admitted = admitPrivateDocument(privateSettled.value);
+      if (admitted.ok) {
+        privateDoc = admitted.doc;
+        privateAdmittedStatus = admitted.sourceStatus;
+      } else {
+        privateFail = 'schema_mismatch';
+      }
+    } else {
+      privateFail = classifyPrivateFailure(privateSettled.reason);
+    }
+
+    if (publicDoc && privateDoc) {
+      const merged = mergeProjections(publicDoc, privateDoc);
+      if (!merged.ok) {
+        privateFail = 'identity_collision';
+        privateDoc = null;
+        state.privateStatusText = privateMetaFromCode(privateFail);
+        state.publicStatusOverride = null;
+        installView(publicDoc);
+        return;
+      }
+      state.privateStatusText = privateMetaFromCode(null, privateAdmittedStatus);
+      state.publicStatusOverride = null;
+      installView(merged.doc);
+      return;
+    }
+
+    if (publicDoc && !privateDoc) {
+      state.privateStatusText = privateMetaFromCode(privateFail);
+      state.publicStatusOverride = null;
+      installView(publicDoc);
+      return;
+    }
+
+    if (!publicDoc && privateDoc) {
+      state.privateStatusText = privateMetaFromCode(null, privateAdmittedStatus);
+      state.publicStatusOverride = publicFail === 'schema_mismatch' ? 'schema_mismatch' : 'unavailable';
+      // Private-only usable projection: wrap as a minimal document for rendering.
+      const privateOnly = {
+        schema_version: privateDoc.schema_version,
+        generated_at: privateDoc.generated_at,
+        cache_age_s: privateDoc.cache_age_s,
+        budget: privateDoc.budget,
+        sources: privateDoc.sources.slice(),
+        items: privateDoc.items.map((item) => {
+          const copy = Object.assign({}, item);
+          copy._orig_rank = item.attention_rank;
+          return copy;
+        }),
+        attention: [],
+        denominator: privateDoc.denominator,
+        capabilities: privateDoc.capabilities,
+        foundation_status: privateDoc.foundation_status,
+      };
+      privateOnly.attention = denseAttention(privateOnly.items);
+      installView(privateOnly);
+      // Ensure public meta shows typed failure even though private source strip may not include public-monitor.
+      els.publicMeta.textContent = 'status=' + state.publicStatusOverride;
+      return;
+    }
+
+    // Both failed
+    state.merged = null;
+    state.projection = null;
+    state.itemsById = new Map();
+    state.attention = [];
+    state.selectedId = null;
+    state.selectedIndex = -1;
+    const pubCode = publicFail === 'schema_mismatch' ? 'schema_mismatch' : 'unreachable';
+    const privCode = privateFail || 'unreachable';
+    showError('Work projection unavailable · public=' + pubCode + ' · private=' + privCode);
+    state.privateStatusText = privateMetaFromCode(privCode);
+    els.publicMeta.textContent = 'status=' + (pubCode === 'schema_mismatch' ? 'schema_mismatch' : 'unavailable');
+    els.privateMeta.textContent = state.privateStatusText;
+    els.list.innerHTML = '<div class="empty">No source projection is available. Retry refresh.</div>';
+    renderDetail(null);
+  }
+
+  function refilterOnly() {
+    if (!state.merged) {
+      const filters = controlsToFilters();
+      writeFiltersToUrl(filters);
+      return;
+    }
+    installView(state.merged);
   }
 
   function openPalette() {
@@ -492,7 +1075,7 @@ button, input, select { font: inherit; }
     }).slice(0, 30);
     els.cmdList.innerHTML = rows.map((row, i) => {
       const item = state.itemsById.get(row.work_id) || row;
-      return `<button type="button" class="cmd-item${i === 0 ? ' active' : ''}" data-id="${escapeAttr(row.work_id)}">${escapeHtml(item.title || row.work_id)} <span class="mono">${escapeHtml(item.resource_kind)} #${escapeHtml(String(item.remote_id))}</span></button>`;
+      return '<button type="button" class="cmd-item' + (i === 0 ? ' active' : '') + '" data-id="' + escapeAttr(row.work_id) + '">' + escapeHtml(item.title || row.work_id) + ' <span class="mono">' + escapeHtml(item.resource_kind) + ' #' + escapeHtml(String(item.remote_id)) + '</span></button>';
     }).join('') || '<div class="empty">No matches</div>';
     els.cmdList.querySelectorAll('.cmd-item').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -516,7 +1099,7 @@ button, input, select { font: inherit; }
   }
 
   document.getElementById('btn-refresh').addEventListener('click', () => loadProjection({ fresh: true }));
-  document.getElementById('btn-apply').addEventListener('click', () => loadProjection());
+  document.getElementById('btn-apply').addEventListener('click', () => refilterOnly());
   document.getElementById('btn-palette').addEventListener('click', openPalette);
   els.cmdInput.addEventListener('input', () => renderPalette(els.cmdInput.value));
   els.cmd.addEventListener('click', (e) => { if (e.target === els.cmd) closePalette(); });

--- a/docs/decisions/ADR-019-work-control-plane.md
+++ b/docs/decisions/ADR-019-work-control-plane.md
@@ -1,38 +1,81 @@
-# ADR-019: Work control plane (public foundation)
+# ADR-019: Work control plane (unified browser projection)
 
-**Status**: Accepted (public foundation P1)
+**Status**: Accepted (public foundation P1 + browser-local unified P3)
 **Date**: 2026-08-16
 **Deciders**: Operator brief v3 + design inspection GO; implementation on public issue #5921
-**Completion vocabulary**: `FOUNDATION_COMPLETE` (never product `COMPLETE`)
+**Completion vocabulary**:
+- Server/schema foundation: `FOUNDATION_COMPLETE` (never product `COMPLETE`)
+- Browser dual-source slice: `UNIFIED_COMPLETE` (dual fetch/validate/merge, public-safe
+  saved views, independent degradation, docs, deterministic proofs, ready PR,
+  exact-head cross-family approval, green checks — not mutation/hosted/proxy)
 
 ## Context
 
-Operators need a single local Work surface that answers what needs attention across the public Learn Ukrainian repository (and later a private infrastructure repository) without creating a second planning authority. GitHub Issues/PRs remain the source of truth. Existing Monitor projections remain authoritative for their domains. Private bodies must never enter the public tree, API, or shareable URLs.
+Operators need a single local Work surface that answers what needs attention across
+the public Learn Ukrainian repository and an optional private infrastructure
+repository without creating a second planning authority. GitHub Issues/PRs remain
+the source of truth. Existing Monitor projections remain authoritative for their
+domains. Private bodies must never enter the public tree, API, shareable URLs, or
+browser-rendered error text.
 
 ## Decision
 
-1. **Public owns the schema.** Authoritative contract: `scripts/work/schema/work_projection.v1.json` (`schema_version: work-projection.v1`). The future private adapter pins this file by public commit + SHA-256 (`schema_digest_sha256` from `/api/work/v1/capabilities`) and must not fork fields. `filters_applied` is a closed object that includes enum-backed `source_id` alongside health/kind/lifecycle/orphan/repository_id, with finite `maxItems`/`uniqueItems` (and repository `const`) aligned to the saved-view parser's raw cardinality bounds.
-2. **Public Monitor serves a read-only projection** at `GET /api/work/v1/projection` (plus `/v1/capabilities`, `/v1/health`) and a UI at `/work.html`.
-3. **Canonical identity** is `(source_id, repository_id, resource_kind, remote_id)` serialized as `wp1:{source_id}:{repository_id}:{resource_kind}:{remote_id}`.
+1. **Public owns the schema.** Authoritative contract:
+   `scripts/work/schema/work_projection.v1.json` (`schema_version: work-projection.v1`).
+   The private adapter pins this file by public commit
+   `f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d` + SHA-256
+   `89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde` and must not
+   fork fields. `filters_applied` remains a closed object on the public API.
+2. **Public Monitor serves a read-only projection** at
+   `GET /api/work/v1/projection` (plus `/v1/capabilities`, `/v1/health`) and a UI
+   at `/work.html`.
+3. **Canonical identity** is
+   `(source_id, repository_id, resource_kind, remote_id)` serialized as
+   `wp1:{source_id}:{repository_id}:{resource_kind}:{remote_id}`.
 4. **Warm refresh denominator (public)**:
    - open public issues (one GH list enumeration, cap 1000, `truncated=true` if incomplete)
    - open public PRs (one GH list enumeration, same cap)
    - complete public `/api/issues/streams` projection (never raw cache private keys)
-   - class-4 summaries only: `GET /api/delegate/active`, `GET /api/delegate/tasks?status=all&limit<=500`, `GET /api/fleet/reviews` (Work's production collectors pass the admitted public repository into internal delegate/fleet loaders so filtering precedes pagination/counting; HTTP surfaces stay unscoped except fleet's exact `repository` query)
-5. **No mutations** in the foundation. FX-10 mutation preview/idempotency remains design-only.
-6. **Private source seam**: public server never fetches, proxies, persists, or renders private-repository data. Capability object reports `available: false` / `not_configured` until a browser-local private adapter exists (P2).
-7. **Health** is rule-derived (`ON_TRACK` / `AT_RISK` / `OFF_TRACK` / `UNKNOWN`). Activity volume is never health evidence.
-8. **UI direction**: Evidence rail — Monitor paper tokens, dense attention list, lifecycle/evidence rail, authority/freshness, keyboard-first, reduced motion, ~390px usable layout.
+   - class-4 summaries only: `GET /api/delegate/active`,
+     `GET /api/delegate/tasks?status=all&limit<=500`, `GET /api/fleet/reviews`
+5. **No mutations.** FX-10 mutation preview/idempotency remains design-only.
+6. **Private source is browser-local only.** The public server never fetches,
+   proxies, persists, configures, or logs the private adapter. Only
+   `dashboards/work.html` may GET the fixed constant
+   `http://127.0.0.1:8766/v1/projection` with a 5s abort budget, CORS-safelisted
+   headers, `credentials: omit`, and no query string. The endpoint is not
+   configurable and never enters shareable saved-view state.
+7. **Independent dual-source settlement.** The browser uses `Promise.allSettled`
+   (or equivalent). Either source may fail without blocking the other. Private
+   admission is closed-world (exact keys, redacted item shape, digest pin, single
+   `private-local-adapter` source). Collisions reject the private payload
+   (`identity_collision`) without overwriting public items. Merge replaces the
+   public placeholder private source, concatenates items, sums denominators, ANDs
+   `streams_complete`, preserves public class-4 authority, installs private
+   capability metadata, takes `max(cache_age_s)`, and densifies attention.
+8. **Health** is rule-derived (`ON_TRACK` / `AT_RISK` / `OFF_TRACK` / `UNKNOWN`).
+   Activity volume is never health evidence.
+9. **UI direction**: Evidence rail — Monitor paper tokens, dense attention list,
+   lifecycle/evidence rail, authority/freshness, keyboard-first, reduced motion,
+   ~390px usable layout without horizontal overflow.
+10. **Saved views**: URL query only; stricter shareable allowlist than local
+    filters so private repository slugs and `private-local-adapter` never enter
+    transferable state.
 
 ## Consequences
 
-- P1 ships and CI-passes with no private checkout.
-- P2 (private repo) adds a local loopback adapter outside Hramatka production routes and pins the public schema digest.
+- P1 ships the public foundation with no private checkout.
+- P2 (private repo adapter process) lives outside Hramatka production routes and
+  pins the public schema digest; it is not imported by the public server.
+- P3 completes browser-local dual-source unification (`UNIFIED_COMPLETE` scope).
 - Adding or removing class-4 endpoints is a counted residual requiring plan re-review.
-- Foundation completion is reported as `FOUNDATION_COMPLETE`, not product complete.
+- Foundation completion remains `FOUNDATION_COMPLETE`; unified browser completion
+  is reported separately as `UNIFIED_COMPLETE` and is still not product-complete
+  for mutation or hosted deployment.
 
 ## Alternatives considered
 
 - Server-side merge of private adapter into public Monitor (rejected: SSRF + privacy boundary).
+- Configurable private endpoint via query/storage/env (rejected: shareable-state + SSRF footgun).
 - Reusing `/api/orient` as the Work denominator (rejected: incomplete GH limits, fat aggregate).
 - Dark ops console UI (rejected: fights Monitor paper language).

--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -1,10 +1,20 @@
-# Work control plane API (public foundation)
+# Work control plane API (unified browser projection)
 
-Read-only projection of public work for the local Monitor. GitHub Issues/PRs remain the source of truth. Completion vocabulary for this foundation: **`FOUNDATION_COMPLETE`** (not product `COMPLETE`).
+Read-only projection of work for the local Monitor. GitHub Issues/PRs remain the
+source of truth. There is no Linear source of truth.
 
-Base URL: `http://127.0.0.1:8765` (prefer loopback IP).
+Completion vocabulary:
 
-## Endpoints
+- Public foundation (server + schema): **`FOUNDATION_COMPLETE`**
+- Browser-local dual-source product slice: **`UNIFIED_COMPLETE`** means dual-source
+  fetch/validation/merge in the browser, public-safe saved views, independent
+  degradation, docs, deterministic unit and headless-browser proofs, ready PR,
+  exact-head cross-family approval, and green repository checks. It does **not**
+  mean mutation, hosted deployment, or private proxying.
+
+Base URL (public Monitor): `http://127.0.0.1:8765` (prefer loopback IP).
+
+## Endpoints (public server)
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -12,14 +22,114 @@ Base URL: `http://127.0.0.1:8765` (prefer loopback IP).
 | `GET` | `/api/work/v1/capabilities` | Schema digest, budgets, class-4 endpoint freeze, private-source seam |
 | `GET` | `/api/work/v1/health` | Cheap Work surface liveness |
 
-UI: [`/work.html`](../../dashboards/work.html) — Evidence rail attention list (Monitor paper language).
+UI: [`/work.html`](../../dashboards/work.html) — Evidence rail attention list
+(Monitor paper language).
 
-## Denominator (public)
+## Browser-local private adapter boundary
 
-At a query instant the projection represents exactly once (or counts in a typed omission):
+Only browser JavaScript in `dashboards/work.html` may fetch the fixed constant:
 
-1. Open public issues — one `gh issue list` enumeration, cap **1000**, `truncated=true` when incomplete.
-2. Open public PRs — one `gh pr list` enumeration, same cap. No per-item detail/comment/check fan-out on refresh.
+`http://127.0.0.1:8766/v1/projection`
+
+Invariants:
+
+1. The public server never imports, reads, proxies, configures, or logs the
+   private adapter. The public capability seam remains
+   `available: false` / `not_configured` until the **browser** admits a private
+   document.
+2. The private endpoint is not configurable: no query parameter, input,
+   environment, local/session storage, cookie, fragment, or server setting. It
+   never enters the page URL, saved views, HTML links, DOM status text as a raw
+   URL, errors, or telemetry.
+3. Both browser requests are GET-only with `Accept: application/json`,
+   `credentials: "omit"`, `cache: "no-store"`, and `referrerPolicy: "no-referrer"`.
+   The private request has an exact 5-second `AbortController` budget and no
+   query string (including on Refresh). Public Refresh may use `fresh=true`.
+   User filters are applied **locally after merge** and are never sent to the
+   private adapter.
+4. Sources settle independently (`Promise.allSettled`). Private availability is
+   never a prerequisite for public rendering or vice versa. Raw
+   fetch/parse/validation exception text is never displayed or logged.
+5. Private admission is closed-world against `work-projection.v1` plus the frozen
+   schema digest `89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde`
+   and public schema commit `f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d`. Any
+   violation rejects the entire private payload as `schema_mismatch` (no partial
+   item admission, no payload echo). Work-id collisions with public items reject
+   the private payload as `identity_collision` without overwriting public data.
+6. Mutation remains false everywhere. No POST/PUT/PATCH/DELETE, dispatch, merge,
+   issue-edit, proxy, websocket, or hosted-resource behavior.
+
+### Private-source status vocabulary (closed)
+
+Rendered only in `#source-private-meta`:
+
+| Condition | Text |
+| --- | --- |
+| Admitted private source | `status=<ok\|degraded\|unavailable\|permission_denied\|timeout\|truncated>` |
+| AbortError / budget exceeded | `unavailable · timeout` |
+| Fetch / non-2xx | `unavailable · unreachable` |
+| Parse / shape failure | `unavailable · schema_mismatch` |
+| Work-id collision | `unavailable · identity_collision` |
+
+When the public document fails but private remains usable,
+`#source-public-meta` is `status=unavailable` (transport) or
+`status=schema_mismatch` (parse/shape). If both fail, the error banner is exactly:
+
+`Work projection unavailable · public=<unreachable|schema_mismatch> · private=<timeout|unreachable|schema_mismatch|identity_collision>`
+
+and the list is exactly: `No source projection is available. Retry refresh.`
+
+### Merge (browser)
+
+On dual admission success the browser:
+
+- replaces only the public `sources[]` member with `source_id=private-local-adapter`
+- concatenates admitted items
+- sums issue/PR denominators, ANDs `streams_complete`, preserves public class-4
+- removes only `{class:"private_adapter",reason:"not_configured"}` from public
+  denominator omissions and appends private omissions
+- installs the validated private `capabilities.private_source`
+- sets `cache_age_s = max(public, private)`
+- emits one dense attention list ordered by health
+  (`OFF_TRACK`, `AT_RISK`, `UNKNOWN`, `ON_TRACK`), then original
+  `attention_rank`, then `source_id`, then `work_id`, rewritten to `0..N-1`
+
+### Saved views
+
+Shareable state is **URL query only** (never fragment, storage, cookie, or other
+encoding). Allowlisted keys: `health`, `kind`, `lifecycle`, `orphan`,
+`repository_id`, `source_id`.
+
+Stricter shareable rules than in-memory filters:
+
+- enums only for health / kind / lifecycle / orphan
+- `repository_id` only when it equals the public singleton
+  `learn-ukrainian/learn-ukrainian.github.io`
+- `source_id` only when it is `public-monitor`
+
+Selecting a private repository or `private-local-adapter` filters the current
+in-memory view only and strips those keys from the URL. Repository choices say
+**All repositories** and include public/private slugs only after they appear in
+an admitted payload.
+
+### Live CORS (private adapter contract)
+
+The private adapter admits exactly Monitor origins
+`http://127.0.0.1:8765` and `http://localhost:8765`. A simple GET returns matching
+`Access-Control-Allow-Origin` plus `Vary: Origin`, no credentials, and needs no
+preflight because `Accept` is CORS-safelisted. Fixture proofs cover real
+cross-origin browser smoke on those fixed loopback ports in addition to request
+interception tests.
+
+## Denominator (public server)
+
+At a query instant the public projection represents exactly once (or counts in a
+typed omission):
+
+1. Open public issues — one `gh issue list` enumeration, cap **1000**,
+   `truncated=true` when incomplete.
+2. Open public PRs — one `gh pr list` enumeration, same cap. No per-item
+   detail/comment/check fan-out on refresh.
 3. Complete public `GET /api/issues/streams` response (private cache keys stripped).
 4. Class-4 summaries only:
    - `GET /api/delegate/active`
@@ -37,38 +147,28 @@ At a query instant the projection represents exactly once (or counts in a typed 
 ## Budgets
 
 - Warm response target: **≤2s** (warm cache ~30s).
-- Optional/failing section → typed degraded/unknown within **≤5s** without hiding healthy sources.
-- `cache_age_s` is always present on the projection.
-
-## Saved-view URL filters
-
-Allowed query keys only: `health`, `kind`, `lifecycle`, `orphan`, `repository_id`, `source_id`.
-
-Multivalue filters are bounded by finite per-key raw cardinality (domain size for health/kind/lifecycle/source_id; singleton for orphan and `repository_id`) **before** canonicalization, then deduplicated + sorted so duplicate/reordered forms within the bound share one permanent warm-cache key and one `filters_applied` object. Excess raw repetitions reject with `400 invalid_saved_view`.
-
-`repository_id` accepts only the closed public repository singleton (`learn-ukrainian/learn-ukrainian.github.io`); it is not overridable by environment. `source_id` is enum-backed (`public-monitor` | `private-local-adapter`) both as a query key and inside the closed `filters_applied` object. The authoritative schema enforces matching `maxItems`, `uniqueItems`, lifecycle enum, and repository `const` on `filters_applied`.
-
-Every projection-builder entry point (`build_projection`, `build_public_projection`, cache-key minting, HTTP) re-enters the shared saved-view admission gate; unknown keys and foreign repository IDs cannot bypass via direct calls.
-
-Formal-review rows are admitted only for that exact public repository (no suffix matching; missing/foreign repositories are dropped at collection and normalization).
-
-Delegate class-4 inventory is filtered by the authoritative task-state fields `repository` / `repository_id` (both must agree when present) **before** sort/limit/total so private volume cannot inflate public counts or starve public rows. Generic `/api/delegate/tasks` and `/api/delegate/active` summaries never re-emit those attribution fields (legacy public shape only). Work's production collectors (`loader is None`) pass the already-admitted public singleton into the fixed internal Python loaders, then stamp Work's own admitted repository metadata under the trusted scoped-loader contract for those claim-less redacted rows; present foreign claims are still dropped defense-in-depth. On that trusted production path, Work **preserves** the scoped loader's authoritative public `total` and sets section `truncated = total > admitted_page_count` (so 501 public tasks with a 500-row page report `total: 501`, `truncated: true`); active inventory has no page budget and does not invent truncation. Caller-injected loaders and mixed/normalize section payloads are untrusted: every retained row must carry an exact authoritative public claim (missing/ambiguous/foreign rows are dropped), and total/count/truncation are recomputed only from admitted rows (a dishonest supplied `total` is ignored; private rows never influence the count). The public HTTP `/api/delegate/*` routes remain unscoped for other Monitor consumers and do not expose a free-form repository selector. Bodies and result files are never read.
-
-Unknown keys, free text, private endpoints, overlong values, and oversized repeated filter values are rejected (`400 invalid_saved_view`).
-
-Schema provenance: `GET /api/work/v1/capabilities` returns live `schema_digest_sha256` over `scripts/work/schema/work_projection.v1.json` (private adapters pin that digest + public commit). Any change to the closed `filters_applied` contract (including maxItems/uniqueItems/enums/const) changes that digest.
+- Optional/failing section → typed degraded/unknown within **≤5s** without hiding
+  healthy sources.
+- Private browser fetch budget: **5s** hard abort.
+- `cache_age_s` is always present on admitted projections.
 
 ## Privacy
 
-- Public server **never** fetches, proxies, persists, or renders private-repository data.
-- Private capability seam returns `available: false`, `reason_if_unavailable: not_configured` until a browser-local adapter is configured (private P2).
-- Mutation is always `false` in the foundation.
+- Public server **never** fetches, proxies, persists, or renders private-repository
+  data.
+- Public capability seam returns `available: false`,
+  `reason_if_unavailable: not_configured`, `endpoint: null` until the browser
+  admits a private document.
+- Mutation is always `false`.
 
 ## Example
 
 ```bash
 curl -sS 'http://127.0.0.1:8765/api/work/v1/capabilities' | .venv/bin/python -m json.tool
-curl -sS 'http://127.0.0.1:8765/api/work/v1/projection?health=AT_RISK&kind=issue' | .venv/bin/python -m json.tool | head
+curl -sS 'http://127.0.0.1:8765/api/work/v1/projection?fresh=true' | .venv/bin/python -m json.tool | head
+# Private adapter (loopback only; never via public Monitor):
+curl -sS -H 'Accept: application/json' -H 'Origin: http://127.0.0.1:8765' \
+  'http://127.0.0.1:8766/v1/projection' | .venv/bin/python -m json.tool | head
 ```
 
 See also: [ADR-019](../decisions/ADR-019-work-control-plane.md).

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -119,6 +119,27 @@ def test_work_page_closed_private_status_vocabulary():
     assert "console.log" not in html
 
 
+def test_work_page_fetchjson_keeps_timeout_through_json_parse():
+    """Private AbortController budget must cover status handling + body parse."""
+    html = WORK.read_text(encoding="utf-8")
+    start = html.index("function fetchJson(")
+    end = html.index("function classifyPublicFailure(", start)
+    body = html[start:end]
+    # Single finalization path clears the timer after settlement.
+    assert ".finally(" in body
+    assert body.count("clearTimeout(timer)") == 1
+    # Abort during body read is typed timeout, not schema_mismatch / raw error.
+    assert "aborted(parseErr)" in body
+    assert "err.code = 'timeout'" in body or 'err.code = "timeout"' in body
+    # Degraded sections are terminal (no admitted counts/items).
+    assert "'degraded'" in html
+    terminal_line = [
+        line for line in html.splitlines() if "new Set(['unavailable', 'permission_denied', 'timeout'" in line
+    ]
+    assert terminal_line, "terminal section status set missing"
+    assert "degraded" in terminal_line[0]
+
+
 def test_work_page_shareable_url_strips_private_selectors():
     html = WORK.read_text(encoding="utf-8")
     assert "PUBLIC_SINGLETON_REPO" in html

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -1,4 +1,4 @@
-"""Static UI contracts for the Work evidence-rail dashboard."""
+"""Static UI contracts for the Work evidence-rail dashboard (unified P3)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORK = ROOT / "dashboards" / "work.html"
 INDEX = ROOT / "dashboards" / "index.html"
+
+PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
+SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
+PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
 
 
 def test_work_page_evidence_rail_and_a11y_surface():
@@ -29,6 +33,7 @@ def test_work_page_evidence_rail_and_a11y_surface():
     # Saved-view allowlist present client-side
     assert "ALLOWED_FILTER_KEYS" in html
     assert "private_endpoint" in html  # rejected explicitly
+    assert "All repositories" in html
 
 
 def test_work_page_has_no_mutation_controls():
@@ -63,26 +68,62 @@ def test_index_and_primary_nav_link_to_work():
 
 def test_saved_view_client_writes_only_allowlisted_keys():
     html = WORK.read_text(encoding="utf-8")
-    # Extract allowlist literal
     match = re.search(r"ALLOWED_FILTER_KEYS = new Set\(\[(.*?)\]\)", html, re.S)
     assert match
     keys = re.findall(r"'([a-z_]+)'", match.group(1))
     assert "health" in keys
     assert "kind" in keys
+    assert "source_id" in keys
     assert "q" not in keys
     assert "endpoint" not in keys
 
 
-def test_work_page_has_no_dead_fresh_url_self_replacement():
-    """CodeQL: dead url construction used no-op replace('&','&') before finalUrl."""
+def test_work_page_public_refresh_and_private_fixed_url_contract():
+    """Public refresh may use fresh=true; private URL is a non-configurable constant."""
     html = WORK.read_text(encoding="utf-8")
     assert "fresh.replace(" not in html
     assert ".replace('&', '&')" not in html
     assert '.replace("&", "&")' not in html
-    # Single live composition for the projection request (public contract).
-    assert "fetch(finalUrl" in html
-    assert re.search(
-        r"const finalUrl = `/api/work/v1/projection\$\{qs\}\$\{opts && opts\.fresh",
-        html,
-    )
+    assert f"'{PRIVATE_URL}'" in html or f'"{PRIVATE_URL}"' in html
+    assert html.count(PRIVATE_URL) >= 1
+    assert "PRIVATE_TIMEOUT_MS = 5000" in html or "timeoutMs: PRIVATE_TIMEOUT_MS" in html
+    assert "Promise.allSettled" in html
+    assert "credentials: 'omit'" in html or 'credentials: "omit"' in html
+    assert "cache: 'no-store'" in html or 'cache: "no-store"' in html
+    assert "referrerPolicy: 'no-referrer'" in html or 'referrerPolicy: "no-referrer"' in html
+    assert "Accept: 'application/json'" in html or 'Accept: "application/json"' in html
+    assert SCHEMA_DIGEST in html
+    assert PUBLIC_COMMIT in html
+    # Public path appears as the constant / composition site only (not private URL host).
     assert html.count("/api/work/v1/projection") == 1
+    assert "fresh=true" in html
+    # Filters must not be composed into the private request.
+    assert "PRIVATE_PROJECTION_URL" in html
+    assert "queryString(filters)" not in html
+
+
+def test_work_page_closed_private_status_vocabulary():
+    html = WORK.read_text(encoding="utf-8")
+    for token in (
+        "unavailable · timeout",
+        "unavailable · unreachable",
+        "unavailable · schema_mismatch",
+        "unavailable · identity_collision",
+        "Work projection unavailable · public=",
+        "No source projection is available. Retry refresh.",
+    ):
+        assert token in html
+    # Must not template raw exception text into the banner.
+    assert "err.message" not in html
+    assert "console.error" not in html
+    assert "console.log" not in html
+
+
+def test_work_page_shareable_url_strips_private_selectors():
+    html = WORK.read_text(encoding="utf-8")
+    assert "PUBLIC_SINGLETON_REPO" in html
+    assert "shareableFilters" in html
+    assert "private-local-adapter" in html
+    # Private source/repo must not be written into transferable saved-view state.
+    assert "value !== PUBLIC_SINGLETON_REPO" in html or "value !== PUBLIC_SINGLETON_REPO" in html
+    assert "value !== PUBLIC_SOURCE_ID" in html

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -1,0 +1,1229 @@
+"""Browser-local dual-source Work projection proofs (unified P3).
+
+Source-blind fixtures only. Never prints private payloads. Does not require a
+real private repository or live adapter process.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORK_HTML = ROOT / "dashboards" / "work.html"
+PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
+PUBLIC_PATH = "/api/work/v1/projection"
+SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
+PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
+PUBLIC_REPO = "learn-ukrainian/learn-ukrainian.github.io"
+# Source-blind synthetic private slug — not a real private repository identifier.
+SYNTH_PRIVATE_REPO = "fixture-owner/fixture-repo"
+CANARY = "FX07_CANARY_SHOULD_NEVER_APPEAR_IN_DOM_OR_URL"
+FIXED_PUBLIC_PORT = 8765
+FIXED_PRIVATE_PORT = 8766
+
+
+def _node_modules() -> Path | None:
+    candidates: list[Path] = [ROOT / "node_modules"]
+    # Dispatch worktrees live under .worktrees/dispatch/<agent>/<task>/
+    if len(ROOT.parents) >= 4:
+        candidates.append(ROOT.parents[3] / "node_modules")
+    try:
+        common = subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=ROOT,
+            text=True,
+            timeout=5,
+        ).strip()
+        # git-common-dir is <repo>/.git → parents[0] is repo root when bare path ends with .git
+        git_path = Path(common)
+        repo_root = git_path.parent if git_path.name == ".git" else git_path
+        candidates.append(repo_root / "node_modules")
+    except (subprocess.SubprocessError, OSError):
+        pass
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve() if candidate.exists() else candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if (candidate / "puppeteer").exists():
+            return candidate
+    return None
+
+
+def _require_puppeteer() -> Path:
+    nm = _node_modules()
+    if nm is None:
+        pytest.skip("puppeteer not available for headless browser proofs")
+    return nm
+
+
+def _public_min() -> dict[str, Any]:
+    item = {
+        "work_id": f"wp1:public-monitor:{PUBLIC_REPO}:issue:5921",
+        "source_id": "public-monitor",
+        "repository_id": PUBLIC_REPO,
+        "resource_kind": "issue",
+        "remote_id": "5921",
+        "title": "Public attention item",
+        "lifecycle": "open",
+        "labels": ["infrastructure"],
+        "assignees": [],
+        "urls": {
+            "html": f"https://github.com/{PUBLIC_REPO}/issues/5921",
+        },
+        "timestamps": {
+            "created_at": "2026-08-16T00:00:00Z",
+            "updated_at": "2026-08-16T00:00:00Z",
+        },
+        "projections": {
+            "stream": {
+                "status": "orphan",
+                "streams": [],
+                "fresh": True,
+                "authority_missing": False,
+            },
+            "dispatch": {"task_ids": [], "statuses": [], "unresolved": False},
+            "review": {
+                "review_ids": [],
+                "states": [],
+                "sealed_verdict_available": False,
+            },
+            "verification": {"kind": "none", "state": "n/a"},
+        },
+        "relationships": [],
+        "health": "AT_RISK",
+        "attention_rank": 0,
+        "safe_next_action": {
+            "code": "TRIAGE_ORPHAN",
+            "reason_codes": ["stream_orphan"],
+        },
+        "authority": [
+            {
+                "domain": "github",
+                "observed_at": "2026-08-16T00:00:00Z",
+                "age_s": 0,
+                "stale": False,
+            }
+        ],
+        "omissions": [],
+        "flags": {"orphan": True, "has_blocker": False},
+    }
+    return {
+        "schema_version": "work-projection.v1",
+        "generated_at": "2026-08-16T00:00:00Z",
+        "cache_age_s": 1.0,
+        "budget": {"warm_target_s": 2, "timeout_s": 5},
+        "sources": [
+            {
+                "source_id": "public-monitor",
+                "status": "ok",
+                "freshness": {"observed_at": "2026-08-16T00:00:00Z", "age_s": 1.0},
+                "capabilities": {"mutation": False, "private_fields": False},
+                "truncation": {"issues": False, "prs": False, "limit": 1000},
+                "sections": {
+                    "issues": {"status": "ok", "count": 1},
+                    "prs": {"status": "ok", "count": 0},
+                    "streams": {"status": "ok", "count": 1},
+                    "delegate_active": {"status": "ok", "count": 0},
+                    "delegate_tasks": {"status": "ok", "count": 0},
+                    "fleet_reviews": {"status": "ok", "count": 0},
+                },
+            },
+            {
+                "source_id": "private-local-adapter",
+                "status": "unavailable",
+                "freshness": {"observed_at": None, "age_s": None},
+                "capabilities": {"mutation": False, "private_fields": False},
+                "truncation": {"issues": False, "prs": False, "limit": 1000},
+                "sections": {},
+                "reason": "not_configured",
+            },
+        ],
+        "items": [item],
+        "attention": [
+            {
+                "work_id": item["work_id"],
+                "attention_rank": 0,
+                "health": item["health"],
+                "safe_next_action": item["safe_next_action"],
+                "title": item["title"],
+                "resource_kind": item["resource_kind"],
+                "repository_id": item["repository_id"],
+                "remote_id": item["remote_id"],
+            }
+        ],
+        "denominator": {
+            "issues_open": 1,
+            "prs_open": 0,
+            "streams_complete": True,
+            "class4": {
+                "delegate_active": True,
+                "delegate_tasks": True,
+                "fleet_reviews": True,
+            },
+            "omissions": [
+                {"class": "private_adapter", "reason": "not_configured", "count": 0}
+            ],
+        },
+        "capabilities": {
+            "mutation": False,
+            "private_source": {
+                "source_id": "private-local-adapter",
+                "available": False,
+                "schema_version": "work-projection.v1",
+                "schema_digest_sha256": None,
+                "public_schema_commit": None,
+                "endpoint": None,
+                "capabilities": [],
+                "redaction": "allowlist_v1",
+                "reason_if_unavailable": "not_configured",
+            },
+        },
+        "foundation_status": "FOUNDATION_COMPLETE",
+    }
+
+
+def _private_ok(*, remote_id: str = "7", kind: str = "issue", rank: int = 0) -> dict[str, Any]:
+    title = f"private-{kind}-{remote_id}"
+    work_id = f"wp1:private-local-adapter:{SYNTH_PRIVATE_REPO}:{kind}:{remote_id}"
+    item = {
+        "work_id": work_id,
+        "source_id": "private-local-adapter",
+        "repository_id": SYNTH_PRIVATE_REPO,
+        "resource_kind": kind,
+        "remote_id": remote_id,
+        "title": title,
+        "lifecycle": "open" if kind == "issue" else "draft",
+        "labels": [],
+        "assignees": [],
+        "urls": {"html": None},
+        "timestamps": {"created_at": "2026-08-16T00:00:00Z", "updated_at": None},
+        "projections": {
+            "stream": {},
+            "dispatch": {},
+            "review": {},
+            "verification": {},
+        },
+        "relationships": [],
+        "health": "UNKNOWN",
+        "attention_rank": rank,
+        "safe_next_action": {
+            "code": "INSPECT_UNKNOWN",
+            "reason_codes": [
+                "private_metadata_redacted",
+                "no_private_authority_evidence",
+            ],
+        },
+        "authority": [],
+        "omissions": [
+            {"class": "private_content", "reason": "redacted"},
+            {"class": "stream_authority", "reason": "not_collected"},
+            {"class": "review_authority", "reason": "not_collected"},
+        ],
+    }
+    issue_count = 1 if kind == "issue" else 0
+    pr_count = 1 if kind == "pr" else 0
+    return {
+        "schema_version": "work-projection.v1",
+        "generated_at": "2026-08-16T00:00:00Z",
+        "cache_age_s": 3.0,
+        "budget": {"warm_target_s": 2, "timeout_s": 5},
+        "sources": [
+            {
+                "source_id": "private-local-adapter",
+                "status": "ok",
+                "freshness": {"observed_at": "2026-08-16T00:00:00Z", "age_s": 3.0},
+                "capabilities": {"mutation": False, "private_fields": False},
+                "truncation": {"issues": False, "prs": False, "limit": 1000},
+                "sections": {
+                    "issues": {"status": "ok", "count": issue_count},
+                    "prs": {"status": "ok", "count": pr_count},
+                },
+            }
+        ],
+        "items": [item],
+        "attention": [
+            {
+                "work_id": work_id,
+                "attention_rank": rank,
+                "health": "UNKNOWN",
+                "safe_next_action": item["safe_next_action"],
+                "title": title,
+                "resource_kind": kind,
+                "repository_id": SYNTH_PRIVATE_REPO,
+                "remote_id": remote_id,
+            }
+        ],
+        "denominator": {
+            "issues_open": issue_count,
+            "prs_open": pr_count,
+            "streams_complete": True,
+            "class4": {
+                "delegate_active": False,
+                "delegate_tasks": False,
+                "fleet_reviews": False,
+            },
+            "omissions": [],
+        },
+        "capabilities": {
+            "mutation": False,
+            "private_source": {
+                "source_id": "private-local-adapter",
+                "available": True,
+                "schema_version": "work-projection.v1",
+                "schema_digest_sha256": SCHEMA_DIGEST,
+                "public_schema_commit": PUBLIC_COMMIT,
+                "endpoint": PRIVATE_URL,
+                "capabilities": ["projection", "capabilities", "health"],
+                "redaction": "strict-metadata-only",
+                "reason_if_unavailable": None,
+            },
+        },
+        "foundation_status": "FOUNDATION_COMPLETE",
+    }
+
+
+def _private_with_extra_canary() -> dict[str, Any]:
+    doc = _private_ok()
+    # Closed-world rejection: free-text / canary-shaped extra key.
+    doc["canary_note"] = CANARY
+    return doc
+
+
+def _public_with_private_id_collision(private_doc: dict[str, Any]) -> dict[str, Any]:
+    pub = _public_min()
+    # Duplicate the private work_id into public items so merge detects collision.
+    clone = json.loads(json.dumps(private_doc["items"][0]))
+    # Public may carry arbitrary work_id strings under loose public admission.
+    pub["items"].append(clone)
+    pub["attention"].append(
+        {
+            "work_id": clone["work_id"],
+            "attention_rank": 1,
+            "health": clone["health"],
+            "safe_next_action": clone["safe_next_action"],
+            "title": clone["title"],
+            "resource_kind": clone["resource_kind"],
+            "repository_id": clone["repository_id"],
+            "remote_id": clone["remote_id"],
+        }
+    )
+    return pub
+
+
+class _FixtureState:
+    def __init__(self) -> None:
+        self.public_body: bytes | None = None
+        self.public_status = 200
+        self.private_body: bytes | None = None
+        self.private_status = 200
+        self.private_delay_s = 0.0
+        self.public_requests: list[dict[str, Any]] = []
+        self.private_requests: list[dict[str, Any]] = []
+        self.options_count = 0
+        self.html = WORK_HTML.read_bytes()
+
+
+def _make_handler(state: _FixtureState, *, role: str, allowed_origins: set[str]):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def _send(
+            self,
+            code: int,
+            body: bytes,
+            *,
+            content_type: str,
+            origin: str | None,
+            extra: dict[str, str] | None = None,
+        ) -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            if origin in allowed_origins:
+                self.send_header("Access-Control-Allow-Origin", origin)
+                self.send_header("Vary", "Origin")
+            if extra:
+                for key, value in extra.items():
+                    self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_OPTIONS(self) -> None:
+            state.options_count += 1
+            origin = self.headers.get("Origin")
+            self._send(204, b"", content_type="text/plain", origin=origin)
+
+        def do_GET(self) -> None:
+            origin = self.headers.get("Origin")
+            path = self.path.split("?", 1)[0]
+            accept = self.headers.get("Accept", "")
+            record = {
+                "path": self.path,
+                "path_only": path,
+                "accept": accept,
+                "origin": origin,
+                "method": "GET",
+            }
+            if role == "public":
+                state.public_requests.append(record)
+                if path == "/work.html":
+                    self._send(200, state.html, content_type="text/html; charset=utf-8", origin=origin)
+                    return
+                if path == PUBLIC_PATH:
+                    body = state.public_body if state.public_body is not None else b"{}"
+                    self._send(
+                        state.public_status,
+                        body,
+                        content_type="application/json",
+                        origin=origin,
+                    )
+                    return
+                self._send(404, b"missing", content_type="text/plain", origin=origin)
+                return
+
+            # private role
+            state.private_requests.append(record)
+            if state.private_delay_s:
+                time.sleep(state.private_delay_s)
+            if path != "/v1/projection":
+                self._send(404, b"missing", content_type="text/plain", origin=origin)
+                return
+            body = state.private_body if state.private_body is not None else b"{}"
+            self._send(
+                state.private_status,
+                body,
+                content_type="application/json",
+                origin=origin,
+            )
+
+    return Handler
+
+
+def _port_free(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def _start_server(
+    host: str,
+    port: int,
+    handler: type[BaseHTTPRequestHandler],
+) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer((host, port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def _run_puppeteer(script: str, *, node_modules: Path, timeout: int = 60) -> dict[str, Any]:
+    env = {
+        **dict(**{k: v for k, v in __import__("os").environ.items()}),
+        "NODE_PATH": str(node_modules),
+    }
+    # Avoid color warnings noise
+    env.pop("NO_COLOR", None)
+    env.pop("FORCE_COLOR", None)
+    # CommonJS + async: wrap user script body so top-level await is legal.
+    wrapped = (
+        "(async () => {\n"
+        + script
+        + "\n})().catch((err) => { console.error(err && err.stack ? err.stack : err); process.exit(1); });\n"
+    )
+    proc = subprocess.run(
+        ["node", "-e", wrapped],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+        cwd=str(ROOT),
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"puppeteer script failed rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+    # Last JSON line is the result; never print fixture payloads from Python.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert lines, f"no JSON result from puppeteer\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    return json.loads(lines[-1])
+
+
+def _browser_scenario(
+    *,
+    public_doc: dict[str, Any] | None,
+    private_doc: dict[str, Any] | None,
+    public_status: int = 200,
+    private_status: int = 200,
+    private_delay_ms: int = 0,
+    private_raw: bytes | None = None,
+    public_raw: bytes | None = None,
+    filter_query: str = "",
+    actions: list[dict[str, Any]] | None = None,
+    viewport: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Serve work.html on an ephemeral public origin and intercept both GETs."""
+    nm = _require_puppeteer()
+    state = _FixtureState()
+    if public_raw is not None:
+        state.public_body = public_raw
+    elif public_doc is not None:
+        state.public_body = json.dumps(public_doc, separators=(",", ":")).encode("utf-8")
+    else:
+        state.public_status = public_status if public_status != 200 else 503
+        state.public_body = b'{"detail":"down"}'
+    if public_status != 200:
+        state.public_status = public_status
+
+    if private_raw is not None:
+        state.private_body = private_raw
+    elif private_doc is not None:
+        state.private_body = json.dumps(private_doc, separators=(",", ":")).encode("utf-8")
+    else:
+        state.private_status = private_status if private_status != 200 else 503
+        state.private_body = b"nope"
+    if private_status != 200:
+        state.private_status = private_status
+    state.private_delay_s = private_delay_ms / 1000.0
+
+    # Ephemeral public server for HTML + public projection (same origin).
+    public_handler = _make_handler(
+        state, role="public", allowed_origins={"http://127.0.0.1", "http://localhost"}
+    )
+    public_server = ThreadingHTTPServer(("127.0.0.1", 0), public_handler)
+    public_port = public_server.server_address[1]
+    thread = threading.Thread(target=public_server.serve_forever, daemon=True)
+    thread.start()
+
+    # Ephemeral private server is NOT used for the fixed URL — browser uses 8766.
+    # Intercept both URLs inside Chromium so proofs do not need free fixed ports.
+    public_json = state.public_body.decode("utf-8") if state.public_body else "{}"
+    private_json = state.private_body.decode("utf-8") if state.private_body else "{}"
+    actions_json = json.dumps(actions or [])
+    viewport = viewport or {"width": 1280, "height": 800}
+    origin = f"http://127.0.0.1:{public_port}"
+    page_url = f"{origin}/work.html{filter_query}"
+
+    script = f"""
+const puppeteer = require('puppeteer');
+const PUBLIC_STATUS = {state.public_status};
+const PRIVATE_STATUS = {state.private_status};
+const PRIVATE_DELAY_MS = {private_delay_ms};
+const PUBLIC_JSON = {json.dumps(public_json)};
+const PRIVATE_JSON = {json.dumps(private_json)};
+const PAGE_URL = {json.dumps(page_url)};
+const ACTIONS = {actions_json};
+const VIEWPORT = {json.dumps(viewport)};
+const PRIVATE_URL = {json.dumps(PRIVATE_URL)};
+const CANARY = {json.dumps(CANARY)};
+
+const observed = {{ public: [], private: [], options: 0, consoleErrors: [], pageErrors: [] }};
+
+const browser = await puppeteer.launch({{
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+}});
+try {{
+  const page = await browser.newPage();
+  await page.setViewport(VIEWPORT);
+  page.on('console', (msg) => {{
+    if (msg.type() === 'error') observed.consoleErrors.push(msg.text());
+  }});
+  page.on('pageerror', (err) => observed.pageErrors.push(String(err && err.message ? err.message : err)));
+
+  await page.setRequestInterception(true);
+  // Fulfill every request exactly once. networkidle0 hangs on some non-2xx
+  // cross-origin fulfills under interception; settle via DOM instead.
+  page.on('request', (req) => {{
+    const finish = async () => {{
+      try {{
+        const url = req.url();
+        const method = req.method();
+        if (method === 'OPTIONS') observed.options += 1;
+        if (url.includes('/api/work/v1/projection')) {{
+          observed.public.push({{
+            url,
+            method,
+            headers: req.headers(),
+          }});
+          await req.respond({{
+            status: PUBLIC_STATUS,
+            contentType: 'application/json',
+            body: PUBLIC_JSON,
+            headers: {{ 'Cache-Control': 'no-store' }},
+          }});
+          return;
+        }}
+        if (url === PRIVATE_URL || url.startsWith(PRIVATE_URL + '?')) {{
+          observed.private.push({{
+            url,
+            method,
+            headers: req.headers(),
+          }});
+          if (PRIVATE_DELAY_MS > 0) {{
+            await new Promise((r) => setTimeout(r, PRIVATE_DELAY_MS));
+          }}
+          const originHeader = 'http://127.0.0.1:' + (new URL(PAGE_URL)).port;
+          await req.respond({{
+            status: PRIVATE_STATUS,
+            contentType: 'application/json',
+            body: PRIVATE_JSON,
+            headers: {{
+              'Cache-Control': 'no-store',
+              'Access-Control-Allow-Origin': originHeader,
+              'Vary': 'Origin',
+            }},
+          }});
+          return;
+        }}
+        await req.continue();
+      }} catch (err) {{
+        try {{
+          await req.abort('failed');
+        }} catch (_e) {{
+          // already handled
+        }}
+      }}
+    }};
+    finish();
+  }});
+
+  // domcontentloaded: dual GETs settle after navigation; do not use networkidle0
+  // (non-2xx intercept fulfills can leave the lifecycle watcher pending).
+  await page.goto(PAGE_URL, {{ waitUntil: 'domcontentloaded', timeout: 30000 }});
+  await page.waitForSelector('#source-private-meta', {{ timeout: 15000 }});
+  // Wait until dual-source settlement replaces the loading placeholders.
+  const settleBudget = Math.max(10000, PRIVATE_DELAY_MS + 3000);
+  await page.waitForFunction(() => {{
+    const priv = (document.getElementById('source-private-meta')?.textContent || '').trim();
+    const pub = (document.getElementById('source-public-meta')?.textContent || '').trim();
+    const err = document.getElementById('error-banner');
+    const errText = (err && err.textContent) || '';
+    const errHidden = !err || err.classList.contains('hidden');
+    const loadingPriv = !priv || priv === 'Checking capability…';
+    const loadingPub = !pub || pub === 'Loading…';
+    if (!errHidden && errText.includes('Work projection unavailable')) return true;
+    if (!loadingPriv && !loadingPub) return true;
+    // Private-only path sets public meta to status=unavailable|schema_mismatch.
+    if (!loadingPriv && pub.startsWith('status=')) return true;
+    return false;
+  }}, {{ timeout: settleBudget }});
+  await new Promise((r) => setTimeout(r, 150));
+
+  for (const action of ACTIONS) {{
+    if (action.type === 'select') {{
+      await page.select(action.selector, action.value);
+    }} else if (action.type === 'click') {{
+      await page.click(action.selector);
+    }} else if (action.type === 'key') {{
+      await page.keyboard.press(action.key);
+    }} else if (action.type === 'wait') {{
+      await new Promise((r) => setTimeout(r, action.ms || 200));
+    }}
+  }}
+  await new Promise((r) => setTimeout(r, 200));
+
+  const snapshot = await page.evaluate((canary) => {{
+    const rows = Array.from(document.querySelectorAll('.work-row')).map((row) => ({{
+      id: row.getAttribute('data-id'),
+      text: row.textContent || '',
+    }}));
+    const overflow = document.documentElement.scrollWidth > document.documentElement.clientWidth + 1
+      || document.body.scrollWidth > document.body.clientWidth + 1;
+    return {{
+      publicMeta: document.getElementById('source-public-meta')?.textContent || '',
+      privateMeta: document.getElementById('source-private-meta')?.textContent || '',
+      error: document.getElementById('error-banner')?.textContent || '',
+      errorHidden: document.getElementById('error-banner')?.classList.contains('hidden') ?? true,
+      listText: document.getElementById('attention-list')?.textContent || '',
+      rowCount: rows.length,
+      rowIds: rows.map((r) => r.id),
+      rowTexts: rows.map((r) => r.text),
+      href: location.href,
+      search: location.search,
+      hash: location.hash,
+      localStorageKeys: Object.keys(localStorage || {{}}),
+      sessionStorageKeys: Object.keys(sessionStorage || {{}}),
+      cookie: document.cookie || '',
+      bodyText: document.body.innerText || '',
+      hasCanary: (document.documentElement.outerHTML || '').includes(canary),
+      overflow,
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }};
+  }}, CANARY);
+
+  console.log(JSON.stringify({{
+    ok: true,
+    observed: {{
+      publicCount: observed.public.length,
+      privateCount: observed.private.length,
+      options: observed.options,
+      public: observed.public,
+      private: observed.private,
+      consoleErrors: observed.consoleErrors,
+      pageErrors: observed.pageErrors,
+    }},
+    snapshot,
+  }}));
+}} finally {{
+  await browser.close();
+}}
+"""
+    try:
+        return _run_puppeteer(script, node_modules=nm, timeout=90)
+    finally:
+        public_server.shutdown()
+        public_server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Static / unit contracts
+# ---------------------------------------------------------------------------
+
+
+def test_static_private_url_is_exact_fixed_constant():
+    html = WORK_HTML.read_text(encoding="utf-8")
+    assert f"'{PRIVATE_URL}'" in html
+    assert html.count("127.0.0.1:8766") == html.count(PRIVATE_URL)
+    assert "localStorage" not in html
+    assert "sessionStorage" not in html
+    assert "document.cookie" not in html
+    assert "Promise.allSettled" in html
+    assert "admitPrivateDocument" in html
+    assert "identity_collision" in html
+    assert SCHEMA_DIGEST in html
+    assert PUBLIC_COMMIT in html
+
+
+def test_private_fixture_shape_is_source_blind():
+    doc = _private_ok()
+    blob = json.dumps(doc)
+    assert "learn-ukrainian-infra" not in blob
+    assert "/Users/" not in blob
+    assert CANARY not in blob
+    assert doc["capabilities"]["private_source"]["endpoint"] == PRIVATE_URL
+    assert doc["capabilities"]["private_source"]["schema_digest_sha256"] == SCHEMA_DIGEST
+
+
+# ---------------------------------------------------------------------------
+# Headless browser behavioral proofs (request interception)
+# ---------------------------------------------------------------------------
+
+
+def test_browser_dual_success_merges_exactly_once():
+    public = _public_min()
+    private = _private_ok()
+    result = _browser_scenario(public_doc=public, private_doc=private)
+    snap = result["snapshot"]
+    obs = result["observed"]
+    assert obs["publicCount"] >= 1
+    assert obs["privateCount"] >= 1
+    assert obs["options"] == 0
+    priv_req = obs["private"][0]
+    assert priv_req["url"] == PRIVATE_URL
+    assert priv_req["method"] == "GET"
+    assert "accept" in {k.lower() for k in priv_req["headers"]}
+    # No query string on private
+    assert "?" not in priv_req["url"]
+    assert snap["rowCount"] == 2
+    assert len(set(snap["rowIds"])) == 2
+    assert any("Public attention item" in t for t in snap["rowTexts"])
+    assert any("private-issue-7" in t for t in snap["rowTexts"])
+    assert "status=ok" in snap["privateMeta"]
+    assert "issues=2" in snap["publicMeta"] or "issues=2" in snap["bodyText"]
+    assert snap["errorHidden"] is True
+    assert CANARY not in snap["bodyText"]
+    assert not snap["hasCanary"]
+    assert not obs["pageErrors"]
+    assert not any(CANARY in e for e in obs["consoleErrors"])
+
+
+def test_browser_private_unreachable_leaves_public_usable():
+    result = _browser_scenario(public_doc=_public_min(), private_doc=None, private_status=503)
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "unavailable · unreachable" in snap["privateMeta"]
+    assert snap["errorHidden"] is True
+
+
+def test_browser_private_timeout_leaves_public_usable():
+    # AbortController budget is 5s; delay beyond that.
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        private_delay_ms=5500,
+    )
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "unavailable · timeout" in snap["privateMeta"]
+    assert snap["errorHidden"] is True
+
+
+def test_browser_private_schema_mismatch_and_canary_rejected():
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_with_extra_canary(),
+    )
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "unavailable · schema_mismatch" in snap["privateMeta"]
+    assert not snap["hasCanary"]
+    assert CANARY not in snap["bodyText"]
+    assert CANARY not in snap["error"]
+    assert CANARY not in snap["href"]
+    assert CANARY not in snap["search"]
+    assert CANARY not in snap["listText"]
+
+
+def test_browser_identity_collision_keeps_public():
+    private = _private_ok()
+    public = _public_with_private_id_collision(private)
+    result = _browser_scenario(public_doc=public, private_doc=private)
+    snap = result["snapshot"]
+    # Public remains usable; private rejected for collision.
+    assert "unavailable · identity_collision" in snap["privateMeta"]
+    assert snap["errorHidden"] is True
+    # Public rows still render (may include the colliding id from public side once).
+    assert snap["rowCount"] >= 1
+    assert "Public attention item" in snap["listText"]
+
+
+def test_browser_public_failure_private_success():
+    result = _browser_scenario(
+        public_doc=None,
+        public_status=503,
+        private_doc=_private_ok(),
+    )
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "private-issue-7" in snap["listText"]
+    assert "status=unavailable" in snap["publicMeta"]
+    assert "status=ok" in snap["privateMeta"]
+    assert snap["errorHidden"] is True
+
+
+def test_browser_public_schema_mismatch_private_success():
+    result = _browser_scenario(
+        public_doc={"not": "valid"},
+        private_doc=_private_ok(),
+    )
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "private-issue-7" in snap["listText"]
+    assert "status=schema_mismatch" in snap["publicMeta"]
+
+
+def test_browser_both_failures_typed_banner():
+    result = _browser_scenario(
+        public_doc=None,
+        public_status=503,
+        private_doc=None,
+        private_status=503,
+    )
+    snap = result["snapshot"]
+    assert snap["errorHidden"] is False
+    assert (
+        snap["error"]
+        == "Work projection unavailable · public=unreachable · private=unreachable"
+    )
+    assert snap["listText"].strip() == "No source projection is available. Retry refresh."
+    assert "HTTP" not in snap["error"]
+    assert "TypeError" not in snap["error"]
+    assert "fetch" not in snap["error"].lower()
+
+
+def test_browser_filters_apply_locally_and_never_hit_private_query():
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        actions=[
+            {"type": "select", "selector": "#filter-health", "value": "AT_RISK"},
+            {"type": "click", "selector": "#btn-apply"},
+            {"type": "wait", "ms": 200},
+        ],
+    )
+    snap = result["snapshot"]
+    obs = result["observed"]
+    # After apply (local only), only public AT_RISK remains.
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "private-issue-7" not in snap["listText"]
+    for req in obs["private"]:
+        assert req["url"] == PRIVATE_URL
+        assert "?" not in req["url"]
+    # Shareable URL may keep health
+    assert "health=AT_RISK" in snap["search"]
+
+
+def test_browser_private_repo_filter_not_shareable_in_url():
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        actions=[
+            {
+                "type": "select",
+                "selector": "#filter-repo",
+                "value": SYNTH_PRIVATE_REPO,
+            },
+            {"type": "click", "selector": "#btn-apply"},
+            {"type": "wait", "ms": 200},
+        ],
+    )
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "private-issue-7" in snap["listText"]
+    assert SYNTH_PRIVATE_REPO not in snap["search"]
+    assert "private-local-adapter" not in snap["search"]
+    assert snap["hash"] == ""
+    assert snap["localStorageKeys"] == []
+    assert snap["sessionStorageKeys"] == []
+    assert snap["cookie"] == ""
+
+
+def test_browser_dense_order_and_no_duplicate_ids():
+    public = _public_min()
+    # Public ON_TRACK + private UNKNOWN + public OFF_TRACK-like via health change
+    public["items"][0]["health"] = "ON_TRACK"
+    public["attention"][0]["health"] = "ON_TRACK"
+    private = _private_ok(remote_id="3", rank=0)
+    result = _browser_scenario(public_doc=public, private_doc=private)
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 2
+    assert len(set(snap["rowIds"])) == 2
+    # UNKNOWN before ON_TRACK
+    assert snap["rowIds"][0].startswith("wp1:private-local-adapter:")
+    assert snap["rowIds"][1].startswith("wp1:public-monitor:")
+
+
+def test_browser_mobile_viewport_no_horizontal_overflow_and_keyboard():
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        viewport={"width": 390, "height": 844},
+        actions=[
+            {"type": "key", "key": "ArrowDown"},
+            {"type": "wait", "ms": 100},
+        ],
+    )
+    snap = result["snapshot"]
+    obs = result["observed"]
+    assert snap["overflow"] is False
+    assert snap["scrollWidth"] <= snap["clientWidth"] + 1
+    assert not obs["pageErrors"]
+    # Uncaught console errors only (ignore optional 3rd-party noise if empty)
+    assert snap["rowCount"] == 2
+
+
+def test_browser_public_only_when_adapter_absent():
+    result = _browser_scenario(public_doc=_public_min(), private_doc=None, private_status=404)
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "unavailable · unreachable" in snap["privateMeta"]
+    assert "status=ok" in snap["publicMeta"]
+
+
+def test_browser_refresh_uses_fresh_on_public_only():
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        actions=[{"type": "click", "selector": "#btn-refresh"}, {"type": "wait", "ms": 400}],
+    )
+    obs = result["observed"]
+    assert obs["publicCount"] >= 2
+    assert obs["privateCount"] >= 2
+    public_urls = [r["url"] for r in obs["public"]]
+    assert any("fresh=true" in u for u in public_urls)
+    for req in obs["private"]:
+        assert req["url"] == PRIVATE_URL
+
+
+# ---------------------------------------------------------------------------
+# Real fixed-port CORS smoke (no payload printing)
+# ---------------------------------------------------------------------------
+
+
+def _cors_handler_factory(hits: dict[str, Any], allowed: set[str], body: bytes):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def do_OPTIONS(self) -> None:
+            hits["options"] = hits.get("options", 0) + 1
+            self.send_response(204)
+            self.end_headers()
+
+        def do_GET(self) -> None:
+            origin = self.headers.get("Origin")
+            path = self.path.split("?", 1)[0]
+            hits.setdefault("gets", []).append(
+                {
+                    "path": self.path,
+                    "path_only": path,
+                    "method": "GET",
+                    "accept": self.headers.get("Accept"),
+                    "origin": origin,
+                }
+            )
+            if path != "/v1/projection":
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            if origin in allowed:
+                self.send_header("Access-Control-Allow-Origin", origin)
+                self.send_header("Vary", "Origin")
+            # No Access-Control-Allow-Credentials
+            self.end_headers()
+            self.wfile.write(body)
+
+    return Handler
+
+
+def test_real_fixed_port_cors_http_and_browser_smoke():
+    """Live CORS on fixed ports 8765/8766 with real browser GET (no preflight)."""
+    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
+        "127.0.0.1", FIXED_PRIVATE_PORT
+    ):
+        pytest.skip(
+            "fixed ports 8765/8766 busy; interception proofs already cover behavior"
+        )
+
+    nm = _require_puppeteer()
+    private_hits: dict[str, Any] = {"options": 0, "gets": []}
+    public_hits: dict[str, Any] = {"options": 0, "gets": []}
+    private_body = json.dumps(_private_ok(), separators=(",", ":")).encode("utf-8")
+    public_body = json.dumps(_public_min(), separators=(",", ":")).encode("utf-8")
+    html = WORK_HTML.read_bytes()
+
+    class PublicHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def do_OPTIONS(self) -> None:
+            public_hits["options"] = public_hits.get("options", 0) + 1
+            self.send_response(204)
+            self.end_headers()
+
+        def do_GET(self) -> None:
+            path = self.path.split("?", 1)[0]
+            public_hits.setdefault("gets", []).append(
+                {"path": self.path, "path_only": path, "accept": self.headers.get("Accept")}
+            )
+            if path == "/work.html":
+                body = html
+                ctype = "text/html; charset=utf-8"
+            elif path == PUBLIC_PATH:
+                body = public_body
+                ctype = "application/json"
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    private_handler = _cors_handler_factory(
+        private_hits,
+        allowed={"http://127.0.0.1:8765", "http://localhost:8765"},
+        body=private_body,
+    )
+    public_server = _start_server("127.0.0.1", FIXED_PUBLIC_PORT, PublicHandler)
+    private_server = _start_server("127.0.0.1", FIXED_PRIVATE_PORT, private_handler)
+    try:
+        # Pure HTTP CORS probe (no browser) — asserts headers + request shape.
+        req = Request(
+            PRIVATE_URL,
+            headers={
+                "Accept": "application/json",
+                "Origin": "http://127.0.0.1:8765",
+            },
+            method="GET",
+        )
+        with urlopen(req, timeout=5) as resp:
+            assert resp.status == 200
+            assert resp.headers.get("Access-Control-Allow-Origin") == "http://127.0.0.1:8765"
+            assert resp.headers.get("Vary") == "Origin"
+            assert resp.headers.get("Access-Control-Allow-Credentials") in (None, "")
+            # Drain body without printing
+            _ = resp.read()
+
+        assert private_hits["options"] == 0
+        assert private_hits["gets"], "private fixture received no GET"
+        got = private_hits["gets"][-1]
+        assert got["path_only"] == "/v1/projection"
+        assert got["path"] == "/v1/projection"  # exact no-query path
+        assert got["accept"] == "application/json"
+        assert got["origin"] == "http://127.0.0.1:8765"
+
+        # Browser smoke from exact Monitor origin.
+        script = """
+const puppeteer = require('puppeteer');
+const browser = await puppeteer.launch({
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+});
+try {
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e.message || e)));
+  await page.goto('http://127.0.0.1:8765/work.html', {
+    waitUntil: 'domcontentloaded',
+    timeout: 30000,
+  });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('source-private-meta');
+    return el && (el.textContent || '').includes('status=');
+  }, { timeout: 15000 });
+  const snap = await page.evaluate(() => ({
+    privateMeta: document.getElementById('source-private-meta')?.textContent || '',
+    rowCount: document.querySelectorAll('.work-row').length,
+    errorHidden: document.getElementById('error-banner')?.classList.contains('hidden') ?? true,
+  }));
+  console.log(JSON.stringify({ ok: true, snap, errors, privateGets: true }));
+} finally {
+  await browser.close();
+}
+"""
+        result = _run_puppeteer(script, node_modules=nm, timeout=60)
+        assert result["snap"]["rowCount"] == 2
+        assert "status=ok" in result["snap"]["privateMeta"]
+        assert result["snap"]["errorHidden"] is True
+        assert not result["errors"]
+        assert private_hits["options"] == 0
+        # At least the HTTP probe + browser GET
+        assert len(private_hits["gets"]) >= 2
+        for entry in private_hits["gets"]:
+            assert entry["path"] == "/v1/projection"
+            assert entry["accept"] == "application/json"
+    finally:
+        public_server.shutdown()
+        public_server.server_close()
+        private_server.shutdown()
+        private_server.server_close()
+
+
+def test_real_fixed_port_cors_localhost_origin_smoke():
+    """Second smoke: page addressed as http://localhost:8765 admits that origin."""
+    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
+        "127.0.0.1", FIXED_PRIVATE_PORT
+    ):
+        pytest.skip(
+            "fixed ports 8765/8766 busy; interception proofs already cover behavior"
+        )
+
+    private_hits: dict[str, Any] = {"options": 0, "gets": []}
+    private_body = json.dumps(_private_ok(), separators=(",", ":")).encode("utf-8")
+
+    class PublicHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def do_GET(self) -> None:
+            path = self.path.split("?", 1)[0]
+            if path == "/work.html":
+                body = WORK_HTML.read_bytes()
+                ctype = "text/html; charset=utf-8"
+            elif path == PUBLIC_PATH:
+                body = json.dumps(_public_min(), separators=(",", ":")).encode("utf-8")
+                ctype = "application/json"
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    private_handler = _cors_handler_factory(
+        private_hits,
+        allowed={"http://127.0.0.1:8765", "http://localhost:8765"},
+        body=private_body,
+    )
+    public_server = _start_server("127.0.0.1", FIXED_PUBLIC_PORT, PublicHandler)
+    private_server = _start_server("127.0.0.1", FIXED_PRIVATE_PORT, private_handler)
+    nm = _require_puppeteer()
+    try:
+        req = Request(
+            PRIVATE_URL,
+            headers={
+                "Accept": "application/json",
+                "Origin": "http://localhost:8765",
+            },
+            method="GET",
+        )
+        with urlopen(req, timeout=5) as resp:
+            assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:8765"
+            assert resp.headers.get("Vary") == "Origin"
+            _ = resp.read()
+
+        script = """
+const puppeteer = require('puppeteer');
+const browser = await puppeteer.launch({
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+});
+try {
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8765/work.html', {
+    waitUntil: 'domcontentloaded',
+    timeout: 30000,
+  });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('source-private-meta');
+    return el && (el.textContent || '').includes('status=');
+  }, { timeout: 15000 });
+  const snap = await page.evaluate(() => ({
+    privateMeta: document.getElementById('source-private-meta')?.textContent || '',
+    rowCount: document.querySelectorAll('.work-row').length,
+  }));
+  console.log(JSON.stringify({ ok: true, snap }));
+} finally {
+  await browser.close();
+}
+"""
+        result = _run_puppeteer(script, node_modules=nm, timeout=60)
+        assert result["snap"]["rowCount"] == 2
+        assert "status=ok" in result["snap"]["privateMeta"]
+        assert private_hits["options"] == 0
+        assert any(g.get("origin") == "http://localhost:8765" for g in private_hits["gets"])
+    finally:
+        public_server.shutdown()
+        public_server.server_close()
+        private_server.shutdown()
+        private_server.server_close()

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -7,10 +7,12 @@ real private repository or live adapter process.
 from __future__ import annotations
 
 import json
+import os
 import socket
 import subprocess
 import threading
 import time
+from collections.abc import Callable, Mapping, Sequence
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -30,6 +32,13 @@ SYNTH_PRIVATE_REPO = "fixture-owner/fixture-repo"
 CANARY = "FX07_CANARY_SHOULD_NEVER_APPEAR_IN_DOM_OR_URL"
 FIXED_PUBLIC_PORT = 8765
 FIXED_PRIVATE_PORT = 8766
+# Linux system Chrome/Chromium candidates for CI runners without Puppeteer's cache.
+LINUX_CHROME_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+)
 
 
 def _node_modules() -> Path | None:
@@ -66,6 +75,56 @@ def _require_puppeteer() -> Path:
     if nm is None:
         pytest.skip("puppeteer not available for headless browser proofs")
     return nm
+
+
+def _path_is_executable(path: str) -> bool:
+    candidate = Path(path)
+    return candidate.is_file() and os.access(candidate, os.X_OK)
+
+
+def _resolve_chrome_executable(
+    *,
+    env: Mapping[str, str] | None = None,
+    candidates: Sequence[str] | None = None,
+    is_executable: Callable[[str], bool] | None = None,
+) -> str | None:
+    """Pick a Chrome/Chromium binary for Puppeteer, or None for managed browser.
+
+    Order:
+    1. ``PUPPETEER_EXECUTABLE_PATH`` when it names an existing executable
+    2. First existing Linux system candidate
+    3. None — omit ``executablePath`` so local Puppeteer uses its cache
+    """
+    check = is_executable or _path_is_executable
+    environ = env if env is not None else os.environ
+    env_path = (environ.get("PUPPETEER_EXECUTABLE_PATH") or "").strip()
+    if env_path and check(env_path):
+        return env_path
+    for candidate in candidates if candidates is not None else LINUX_CHROME_CANDIDATES:
+        if check(candidate):
+            return candidate
+    return None
+
+
+def _puppeteer_launch_options(
+    *,
+    env: Mapping[str, str] | None = None,
+    candidates: Sequence[str] | None = None,
+    is_executable: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
+    """Deterministic launch options shared by every Puppeteer script here."""
+    options: dict[str, Any] = {
+        "headless": "new",
+        "args": ["--no-sandbox", "--disable-setuid-sandbox"],
+    }
+    executable = _resolve_chrome_executable(
+        env=env,
+        candidates=candidates,
+        is_executable=is_executable,
+    )
+    if executable is not None:
+        options["executablePath"] = executable
+    return options
 
 
 def _public_min() -> dict[str, Any]:
@@ -438,7 +497,7 @@ def _start_server(
 
 def _run_puppeteer(script: str, *, node_modules: Path, timeout: int = 60) -> dict[str, Any]:
     env = {
-        **dict(**{k: v for k, v in __import__("os").environ.items()}),
+        **dict(**{k: v for k, v in os.environ.items()}),
         "NODE_PATH": str(node_modules),
     }
     # Avoid color warnings noise
@@ -526,6 +585,7 @@ def _browser_scenario(
     hang_json_js = "true" if private_hang_json else "false"
     # Hang-json proofs still need the 5s abort budget + small settle margin.
     settle_floor_ms = 9000 if private_hang_json else 10000
+    launch_options_json = json.dumps(_puppeteer_launch_options())
 
     script = f"""
 const puppeteer = require('puppeteer');
@@ -540,13 +600,11 @@ const ACTIONS = {actions_json};
 const VIEWPORT = {json.dumps(viewport)};
 const PRIVATE_URL = {json.dumps(PRIVATE_URL)};
 const CANARY = {json.dumps(CANARY)};
+const LAUNCH_OPTIONS = {launch_options_json};
 
 const observed = {{ public: [], private: [], options: 0, consoleErrors: [], pageErrors: [] }};
 
-const browser = await puppeteer.launch({{
-  headless: 'new',
-  args: ['--no-sandbox', '--disable-setuid-sandbox'],
-}});
+const browser = await puppeteer.launch(LAUNCH_OPTIONS);
 try {{
   const page = await browser.newPage();
   await page.setViewport(VIEWPORT);
@@ -775,6 +833,60 @@ def test_private_fixture_shape_is_source_blind():
     assert CANARY not in blob
     assert doc["capabilities"]["private_source"]["endpoint"] == PRIVATE_URL
     assert doc["capabilities"]["private_source"]["schema_digest_sha256"] == SCHEMA_DIGEST
+
+
+def test_puppeteer_launch_options_honors_env_executable():
+    opts = _puppeteer_launch_options(
+        env={"PUPPETEER_EXECUTABLE_PATH": "/custom/chrome"},
+        candidates=("/usr/bin/google-chrome",),
+        is_executable=lambda path: path == "/custom/chrome",
+    )
+    assert opts["executablePath"] == "/custom/chrome"
+    assert opts["headless"] == "new"
+    assert opts["args"] == ["--no-sandbox", "--disable-setuid-sandbox"]
+
+
+def test_puppeteer_launch_options_ignores_missing_env_and_picks_first_candidate():
+    opts = _puppeteer_launch_options(
+        env={"PUPPETEER_EXECUTABLE_PATH": "/missing/chrome"},
+        candidates=(
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+        ),
+        is_executable=lambda path: path
+        in {"/usr/bin/chromium", "/usr/bin/chromium-browser"},
+    )
+    assert opts["executablePath"] == "/usr/bin/chromium"
+
+
+def test_puppeteer_launch_options_omits_path_when_none_available():
+    opts = _puppeteer_launch_options(
+        env={},
+        candidates=("/nope/a", "/nope/b"),
+        is_executable=lambda _path: False,
+    )
+    assert "executablePath" not in opts
+    assert opts["headless"] == "new"
+    assert "--no-sandbox" in opts["args"]
+    assert "--disable-setuid-sandbox" in opts["args"]
+
+
+def test_resolve_chrome_executable_order_matches_linux_candidates():
+    seen: list[str] = []
+
+    def probe(path: str) -> bool:
+        seen.append(path)
+        return path == "/usr/bin/chromium-browser"
+
+    resolved = _resolve_chrome_executable(
+        env={},
+        candidates=LINUX_CHROME_CANDIDATES,
+        is_executable=probe,
+    )
+    assert resolved == "/usr/bin/chromium-browser"
+    assert seen == list(LINUX_CHROME_CANDIDATES)
 
 
 # ---------------------------------------------------------------------------
@@ -1170,33 +1282,32 @@ def test_real_fixed_port_cors_http_and_browser_smoke():
         assert got["origin"] == "http://127.0.0.1:8765"
 
         # Browser smoke from exact Monitor origin.
-        script = """
+        launch_options_json = json.dumps(_puppeteer_launch_options())
+        script = f"""
 const puppeteer = require('puppeteer');
-const browser = await puppeteer.launch({
-  headless: 'new',
-  args: ['--no-sandbox', '--disable-setuid-sandbox'],
-});
-try {
+const LAUNCH_OPTIONS = {launch_options_json};
+const browser = await puppeteer.launch(LAUNCH_OPTIONS);
+try {{
   const page = await browser.newPage();
   const errors = [];
   page.on('pageerror', (e) => errors.push(String(e.message || e)));
-  await page.goto('http://127.0.0.1:8765/work.html', {
+  await page.goto('http://127.0.0.1:8765/work.html', {{
     waitUntil: 'domcontentloaded',
     timeout: 30000,
-  });
-  await page.waitForFunction(() => {
+  }});
+  await page.waitForFunction(() => {{
     const el = document.getElementById('source-private-meta');
     return el && (el.textContent || '').includes('status=');
-  }, { timeout: 15000 });
-  const snap = await page.evaluate(() => ({
+  }}, {{ timeout: 15000 }});
+  const snap = await page.evaluate(() => ({{
     privateMeta: document.getElementById('source-private-meta')?.textContent || '',
     rowCount: document.querySelectorAll('.work-row').length,
     errorHidden: document.getElementById('error-banner')?.classList.contains('hidden') ?? true,
-  }));
-  console.log(JSON.stringify({ ok: true, snap, errors, privateGets: true }));
-} finally {
+  }}));
+  console.log(JSON.stringify({{ ok: true, snap, errors, privateGets: true }}));
+}} finally {{
   await browser.close();
-}
+}}
 """
         result = _run_puppeteer(script, node_modules=nm, timeout=60)
         assert result["snap"]["rowCount"] == 2
@@ -1274,30 +1385,29 @@ def test_real_fixed_port_cors_localhost_origin_smoke():
             assert resp.headers.get("Vary") == "Origin"
             _ = resp.read()
 
-        script = """
+        launch_options_json = json.dumps(_puppeteer_launch_options())
+        script = f"""
 const puppeteer = require('puppeteer');
-const browser = await puppeteer.launch({
-  headless: 'new',
-  args: ['--no-sandbox', '--disable-setuid-sandbox'],
-});
-try {
+const LAUNCH_OPTIONS = {launch_options_json};
+const browser = await puppeteer.launch(LAUNCH_OPTIONS);
+try {{
   const page = await browser.newPage();
-  await page.goto('http://localhost:8765/work.html', {
+  await page.goto('http://localhost:8765/work.html', {{
     waitUntil: 'domcontentloaded',
     timeout: 30000,
-  });
-  await page.waitForFunction(() => {
+  }});
+  await page.waitForFunction(() => {{
     const el = document.getElementById('source-private-meta');
     return el && (el.textContent || '').includes('status=');
-  }, { timeout: 15000 });
-  const snap = await page.evaluate(() => ({
+  }}, {{ timeout: 15000 }});
+  const snap = await page.evaluate(() => ({{
     privateMeta: document.getElementById('source-private-meta')?.textContent || '',
     rowCount: document.querySelectorAll('.work-row').length,
-  }));
-  console.log(JSON.stringify({ ok: true, snap }));
-} finally {
+  }}));
+  console.log(JSON.stringify({{ ok: true, snap }}));
+}} finally {{
   await browser.close();
-}
+}}
 """
         result = _run_puppeteer(script, node_modules=nm, timeout=60)
         assert result["snap"]["rowCount"] == 2

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -475,6 +475,7 @@ def _browser_scenario(
     public_status: int = 200,
     private_status: int = 200,
     private_delay_ms: int = 0,
+    private_hang_json: bool = False,
     private_raw: bytes | None = None,
     public_raw: bytes | None = None,
     filter_query: str = "",
@@ -522,12 +523,16 @@ def _browser_scenario(
     viewport = viewport or {"width": 1280, "height": 800}
     origin = f"http://127.0.0.1:{public_port}"
     page_url = f"{origin}/work.html{filter_query}"
+    hang_json_js = "true" if private_hang_json else "false"
+    # Hang-json proofs still need the 5s abort budget + small settle margin.
+    settle_floor_ms = 9000 if private_hang_json else 10000
 
     script = f"""
 const puppeteer = require('puppeteer');
 const PUBLIC_STATUS = {state.public_status};
 const PRIVATE_STATUS = {state.private_status};
 const PRIVATE_DELAY_MS = {private_delay_ms};
+const PRIVATE_HANG_JSON = {hang_json_js};
 const PUBLIC_JSON = {json.dumps(public_json)};
 const PRIVATE_JSON = {json.dumps(private_json)};
 const PAGE_URL = {json.dumps(page_url)};
@@ -549,6 +554,48 @@ try {{
     if (msg.type() === 'error') observed.consoleErrors.push(msg.text());
   }});
   page.on('pageerror', (err) => observed.pageErrors.push(String(err && err.message ? err.message : err)));
+
+  // Source-blind body-stall mock: fulfilled 200 Response whose json() never
+  // settles unless AbortSignal fires. Proves the private 5s budget covers body
+  // parse, not only response headers. No real private service is contacted.
+  if (PRIVATE_HANG_JSON) {{
+    await page.evaluateOnNewDocument((privateUrl) => {{
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = function(input, init) {{
+        const url = typeof input === 'string' ? input : (input && input.url) || '';
+        if (url === privateUrl || url.startsWith(privateUrl + '?')) {{
+          const signal = init && init.signal;
+          const body = new ReadableStream({{
+            start(controller) {{
+              const fail = () => {{
+                try {{
+                  controller.error(new DOMException('The user aborted a request.', 'AbortError'));
+                }} catch (_e) {{
+                  // already errored/closed
+                }}
+              }};
+              if (signal) {{
+                if (signal.aborted) {{
+                  fail();
+                  return;
+                }}
+                signal.addEventListener('abort', fail, {{ once: true }});
+              }}
+              // Never enqueue/close — body/json() hangs until abort.
+            }},
+          }});
+          return Promise.resolve(new Response(body, {{
+            status: 200,
+            headers: {{
+              'Content-Type': 'application/json',
+              'Cache-Control': 'no-store',
+            }},
+          }}));
+        }}
+        return originalFetch(input, init);
+      }};
+    }}, PRIVATE_URL);
+  }}
 
   await page.setRequestInterception(true);
   // Fulfill every request exactly once. networkidle0 hangs on some non-2xx
@@ -579,6 +626,11 @@ try {{
             method,
             headers: req.headers(),
           }});
+          // Body-stall proofs are owned by the page-level fetch mock; leave any
+          // native private request pending rather than fulfilling a body.
+          if (PRIVATE_HANG_JSON) {{
+            return;
+          }}
           if (PRIVATE_DELAY_MS > 0) {{
             await new Promise((r) => setTimeout(r, PRIVATE_DELAY_MS));
           }}
@@ -612,7 +664,7 @@ try {{
   await page.goto(PAGE_URL, {{ waitUntil: 'domcontentloaded', timeout: 30000 }});
   await page.waitForSelector('#source-private-meta', {{ timeout: 15000 }});
   // Wait until dual-source settlement replaces the loading placeholders.
-  const settleBudget = Math.max(10000, PRIVATE_DELAY_MS + 3000);
+  const settleBudget = Math.max({settle_floor_ms}, PRIVATE_DELAY_MS + 3000);
   await page.waitForFunction(() => {{
     const priv = (document.getElementById('source-private-meta')?.textContent || '').trim();
     const pub = (document.getElementById('source-public-meta')?.textContent || '').trim();
@@ -779,6 +831,36 @@ def test_browser_private_timeout_leaves_public_usable():
     assert "Public attention item" in snap["listText"]
     assert "unavailable · timeout" in snap["privateMeta"]
     assert snap["errorHidden"] is True
+
+
+def test_browser_private_stalled_json_body_is_typed_timeout():
+    """Fulfilled headers + never-settling json() must still hit the 5s budget.
+
+    Source-blind page fetch mock only — no real private adapter process.
+    """
+    started = time.monotonic()
+    result = _browser_scenario(
+        public_doc=_public_min(),
+        private_doc=_private_ok(),
+        private_hang_json=True,
+    )
+    elapsed = time.monotonic() - started
+    snap = result["snapshot"]
+    obs = result["observed"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "unavailable · timeout" in snap["privateMeta"]
+    assert snap["errorHidden"] is True
+    # Typed meta only — never raw abort/exception text in banner or strip.
+    assert "AbortError" not in snap["privateMeta"]
+    assert "AbortError" not in snap["error"]
+    assert "TypeError" not in snap["error"]
+    assert "Failed to fetch" not in snap["error"]
+    # Budget is 5s; allow Chromium/settle overhead but refuse unbounded hang.
+    assert elapsed < 12.0, f"stalled-body timeout took too long: {elapsed:.2f}s"
+    assert elapsed >= 4.0, f"stalled-body timed out too early: {elapsed:.2f}s"
+    assert not any("AbortError" in e for e in obs.get("pageErrors") or [])
+    assert not any("AbortError" in e for e in obs.get("consoleErrors") or [])
 
 
 def test_browser_private_schema_mismatch_and_canary_rejected():

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -1185,6 +1185,7 @@ def _cors_handler_factory(hits: dict[str, Any], allowed: set[str], body: bytes):
             )
             if path != "/v1/projection":
                 self.send_response(404)
+                self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
             self.send_response(200)
@@ -1235,11 +1236,15 @@ def test_real_fixed_port_cors_http_and_browser_smoke():
             if path == "/work.html":
                 body = html
                 ctype = "text/html; charset=utf-8"
+            elif path == "/monitor.css":
+                body = b""
+                ctype = "text/css; charset=utf-8"
             elif path == PUBLIC_PATH:
                 body = public_body
                 ctype = "application/json"
             else:
                 self.send_response(404)
+                self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
             self.send_response(200)
@@ -1350,11 +1355,15 @@ def test_real_fixed_port_cors_localhost_origin_smoke():
             if path == "/work.html":
                 body = WORK_HTML.read_bytes()
                 ctype = "text/html; charset=utf-8"
+            elif path == "/monitor.css":
+                body = b""
+                ctype = "text/css; charset=utf-8"
             elif path == PUBLIC_PATH:
                 body = json.dumps(_public_min(), separators=(",", ":")).encode("utf-8")
                 ctype = "application/json"
             else:
                 self.send_response(404)
+                self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
             self.send_response(200)

--- a/tests/test_work_privacy.py
+++ b/tests/test_work_privacy.py
@@ -1,4 +1,4 @@
-"""Privacy oracle for the public Work foundation (FX-07)."""
+"""Privacy oracle for the public Work foundation + browser-local private boundary."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ from scripts.work.sources_public import SectionResult, private_capability_seam
 
 ROOT = Path(__file__).resolve().parents[1]
 CANARY_FILE = ROOT / "tests" / "fixtures" / "work" / "fx07_canaries.txt"
+PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
 # Product + fixture surfaces only. Privacy tests may inject canaries as inputs;
 # the oracle asserts they never appear in public outputs or non-test artifacts.
 WORK_OWNED = [
@@ -25,6 +26,9 @@ WORK_OWNED = [
     ROOT / "tests" / "fixtures" / "work",
     ROOT / "docs" / "decisions" / "ADR-019-work-control-plane.md",
     ROOT / "docs" / "monitor-api" / "work.md",
+    ROOT / "tests" / "test_work_dashboard.py",
+    ROOT / "tests" / "test_work_privacy.py",
+    ROOT / "tests" / "test_work_dashboard_private_integration.py",
 ]
 
 client = TestClient(app, raise_server_exceptions=False)
@@ -119,9 +123,11 @@ def test_fx07_canaries_never_enter_public_api_payload(monkeypatch):
     monkeypatch.setattr(
         work_router,
         "build_public_projection",
-        lambda **kwargs: build_projection(sections, repository_id="learn-ukrainian/learn-ukrainian.github.io", **{
-            k: v for k, v in kwargs.items() if k in {"filters", "cache_age_s"}
-        }),
+        lambda **kwargs: build_projection(
+            sections,
+            repository_id="learn-ukrainian/learn-ukrainian.github.io",
+            **{k: v for k, v in kwargs.items() if k in {"filters", "cache_age_s"}},
+        ),
     )
 
     response = client.get("/api/work/v1/projection")
@@ -145,6 +151,9 @@ def test_private_capability_seam_is_truthful_and_non_proxying():
     assert "requests.get" not in source
     assert "httpx" not in source
     assert "private-local-adapter" in source or "private_capability" in source
+    # Public server must never hardcode the private loopback adapter URL.
+    assert PRIVATE_URL not in source
+    assert "127.0.0.1:8766" not in source
 
 
 def test_saved_view_urls_reject_private_values():
@@ -180,14 +189,37 @@ def test_owned_paths_and_work_html_have_no_canaries_or_private_paths():
             assert private_path_re.search(text) is None, f"{file}: private checkout path"
 
 
-def test_work_html_is_read_only_and_public_api_only():
+def test_work_html_is_read_only_and_browser_local_private_only():
     html = (ROOT / "dashboards" / "work.html").read_text(encoding="utf-8")
     assert 'data-read-only="true"' in html
     assert "FOUNDATION_COMPLETE" in html
     assert "/api/work/v1/projection" in html
+    assert PRIVATE_URL in html
     assert "method: 'POST'" not in html
     assert 'method: "POST"' not in html
+    assert "method: 'PUT'" not in html
+    assert "method: 'PATCH'" not in html
+    assert "method: 'DELETE'" not in html
     assert "dispatch" in html.lower()  # mention only
+    # Fixed private URL only; no configurability surfaces.
+    assert "localStorage" not in html
+    assert "sessionStorage" not in html
+    assert "document.cookie" not in html
+    assert "private_endpoint" in html  # explicitly rejected
     # Must not hardcode private absolute paths or private host canaries
     for canary in _load_canaries():
         assert canary not in html
+
+
+def test_public_server_owned_python_never_imports_private_adapter_url():
+    """Architecture invariant: only browser JS may fetch the fixed private URL."""
+    server_paths = [
+        ROOT / "scripts" / "api" / "work_router.py",
+        ROOT / "scripts" / "work",
+    ]
+    for path in server_paths:
+        files = [path] if path.is_file() else sorted(path.rglob("*.py"))
+        for file in files:
+            text = file.read_text(encoding="utf-8", errors="replace")
+            assert PRIVATE_URL not in text, f"{file} embeds private adapter URL"
+            assert "8766/v1/projection" not in text, f"{file} embeds private adapter path"


### PR DESCRIPTION
## Summary

Closes the browser-local unified Work control plane for #5921 (`UNIFIED_COMPLETE` scope).

When `/work.html` is opened from local Monitor (`:8765`), the browser **independently** fetches:

1. Public same-origin `GET /api/work/v1/projection`
2. Fixed private loopback `GET http://127.0.0.1:8766/v1/projection` (non-configurable, 5s abort)

Both are validated closed-world; admitted items merge exactly once with dense attention ordering; either source may fail without blocking the other. Typed private-source status only (`ok` / `unreachable` / `timeout` / `schema_mismatch` / `identity_collision` / admitted adapter statuses). Mutation remains false. No private repository slug, path, remote, or payload is embedded.

### Frozen contract

| Item | Value |
| --- | --- |
| Public issue | #5921 |
| Public base | `f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d` |
| Schema | `work-projection.v1` |
| Schema SHA-256 | `89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde` |
| Brief SHA-256 | `6f877822583fbf2957b49ce57ca0dfb20bc3004eab3635732a811fdde1590185` |
| Private endpoint | fixed `http://127.0.0.1:8766/v1/projection` (browser-only) |

### Architecture / privacy boundary

- Public server never imports, proxies, configures, or logs the private adapter.
- Private URL never enters page URL, saved views, storage, cookies, DOM errors, or telemetry.
- Shareable saved-view query allowlist is stricter than in-memory filters: private repos and `private-local-adapter` filter locally only and are stripped from the URL.
- Live CORS contract retained for adapter origins `http://127.0.0.1:8765` and `http://localhost:8765` (`ACAO` + `Vary: Origin`, no credentials, no preflight).

## Changed paths (owned only)

- `dashboards/work.html`
- `tests/test_work_dashboard.py`
- `tests/test_work_privacy.py`
- `tests/test_work_dashboard_private_integration.py` (new)
- `docs/monitor-api/work.md`
- `docs/decisions/ADR-019-work-control-plane.md`

## Validation

```text
.venv/bin/python -m pytest tests/test_work_dashboard.py tests/test_work_privacy.py tests/test_work_dashboard_private_integration.py -q
# → 30 passed, 2 skipped

.venv/bin/python -m pytest tests/test_work_api.py tests/test_work_contract.py tests/test_monitor_ui_contracts.py tests/test_monitor_route_contracts.py -q
# → 65 passed

.venv/bin/python -m ruff check tests/test_work_dashboard.py tests/test_work_privacy.py tests/test_work_dashboard_private_integration.py
# → All checks passed

git diff --check
# → clean
```

Interception proofs cover dual success, private unreachable/timeout/schema_mismatch/collision, public failure with private usable, both-failure typed banner, local filters without private query, non-shareable private repo filter, dense order, mobile 390×844 no overflow, public-only when adapter absent, and refresh `fresh=true` on public only.

**Fixed-port live CORS smokes** (`test_real_fixed_port_cors_*`) are retained uncompromised for CI; locally skipped because ports **8765/8766 are already occupied** by running Monitor/private adapter services (do not kill). Interception suite fully green.

`scripts/validate/validate_html.py` targets Starlight MDX on port 3000 (Playwright Python package not installed in this worktree venv); dashboard browser proof is the Puppeteer suite above. Basic HTML shell parse + static contracts also clean.

## Privacy / secrets

- No secrets, credentials, private repository identifiers, checkout paths, or private payloads in public code/docs/tests.
- Source-blind synthetic private slug `fixture-owner/fixture-repo` only.
- Canary free-text extras reject whole private payload and never enter DOM/URL/storage/errors.

## Hosted resources

**No hosted resources provisioned.**

## Test plan

- [x] Unit/static Work dashboard + privacy tests
- [x] Headless dual-source interception integration tests (all non-CORS cases)
- [x] Related Work API / contract / Monitor UI route tests
- [x] Ruff on owned test paths
- [ ] CI green on this head
- [ ] Independent cross-family exact-head review (Claude family)
- [ ] Fixed-port CORS smokes when 8765/8766 free (CI or idle host)

Do not merge or enable auto-merge from this seat.