### PR TITLE
feat(drive-epic): onboard drivers onto Work API and grok-bot QA queue (#6851)

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -26,6 +26,12 @@ If any claim you are about to make (a lane name, a cap, a word/stress/morphology
 a gate status, a count) is not in fresh tool output, **STOP and run the tool** — every
 verifiable claim is tool-backed (deterministic-over-hallucination).
 
+**Work-board orientation surface:** `GET http://127.0.0.1:8765/api/work/v1/projection`
+returns the merged work board — issues, PRs, dispatch tasks, and reviews — with each item
+carrying a rule-derived `health` (`ON_TRACK` / `AT_RISK` / `OFF_TRACK`), an `attention_rank`,
+and a `safe_next_action`. Query it at orient and again when picking the next unblocked action
+(§2); it is a queue INPUT alongside your stream/GH/issue sources, never a replacement for them.
+
 ---
 
 ## The loop (run it every cycle)
@@ -109,9 +115,10 @@ stale in-context snapshot. For per-lane budget health before dispatch:
 
 ### 2. Pick the next unblocked action
 
-Source of next work: your epic's stream tail / handoff, open GH issues for the epic, and
-the build/review queue. **Step 0 of any dispatch:** `gh pr list --state all --search
-"<issue-nr>"` by issue reference (an open issue ≠ unfixed; a sibling PR may already
+Source of next work: your epic's stream tail / handoff, open GH issues for the epic, the
+build/review queue, and the Work API projection's ranked attention list (§0) — cross-check
+against it before committing to an action. **Step 0 of any dispatch:** `gh pr list --state all
+--search "<issue-nr>"` by issue reference (an open issue ≠ unfixed; a sibling PR may already
 carry it). If nothing genuinely fits a free lane, log it and leave it idle — never
 manufacture busywork (quality > utilization).
 
@@ -124,6 +131,14 @@ manufacture busywork (quality > utilization).
 - Never relabel unfinished work as an intentional skip without issue text or tool proof.
 - Before "done" or handback, quote the tool residual count; `residual > 0` requires a
   next dispatch in the same session.
+
+### 2b. Grok-bot QA findings — queue input, not a fleet seat
+
+Grok Bot (`app/cursor`) is an **external QA observer** — it reads CI/site signals and files
+labeled GitHub issues; drivers consume those issues through the normal loop above like any
+other open issue. It is **never** a dispatch target: no `--agent grok-bot`, no `ask-grok-bot`,
+no fleet-comms seat. If Grok Bot ever authors a PR, same-family Grok must not CF it — route to
+an outside-family reviewer per §6. Full contract: `docs/runbooks/grok-bot-qa-observer.md`.
 
 ### 3. Route by model × harness fit
 

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -505,7 +505,7 @@ launcher_bind_drive_epic() {
   else
     fleet_clause='Fleet-comms: run plane-status and review-pr; authority mode is durable state and ACP is provider transport.'
   fi
-  LC_DRIVER_PROMPT="Load agents_extensions/shared/skills/drive-epic/SKILL.md before acting. The launcher already claimed the ${LC_EPIC} lease and ran its provider canary; do not claim, renew, or reopen the lease. ${fleet_clause} Obtain independent cross-family review."
+  LC_DRIVER_PROMPT="Load agents_extensions/shared/skills/drive-epic/SKILL.md before acting. The launcher already claimed the ${LC_EPIC} lease and ran its provider canary; do not claim, renew, or reopen the lease. ${fleet_clause} Consult the Work API projection (http://127.0.0.1:8765/api/work/v1/projection) for orientation and treat grok-bot QA-observer issues as a queue input — the skill covers both. Obtain independent cross-family review."
   LC_FORWARD_ARGS+=("$LC_DRIVER_PROMPT")
   if [ "$LC_DRY_RUN" = "1" ]; then
     printf 'launcher: would bind drive-epic after lease and provider canary\n'

--- a/tests/test_driver_work_api_onboarding.py
+++ b/tests/test_driver_work_api_onboarding.py
@@ -1,0 +1,73 @@
+"""Drivers must be onboarded onto the Work API and grok-bot QA findings.
+
+Issue #6851: every start-*.sh launch injects a driver instruction naming the
+Work API as an orientation surface and grok-bot QA issues as a queue input;
+the deployed skill teaches the projection endpoint's attention/health
+semantics and grok-bot's hard exclusions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+LAUNCHER_CORE = REPO / "scripts/lib/launcher_core.sh"
+SKILL = REPO / "agents_extensions/shared/skills/drive-epic/SKILL.md"
+
+# All 12 start-*.sh launchers source launcher_core.sh (verified by
+# test_launcher_contract.py's PUBLIC tuple); this test guards the one
+# LC_DRIVER_PROMPT string they all forward.
+PUBLIC_LAUNCHERS = (
+    "start-claude.sh",
+    "start-claude-driver.sh",
+    "start-codex.sh",
+    "start-codex-driver.sh",
+    "start-gemini.sh",
+    "start-gemini-driver.sh",
+    "start-grok.sh",
+    "start-grok-driver.sh",
+    "start-kimi.sh",
+    "start-kimicc.sh",
+    "start-glm.sh",
+    "start-glmcc.sh",
+)
+
+
+def test_all_public_launchers_source_launcher_core() -> None:
+    for name in PUBLIC_LAUNCHERS:
+        path = REPO / name
+        assert path.is_file(), f"missing launcher {name}"
+        assert "launcher_core.sh" in path.read_text(encoding="utf-8")
+
+
+def test_driver_prompt_names_work_api_and_grok_bot_queue_input() -> None:
+    core = LAUNCHER_CORE.read_text(encoding="utf-8")
+    # Isolate the LC_DRIVER_PROMPT assignment line itself, not just the file,
+    # so the guard fails if the sentence moves out of the injected prompt.
+    prompt_line = next(
+        line for line in core.splitlines() if line.strip().startswith("LC_DRIVER_PROMPT=")
+    )
+    assert "http://127.0.0.1:8765/api/work/v1/projection" in prompt_line
+    assert "grok-bot" in prompt_line
+    assert "queue input" in prompt_line
+    # Golden rule: launcher stays a thin pointer — no roster/routing data inline.
+    assert "codex" not in prompt_line.lower()
+    assert "capacity" not in prompt_line.lower()
+
+
+def test_skill_teaches_work_api_projection_semantics() -> None:
+    body = SKILL.read_text(encoding="utf-8")
+    assert "http://127.0.0.1:8765/api/work/v1/projection" in body
+    for term in ("health", "attention_rank", "safe_next_action"):
+        assert term in body, f"skill must document {term!r} from the projection response"
+
+
+def test_skill_teaches_grok_bot_with_hard_exclusions() -> None:
+    body = SKILL.read_text(encoding="utf-8")
+    assert "docs/runbooks/grok-bot-qa-observer.md" in body
+    assert "external QA observer" in body
+    # Hard exclusions preserved verbatim in meaning from the runbook.
+    assert "--agent grok-bot" in body
+    assert "ask-grok-bot" in body
+    assert "never" in body.lower() and "dispatch target" in body
+    assert "same-family Grok must not CF" in body


### PR DESCRIPTION
Implements the design note on #6851 (infra driver, reconciled without changes — no counter-design needed).

## What changed

- `agents_extensions/shared/skills/drive-epic/SKILL.md` (git SSOT, not `.claude/skills/`):
  - §0 Orient: new paragraph teaching `GET http://127.0.0.1:8765/api/work/v1/projection` as
    an orientation surface — merged board (issues/PRs/dispatch tasks/reviews), each item's
    `health` (`ON_TRACK`/`AT_RISK`/`OFF_TRACK`), `attention_rank`, `safe_next_action`.
  - §2 Pick next action: references the projection's ranked attention list alongside the
    existing stream/GH/issue sources.
  - §2b (new): grok-bot QA-observer awareness, pointing at
    `docs/runbooks/grok-bot-qa-observer.md`, preserving its hard exclusions verbatim in
    meaning (never a dispatch target, no `--agent grok-bot`, no `ask-grok-bot`, same-family
    Grok must not CF its PRs).
- `scripts/lib/launcher_core.sh` `LC_DRIVER_PROMPT`: one added sentence naming the Work API
  for orientation and grok-bot issues as a queue input. No roster/routing data — launcher
  stays a thin pointer to the skill.
- `tests/test_driver_work_api_onboarding.py` (new): guards both files' content.

## Evidence (#M-4 tool-backed)

**All 12 launchers source `launcher_core.sh`:**
```
$ grep -n "launcher_core.sh" start-*.sh
start-claude-driver.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-claude.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-codex.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-codex-driver.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-gemini.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-gemini-driver.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-glmcc.sh:10:# guards remain in scripts/lib/glmcc_route.sh + launcher_core.sh.
start-glm.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-kimicc.sh:10:# guards remain in scripts/lib/kimicc_route.sh + launcher_core.sh.
start-grok.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-grok-driver.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
start-kimi.sh:4:source "$ROOT/scripts/lib/launcher_core.sh"
```
(12 files, `LC_DRIVER_PROMPT` is bound once, in `launcher_bind_drive_epic`, and forwarded via
`LC_FORWARD_ARGS` to every launch — no per-launcher duplication.)

**New guard tests pass, and mutation-checked (fail without the change, confirmed by
`git stash` on the two changed files then re-running):**
```
$ .venv/bin/python -m pytest tests/test_driver_work_api_onboarding.py -v
tests/test_driver_work_api_onboarding.py::test_all_public_launchers_source_launcher_core PASSED
tests/test_driver_work_api_onboarding.py::test_driver_prompt_names_work_api_and_grok_bot_queue_input PASSED
tests/test_driver_work_api_onboarding.py::test_skill_teaches_work_api_projection_semantics PASSED
tests/test_driver_work_api_onboarding.py::test_skill_teaches_grok_bot_with_hard_exclusions PASSED
4 passed in 0.38s
```
Reverting the two source files (`git stash`) turns 3 of the 4 into failures (the launcher
sourcing test is a pre-existing invariant, unaffected) — confirms the tests aren't vacuous.

**Existing fleet-comms/launcher suites unaffected (14 passed):**
```
$ .venv/bin/python -m pytest tests/test_driver_work_api_onboarding.py tests/test_fleet_comms_launcher_awareness.py -q
14 passed in 0.37s
```

**Broader launcher-contract suites (`test_launcher_contract.py`, `test_start_codex_*.py`,
`test_start_claude_supervisor.py`):** 25 pre-existing failures, identical before and after
this change (confirmed by `git stash`-ing the two changed files and re-running) — sandbox
lacks the native Codex/Claude binaries and worktree `.venv` these tests spawn subprocesses
against (`Context-profile resolution failed`, `.venv/bin/python: No such file or directory`).
Not caused by or related to this PR.

**Shellcheck** (binary available, no CI target scopes this file specifically):
```
$ shellcheck scripts/lib/launcher_core.sh
```
Only pre-existing `SC1091` info notices on unrelated `source` lines; the edited
`LC_DRIVER_PROMPT` line is clean.

**Prompt-lint:** does not cover this file — `scripts/lint/lint_prompts.py`'s
`PROMPT_SCAN_DIRS` is `[gemini_extensions/skills, agents_extensions/shared/phases]`;
`agents_extensions/shared/skills/` is not scanned. Stating this explicitly per the dispatch
brief rather than silently skipping it.

**Work API probed live** to ground the SKILL.md text in the real surface:
```
$ curl -s http://127.0.0.1:8765/api/work/v1/projection
{"schema_version":"work-projection.v1", ..., "items":[{... "health":"ON_TRACK",
"attention_rank":81,"safe_next_action":{"code":"OPEN_GITHUB", ...}, ...}]}
```

## Audit note — other shipped orchestrator features (list only, not fixed here)

Per the design note's audit ask, the rest of the named orchestrator feature suite
(fleet_comms `cold-start-board`, `capacity_pick`, `driver_breadth_report`,
`post_task_reap`, `entire_context`) is already taught by the skill (§ Fleet-comms state,
§3-routing, §4, §5, §8 respectively) — no gaps found there. Two `fleet_comms` CLI
subcommands exist but aren't mentioned in the skill: `bottleneck-metrics` (per-stream
dispatch/review/merge bottleneck metadata) and `github-metrics` (PR open→merge latency).
Both are lower-value variants of the already-taught `metrics`/`backlog`/`dead-letters`
trio (§1) — flagging per the audit ask, not scoping a fix into this PR.

## Not touched (per hard constraints)

`scripts/work/`, `scripts/api/`, `dashboards/` — owned by parallel tasks (#6849/#6850).

Closes #6851 (pending review — not merging; infra driver owns review + merge per the
dispatch brief).
