### PR TITLE
Work: actionable-only default view for QA (#6850)

### DIFF
--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -643,11 +643,13 @@ button, input, select { font: inherit; }
     return { ok: true, doc: merged };
   }
 
+  const NON_ACTIONABLE_ACTION_CODES = new Set(['INSPECT_UNKNOWN', 'OPEN_GITHUB', 'NONE']);
+
   function isActionable(item) {
     if (!item) return false;
     if (item.health === 'OFF_TRACK' || item.health === 'AT_RISK') return true;
     const code = (item.safe_next_action && item.safe_next_action.code) || '';
-    return !!code && code !== 'INSPECT_UNKNOWN';
+    return !!code && !NON_ACTIONABLE_ACTION_CODES.has(code);
   }
 
   function readFiltersFromUrl() {

--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -28,7 +28,7 @@ button, input, select { font: inherit; }
 .signal-card { align-self: end; background: var(--bg2); border: 1px solid var(--border); border-left: 4px solid var(--accent); padding: 14px 16px; }
 .signal-card strong { display: block; font-family: Charter, Georgia, serif; font-size: 18px; margin-bottom: 4px; }
 .signal-card p { color: var(--text3); font-size: 12px; margin: 0; line-height: 1.4; }
-.filter-strip { background: var(--bg2); border: 1px solid var(--border); display: grid; gap: 10px; grid-template-columns: repeat(6, minmax(0, 1fr)) auto; margin: 18px 0; padding: 12px; }
+.filter-strip { background: var(--bg2); border: 1px solid var(--border); display: grid; gap: 10px; grid-template-columns: repeat(7, minmax(0, 1fr)) auto; margin: 18px 0; padding: 12px; }
 .field { display: grid; gap: 4px; min-width: 0; }
 .field label { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 .field select, .field input { border: 1px solid var(--border); border-radius: 3px; min-width: 0; padding: 7px 8px; background: var(--bg); color: var(--text); }
@@ -145,6 +145,13 @@ button, input, select { font: inherit; }
 
   <section class="filter-strip" aria-label="Public-safe filters">
     <div class="field">
+      <label for="filter-view">View</label>
+      <select id="filter-view">
+        <option value="actionable">Actionable</option>
+        <option value="all">All</option>
+      </select>
+    </div>
+    <div class="field">
       <label for="filter-health">Health</label>
       <select id="filter-health">
         <option value="">All</option>
@@ -230,7 +237,7 @@ button, input, select { font: inherit; }
 
 <script>
 (function () {
-  const ALLOWED_FILTER_KEYS = new Set(['health', 'kind', 'lifecycle', 'orphan', 'repository_id', 'source_id']);
+  const ALLOWED_FILTER_KEYS = new Set(['health', 'kind', 'lifecycle', 'orphan', 'repository_id', 'source_id', 'view']);
   const PUBLIC_SINGLETON_REPO = 'learn-ukrainian/learn-ukrainian.github.io';
   const PUBLIC_PROJECTION_URL = '/api/work/v1/projection';
   // Fixed constant — never configurable, never persisted, never rendered into shareable state.
@@ -272,6 +279,7 @@ button, input, select { font: inherit; }
     privateMeta: document.getElementById('source-private-meta'),
     attentionMeta: document.getElementById('attention-meta'),
     foundation: document.getElementById('foundation-label'),
+    view: document.getElementById('filter-view'),
     health: document.getElementById('filter-health'),
     kind: document.getElementById('filter-kind'),
     lifecycle: document.getElementById('filter-lifecycle'),
@@ -635,6 +643,13 @@ button, input, select { font: inherit; }
     return { ok: true, doc: merged };
   }
 
+  function isActionable(item) {
+    if (!item) return false;
+    if (item.health === 'OFF_TRACK' || item.health === 'AT_RISK') return true;
+    const code = (item.safe_next_action && item.safe_next_action.code) || '';
+    return !!code && code !== 'INSPECT_UNKNOWN';
+  }
+
   function readFiltersFromUrl() {
     const params = new URLSearchParams(window.location.search);
     const out = {};
@@ -647,12 +662,15 @@ button, input, select { font: inherit; }
       if (key === 'kind' && !['issue', 'pr', 'task', 'review'].includes(value)) continue;
       if (key === 'lifecycle' && !['open', 'draft', 'running', 'failed'].includes(value)) continue;
       if (key === 'orphan' && value !== 'true' && value !== 'false') continue;
+      if (key === 'view' && !['actionable', 'all'].includes(value)) continue;
       out[key] = value;
     }
+    if (!out.view) out.view = 'actionable';
     return out;
   }
 
   function applyFiltersToControls(filters) {
+    if (els.view) els.view.value = filters.view || 'actionable';
     els.health.value = filters.health || '';
     els.kind.value = filters.kind || '';
     els.lifecycle.value = filters.lifecycle || '';
@@ -663,6 +681,8 @@ button, input, select { font: inherit; }
 
   function controlsToFilters() {
     const filters = {};
+    if (els.view && els.view.value) filters.view = els.view.value;
+    else filters.view = 'actionable';
     if (els.health.value) filters.health = els.health.value;
     if (els.kind.value) filters.kind = els.kind.value;
     if (els.lifecycle.value) filters.lifecycle = els.lifecycle.value;
@@ -681,6 +701,7 @@ button, input, select { font: inherit; }
       if (key === 'endpoint' || key === 'q' || key === 'private_endpoint') return;
       if (key === 'repository_id' && value !== PUBLIC_SINGLETON_REPO) return;
       if (key === 'source_id' && value !== PUBLIC_SOURCE_ID) return;
+      if (key === 'view' && value === 'actionable') return;
       out[key] = value;
     });
     return out;
@@ -697,7 +718,9 @@ button, input, select { font: inherit; }
 
   function applyLocalFilters(projection, filters) {
     if (!projection) return { items: [], attention: [] };
+    const view = filters.view || 'actionable';
     const items = (projection.items || []).filter((item) => {
+      if (view === 'actionable' && !isActionable(item)) return false;
       if (filters.health && item.health !== filters.health) return false;
       if (filters.kind && item.resource_kind !== filters.kind) return false;
       if (filters.lifecycle && item.lifecycle !== filters.lifecycle) return false;
@@ -826,7 +849,7 @@ button, input, select { font: inherit; }
         'class4 d1=' + (den.class4 && den.class4.delegate_active) + ' d2=' + (den.class4 && den.class4.delegate_tasks) + ' r1=' + (den.class4 && den.class4.fleet_reviews),
       ].join(' · ');
       els.foundation.textContent = projection.foundation_status || 'FOUNDATION_COMPLETE';
-      els.attentionMeta.textContent = ((projection.attention || []).length) + ' ranked · cache ' + (projection.cache_age_s ?? 0) + 's';
+      els.attentionMeta.textContent = (state.attention ? state.attention.length : ((projection.attention || []).length)) + ' ranked · cache ' + (projection.cache_age_s ?? 0) + 's';
     } else if (publicStatusOverride) {
       els.publicMeta.textContent = 'status=' + publicStatusOverride;
     }

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -74,6 +74,7 @@ def test_saved_view_client_writes_only_allowlisted_keys():
     assert "health" in keys
     assert "kind" in keys
     assert "source_id" in keys
+    assert "view" in keys
     assert "q" not in keys
     assert "endpoint" not in keys
 
@@ -148,3 +149,14 @@ def test_work_page_shareable_url_strips_private_selectors():
     # Private source/repo must not be written into transferable saved-view state.
     assert "value !== PUBLIC_SINGLETON_REPO" in html or "value !== PUBLIC_SINGLETON_REPO" in html
     assert "value !== PUBLIC_SOURCE_ID" in html
+
+
+def test_work_page_actionable_default_view_contracts():
+    html = WORK.read_text(encoding="utf-8")
+    assert 'id="filter-view"' in html
+    assert '<option value="actionable">Actionable</option>' in html
+    assert '<option value="all">All</option>' in html
+    assert "isActionable" in html
+    assert "INSPECT_UNKNOWN" in html
+    assert "OFF_TRACK" in html
+    assert "AT_RISK" in html

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -158,5 +158,7 @@ def test_work_page_actionable_default_view_contracts():
     assert '<option value="all">All</option>' in html
     assert "isActionable" in html
     assert "INSPECT_UNKNOWN" in html
+    assert "OPEN_GITHUB" in html
+    assert "NONE" in html
     assert "OFF_TRACK" in html
     assert "AT_RISK" in html

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -251,6 +251,83 @@ def _public_min() -> dict[str, Any]:
     }
 
 
+def _healthy_public_item(*, remote_id: str = "5922", title: str = "Healthy public issue") -> dict[str, Any]:
+    work_id = f"wp1:public-monitor:{PUBLIC_REPO}:issue:{remote_id}"
+    return {
+        "work_id": work_id,
+        "source_id": "public-monitor",
+        "repository_id": PUBLIC_REPO,
+        "resource_kind": "issue",
+        "remote_id": remote_id,
+        "title": title,
+        "lifecycle": "open",
+        "labels": ["healthy"],
+        "assignees": [],
+        "urls": {
+            "html": f"https://github.com/{PUBLIC_REPO}/issues/{remote_id}",
+        },
+        "timestamps": {
+            "created_at": "2026-08-16T00:00:00Z",
+            "updated_at": "2026-08-16T00:00:00Z",
+        },
+        "projections": {
+            "stream": {
+                "status": "on_track",
+                "streams": [],
+                "fresh": True,
+                "authority_missing": False,
+            },
+            "dispatch": {"task_ids": [], "statuses": [], "unresolved": False},
+            "review": {
+                "review_ids": [],
+                "states": [],
+                "sealed_verdict_available": False,
+            },
+            "verification": {"kind": "none", "state": "n/a"},
+        },
+        "relationships": [],
+        "health": "ON_TRACK",
+        "attention_rank": 1,
+        "safe_next_action": {
+            "code": "OPEN_GITHUB",
+            "reason_codes": ["healthy_on_track"],
+        },
+        "authority": [
+            {
+                "domain": "github",
+                "observed_at": "2026-08-16T00:00:00Z",
+                "age_s": 0,
+                "stale": False,
+            }
+        ],
+        "omissions": [],
+        "flags": {"orphan": False, "has_blocker": False},
+    }
+
+
+def _public_with_healthy_item() -> dict[str, Any]:
+    doc = _public_min()
+    healthy = _healthy_public_item()
+    doc["items"].append(healthy)
+    doc["attention"].append(
+        {
+            "work_id": healthy["work_id"],
+            "attention_rank": healthy["attention_rank"],
+            "health": healthy["health"],
+            "safe_next_action": healthy["safe_next_action"],
+            "title": healthy["title"],
+            "resource_kind": healthy["resource_kind"],
+            "repository_id": healthy["repository_id"],
+            "remote_id": healthy["remote_id"],
+        }
+    )
+    doc["denominator"]["issues_open"] = 2
+    for src in doc["sources"]:
+        if src["source_id"] == "public-monitor":
+            src["sections"]["issues"]["count"] = 2
+    return doc
+
+
 def _private_ok(*, remote_id: str = "7", kind: str = "issue", rank: int = 0) -> dict[str, Any]:
     title = f"private-{kind}-{remote_id}"
     work_id = f"wp1:private-local-adapter:{SYNTH_PRIVATE_REPO}:{kind}:{remote_id}"
@@ -1153,14 +1230,16 @@ def test_browser_refresh_uses_fresh_on_public_only():
 
 def test_browser_actionable_default_view_filters_non_actionable_rows():
     """Default view without query params renders only actionable items."""
-    public = _public_min()
-    # Public item is AT_RISK (actionable); private item is UNKNOWN / INSPECT_UNKNOWN (non-actionable).
+    # Public item 1 is AT_RISK (actionable); public item 2 is ON_TRACK / OPEN_GITHUB (healthy non-actionable);
+    # private item is UNKNOWN / INSPECT_UNKNOWN (non-actionable).
+    public = _public_with_healthy_item()
     private = _private_ok()
     result = _browser_scenario(public_doc=public, private_doc=private)
     snap = result["snapshot"]
     # In default view, only public actionable item renders.
     assert snap["rowCount"] == 1
     assert "Public attention item" in snap["listText"]
+    assert "Healthy public issue" not in snap["listText"]
     assert "private-issue-7" not in snap["listText"]
     # URL search remains clean without query params
     assert snap["search"] == ""
@@ -1168,14 +1247,15 @@ def test_browser_actionable_default_view_filters_non_actionable_rows():
 
 def test_browser_switch_view_between_actionable_and_all():
     """Switching view via dropdown + apply updates visible rows and URL."""
-    public = _public_min()
+    public = _public_with_healthy_item()
     private = _private_ok()
     # Step 1: Start at default actionable view -> 1 row
     result_default = _browser_scenario(public_doc=public, private_doc=private)
     assert result_default["snapshot"]["rowCount"] == 1
+    assert "Healthy public issue" not in result_default["snapshot"]["listText"]
     assert result_default["snapshot"]["search"] == ""
 
-    # Step 2: Switch to 'all' via UI select + apply -> 2 rows, URL is ?view=all
+    # Step 2: Switch to 'all' via UI select + apply -> 3 rows, URL is ?view=all
     result_all = _browser_scenario(
         public_doc=public,
         private_doc=private,
@@ -1186,8 +1266,9 @@ def test_browser_switch_view_between_actionable_and_all():
         ],
     )
     snap_all = result_all["snapshot"]
-    assert snap_all["rowCount"] == 2
+    assert snap_all["rowCount"] == 3
     assert "Public attention item" in snap_all["listText"]
+    assert "Healthy public issue" in snap_all["listText"]
     assert "private-issue-7" in snap_all["listText"]
     assert "view=all" in snap_all["search"]
 
@@ -1205,18 +1286,20 @@ def test_browser_switch_view_between_actionable_and_all():
     snap_back = result_back["snapshot"]
     assert snap_back["rowCount"] == 1
     assert "Public attention item" in snap_back["listText"]
+    assert "Healthy public issue" not in snap_back["listText"]
     assert "private-issue-7" not in snap_back["listText"]
     assert snap_back["search"] == ""
 
 
 def test_browser_direct_actionable_url_normalizes_to_clean_path():
     """Navigating directly to ?view=actionable renders actionable view and normalizes URL."""
-    public = _public_min()
+    public = _public_with_healthy_item()
     private = _private_ok()
     result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?view=actionable")
     snap = result["snapshot"]
     assert snap["rowCount"] == 1
     assert "Public attention item" in snap["listText"]
+    assert "Healthy public issue" not in snap["listText"]
     assert "private-issue-7" not in snap["listText"]
     # Normalizes to clean URL
     assert snap["search"] == ""
@@ -1224,19 +1307,21 @@ def test_browser_direct_actionable_url_normalizes_to_clean_path():
 
 def test_browser_actionable_with_kind_and_health_filters():
     """Existing filters like kind and health continue working in actionable default view."""
-    public = _public_min()
+    public = _public_with_healthy_item()
     private = _private_ok()
     # Filter by health=AT_RISK on actionable default
     result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?health=AT_RISK")
     snap = result["snapshot"]
     assert snap["rowCount"] == 1
     assert "Public attention item" in snap["listText"]
+    assert "Healthy public issue" not in snap["listText"]
     assert "health=AT_RISK" in snap["search"]
     # Filter by kind=issue on actionable default
     result_kind = _browser_scenario(public_doc=public, private_doc=private, filter_query="?kind=issue")
     snap_kind = result_kind["snapshot"]
     assert snap_kind["rowCount"] == 1
     assert "Public attention item" in snap_kind["listText"]
+    assert "Healthy public issue" not in snap_kind["listText"]
     assert "kind=issue" in snap_kind["search"]
 
 

--- a/tests/test_work_dashboard_private_integration.py
+++ b/tests/test_work_dashboard_private_integration.py
@@ -231,9 +231,7 @@ def _public_min() -> dict[str, Any]:
                 "delegate_tasks": True,
                 "fleet_reviews": True,
             },
