### PR TITLE
feat(services): manage private Work adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ python -m venv .venv
 cd starlight && npm install && cd ..
 
 # 4. Start services
-./services.sh start   # Sources 8766, Monitor 8765, Astro 4321, private Work 8767
+./services.sh start   # Sources 8766, Monitor 8765, Astro 4321, private Work 8769
 
 # 5. Verify
 ./services.sh status
@@ -59,7 +59,7 @@ cd starlight && npm install && cd ..
 | MCP sources server | 8766 | `./services.sh start` |
 | Monitor API | 8765 | `./services.sh start` |
 | Astro dev | 4321 | `./services.sh start` |
-| Private Work adapter | 8767 | `./services.sh start` |
+| Private Work adapter | 8769 | `./services.sh start` |
 
 ```bash
 ./services.sh start    # Start all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ python -m venv .venv
 cd starlight && npm install && cd ..
 
 # 4. Start services
-./services.sh start   # RAG on 8766, API on 8765, Starlight on 4321
+./services.sh start   # Sources 8766, Monitor 8765, Astro 4321, private Work 8767
 
 # 5. Verify
 ./services.sh status
@@ -58,12 +58,15 @@ cd starlight && npm install && cd ..
 |---------|------|---------|
 | MCP sources server | 8766 | `./services.sh start` |
 | Monitor API | 8765 | `./services.sh start` |
-| Starlight dev | 4321 | `./services.sh start` |
+| Astro dev | 4321 | `./services.sh start` |
+| Private Work adapter | 8767 | `./services.sh start` |
 
 ```bash
 ./services.sh start    # Start all
 ./services.sh stop     # Stop all
 ./services.sh status   # Check status
+./services.sh status work  # Typed private-adapter status
+./services.sh logs work    # Latest adapter log (stored in private checkout)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ python -m venv .venv
 # 2. Frontend
 cd starlight && npm install && cd ..
 
-# 3. Services (Sources 8766, Monitor 8765, Astro 4321, private Work 8767)
+# 3. Services (Sources 8766, Monitor 8765, Astro 4321, private Work 8769)
 ./services.sh start
 ./services.sh status
 # Work adapter diagnostics: ./services.sh status work && ./services.sh logs work

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ python -m venv .venv
 # 2. Frontend
 cd starlight && npm install && cd ..
 
-# 3. Services (RAG on 8766, monitor API on 8765, Starlight on 4321)
+# 3. Services (Sources 8766, Monitor 8765, Astro 4321, private Work 8767)
 ./services.sh start
 ./services.sh status
+# Work adapter diagnostics: ./services.sh status work && ./services.sh logs work
 
 # 4. Pre-commit hooks — mirror CI locally
 pip install pre-commit && pre-commit install

--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -234,7 +234,7 @@ button, input, select { font: inherit; }
   const PUBLIC_SINGLETON_REPO = 'learn-ukrainian/learn-ukrainian.github.io';
   const PUBLIC_PROJECTION_URL = '/api/work/v1/projection';
   // Fixed constant — never configurable, never persisted, never rendered into shareable state.
-  const PRIVATE_PROJECTION_URL = 'http://127.0.0.1:8767/v1/projection';
+  const PRIVATE_PROJECTION_URL = 'http://127.0.0.1:8769/v1/projection';
   const PRIVATE_SCHEMA_DIGEST = '89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde';
   const PUBLIC_SCHEMA_COMMIT = 'f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d';
   const PRIVATE_SOURCE_ID = 'private-local-adapter';

--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -234,7 +234,7 @@ button, input, select { font: inherit; }
   const PUBLIC_SINGLETON_REPO = 'learn-ukrainian/learn-ukrainian.github.io';
   const PUBLIC_PROJECTION_URL = '/api/work/v1/projection';
   // Fixed constant — never configurable, never persisted, never rendered into shareable state.
-  const PRIVATE_PROJECTION_URL = 'http://127.0.0.1:8766/v1/projection';
+  const PRIVATE_PROJECTION_URL = 'http://127.0.0.1:8767/v1/projection';
   const PRIVATE_SCHEMA_DIGEST = '89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde';
   const PUBLIC_SCHEMA_COMMIT = 'f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d';
   const PRIVATE_SOURCE_ID = 'private-local-adapter';

--- a/docs/decisions/ADR-019-work-control-plane.md
+++ b/docs/decisions/ADR-019-work-control-plane.md
@@ -42,7 +42,7 @@ browser-rendered error text.
 6. **Private source is browser-local only.** The public server never fetches,
    proxies, persists, configures, or logs the private adapter. Only
    `dashboards/work.html` may GET the fixed constant
-   `http://127.0.0.1:8766/v1/projection` with a 5s abort budget, CORS-safelisted
+   `http://127.0.0.1:8767/v1/projection` with a 5s abort budget, CORS-safelisted
    headers, `credentials: omit`, and no query string. The endpoint is not
    configurable and never enters shareable saved-view state.
 7. **Independent dual-source settlement.** The browser uses `Promise.allSettled`
@@ -61,6 +61,11 @@ browser-rendered error text.
 10. **Saved views**: URL query only; stricter shareable allowlist than local
     filters so private repository slugs and `private-local-adapter` never enter
     transferable state.
+11. **Local topology**: public `services.sh` owns the optional sibling adapter
+    lifecycle on loopback port `8767`. Sources remains on `8766`; KubeDojo's API
+    and Astro ports remain `8768` and `4333`. Missing private prerequisites are
+    typed `unavailable`, a foreign listener is `blocked`, and neither condition
+    prevents the public Monitor or Sources services from running.
 
 ## Consequences
 

--- a/docs/decisions/ADR-019-work-control-plane.md
+++ b/docs/decisions/ADR-019-work-control-plane.md
@@ -42,7 +42,7 @@ browser-rendered error text.
 6. **Private source is browser-local only.** The public server never fetches,
    proxies, persists, configures, or logs the private adapter. Only
    `dashboards/work.html` may GET the fixed constant
