### PR TITLE
fix(work): correct fleet_reviews route defaults and public-monitor status degradation (#6849)

### DIFF
--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -2025,18 +2025,20 @@ def _review_item(row: sqlite3.Row) -> dict[str, Any]:
 
 @router.get("/reviews")
 def fleet_reviews(
-    kind: str | None = Query(default=None),
-    state: str | None = Query(default=None),
-    source: str | None = Query(default=None),
-    repository: str | None = Query(
-        default=None,
-        description="Exact repository identity (owner/name). Applied in SQL before count/pagination.",
-    ),
-    pr: int | None = Query(default=None, ge=1),
-    since: str | None = Query(default=None),
-    until: str | None = Query(default=None),
-    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
-    offset: int = Query(default=0, ge=0),
+    kind: Annotated[str | None, Query()] = None,
+    state: Annotated[str | None, Query()] = None,
+    source: Annotated[str | None, Query()] = None,
+    repository: Annotated[
+        str | None,
+        Query(
+            description="Exact repository identity (owner/name). Applied in SQL before count/pagination.",
+        ),
+    ] = None,
+    pr: Annotated[int | None, Query(ge=1)] = None,
+    since: Annotated[str | None, Query()] = None,
+    until: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=MAX_PAGE_SIZE)] = DEFAULT_PAGE_SIZE,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict[str, Any]:
     """Formal-review jobs, attempts, and publication counts without sealed blobs.
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -38,6 +38,7 @@ try:
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
+from scripts.orchestration import issue_stream_audit as isa
 from scripts.orchestration.reap_worktrees import primary_checkout_root, reap_worktrees
 
 from . import delegate_router as delegate_api
@@ -119,6 +120,10 @@ async def _lifespan(_app: FastAPI):
         initialize_hramatka_store()
     except (OSError, RuntimeError, sqlite3.Error) as exc:
         logger.error("Hramatka store initialization failed; readyz will remain unhealthy: %s", exc)
+    try:
+        isa.schedule_refresh(force=False)
+    except Exception as exc:
+        logger.warning("Issue stream audit refresh schedule on startup failed: %s", exc)
     start_periodic_refresh()
     try:
         yield

--- a/scripts/work/sources_public.py
+++ b/scripts/work/sources_public.py
@@ -359,7 +359,11 @@ def fetch_streams_projection(
 
         report = audit.read_cache(max_age_s=3600)
         stale = None if report is not None else audit.read_cache(max_age_s=7 * 24 * 3600)
-        state = audit.read_refresh_state()
+        state = (
+            audit.schedule_refresh(force=False)
+            if report is None
+            else audit.read_refresh_state()
+        )
         if report is not None:
             payload = _strip_private_index(report)
             status = "ok"
@@ -712,9 +716,18 @@ def public_source_envelope(sections: dict[str, SectionResult]) -> dict[str, Any]
             worst = section.status
     issues = sections.get("issues")
     prs = sections.get("prs")
+    core_ok = (
+        issues is not None
+        and issues.status in {"ok", "truncated"}
+        and prs is not None
+        and prs.status in {"ok", "truncated"}
+    )
+    source_status = (
+        "degraded" if core_ok and rank.get(worst, 0) > rank.get("degraded", 0) else worst
+    )
     return {
         "source_id": SOURCE_PUBLIC,
-        "status": worst,
+        "status": source_status,
         "freshness": {
             "observed_at": _iso_now(),
             "age_s": max(ages) if ages else 0.0,

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -579,6 +579,26 @@ def test_discussion_review_and_dead_letter_metadata_stay_read_only(
     assert dead_letters.json()["dead_letters"][0]["via"] == "fleet-comms"
 
 
+def test_fleet_reviews_direct_python_call_with_defaults(fleet_root: Path) -> None:
+    """Calling fleet_reviews directly as a Python function with defaults must not
+    raise AttributeError or pass Query sentinel objects into SQL/filters (#6849)."""
+    _seed_plane(fleet_root)
+    from scripts.api.fleet_router import fleet_reviews
+
+    public_repo = "learn-ukrainian/learn-ukrainian.github.io"
+    result = fleet_reviews(limit=10, offset=0, repository=public_repo)
+    assert isinstance(result, dict)
+    assert result["total"] >= 1
+    assert "reviews" in result
+    assert result["filters"]["kind"] is None
+    assert result["filters"]["state"] is None
+    assert result["filters"]["source"] is None
+    assert result["filters"]["since"] is None
+    assert result["filters"]["until"] is None
+    assert result["filters"]["pr"] is None
+    assert result["filters"]["repository"] == public_repo
+
+
 def test_reviews_repository_filter_applies_before_count_and_pagination(
     client: TestClient, fleet_root: Path
 ) -> None:

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -282,3 +282,10 @@ def test_independent_degradation_when_one_section_fails(monkeypatch):
     assert data["denominator"]["class4"]["fleet_reviews"] is False
     assert any(o["class"] == "fleet_reviews" for o in data["denominator"]["omissions"])
     assert any(o["class"] == "streams" for o in data["denominator"]["omissions"])
+    # Source status must be degraded (NOT unavailable) when core enumerations succeed
+    public_source = next(s for s in data["sources"] if s["source_id"] == "public-monitor")
+    assert public_source["status"] == "degraded"
+    assert public_source["sections"]["fleet_reviews"]["status"] == "timeout"
+    assert public_source["sections"]["streams"]["status"] == "stale"
+    assert public_source["sections"]["issues"]["status"] == "ok"
+    assert public_source["sections"]["prs"]["status"] == "ok"

--- a/tests/test_work_contract.py
+++ b/tests/test_work_contract.py
@@ -24,7 +24,12 @@ from scripts.work.schema import (
     schema_digest_sha256,
     validate_projection,
 )
-from scripts.work.sources_public import SectionResult, fetch_fleet_reviews
+from scripts.work.sources_public import (
+    SectionResult,
+    fetch_fleet_reviews,
+    fetch_streams_projection,
+    public_source_envelope,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURE = ROOT / "tests" / "fixtures" / "work" / "projection_public_min.json"
@@ -2000,3 +2005,208 @@ def test_build_projection_joins_sources_deterministically():
     # Deterministic: same inputs → same first attention id
     again = build_projection(sections, repository_id=REPO)
     assert again["attention"][0]["work_id"] == projection["attention"][0]["work_id"]
+
+
+def test_fetch_fleet_reviews_production_default_loader():
+    """Default loader in fetch_fleet_reviews calls fleet_reviews directly without
+    raising AttributeError on Query sentinels (#6849)."""
+    section = fetch_fleet_reviews(loader=None, repository_id=REPO)
+    assert isinstance(section, SectionResult)
+    assert section.status in {"ok", "truncated"}
+    assert section.reason is None
+    assert isinstance(section.payload, dict)
+    assert "reviews" in section.payload
+    assert all(r["repository"] == REPO for r in section.payload["reviews"])
+
+
+def test_public_source_envelope_independent_degradation_matrix():
+    """Verify source envelope status classification under various section health states (#6849)."""
+
+    def _base_sections(issues_st="ok", prs_st="ok"):
+        return {
+            "issues": SectionResult("issues", issues_st, count=5),
+            "prs": SectionResult("prs", prs_st, count=2),
+            "streams": SectionResult("streams", "ok", count=5),
+            "delegate_active": SectionResult("delegate_active", "ok", count=0),
+            "delegate_tasks": SectionResult("delegate_tasks", "ok", count=1),
+            "fleet_reviews": SectionResult("fleet_reviews", "ok", count=3),
+        }
+
+    # 1. All sections ok -> source ok
+    env_all_ok = public_source_envelope(_base_sections())
+    assert env_all_ok["status"] == "ok"
+
+    # 2. Core ok, optional truncated -> source truncated
+    sec_trunc = _base_sections()
+    sec_trunc["delegate_tasks"] = SectionResult("delegate_tasks", "truncated", count=500, truncated=True)
+    env_trunc = public_source_envelope(sec_trunc)
+    assert env_trunc["status"] == "truncated"
+
+    # 3. Core ok, optional stale -> source stale
+    sec_stale = _base_sections()
+    sec_stale["streams"] = SectionResult("streams", "stale", count=5, reason="stale")
+    env_stale = public_source_envelope(sec_stale)
+    assert env_stale["status"] == "stale"
+
+    # 4. Core ok, optional section unavailable -> source degraded (NOT unavailable)
+    sec_unavail = _base_sections()
+    sec_unavail["fleet_reviews"] = SectionResult("fleet_reviews", "unavailable", reason="db_error")
+    env_unavail = public_source_envelope(sec_unavail)
+    assert env_unavail["status"] == "degraded"
+    assert env_unavail["sections"]["fleet_reviews"]["status"] == "unavailable"
+    assert env_unavail["sections"]["issues"]["status"] == "ok"
+
+    # 5. Core ok, optional section timeout -> source degraded (NOT timeout)
+    sec_timeout = _base_sections()
+    sec_timeout["streams"] = SectionResult("streams", "timeout", reason="timeout")
+    env_timeout = public_source_envelope(sec_timeout)
+    assert env_timeout["status"] == "degraded"
+    assert env_timeout["sections"]["streams"]["status"] == "timeout"
+
+    # 6. Core issues unavailable -> source unavailable (reflects core failure)
+    sec_core_fail = _base_sections(issues_st="unavailable")
+    env_core_fail = public_source_envelope(sec_core_fail)
+    assert env_core_fail["status"] == "unavailable"
+
+    # 7. Core prs timeout -> source timeout (reflects core failure)
+    sec_core_timeout = _base_sections(prs_st="timeout")
+    env_core_timeout = public_source_envelope(sec_core_timeout)
+    assert env_core_timeout["status"] == "timeout"
+
+
+def test_missing_streams_cache_and_simulated_restart_behavior():
+    """Simulate missing streams cache at Monitor start:
+    - issues derive UNKNOWN health / INSPECT_UNKNOWN action (honest health)
+    - public PRs with real signals sort ahead of UNKNOWN issues
+    - source envelope is degraded (not unavailable)
+    - denominator omissions records streams unavailable
+    (#6849 Scope item 3)."""
+    sections = {
+        "issues": SectionResult(
+            "issues",
+            "ok",
+            payload=[
+                {
+                    "number": 2353,
+                    "title": "Oldest issue",
+                    "labels": [],
+                    "assignees": [],
+                    "body": None,
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "url": f"https://github.com/{REPO}/issues/2353",
+                    "state": "OPEN",
+                },
+                {
+                    "number": 6847,
+                    "title": "Current issue",
+                    "labels": [],
+                    "assignees": [],
+                    "body": None,
+                    "createdAt": "2026-08-16T00:00:00Z",
+                    "updatedAt": "2026-08-16T00:00:00Z",
+                    "url": f"https://github.com/{REPO}/issues/6847",
+                    "state": "OPEN",
+                },
+            ],
+            count=2,
+        ),
+        "prs": SectionResult(
+            "prs",
+            "ok",
+            payload=[
+                {
+                    "number": 6848,
+                    "title": "Failing CI PR",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": "NONE",
+                    "statusCheckRollup": [{"state": "FAILURE"}],
+                    "mergeStateStatus": "BLOCKED",
+                    "labels": [],
+                    "assignees": [],
+                    "url": f"https://github.com/{REPO}/pull/6848",
+                    "createdAt": "2026-08-16T00:00:00Z",
+                    "updatedAt": "2026-08-16T00:00:00Z",
+                    "headRefOid": "deadbeef",
+                    "headRefName": "fix/ci",
+                },
+                {
+                    "number": 6809,
+                    "title": "PR waiting review",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "statusCheckRollup": [{"state": "SUCCESS"}],
+                    "mergeStateStatus": "BLOCKED",
+                    "labels": [],
+                    "assignees": [],
+                    "url": f"https://github.com/{REPO}/pull/6809",
+                    "createdAt": "2026-08-15T00:00:00Z",
+                    "updatedAt": "2026-08-15T00:00:00Z",
+                    "headRefOid": "feedface",
+                    "headRefName": "feat/cf",
+                },
+            ],
+            count=2,
+        ),
+        # Missing streams cache (fresh start)
+        "streams": SectionResult("streams", "unavailable", reason="no-cache"),
+        "delegate_active": SectionResult("delegate_active", "ok", payload={"total": 0, "tasks": []}, count=0),
+        "delegate_tasks": SectionResult("delegate_tasks", "ok", payload={"total": 0, "tasks": []}, count=0),
+        "fleet_reviews": SectionResult("fleet_reviews", "ok", payload={"total": 0, "reviews": []}, count=0),
+    }
+
+    projection = build_projection(sections, repository_id=REPO)
+    validate_projection(projection)
+
+    # 1. Source envelope is degraded, not unavailable
+    public_src = next(s for s in projection["sources"] if s["source_id"] == "public-monitor")
+    assert public_src["status"] == "degraded"
+    assert public_src["sections"]["streams"]["status"] == "unavailable"
+
+    # 2. Streams omission is tracked
+    assert any(
+        o["class"] == "streams" and o["reason"] == "no-cache" for o in projection["denominator"]["omissions"]
+    )
+    assert projection["denominator"]["streams_complete"] is False
+
+    # 3. Honest health: issues have UNKNOWN health and INSPECT_UNKNOWN safe_next_action
+    items_by_num = {item["remote_id"]: item for item in projection["items"]}
+    assert items_by_num["2353"]["health"] == "UNKNOWN"
+    assert items_by_num["2353"]["safe_next_action"]["code"] == "INSPECT_UNKNOWN"
+    assert items_by_num["6847"]["health"] == "UNKNOWN"
+    assert items_by_num["6847"]["safe_next_action"]["code"] == "INSPECT_UNKNOWN"
+
+    # 4. PRs have correct real health
+    assert items_by_num["6848"]["health"] == "OFF_TRACK"
+    assert items_by_num["6848"]["safe_next_action"]["code"] == "FIX_CI"
+    assert items_by_num["6809"]["health"] == "AT_RISK"
+    assert items_by_num["6809"]["safe_next_action"]["code"] == "REQUEST_CF_REVIEW"
+
+    # 5. Real PR signals rank at the top of the Attention list ahead of the UNKNOWN issues
+    att = projection["attention"]
+    assert att[0]["remote_id"] == "6848"
+    assert att[0]["health"] == "OFF_TRACK"
+    assert att[1]["remote_id"] == "6809"
+    assert att[1]["health"] == "AT_RISK"
+    assert att[2]["health"] == "UNKNOWN"
+    assert att[3]["health"] == "UNKNOWN"
+
+
+def test_fetch_streams_projection_default_loader_schedules_refresh_when_missing(monkeypatch):
+    """When streams cache is missing, fetch_streams_projection schedules background refresh (#6849)."""
+    from scripts.orchestration import issue_stream_audit as audit
+
+    scheduled = []
+    monkeypatch.setattr(audit, "read_cache", lambda max_age_s: None)
+    monkeypatch.setattr(
+        audit,
+        "schedule_refresh",
+        lambda *, force=False: scheduled.append(force) or audit._default_refresh_state(),
+    )
+
+    sec = fetch_streams_projection(loader=None)
+    assert sec.status == "unavailable"
+    assert len(scheduled) == 1
+    assert scheduled[0] is False


### PR DESCRIPTION
## Summary
Addresses all three symptoms reported in #6849:
1. **fleet_reviews AttributeError**: `scripts/api/fleet_router.py::fleet_reviews` parameter defaults migrated to FastAPI `Annotated[..., Query(...)] = default` so Python callers (e.g. `fetch_fleet_reviews` default loader) pass actual default values (`None`, `DEFAULT_PAGE_SIZE`, `0`) rather than `QueryInfo` sentinel objects. This prevents `_normalize_time` / SQL filter construction from raising `AttributeError: 'Query' object has no attribute 'replace'`.
2. **public-monitor source status degradation**: `scripts/work/sources_public.py::public_source_envelope` now preserves source status as `degraded` (or `stale` / `truncated`) when core GitHub enumerations (`issues`, `prs`) succeed but optional/class-4 sections (`streams`, `fleet_reviews`, etc.) experience errors or timeouts, keeping omissions visible in per-section metadata and `denominator.omissions`. Only true core enumeration failures (`issues` or `prs`) mark the overall source `unavailable` / `timeout`.
3. **Streams cache availability & honest issue health**:
   - `scripts/work/sources_public.py::fetch_streams_projection` now schedules a detached background refresh via `audit.schedule_refresh(force=False)` when the cache is absent (`report is None`).
   - `scripts/api/main.py::_lifespan` triggers `isa.schedule_refresh(force=False)` on Monitor startup to pre-warm the cache.
   - When streams cache is missing, issue health honestly derives `UNKNOWN` (`authority_unknown`) and `INSPECT_UNKNOWN` action without falsely marking the entire source down; PRs with active CI or review signals sort to the top of Attention ahead of the `UNKNOWN` issues.

## Evidence (#M-4)

### Live probe reproduction (pre-fix symptom on running server)
Command:
```bash
curl -s http://127.0.0.1:8765/api/work/v1/projection | python -c 'import sys, json; d=json.load(sys.stdin); print("sources:", [(s["source_id"], s["status"]) for s in d.get("sources", [])]); print("sections:", d.get("sources", [])[0].get("sections")); print("omissions:", d.get("denominator", {}).get("omissions"))'
```
Raw Output:
```
sources: [('public-monitor', 'unavailable'), ('private-local-adapter', 'unavailable')]
sections: {'fleet_reviews': {'status': 'unavailable', 'count': 0, 'reason': 'fleet_reviews_error:AttributeError', 'age_s': 0.0}, 'streams': {'status': 'stale', 'count': 76, 'age_s': 13899.564613819122}, 'delegate_tasks': {'status': 'ok', 'count': 1, 'age_s': 0.0}, 'delegate_active': {'status': 'ok', 'count': 0, 'age_s': 0.0}, 'prs': {'status': 'ok', 'count': 1, 'age_s': 0.0}, 'issues': {'status': 'ok', 'count': 78, 'age_s': 0.0}}
omissions: [{'class': 'streams', 'reason': 'stale', 'count': 0}, {'class': 'fleet_reviews', 'reason': 'fleet_reviews_error:AttributeError', 'count': 0}, {'class': 'private_adapter', 'reason': 'not_configured', 'count': 0}]
```

### Post-fix direct Python probe for fetch_fleet_reviews
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -c 'from scripts.work.sources_public import fetch_fleet_reviews; print(fetch_fleet_reviews())'
```
Raw Output:
```
SectionResult(name='fleet_reviews', status='ok', payload={'total': 498, 'reviews': [...]}, reason=None, age_s=0.0, observed_at='2026-08-16T10:45:27.058641Z', count=498, truncated=False)
```

### Mutation checks (#M-16)
1. Reverting `fleet_reviews` parameter defaults from `Annotated[..., Query()] = None` back to `Query(default=None)` reproduces `AttributeError: 'Query' object has no attribute 'replace'` on direct Python call.
2. Reverting `public_source_envelope` back to worst-status reduction marks the public source `unavailable` when `fleet_reviews` or `streams` fails despite `issues` and `prs` being `ok`, failing the degradation matrix test.

### Test suite verification
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_work_api.py tests/test_work_contract.py tests/test_work_dashboard.py tests/test_work_privacy.py tests/test_work_dashboard_private_integration.py tests/test_fleet_observer_api.py
```
Raw Output:
```
======================== 90 passed, 2 skipped in 44.72s ========================
```

### Ruff check
Command:
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/api/fleet_router.py scripts/api/main.py scripts/work/sources_public.py tests/test_fleet_observer_api.py tests/test_work_api.py tests/test_work_contract.py
```
Raw Output:
```
All checks passed!
```

Refs #6849