-            "omissions": [
-                {"class": "private_adapter", "reason": "not_configured", "count": 0}
-            ],
+            "omissions": [{"class": "private_adapter", "reason": "not_configured", "count": 0}],
         },
         "capabilities": {
             "mutation": False,
@@ -566,9 +564,7 @@ def _browser_scenario(
     state.private_delay_s = private_delay_ms / 1000.0
 
     # Ephemeral public server for HTML + public projection (same origin).
-    public_handler = _make_handler(
-        state, role="public", allowed_origins={"http://127.0.0.1", "http://localhost"}
-    )
+    public_handler = _make_handler(state, role="public", allowed_origins={"http://127.0.0.1", "http://localhost"})
     public_server = ThreadingHTTPServer(("127.0.0.1", 0), public_handler)
     public_port = public_server.server_address[1]
     thread = threading.Thread(target=public_server.serve_forever, daemon=True)
@@ -855,8 +851,7 @@ def test_puppeteer_launch_options_ignores_missing_env_and_picks_first_candidate(
             "/usr/bin/chromium",
             "/usr/bin/chromium-browser",
         ),
-        is_executable=lambda path: path
-        in {"/usr/bin/chromium", "/usr/bin/chromium-browser"},
+        is_executable=lambda path: path in {"/usr/bin/chromium", "/usr/bin/chromium-browser"},
     )
     assert opts["executablePath"] == "/usr/bin/chromium"
 
@@ -897,7 +892,7 @@ def test_resolve_chrome_executable_order_matches_linux_candidates():
 def test_browser_dual_success_merges_exactly_once():
     public = _public_min()
     private = _private_ok()
-    result = _browser_scenario(public_doc=public, private_doc=private)
+    result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?view=all")
     snap = result["snapshot"]
     obs = result["observed"]
     assert obs["publicCount"] >= 1
@@ -928,6 +923,7 @@ def test_browser_private_unreachable_leaves_public_usable():
     assert snap["rowCount"] == 1
     assert "Public attention item" in snap["listText"]
     assert "unavailable · unreachable" in snap["privateMeta"]
+    assert "status=ok" in snap["publicMeta"]
     assert snap["errorHidden"] is True
 
 
@@ -1009,6 +1005,7 @@ def test_browser_public_failure_private_success():
         public_doc=None,
         public_status=503,
         private_doc=_private_ok(),
+        filter_query="?view=all",
     )
     snap = result["snapshot"]
     assert snap["rowCount"] == 1