-   `http://127.0.0.1:8767/v1/projection` with a 5s abort budget, CORS-safelisted
+   `http://127.0.0.1:8769/v1/projection` with a 5s abort budget, CORS-safelisted
    headers, `credentials: omit`, and no query string. The endpoint is not
    configurable and never enters shareable saved-view state.
 7. **Independent dual-source settlement.** The browser uses `Promise.allSettled`
@@ -62,8 +62,9 @@ browser-rendered error text.
     filters so private repository slugs and `private-local-adapter` never enter
     transferable state.
 11. **Local topology**: public `services.sh` owns the optional sibling adapter
-    lifecycle on loopback port `8767`. Sources remains on `8766`; KubeDojo's API
-    and Astro ports remain `8768` and `4333`. Missing private prerequisites are
+    lifecycle on loopback port `8769`. Sources remains on `8766`, the optional
+    OpenAI-compatible bridge retains `8767`, and KubeDojo's API and Astro ports
+    remain `8768` and `4333`. Missing private prerequisites are
     typed `unavailable`, a foreign listener is `blocked`, and neither condition
     prevents the public Monitor or Sources services from running.
 

--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -29,7 +29,7 @@ UI: [`/work.html`](../../dashboards/work.html) — Evidence rail attention list
 
 Only browser JavaScript in `dashboards/work.html` may fetch the fixed constant:
 
-`http://127.0.0.1:8766/v1/projection`
+`http://127.0.0.1:8767/v1/projection`
 
 Invariants:
 
@@ -121,6 +121,25 @@ preflight because `Accept` is CORS-safelisted. Fixture proofs cover real
 cross-origin browser smoke on those fixed loopback ports in addition to request
 interception tests.
 