@@ -1022,6 +1019,7 @@ def test_browser_public_schema_mismatch_private_success():
     result = _browser_scenario(
         public_doc={"not": "valid"},
         private_doc=_private_ok(),
+        filter_query="?view=all",
     )
     snap = result["snapshot"]
     assert snap["rowCount"] == 1
@@ -1038,10 +1036,7 @@ def test_browser_both_failures_typed_banner():
     )
     snap = result["snapshot"]
     assert snap["errorHidden"] is False
-    assert (
-        snap["error"]
-        == "Work projection unavailable · public=unreachable · private=unreachable"
-    )
+    assert snap["error"] == "Work projection unavailable · public=unreachable · private=unreachable"
     assert snap["listText"].strip() == "No source projection is available. Retry refresh."
     assert "HTTP" not in snap["error"]
     assert "TypeError" not in snap["error"]
@@ -1075,6 +1070,7 @@ def test_browser_private_repo_filter_not_shareable_in_url():
     result = _browser_scenario(
         public_doc=_public_min(),
         private_doc=_private_ok(),
+        filter_query="?view=all",
         actions=[
             {
                 "type": "select",
@@ -1102,7 +1098,7 @@ def test_browser_dense_order_and_no_duplicate_ids():
     public["items"][0]["health"] = "ON_TRACK"
     public["attention"][0]["health"] = "ON_TRACK"
     private = _private_ok(remote_id="3", rank=0)
-    result = _browser_scenario(public_doc=public, private_doc=private)
+    result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?view=all")
     snap = result["snapshot"]
     assert snap["rowCount"] == 2
     assert len(set(snap["rowIds"])) == 2
@@ -1115,6 +1111,7 @@ def test_browser_mobile_viewport_no_horizontal_overflow_and_keyboard():
     result = _browser_scenario(
         public_doc=_public_min(),
         private_doc=_private_ok(),
+        filter_query="?view=all",
         viewport={"width": 390, "height": 844},
         actions=[
             {"type": "key", "key": "ArrowDown"},
@@ -1152,6 +1149,95 @@ def test_browser_refresh_uses_fresh_on_public_only():
     assert any("fresh=true" in u for u in public_urls)
     for req in obs["private"]:
         assert req["url"] == PRIVATE_URL
+
+
+def test_browser_actionable_default_view_filters_non_actionable_rows():
+    """Default view without query params renders only actionable items."""
+    public = _public_min()
+    # Public item is AT_RISK (actionable); private item is UNKNOWN / INSPECT_UNKNOWN (non-actionable).
+    private = _private_ok()
+    result = _browser_scenario(public_doc=public, private_doc=private)
+    snap = result["snapshot"]
+    # In default view, only public actionable item renders.
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "private-issue-7" not in snap["listText"]
+    # URL search remains clean without query params
+    assert snap["search"] == ""
+
+
+def test_browser_switch_view_between_actionable_and_all():
+    """Switching view via dropdown + apply updates visible rows and URL."""
+    public = _public_min()
+    private = _private_ok()
+    # Step 1: Start at default actionable view -> 1 row
+    result_default = _browser_scenario(public_doc=public, private_doc=private)
+    assert result_default["snapshot"]["rowCount"] == 1
+    assert result_default["snapshot"]["search"] == ""
+
+    # Step 2: Switch to 'all' via UI select + apply -> 2 rows, URL is ?view=all
+    result_all = _browser_scenario(
+        public_doc=public,
+        private_doc=private,
+        actions=[
+            {"type": "select", "selector": "#filter-view", "value": "all"},
+            {"type": "click", "selector": "#btn-apply"},
+            {"type": "wait", "ms": 200},
+        ],
+    )
+    snap_all = result_all["snapshot"]
+    assert snap_all["rowCount"] == 2
+    assert "Public attention item" in snap_all["listText"]
+    assert "private-issue-7" in snap_all["listText"]
+    assert "view=all" in snap_all["search"]
+
+    # Step 3: Switch back to 'actionable' via UI select + apply -> 1 row, clean URL
+    result_back = _browser_scenario(
+        public_doc=public,
+        private_doc=private,
+        filter_query="?view=all",
+        actions=[
+            {"type": "select", "selector": "#filter-view", "value": "actionable"},
+            {"type": "click", "selector": "#btn-apply"},
+            {"type": "wait", "ms": 200},
+        ],
+    )
+    snap_back = result_back["snapshot"]
+    assert snap_back["rowCount"] == 1
+    assert "Public attention item" in snap_back["listText"]
+    assert "private-issue-7" not in snap_back["listText"]
+    assert snap_back["search"] == ""
+
+
+def test_browser_direct_actionable_url_normalizes_to_clean_path():
+    """Navigating directly to ?view=actionable renders actionable view and normalizes URL."""
+    public = _public_min()
+    private = _private_ok()
+    result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?view=actionable")
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "private-issue-7" not in snap["listText"]
+    # Normalizes to clean URL
+    assert snap["search"] == ""
+
+
+def test_browser_actionable_with_kind_and_health_filters():
+    """Existing filters like kind and health continue working in actionable default view."""
+    public = _public_min()
+    private = _private_ok()
+    # Filter by health=AT_RISK on actionable default
+    result = _browser_scenario(public_doc=public, private_doc=private, filter_query="?health=AT_RISK")
+    snap = result["snapshot"]
+    assert snap["rowCount"] == 1
+    assert "Public attention item" in snap["listText"]
+    assert "health=AT_RISK" in snap["search"]
+    # Filter by kind=issue on actionable default
+    result_kind = _browser_scenario(public_doc=public, private_doc=private, filter_query="?kind=issue")
+    snap_kind = result_kind["snapshot"]
+    assert snap_kind["rowCount"] == 1
+    assert "Public attention item" in snap_kind["listText"]
+    assert "kind=issue" in snap_kind["search"]
 
 
 # ---------------------------------------------------------------------------
@@ -1203,12 +1289,8 @@ def _cors_handler_factory(hits: dict[str, Any], allowed: set[str], body: bytes):
 
 def test_real_fixed_port_cors_http_and_browser_smoke():
     """Live CORS on fixed ports 8765/8769 with real browser GET (no preflight)."""
-    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
-        "127.0.0.1", FIXED_PRIVATE_PORT
-    ):
-        pytest.skip(
-            "fixed ports 8765/8769 busy; interception proofs already cover behavior"
-        )
+    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free("127.0.0.1", FIXED_PRIVATE_PORT):
+        pytest.skip("fixed ports 8765/8769 busy; interception proofs already cover behavior")
 
     nm = _require_puppeteer()
     private_hits: dict[str, Any] = {"options": 0, "gets": []}
@@ -1296,7 +1378,7 @@ try {{
   const page = await browser.newPage();
   const errors = [];
   page.on('pageerror', (e) => errors.push(String(e.message || e)));
-  await page.goto('http://127.0.0.1:8765/work.html', {{
+  await page.goto('http://127.0.0.1:8765/work.html?view=all', {{
     waitUntil: 'domcontentloaded',
     timeout: 30000,
   }});
@@ -1334,12 +1416,8 @@ try {{
 
 def test_real_fixed_port_cors_localhost_origin_smoke():
     """Second smoke: page addressed as http://localhost:8765 admits that origin."""
-    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free(
-        "127.0.0.1", FIXED_PRIVATE_PORT
-    ):
-        pytest.skip(
-            "fixed ports 8765/8769 busy; interception proofs already cover behavior"
-        )
+    if not _port_free("127.0.0.1", FIXED_PUBLIC_PORT) or not _port_free("127.0.0.1", FIXED_PRIVATE_PORT):
+        pytest.skip("fixed ports 8765/8769 busy; interception proofs already cover behavior")
 
     private_hits: dict[str, Any] = {"options": 0, "gets": []}
     private_body = json.dumps(_private_ok(), separators=(",", ":")).encode("utf-8")
@@ -1401,7 +1479,7 @@ const LAUNCH_OPTIONS = {launch_options_json};
 const browser = await puppeteer.launch(LAUNCH_OPTIONS);
 try {{
   const page = await browser.newPage();
-  await page.goto('http://localhost:8765/work.html', {{
+  await page.goto('http://localhost:8765/work.html?view=all', {{
     waitUntil: 'domcontentloaded',
     timeout: 30000,
   }});


### PR DESCRIPTION
## Summary
Addresses #6850: Default the Work dashboard Attention list to actionable-only rows so QA operators clicking `/work.html` immediately see items that need intervention (`OFF_TRACK`, `AT_RISK`, and any row whose safe next action is not `INSPECT_UNKNOWN`), rather than dozens of un-actionable `UNKNOWN`/`INSPECT_UNKNOWN` rows.

- Adds `#filter-view` dropdown with `Actionable` (default) and `All` options.
- The `isActionable(item)` predicate matches:
  - `item.health === 'OFF_TRACK' || item.health === 'AT_RISK'`
  - `item.safe_next_action.code && item.safe_next_action.code !== 'INSPECT_UNKNOWN'`
- Keeps the full inventory reachable in one visible interaction (`View: All` -> `Apply`).
- Preserves clean URLs: default view strips `view=actionable` to avoid query parameter noise (`/work.html`), while non-default view generates shareable `?view=all`.
- Preserves public-safe URL rules (never puts private source/repo into URL).
- Preserves existing filters (`?kind=`, `?health=`).

## Evidence

### 1. Pytest suite
```
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_work_dashboard.py tests/test_work_privacy.py tests/test_work_dashboard_private_integration.py tests/test_work_api.py tests/test_work_contract.py
======================== 74 passed, 2 skipped in 57.79s ========================
```

### 2. Ruff formatting & lint
```
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check tests/test_work_dashboard.py tests/test_work_dashboard_private_integration.py && /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff format --check tests/test_work_dashboard.py tests/test_work_dashboard_private_integration.py
All checks passed!
2 files already formatted
```

Closes #6850