+### Local service lifecycle
+
+Run `./services.sh start` from the public checkout to start Sources (`8766`),
+Monitor (`8765`), Astro (`4321`), and the sibling private Work adapter (`8767`).
+The sibling checkout is discovered as `../learn-ukrainian-infra-private`; a
+nonstandard layout may set `LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT` to its root.
+The browser endpoint and loopback bind remain fixed.
+
+Use `./services.sh status work`, `./services.sh restart work`,
+`./services.sh stop work`, and `./services.sh logs work` for the adapter. Status
+reports `unavailable` with a typed reason when the checkout, virtualenv, or
+module is missing, and `blocked` when a foreign process owns `127.0.0.1:8767`.
+An unavailable adapter does not prevent the public services from starting.
+Adapter logs remain in the private checkout at `logs/work-projection.log`; the
+public tree never stores private adapter output.
+
+The local port allocation is collision-free with KubeDojo: its API and Astro
+development server remain on `8768` and `4333`, respectively.
+
 ## Denominator (public server)
 
 At a query instant the public projection represents exactly once (or counts in a
@@ -168,7 +187,7 @@ curl -sS 'http://127.0.0.1:8765/api/work/v1/capabilities' | .venv/bin/python -m 
 curl -sS 'http://127.0.0.1:8765/api/work/v1/projection?fresh=true' | .venv/bin/python -m json.tool | head
 # Private adapter (loopback only; never via public Monitor):
 curl -sS -H 'Accept: application/json' -H 'Origin: http://127.0.0.1:8765' \
-  'http://127.0.0.1:8766/v1/projection' | .venv/bin/python -m json.tool | head
+  'http://127.0.0.1:8767/v1/projection' | .venv/bin/python -m json.tool | head
 ```
 
 See also: [ADR-019](../decisions/ADR-019-work-control-plane.md).

--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -29,7 +29,7 @@ UI: [`/work.html`](../../dashboards/work.html) — Evidence rail attention list
 
 Only browser JavaScript in `dashboards/work.html` may fetch the fixed constant:
 
-`http://127.0.0.1:8767/v1/projection`
+`http://127.0.0.1:8769/v1/projection`
 
 Invariants:
 
@@ -124,7 +124,7 @@ interception tests.
 ### Local service lifecycle
 
 Run `./services.sh start` from the public checkout to start Sources (`8766`),
-Monitor (`8765`), Astro (`4321`), and the sibling private Work adapter (`8767`).
+Monitor (`8765`), Astro (`4321`), and the sibling private Work adapter (`8769`).
 The sibling checkout is discovered as `../learn-ukrainian-infra-private`; a
 nonstandard layout may set `LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT` to its root.
 The browser endpoint and loopback bind remain fixed.
@@ -132,13 +132,14 @@ The browser endpoint and loopback bind remain fixed.
 Use `./services.sh status work`, `./services.sh restart work`,
 `./services.sh stop work`, and `./services.sh logs work` for the adapter. Status
 reports `unavailable` with a typed reason when the checkout, virtualenv, or
-module is missing, and `blocked` when a foreign process owns `127.0.0.1:8767`.
+module is missing, and `blocked` when a foreign process owns `127.0.0.1:8769`.
 An unavailable adapter does not prevent the public services from starting.
 Adapter logs remain in the private checkout at `logs/work-projection.log`; the
 public tree never stores private adapter output.
 
-The local port allocation is collision-free with KubeDojo: its API and Astro
-development server remain on `8768` and `4333`, respectively.
+The local port allocation also preserves the optional OpenAI-compatible bridge
+on `8767` and is collision-free with KubeDojo: its API and Astro development
+server remain on `8768` and `4333`, respectively.
 
 ## Denominator (public server)
 
@@ -187,7 +188,7 @@ curl -sS 'http://127.0.0.1:8765/api/work/v1/capabilities' | .venv/bin/python -m 
 curl -sS 'http://127.0.0.1:8765/api/work/v1/projection?fresh=true' | .venv/bin/python -m json.tool | head
 # Private adapter (loopback only; never via public Monitor):
 curl -sS -H 'Accept: application/json' -H 'Origin: http://127.0.0.1:8765' \
-  'http://127.0.0.1:8767/v1/projection' | .venv/bin/python -m json.tool | head
+  'http://127.0.0.1:8769/v1/projection' | .venv/bin/python -m json.tool | head
 ```
 
 See also: [ADR-019](../decisions/ADR-019-work-control-plane.md).

--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -24,11 +24,11 @@ _ALLOWLIST: frozenset[str] = frozenset(
     {
         # services.sh: restart lockdir reclaim/release + Astro/Vite cache dirs
         # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
-        "services.sh:121",
-        "services.sh:140",
-        "services.sh:633",
-        "services.sh:643",
-        "services.sh:647",
+        "services.sh:142",
+        "services.sh:161",
+        "services.sh:722",
+        "services.sh:732",
+        "services.sh:736",
         # Scratch-dir EXIT traps for one-shot installer scripts.
         "scripts/entire/install_kimi_external_agent.sh:18",
         "scripts/entire/install_fleet_external_agent.sh:36",

--- a/services.sh
+++ b/services.sh
@@ -70,11 +70,11 @@ SVC_HEALTH_ALT[api]="http://localhost:8765/api/health"
 SVC_MATCH[api]="scripts.api.main:app --host 0.0.0.0 --port 8765"
 
 SVC_CMD[work]="$WORK_PRIVATE_ROOT/.venv/bin/python -m work_projection"
-SVC_PORT[work]=8767
+SVC_PORT[work]=8769
 SVC_HOST[work]=127.0.0.1
 SVC_LOG[work]="$WORK_PRIVATE_ROOT/logs/work-projection.log"
 SVC_DESC[work]="Private Work Projection Adapter (read-only, sibling checkout)"
-SVC_HEALTH[work]="http://127.0.0.1:8767/v1/health"
+SVC_HEALTH[work]="http://127.0.0.1:8769/v1/health"
 SVC_MATCH[work]="-m work_projection"
 
 SVC_CMD[astro]="npm run dev --prefix site -- --host 127.0.0.1 --port 4321 --force"

--- a/services.sh
+++ b/services.sh
@@ -10,12 +10,14 @@
 #   ./services.sh restart api        # Restart specific service
 #   ./services.sh start api --live   # Emergency mutable-checkout API mode
 #   ./services.sh status             # Show what's running
+#   ./services.sh status work        # Show one service
+#   ./services.sh logs work          # Show the latest service log
 #   ./services.sh supervise api install|status|uninstall
 #   ./services.sh build astro        # Run Astro production build (no dev server)
 #   ./services.sh clean astro        # Remove Astro build/cache outputs
 #   ./services.sh rebuild astro      # Run Astro clean then build
 #
-# Services: sources, api, astro
+# Services: sources, api, astro, work
 #
 # Note: the `sources` service was historically called `rag`. It serves
 # SQLite FTS5 indices over textbook chunks, dictionaries, VESUM, literary
@@ -31,6 +33,17 @@ SVC_LSOF_BIN="${SVC_LSOF_BIN:-lsof}"
 LOGS_DIR="$PROJECT_ROOT/logs"
 PIDS_DIR="$PROJECT_ROOT/.pids"
 VENV="$PROJECT_ROOT/.venv/bin"
+
+# Resolve the human-owned primary checkout even when this script runs from a
+# dispatch worktree. The private Work adapter lives in a deterministic sibling
+# checkout; tests and nonstandard layouts may override only that filesystem
+# root, never the browser endpoint or bind address.
+PUBLIC_PRIMARY_ROOT="$PROJECT_ROOT"
+git_common_dir="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [[ -n "$git_common_dir" && "$(basename "$git_common_dir")" == ".git" ]]; then
+    PUBLIC_PRIMARY_ROOT="$(cd "$(dirname "$git_common_dir")" && pwd)"
+fi
+WORK_PRIVATE_ROOT="${LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT:-$(dirname "$PUBLIC_PRIMARY_ROOT")/learn-ukrainian-infra-private}"
 
 mkdir -p "$LOGS_DIR" "$PIDS_DIR"
 
@@ -56,6 +69,14 @@ SVC_HEALTH[api]="http://127.0.0.1:8765/api/health"
 SVC_HEALTH_ALT[api]="http://localhost:8765/api/health"
 SVC_MATCH[api]="scripts.api.main:app --host 0.0.0.0 --port 8765"
 
+SVC_CMD[work]="$WORK_PRIVATE_ROOT/.venv/bin/python -m work_projection"
+SVC_PORT[work]=8767
+SVC_HOST[work]=127.0.0.1
+SVC_LOG[work]="$WORK_PRIVATE_ROOT/logs/work-projection.log"
+SVC_DESC[work]="Private Work Projection Adapter (read-only, sibling checkout)"
+SVC_HEALTH[work]="http://127.0.0.1:8767/v1/health"
+SVC_MATCH[work]="-m work_projection"
+
 SVC_CMD[astro]="npm run dev --prefix site -- --host 127.0.0.1 --port 4321 --force"
 SVC_PORT[astro]=4321
 SVC_HOST[astro]=127.0.0.1
@@ -67,7 +88,7 @@ SVC_HEALTH_ALT[astro]="http://localhost:4321/"
 # installs still expose ``astro.mjs dev``. Match either argv form.
 SVC_MATCH[astro]=".bin/astro dev|astro.mjs dev"
 
-ALL_SERVICES="sources api astro"
+ALL_SERVICES="sources api astro work"
 
 # Legacy aliases: rewrite old service names when passed as CLI args.
 # Accept shell history + scripts that still say `./services.sh start rag`
@@ -372,8 +393,43 @@ _reconcile_api_pid() {
     fi
 }
 
+_work_unavailable_reason() {
+    if [[ ! -d "$WORK_PRIVATE_ROOT/.git" && ! -f "$WORK_PRIVATE_ROOT/.git" ]]; then
+        echo "private_checkout_missing"
+    elif [[ ! -x "$WORK_PRIVATE_ROOT/.venv/bin/python" ]]; then
+        echo "private_venv_missing"
+    elif [[ ! -d "$WORK_PRIVATE_ROOT/work_projection" ]]; then
+        echo "private_module_missing"
+    fi
+    return 0
+}
+
 _service_state() {
     local name="$1"
+
+    # The Work health path is not identity. A foreign listener can return 2xx
+    # from /v1/health, so require a matching argv before declaring it running.
+    if [[ "$name" == "work" ]]; then
+        if _known_service_pid "$name" >/dev/null; then
+            if _health_check "$name"; then
+                echo "running"
+            else
+                echo "degraded"
+            fi
+            return 0
+        fi
+        if _foreign_port_pid "$name" >/dev/null; then
+            echo "blocked"
+            return 0
+        fi
+        if [[ -n "$(_work_unavailable_reason)" ]]; then
+            echo "unavailable"
+            return 0
+        fi
+        echo "stopped"
+        return 0
+    fi
+
     if _health_check "$name"; then
         echo "running"
         return 0
@@ -452,6 +508,10 @@ _start_service() {
         echo "  $name process exists but is unhealthy (PID ${pid:-unknown}); restart it instead"
         return 0
     fi
+    if [[ "$state" == "unavailable" ]]; then
+        echo "  work unavailable ($(_work_unavailable_reason)); public services remain independent"
+        return 0
+    fi
 
     # Self-heal astro deps before spawning the dev server (node_modules can be wiped).
     if [[ "$name" == "astro" ]]; then
@@ -488,7 +548,14 @@ _start_service() {
     cd "$PROJECT_ROOT"
 
     local pid=""
-    if [[ "$name" == "astro" ]] && command -v tmux >/dev/null 2>&1; then
+    if [[ "$name" == "work" ]]; then
+        mkdir -p "$(dirname "${SVC_LOG[work]}")"
+        (
+            cd "$WORK_PRIVATE_ROOT"
+            exec "$WORK_PRIVATE_ROOT/.venv/bin/python" -m work_projection
+        ) </dev/null >> "${SVC_LOG[$name]}" 2>&1 &
+        pid=$!
+    elif [[ "$name" == "astro" ]] && command -v tmux >/dev/null 2>&1; then
         local session
         session="$(_tmux_session_name "$name")"
         tmux kill-session -t "$session" 2>/dev/null || true
@@ -505,6 +572,28 @@ _start_service() {
         # shellcheck disable=SC2086
         nohup ${SVC_CMD[$name]} </dev/null >> "${SVC_LOG[$name]}" 2>&1 &
         pid=$!
+    fi
+
+    if [[ "$name" == "work" ]]; then
+        local healthy=0
+        local listener_pid=""
+        for _ in $(seq 1 20); do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                break
+            fi
+            listener_pid="$(_verified_port_pid work || true)"
+            if [[ "$listener_pid" == "$pid" ]] && _health_check work; then
+                healthy=1
+                break
+            fi
+            sleep 0.25
+        done
+        if [[ "$healthy" -ne 1 ]]; then
+            kill "$pid" 2>/dev/null || true
+            rm -f "$(_pid_file work)"
+            echo "  work failed to become healthy; inspect with: $0 logs work" >&2
+            return 1
+        fi
     fi
 
     if [[ -n "$pid" ]]; then
@@ -698,10 +787,16 @@ _rebuild_astro() {
 }
 
 _status() {
-    printf "%-12s %-8s %-8s %s\n" "SERVICE" "STATUS" "PID" "PORT"
-    printf "%-12s %-8s %-8s %s\n" "-------" "------" "---" "----"
-    for name in $ALL_SERVICES; do
-        local state pid
+    local selected="${*:-$ALL_SERVICES}"
+    printf "%-12s %-11s %-8s %-15s %s\n" "SERVICE" "STATUS" "PID" "PORT" "DETAIL"
+    printf "%-12s %-11s %-8s %-15s %s\n" "-------" "------" "---" "----" "------"
+    for name in $selected; do
+        if [[ -z "${SVC_CMD[$name]+x}" ]]; then
+            printf "%-12s %-11s %-8s %-15s %s\n" "$name" "unknown" "-" "-" "not_managed"
+            continue
+        fi
+
+        local state pid detail="-"
         state="$(_service_state "$name")"
         pid="$(_known_service_pid "$name" || true)"
         if [[ -z "$pid" ]]; then
@@ -710,16 +805,34 @@ _status() {
 
         case "$state" in
             running)
-                printf "%-12s \033[32m%-8s\033[0m %-8s %s\n" "$name" "$state" "$pid" "${SVC_PORT[$name]}"
+                printf "%-12s \033[32m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "$detail"
                 ;;
             degraded)
-                printf "%-12s \033[33m%-8s\033[0m %-8s %s\n" "$name" "$state" "$pid" "${SVC_PORT[$name]}"
+                printf "%-12s \033[33m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "health_check_failed"
+                ;;
+            blocked)
+                printf "%-12s \033[31m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "foreign_listener"
+                ;;
+            unavailable)
+                detail="$(_work_unavailable_reason)"
+                printf "%-12s \033[33m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "$detail"
                 ;;
             *)
-                printf "%-12s \033[31m%-8s\033[0m %-8s %s\n" "$name" "$state" "$pid" "${SVC_PORT[$name]}"
+                printf "%-12s \033[31m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "$detail"
                 ;;
         esac
     done
+}
+
+_logs() {
+    local name="$1"
+    local logfile="${SVC_LOG[$name]}"
+    echo "Log: $logfile"
+    if [[ ! -f "$logfile" ]]; then
+        echo "  No log has been created for $name yet."
+        return 0
+    fi
+    tail -n 80 "$logfile"
 }
 
 # Parse arguments
@@ -750,15 +863,21 @@ fi
 case "$action" in
     start)
         echo "Starting services..."
+        start_failed=0
         for svc in $services; do
             if [[ -z "${SVC_CMD[$svc]+x}" ]]; then
                 echo "  Unknown service: $svc (available: $ALL_SERVICES)"
                 continue
             fi
-            _start_service "$svc"
+            if ! _start_service "$svc"; then
+                start_failed=1
+            fi
         done
         echo ""
         _status
+        if [[ "$start_failed" -ne 0 ]]; then
+            exit 1
+        fi
         ;;
     stop)
         echo "Stopping services..."
@@ -783,6 +902,7 @@ case "$action" in
         trap _release_restart_lock EXIT INT TERM
 
         echo "Restarting services..."
+        restart_failed=0
         for svc in $services; do
             if [[ -z "${SVC_CMD[$svc]+x}" ]]; then
                 echo "  Unknown service: $svc"
@@ -792,10 +912,15 @@ case "$action" in
                 _reconcile_api_pid
             fi
             _stop_service "$svc"
-            _start_service "$svc"
+            if ! _start_service "$svc"; then
+                restart_failed=1
+            fi
         done
         echo ""
         _status
+        if [[ "$restart_failed" -ne 0 ]]; then
+            exit 1
+        fi
         ;;
     supervise)
         supervisor_service="${remaining_args[0]:-}"
@@ -878,11 +1003,25 @@ case "$action" in
         fi
         ;;
     status)
-        _reconcile_api_pid
-        _status
+        if [[ " $services " == *" api "* ]]; then
+            _reconcile_api_pid
+        fi
+        _status "$services"
+        ;;
+    logs)
+        if [[ "${#remaining_args[@]}" -ne 1 ]]; then
+            echo "Usage: $0 logs <service>" >&2
+            exit 1
+        fi
+        log_service="${remaining_args[0]}"
+        if [[ -z "${SVC_CMD[$log_service]+x}" ]]; then
+            echo "Unknown service: $log_service (available: $ALL_SERVICES)" >&2
+            exit 1
+        fi
+        _logs "$log_service"
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|status|supervise|build|clean|rebuild} [service ...]"
+        echo "Usage: $0 {start|stop|restart|status|logs|supervise|build|clean|rebuild} [service ...]"
         echo ""
         echo "Services:"
         for name in $ALL_SERVICES; do
@@ -892,6 +1031,7 @@ case "$action" in
         echo "Examples:"
         echo "  $0 start                  # Start all"
         echo "  $0 start sources api      # Start specific"
+        echo "  $0 start work             # Start the private sibling adapter"
         echo "  $0 start api --live       # Emergency API fallback (mutable checkout)"
         echo "  $0 stop sources           # Stop one"
         echo "  $0 restart                # Restart all"
@@ -901,6 +1041,8 @@ case "$action" in
         echo "  $0 clean astro            # Clean Astro cache/build outputs"
         echo "  $0 rebuild astro          # Clean then build Astro"
         echo "  $0 status                 # Show status"
+        echo "  $0 status work            # Show adapter status and typed failure reason"
+        echo "  $0 logs work              # Show the latest adapter log"
         echo ""
         echo "Note: 'rag' is accepted as a legacy alias for 'sources'; 'site' is accepted as a legacy alias for 'astro'."
         ;;

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -500,3 +501,213 @@ def test_status_does_not_print_proc_on_missing_procfs(temp_services_sh, mock_lso
         if proc.poll() is None:
             proc.terminate()
             proc.wait(timeout=5)
+
+
+def test_work_status_reports_typed_missing_checkout(tmp_path, mock_lsof_env) -> None:
+    """A missing private sibling is explicit and does not crash public status."""
+    _, _, env = mock_lsof_env
+    env["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] = str(tmp_path / "missing-private")
+    result = subprocess.run(
+        [str(SERVICES_SH), "status", "work"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "work" in result.stdout
+    assert "unavailable" in result.stdout
+    assert "private_checkout_missing" in result.stdout
+    assert "sources" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("create_venv", "create_module", "reason"),
+    [
+        (False, False, "private_venv_missing"),
+        (True, False, "private_module_missing"),
+    ],
+)
+def test_work_status_reports_other_typed_prerequisite_failures(
+    tmp_path, mock_lsof_env, create_venv: bool, create_module: bool, reason: str
+) -> None:
+    """Every private prerequisite failure has a stable operator-facing type."""
+    _, _, env = mock_lsof_env
+    private_root = tmp_path / "private"
+    (private_root / ".git").mkdir(parents=True)
+    if create_venv:
+        (private_root / ".venv" / "bin").mkdir(parents=True)
+        (private_root / ".venv" / "bin" / "python").symlink_to(VENV_PYTHON)
+    if create_module:
+        (private_root / "work_projection").mkdir()
+    env["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] = str(private_root)
+
+    result = subprocess.run(
+        [str(SERVICES_SH), "status", "work"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "unavailable" in result.stdout
+    assert reason in result.stdout
+
+
+def test_work_status_rejects_foreign_health_listener(tmp_path, mock_lsof_env) -> None:
+    """A foreign 8767 owner is blocked even if it could answer the health path."""
+    set_pids, _, env = mock_lsof_env
+    private_root = tmp_path / "private"
+    (private_root / ".git").mkdir(parents=True)
+    (private_root / ".venv" / "bin").mkdir(parents=True)
+    (private_root / "work_projection").mkdir()
+    (private_root / ".venv" / "bin" / "python").symlink_to(VENV_PYTHON)
+    env["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] = str(private_root)
+
+    proc = subprocess.Popen([str(VENV_PYTHON), "-c", "import time; time.sleep(30)"])
+    reap_process_on_exit(proc)
+    set_pids([proc.pid])
+    try:
+        result = subprocess.run(
+            [str(SERVICES_SH), "status", "work"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "blocked" in result.stdout
+        assert "foreign_listener" in result.stdout
+        assert "running" not in result.stdout
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_work_lifecycle_uses_sibling_checkout_and_fixed_loopback(tmp_path) -> None:
+    """Start/status/stop owns the adapter without a manual private-repo command."""
+    port = find_free_port()
+    script_path = tmp_path / "services.sh"
+    script_path.write_text(
+        SERVICES_SH.read_text(encoding="utf-8").replace("8767", str(port)),
+        encoding="utf-8",
+    )
+    script_path.chmod(0o755)
+
+    private_root = tmp_path / "private"
+    (private_root / ".git").mkdir(parents=True)
+    (private_root / ".venv" / "bin").mkdir(parents=True)
+    module = private_root / "work_projection"
+    module.mkdir()
+    (private_root / ".venv" / "bin" / "python").symlink_to(VENV_PYTHON)
+    (module / "__init__.py").write_text("", encoding="utf-8")
+    (module / "__main__.py").write_text(
+        """from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+
+with open(os.environ["WORK_FAKE_PID_FILE"], "w", encoding="utf-8") as pid_file:
+    pid_file.write(str(os.getpid()))
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/v1/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = b'{"status":"ok"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *_args):
+        return
+
+HTTPServer(("127.0.0.1", int(os.environ["WORK_TEST_PORT"])), Handler).serve_forever()
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    fake_pid_file = tmp_path / "work.pid"
+    mock_lsof = tmp_path / "mock_lsof"
+    mock_lsof.write_text(
+        "#!/bin/sh\n"
+        f"if [ -f '{fake_pid_file}' ]; then\n"
+        f"  pid=$(cat '{fake_pid_file}')\n"
+        "  if kill -0 \"$pid\" 2>/dev/null; then echo \"$pid\"; fi\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    mock_lsof.chmod(0o755)
+    env["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] = str(private_root)
+    env["WORK_TEST_PORT"] = str(port)
+    env["WORK_FAKE_PID_FILE"] = str(fake_pid_file)
+    env["SVC_LSOF_BIN"] = str(mock_lsof)
+    start = subprocess.run(
+        [str(script_path), "start", "work"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+        timeout=30,
+    )
+    try:
+        assert start.returncode == 0, f"{start.stdout}\n{start.stderr}"
+        status = None
+        for _ in range(40):
+            status = subprocess.run(
+                [str(script_path), "status", "work"],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+                env=env,
+                timeout=30,
+            )
+            if "running" in status.stdout:
+                break
+            time.sleep(0.1)
+        assert status is not None
+        assert status.returncode == 0, status.stderr
+        assert "running" in status.stdout
+        assert f"127.0.0.1:{port}" in status.stdout
+        assert str(private_root / "logs" / "work-projection.log") in start.stdout
+    finally:
+        stop = subprocess.run(
+            [str(script_path), "stop", "work"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=env,
+            timeout=30,
+        )
+        assert stop.returncode == 0, f"{stop.stdout}\n{stop.stderr}"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(1)
+        assert probe.connect_ex(("127.0.0.1", port)) != 0
+
+
+def test_local_service_ports_do_not_collide_with_kubedojo() -> None:
+    """Frozen Learn Ukrainian ports remain disjoint from KubeDojo declarations."""
+    assignment = re.compile(r"^SVC_PORT\[([^]]+)\]=\"?(\d+)\"?$", re.MULTILINE)
+    learn_ports = {
+        name: int(port)
+        for name, port in assignment.findall(SERVICES_SH.read_text(encoding="utf-8"))
+    }
+    assert learn_ports == {"sources": 8766, "api": 8765, "work": 8767, "astro": 4321}
+
+    # CI has no sibling checkout, so the reviewed KubeDojo contract is frozen
+    # here and cross-checked against its real services.sh whenever available.
+    kubedojo_ports = {"api": 8768, "dev": 4333}
+    kubedojo_script = main_checkout_root(PROJECT_ROOT).parent / "kubedojo" / "services.sh"
+    if kubedojo_script.exists():
+        declared = {
+            name: int(port)
+            for name, port in assignment.findall(kubedojo_script.read_text(encoding="utf-8"))
+        }
+        assert {name: declared[name] for name in kubedojo_ports} == kubedojo_ports
+
+    assert set(learn_ports.values()).isdisjoint(kubedojo_ports.values())

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -557,7 +557,7 @@ def test_work_status_reports_other_typed_prerequisite_failures(
 
 
 def test_work_status_rejects_foreign_health_listener(tmp_path, mock_lsof_env) -> None:
-    """A foreign 8767 owner is blocked even if it could answer the health path."""
+    """A foreign 8769 owner is blocked even if it could answer the health path."""
     set_pids, _, env = mock_lsof_env
     private_root = tmp_path / "private"
     (private_root / ".git").mkdir(parents=True)
@@ -592,7 +592,7 @@ def test_work_lifecycle_uses_sibling_checkout_and_fixed_loopback(tmp_path) -> No
     port = find_free_port()
     script_path = tmp_path / "services.sh"
     script_path.write_text(
-        SERVICES_SH.read_text(encoding="utf-8").replace("8767", str(port)),
+        SERVICES_SH.read_text(encoding="utf-8").replace("8769", str(port)),
         encoding="utf-8",
     )
     script_path.chmod(0o755)
@@ -690,14 +690,25 @@ HTTPServer(("127.0.0.1", int(os.environ["WORK_TEST_PORT"])), Handler).serve_fore
         assert probe.connect_ex(("127.0.0.1", port)) != 0
 
 
-def test_local_service_ports_do_not_collide_with_kubedojo() -> None:
-    """Frozen Learn Ukrainian ports remain disjoint from KubeDojo declarations."""
+def test_local_service_ports_do_not_collide_with_bridge_or_kubedojo() -> None:
+    """Frozen Learn Ukrainian ports avoid the bridge and KubeDojo declarations."""
     assignment = re.compile(r"^SVC_PORT\[([^]]+)\]=\"?(\d+)\"?$", re.MULTILINE)
     learn_ports = {
         name: int(port)
         for name, port in assignment.findall(SERVICES_SH.read_text(encoding="utf-8"))
     }
-    assert learn_ports == {"sources": 8766, "api": 8765, "work": 8767, "astro": 4321}
+    assert learn_ports == {"sources": 8766, "api": 8765, "work": 8769, "astro": 4321}
+
+    bridge_source = (PROJECT_ROOT / "scripts" / "ai_agent_bridge" / "_cli.py").read_text(
+        encoding="utf-8"
+    )
+    bridge_port_match = re.search(
+        r'add_argument\(\s*"--port",\s*type=int,\s*default=(\d+),', bridge_source
+    )
+    assert bridge_port_match is not None
+    openai_compat_proxy_port = int(bridge_port_match.group(1))
+    assert openai_compat_proxy_port == 8767
+    assert learn_ports["work"] != openai_compat_proxy_port
 
     # CI has no sibling checkout, so the reviewed KubeDojo contract is frozen
     # here and cross-checked against its real services.sh whenever available.

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORK = ROOT / "dashboards" / "work.html"
 INDEX = ROOT / "dashboards" / "index.html"
 
-PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
 SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
 PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
 

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORK = ROOT / "dashboards" / "work.html"
 INDEX = ROOT / "dashboards" / "index.html"
 
-PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8769/v1/projection"
 SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
 PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
 

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -22,7 +22,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORK_HTML = ROOT / "dashboards" / "work.html"
-PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
 PUBLIC_PATH = "/api/work/v1/projection"
 SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
 PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
@@ -31,7 +31,7 @@ PUBLIC_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 SYNTH_PRIVATE_REPO = "fixture-owner/fixture-repo"
 CANARY = "FX07_CANARY_SHOULD_NEVER_APPEAR_IN_DOM_OR_URL"
 FIXED_PUBLIC_PORT = 8765
-FIXED_PRIVATE_PORT = 8766
+FIXED_PRIVATE_PORT = 8767
 # Linux system Chrome/Chromium candidates for CI runners without Puppeteer's cache.
 LINUX_CHROME_CANDIDATES: tuple[str, ...] = (
     "/usr/bin/google-chrome",
@@ -574,7 +574,7 @@ def _browser_scenario(
     thread = threading.Thread(target=public_server.serve_forever, daemon=True)
     thread.start()
 
-    # Ephemeral private server is NOT used for the fixed URL — browser uses 8766.
+    # Ephemeral private server is NOT used for the fixed URL — browser uses 8767.
     # Intercept both URLs inside Chromium so proofs do not need free fixed ports.
     public_json = state.public_body.decode("utf-8") if state.public_body else "{}"
     private_json = state.private_body.decode("utf-8") if state.private_body else "{}"
@@ -814,7 +814,7 @@ try {{
 def test_static_private_url_is_exact_fixed_constant():
     html = WORK_HTML.read_text(encoding="utf-8")
     assert f"'{PRIVATE_URL}'" in html
-    assert html.count("127.0.0.1:8766") == html.count(PRIVATE_URL)
+    assert html.count("127.0.0.1:8767") == html.count(PRIVATE_URL)
     assert "localStorage" not in html
     assert "sessionStorage" not in html
     assert "document.cookie" not in html
@@ -1202,12 +1202,12 @@ def _cors_handler_factory(hits: dict[str, Any], allowed: set[str], body: bytes):
 
 
 def test_real_fixed_port_cors_http_and_browser_smoke():
-    """Live CORS on fixed ports 8765/8766 with real browser GET (no preflight)."""
+    """Live CORS on fixed ports 8765/8767 with real browser GET (no preflight)."""
     if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
         "127.0.0.1", FIXED_PRIVATE_PORT
     ):
         pytest.skip(
-            "fixed ports 8765/8766 busy; interception proofs already cover behavior"
+            "fixed ports 8765/8767 busy; interception proofs already cover behavior"
         )
 
     nm = _require_puppeteer()
@@ -1338,7 +1338,7 @@ def test_real_fixed_port_cors_localhost_origin_smoke():
         "127.0.0.1", FIXED_PRIVATE_PORT
     ):
         pytest.skip(
-            "fixed ports 8765/8766 busy; interception proofs already cover behavior"
+            "fixed ports 8765/8767 busy; interception proofs already cover behavior"
         )
 
     private_hits: dict[str, Any] = {"options": 0, "gets": []}

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -22,7 +22,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORK_HTML = ROOT / "dashboards" / "work.html"
-PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8769/v1/projection"
 PUBLIC_PATH = "/api/work/v1/projection"
 SCHEMA_DIGEST = "89fb9c1eec41baaa00a328d456340111163c1e3ab899cd7baa15e284fff65bde"
 PUBLIC_COMMIT = "f522c8dba5a68d86fe29d1a36bd8cfeb8c3acb9d"
@@ -31,7 +31,7 @@ PUBLIC_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 SYNTH_PRIVATE_REPO = "fixture-owner/fixture-repo"
 CANARY = "FX07_CANARY_SHOULD_NEVER_APPEAR_IN_DOM_OR_URL"
 FIXED_PUBLIC_PORT = 8765
-FIXED_PRIVATE_PORT = 8767
+FIXED_PRIVATE_PORT = 8769
 # Linux system Chrome/Chromium candidates for CI runners without Puppeteer's cache.
 LINUX_CHROME_CANDIDATES: tuple[str, ...] = (
     "/usr/bin/google-chrome",
@@ -574,7 +574,7 @@ def _browser_scenario(
     thread = threading.Thread(target=public_server.serve_forever, daemon=True)
     thread.start()
 
-    # Ephemeral private server is NOT used for the fixed URL — browser uses 8767.
+    # Ephemeral private server is NOT used for the fixed URL — browser uses 8769.
     # Intercept both URLs inside Chromium so proofs do not need free fixed ports.
     public_json = state.public_body.decode("utf-8") if state.public_body else "{}"
     private_json = state.private_body.decode("utf-8") if state.private_body else "{}"
@@ -814,7 +814,7 @@ try {{
 def test_static_private_url_is_exact_fixed_constant():
     html = WORK_HTML.read_text(encoding="utf-8")
     assert f"'{PRIVATE_URL}'" in html
-    assert html.count("127.0.0.1:8767") == html.count(PRIVATE_URL)
+    assert html.count("127.0.0.1:8769") == html.count(PRIVATE_URL)
     assert "localStorage" not in html
     assert "sessionStorage" not in html
     assert "document.cookie" not in html
@@ -1202,12 +1202,12 @@ def _cors_handler_factory(hits: dict[str, Any], allowed: set[str], body: bytes):
 
 
 def test_real_fixed_port_cors_http_and_browser_smoke():
-    """Live CORS on fixed ports 8765/8767 with real browser GET (no preflight)."""
+    """Live CORS on fixed ports 8765/8769 with real browser GET (no preflight)."""
     if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
         "127.0.0.1", FIXED_PRIVATE_PORT
     ):
         pytest.skip(
-            "fixed ports 8765/8767 busy; interception proofs already cover behavior"
+            "fixed ports 8765/8769 busy; interception proofs already cover behavior"
         )
 
     nm = _require_puppeteer()
@@ -1338,7 +1338,7 @@ def test_real_fixed_port_cors_localhost_origin_smoke():
         "127.0.0.1", FIXED_PRIVATE_PORT
     ):
         pytest.skip(
-            "fixed ports 8765/8767 busy; interception proofs already cover behavior"
+            "fixed ports 8765/8769 busy; interception proofs already cover behavior"
         )
 
     private_hits: dict[str, Any] = {"options": 0, "gets": []}

--- a/tests/test_work_privacy.py
+++ b/tests/test_work_privacy.py
@@ -16,7 +16,7 @@ from scripts.work.sources_public import SectionResult, private_capability_seam
 
 ROOT = Path(__file__).resolve().parents[1]
 CANARY_FILE = ROOT / "tests" / "fixtures" / "work" / "fx07_canaries.txt"
-PRIVATE_URL = "http://127.0.0.1:8766/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
 # Product + fixture surfaces only. Privacy tests may inject canaries as inputs;
 # the oracle asserts they never appear in public outputs or non-test artifacts.
 WORK_OWNED = [
@@ -153,7 +153,7 @@ def test_private_capability_seam_is_truthful_and_non_proxying():
     assert "private-local-adapter" in source or "private_capability" in source
     # Public server must never hardcode the private loopback adapter URL.
     assert PRIVATE_URL not in source
-    assert "127.0.0.1:8766" not in source
+    assert "127.0.0.1:8767" not in source
 
 
 def test_saved_view_urls_reject_private_values():
@@ -222,4 +222,4 @@ def test_public_server_owned_python_never_imports_private_adapter_url():
         for file in files:
             text = file.read_text(encoding="utf-8", errors="replace")
             assert PRIVATE_URL not in text, f"{file} embeds private adapter URL"
-            assert "8766/v1/projection" not in text, f"{file} embeds private adapter path"
+            assert "8767/v1/projection" not in text, f"{file} embeds private adapter path"

--- a/tests/test_work_privacy.py
+++ b/tests/test_work_privacy.py
@@ -16,7 +16,7 @@ from scripts.work.sources_public import SectionResult, private_capability_seam
 
 ROOT = Path(__file__).resolve().parents[1]
 CANARY_FILE = ROOT / "tests" / "fixtures" / "work" / "fx07_canaries.txt"
-PRIVATE_URL = "http://127.0.0.1:8767/v1/projection"
+PRIVATE_URL = "http://127.0.0.1:8769/v1/projection"
 # Product + fixture surfaces only. Privacy tests may inject canaries as inputs;
 # the oracle asserts they never appear in public outputs or non-test artifacts.
 WORK_OWNED = [
@@ -153,7 +153,7 @@ def test_private_capability_seam_is_truthful_and_non_proxying():
     assert "private-local-adapter" in source or "private_capability" in source
     # Public server must never hardcode the private loopback adapter URL.
     assert PRIVATE_URL not in source
-    assert "127.0.0.1:8767" not in source
+    assert "127.0.0.1:8769" not in source
 
 
 def test_saved_view_urls_reject_private_values():
@@ -222,4 +222,4 @@ def test_public_server_owned_python_never_imports_private_adapter_url():
         for file in files:
             text = file.read_text(encoding="utf-8", errors="replace")
             assert PRIVATE_URL not in text, f"{file} embeds private adapter URL"
-            assert "8767/v1/projection" not in text, f"{file} embeds private adapter path"
+            assert "8769/v1/projection" not in text, f"{file} embeds private adapter path"


### PR DESCRIPTION
## Outcome

Makes the unified Work dashboard usable through the normal `./services.sh` lifecycle. Sources remains on 8766, the private sibling Work adapter runs loopback-only on 8769, and KubeDojo remains on 8768/4333.

## What changed

- adds `work` to start/stop/restart/status/help/logs and default-all service handling
- reports typed unavailable prerequisites and blocked foreign listeners without breaking public-only startup
- requires the exact launched process to own the healthy 8769 listener
- stores adapter output only in the private checkout
- moves the browser fixed endpoint and docs/tests to 8769
- preserves the existing OpenAI-compatible bridge on 8767
- verifies Learn Ukrainian/KubeDojo port allocations are disjoint

## Verification

- 80 passed, 1 skipped across affected public service, dashboard, privacy, path-safety, and primary-integrity tests
- Grok Build first review found two medium hardening gaps; both were fixed
- Grok Build follow-up: PASS, no findings
- live concurrent health: Sources 8766 + Monitor 8765 + Work 8769
- `bash -n services.sh`, Ruff, and `git diff --check` clean

Refs #6847

