### PR TITLE
feat(storage): storage topology v1 resolver, Windows copy/verify, agent rule

### DIFF
--- a/agents_extensions/shared/rules/storage-topology.md
+++ b/agents_extensions/shared/rules/storage-topology.md
@@ -41,10 +41,12 @@ as directories. If roots are missing or ambiguous, treat bulk as **unavailable**
 
 | Variable | Meaning |
 | --- | --- |
-| `LU_BULK_ROOT` | Force bulk root (must be marker-valid) |
+| `LU_BULK_ROOT` | Force bulk root (must be marker-valid; invalid → unavailable) |
 | `LU_SMB_BULK_ROOT` | SMB candidate |
-| `LU_GDRIVE_DATA` | Drive candidate |
+| `LU_GDRIVE_DATA` | Force Drive bulk path when SMB is absent (marker-valid). Authoritative over auto/caller Drive candidates; **invalid → fail closed** (no silent Drive fallback). |
 | `LU_SOURCES_DB` | Active DB override; **network paths are refused** |
+
+Precedence: `LU_BULK_ROOT` → SMB → `LU_GDRIVE_DATA` → auto Drive → unavailable.
 
 ## Privacy
 

--- a/agents_extensions/shared/rules/storage-topology.md
+++ b/agents_extensions/shared/rules/storage-topology.md
@@ -1,0 +1,53 @@
+# Storage Topology v1
+
+> Binding layout for bulk sources and active SQLite. Full runbook:
+> [`docs/runbooks/storage-topology.md`](../../../docs/runbooks/storage-topology.md).
+
+## Where things live
+
+| Kind | Location | Rule |
+| --- | --- | --- |
+| Active `sources.db` / VESUM / hot DBs | Repository `data/` on the Mac | **Local only.** Never open SQLite from SMB or another network filesystem. |
+| Bulk raw sources (primary) | Windows NTFS share **UkrainianData** → `raw-sources/learn-ukrainian-data` | Prefer when mounted and **marker-valid**. |
+| Bulk raw sources (fallback) | Google Drive `My Drive/Projects/learn-ukrainian-data` | Use when SMB is absent; on-demand File Provider retrieval. |
+| Sources MCP | Local `data/sources.db` | An SMB outage must **not** break MCP, tests, or ordinary repo work. |
+
+**Marker-valid bulk root:** both `literary_texts/` and `textbook_chunks/` exist
+as directories. If roots are missing or ambiguous, treat bulk as **unavailable**
+— do not guess paths or invent host-specific mounts in commits.
+
+## Required agent behavior
+
+1. **Status before path invention:**
+   ```bash
+   .venv/bin/python -m scripts.storage status
+   # or absolute primary interpreter from a worktree
+   ```
+2. **Rebuild / raw JSONL consumers** go through
+   `scripts/wiki/config.py` (`GDRIVE_DATA` is the bulk root alias) or
+   `scripts.storage.topology.resolve_bulk_root` — not a second Drive-only path.
+3. **Never** set active DB tooling to a path under `/Volumes/UkrainianData` or
+   a UNC share.
+4. **Never** delete, move, or auto-evict bulk corpus, Drive objects, or SMB
+   payloads unless a separate operator-authorized task says so.
+5. **Mac cache:** report-only. Supported reclaim is Finder **Remove Download**.
+   Do not invent eviction commands.
+6. **Windows mirror maintenance:** only
+   `scripts/storage/windows/Copy-BulkSourcesFromDrive.ps1` (`rclone copy`, never
+   sync) and `Verify-BulkSources.ps1` (receipt only after successful verify), on
+   **local NTFS** via `Get-SmbShare`.
+
+## Env overrides (optional)
+
+| Variable | Meaning |
+| --- | --- |
+| `LU_BULK_ROOT` | Force bulk root (must be marker-valid) |
+| `LU_SMB_BULK_ROOT` | SMB candidate |
+| `LU_GDRIVE_DATA` | Drive candidate |
+| `LU_SOURCES_DB` | Active DB override; **network paths are refused** |
+
+## Privacy
+
+Do not commit absolute operator home paths, account emails, hostnames, raw IPs,
+credentials, or private corpus bodies. Share **name** `UkrainianData` and the
+relative folder `learn-ukrainian-data` are the public topology labels.

--- a/docs/corpus-inventory.md
+++ b/docs/corpus-inventory.md
@@ -18,7 +18,8 @@
   `search_literary`, etc. hit this file.
 - It holds **137.7K literary chunks + 55.0K textbook chunks + ~1M dictionary rows +
   22.4K wiki + Wikipedia** across ~27 content/dictionary tables.
-- It is **BUILT from a Google Drive mount**, not local `data/`. That split is the #1
+- It is **BUILT from the bulk raw-source root** (SMB mirror preferred, Google Drive
+  fallback), not from local scraper output under `data/`. That split is the #1
   gotcha — see
   [§ Architecture](#architecture--where-the-data-lives-the-1-gotcha).
 - **What we have a LOT of:** chronicles (litopys/izbornyk), Грушевський, encyclopedias,
@@ -38,17 +39,34 @@
         │
         ▼
   build_sources_db.py  (scripts/wiki/)
-        │ reads literary + textbooks ← GDRIVE_DATA  ←  Google Drive mount, NOT local data/!
+        │ reads literary + textbooks ← GDRIVE_DATA  ←  bulk raw-source root (see below)
         │ reads external             ← data/external_articles/  (local)
         ▼
   data/sources.db  (1.8 GB SQLite + FTS5)  ←  what the MCP `sources` server serves
+                                               (ALWAYS local — never open from SMB)
 ```
 
-- **`GDRIVE_DATA`** is resolved by `scripts/wiki/config.py` from
-  `LU_GDRIVE_DATA` or the standard Google Drive mount pattern. It contains 229
-  `literary_texts/*.jsonl` files and 158 public
-  `textbook_chunks/grade-*/*.jsonl` files. Never commit an operator-specific
-  mount path. This is the rebuild source of record.
+### Storage topology v1 (bulk root + local DB)
+
+- **Active DB:** `data/sources.db` stays on the Mac repository volume. Sources MCP
+  and ordinary tests depend on this local file; an SMB outage must not break them.
+- **Bulk raw-source root** (legacy name `GDRIVE_DATA` in `scripts/wiki/config.py`)
+  is resolved by `scripts.storage.topology.resolve_bulk_root`:
+  1. `LU_BULK_ROOT` when marker-valid
+  2. Windows **UkrainianData** SMB mirror
+     (`…/raw-sources/learn-ukrainian-data`) when mounted and marker-valid
+  3. Google Drive File Provider
+     (`My Drive/Projects/learn-ukrainian-data` or `LU_GDRIVE_DATA`) when marker-valid
+  4. Structured **unavailable** (no path guessing)
+- **Markers:** both `literary_texts/` and `textbook_chunks/` must exist.
+- **Status CLI (read-only):** `.venv/bin/python -m scripts.storage status`
+- **Windows mirror maintenance:** `scripts/storage/windows/` (`rclone copy` only;
+  verify before receipt). Full contract: [`docs/runbooks/storage-topology.md`](runbooks/storage-topology.md).
+
+- **`GDRIVE_DATA`** is the bulk-root alias above (SMB preferred, Drive fallback).
+  It contains 229 `literary_texts/*.jsonl` files and 158 public
+  `textbook_chunks/grade-*/*.jsonl` files on the full mirror. Never commit an
+  operator-specific mount path. This is the rebuild source of record.
 - **⚠️ DIR MISMATCH:** scrapers write to LOCAL `data/literary_texts/`, but `build_sources_db.py`
   reads literary from **`GDRIVE_DATA/literary_texts/`**. A freshly-scraped jsonl in `data/`
   is **invisible** to a `--force` rebuild until it's also placed on the GDrive mount.

--- a/docs/runbooks/storage-topology.md
+++ b/docs/runbooks/storage-topology.md
@@ -21,23 +21,26 @@ unavailable (no guessing).
 Read-only status (never materializes cloud-only files):
 
 ```bash
-# Prefer the primary project interpreter from any worktree
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.storage status
-/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.storage status --json
+# Primary checkout (or any tree that already has the shared project venv)
+.venv/bin/python -m scripts.storage status
+.venv/bin/python -m scripts.storage status --json
+
+# Dispatch worktree: use the primary checkout interpreter, never a worktree .venv
+<path-to-primary-checkout>/.venv/bin/python -m scripts.storage status
 ```
 
 Environment overrides (optional):
 
 | Variable | Purpose |
 | --- | --- |
-| `LU_BULK_ROOT` | Force bulk root (must be marker-valid) |
+| `LU_BULK_ROOT` | Force bulk root (must be marker-valid; invalid → unavailable) |
 | `LU_SMB_BULK_ROOT` | Preferred SMB bulk path candidate |
-| `LU_GDRIVE_DATA` | Preferred Drive bulk path candidate |
+| `LU_GDRIVE_DATA` | Force Drive bulk path when SMB is absent (must be marker-valid). Authoritative over auto/caller Drive candidates; **invalid values fail closed** (no silent fallback to other Drive roots). |
 | `LU_SOURCES_DB` | Override active DB path (**network paths are refused**) |
 
 Rebuild consumers (`scripts/wiki/config.py` → `GDRIVE_DATA`) use the same
-resolver: SMB first, then Drive. The legacy name `GDRIVE_DATA` is retained for
-call-site compatibility.
+resolver: `LU_BULK_ROOT` → SMB → `LU_GDRIVE_DATA` → auto Drive → unavailable.
+The legacy name `GDRIVE_DATA` is retained for call-site compatibility.
 
 ## Windows maintenance
 

--- a/docs/runbooks/storage-topology.md
+++ b/docs/runbooks/storage-topology.md
@@ -1,0 +1,86 @@
+# Storage topology v1
+
+Approved layout for bulk sources, active SQLite, and agent-safe fallbacks.
+
+## Topology
+
+| Role | Location | Notes |
+| --- | --- | --- |
+| Active SQLite | Repository `data/sources.db` | **Always local.** Never open from SMB/network FS. Sources MCP reads this file only. |
+| Bulk raw sources (primary) | Windows NTFS share **UkrainianData** → `raw-sources/learn-ukrainian-data` | Full materialized mirror. Mac mounts as `/Volumes/UkrainianData/…` when available. |
+| Bulk raw sources (fallback) | Google Drive File Provider `My Drive/Projects/learn-ukrainian-data` | On-demand retrieval when SMB is absent. |
+| Mac working set | Git repo + active DBs + small shards | Keep hot runtime artifacts local. |
+| Offsite backup | Google Drive (and restic runbook) | Drive is source/backup, not live SQLite. |
+
+**Marker-valid bulk root:** top-level directories `literary_texts/` and
+`textbook_chunks/` must both exist. Ambiguous multi-match roots are treated as
+unavailable (no guessing).
+
+## Agent / developer commands (Mac)
+
+Read-only status (never materializes cloud-only files):
+
+```bash
+# Prefer the primary project interpreter from any worktree
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.storage status
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.storage status --json
+```
+
+Environment overrides (optional):
+
+| Variable | Purpose |
+| --- | --- |
+| `LU_BULK_ROOT` | Force bulk root (must be marker-valid) |
+| `LU_SMB_BULK_ROOT` | Preferred SMB bulk path candidate |
+| `LU_GDRIVE_DATA` | Preferred Drive bulk path candidate |
+| `LU_SOURCES_DB` | Override active DB path (**network paths are refused**) |
+
+Rebuild consumers (`scripts/wiki/config.py` → `GDRIVE_DATA`) use the same
+resolver: SMB first, then Drive. The legacy name `GDRIVE_DATA` is retained for
+call-site compatibility.
+
+## Windows maintenance
+
+Tracked scripts (manual, non-destructive):
+
+1. `scripts/storage/windows/Copy-BulkSourcesFromDrive.ps1` — `rclone copy` only
+   (never `sync` / purge / delete) into the share’s **local NTFS** path from
+   `Get-SmbShare -Name UkrainianData`.
+2. `scripts/storage/windows/Verify-BulkSources.ps1` — marker check and optional
+   exact-file JSONL manifest; writes a success receipt **only** on pass.
+
+See `scripts/storage/windows/README.md`. Scheduled Task install is optional and
+opt-in; default is a manual run.
+
+## Mac cache (report-only)
+
+When the bulk root is the Drive File Provider path, `status` samples dataless
+flags without opening file bodies. To free SSD space after SMB is verified:
+
+1. In **Finder**, select cloud-only items under the Drive project folder.
+2. **File → Remove Download**.
+
+Do not invent eviction CLIs, delete cloud objects, or delete the SMB mirror as
+part of routine cache reclaim.
+
+## Outage posture
+
+| Failure | Expected behavior |
+| --- | --- |
+| SMB unmounted | Bulk resolver falls back to marker-valid Drive; repo work continues |
+| Drive + SMB both absent | Bulk root `unavailable`; rebuilds that need raw JSONL fail closed; Sources MCP still serves local `data/sources.db` |
+| Someone points `LU_SOURCES_DB` at SMB | Resolver **refuses**; active DB stays repository-local |
+
+## Safety boundaries
+
+- Do not move live SQLite onto SMB or open it across a network filesystem.
+- Do not delete or evict corpus bytes from automation in this topology slice.
+- Do not commit secrets, account emails, host/IP addresses, or private source text.
+- Phase 3/4 product artifacts are out of scope for this runbook.
+
+## Related
+
+- Shared agent rule: `agents_extensions/shared/rules/storage-topology.md`
+- Corpus inventory architecture: `docs/corpus-inventory.md`
+- Data backup (restic): `docs/runbooks/data-backup.md`
+- Issue context: #6375 (Phase 3 recovery depends on durable bulk storage)

--- a/scripts/storage/__init__.py
+++ b/scripts/storage/__init__.py
@@ -1,0 +1,28 @@
+"""Approved bulk-source storage topology (SMB mirror + Drive fallback).
+
+Public entry points:
+
+- ``resolve_topology`` / ``resolve_bulk_root`` — deterministic bulk-root choice
+- ``python -m scripts.storage status`` — read-only status report
+
+See ``docs/runbooks/storage-topology.md`` and the shared rule
+``agents_extensions/shared/rules/storage-topology.md``.
+"""
+
+from __future__ import annotations
+
+from scripts.storage.topology import (
+    BulkRootResolution,
+    TopologyStatus,
+    resolve_active_sources_db,
+    resolve_bulk_root,
+    resolve_topology,
+)
+
+__all__ = [
+    "BulkRootResolution",
+    "TopologyStatus",
+    "resolve_active_sources_db",
+    "resolve_bulk_root",
+    "resolve_topology",
+]

--- a/scripts/storage/__main__.py
+++ b/scripts/storage/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m scripts.storage``."""
+
+from scripts.storage.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/storage/cli.py
+++ b/scripts/storage/cli.py
@@ -1,0 +1,128 @@
+"""CLI for the storage topology status/resolver.
+
+What it does: reports the approved bulk-root and active-DB topology read-only.
+When to use: agent onboarding, rebuild path debugging, SMB outage checks.
+When NOT to use: do not use this to copy, delete, or evict corpus files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from scripts.storage.topology import resolve_topology
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.storage",
+        description=(
+            "Report the approved storage topology (local sources.db, SMB bulk "
+            "mirror, Google Drive fallback) without mutating any files.\n"
+            "Use for status/debugging only — never to open SQLite on SMB or to "
+            "evict/delete bulk sources."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python "
+            "-m scripts.storage status\n"
+            "  .venv/bin/python -m scripts.storage status --json\n"
+            "  .venv/bin/python -m scripts.storage status --repo /path/to/checkout\n"
+            "\n"
+            "Outputs:\n"
+            "  Human text or JSON on stdout. No files written. No cloud materialization.\n"
+            "\n"
+            "Exit codes:\n"
+            "  0 — status emitted (bulk may still be unavailable)\n"
+            "  2 — invalid arguments\n"
+            "\n"
+            "Related:\n"
+            "  docs/runbooks/storage-topology.md\n"
+            "  agents_extensions/shared/rules/storage-topology.md\n"
+            "  issue #6375 (Phase 3 recovery storage dependency)\n"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser(
+        "status",
+        help="Print read-only topology status (active DB + bulk root + Mac cache).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    status.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON (default: human text). Default: false.",
+    )
+    status.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="Repository root to inspect (default: discover from cwd).",
+    )
+    return parser
+
+
+def _format_human(payload: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"schema: {payload['schema']}")
+    lines.append(f"repository_root: {payload['repository_root']}")
+    adb = payload["active_database"]
+    lines.append("active_database:")
+    lines.append(f"  path: {adb['path']}")
+    lines.append(f"  exists: {adb['exists']}")
+    lines.append(f"  is_local: {adb['is_local']}")
+    lines.append(f"  refused_network: {adb['refused_network']}")
+    lines.append(f"  reason: {adb['reason']}")
+    bulk = payload["bulk_root"]
+    lines.append("bulk_root:")
+    lines.append(f"  available: {bulk['available']}")
+    lines.append(f"  path: {bulk['path']}")
+    lines.append(f"  source: {bulk['source']}")
+    lines.append(f"  reason: {bulk['reason']}")
+    if bulk.get("candidates"):
+        lines.append("  candidates:")
+        for cand in bulk["candidates"]:
+            lines.append(
+                f"    - kind={cand['kind']} present={cand['present']} "
+                f"marker_valid={cand['marker_valid']} path={cand['path']} "
+                f"reason={cand['reason']}"
+            )
+    cache = payload["mac_cache"]
+    lines.append("mac_cache:")
+    lines.append(f"  applicable: {cache['applicable']}")
+    lines.append(f"  bulk_source: {cache['bulk_source']}")
+    lines.append(f"  sampled_entries: {cache['sampled_entries']}")
+    lines.append(f"  local_or_unknown: {cache['local_or_unknown']}")
+    lines.append(f"  dataless_or_cloud_only: {cache['dataless_or_cloud_only']}")
+    lines.append(f"  reason: {cache['reason']}")
+    lines.append(f"  remove_download: {cache['remove_download_instruction']}")
+    if payload.get("notes"):
+        lines.append("notes:")
+        for note in payload["notes"]:
+            lines.append(f"  - {note}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command != "status":
+        parser.error(f"unsupported command: {args.command}")
+        return 2
+
+    status = resolve_topology(repository_root=args.repo)
+    payload = status.to_dict()
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_human(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/storage/cli.py
+++ b/scripts/storage/cli.py
@@ -27,10 +27,13 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Examples:\n"
-            "  /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python "
-            "-m scripts.storage status\n"
+            "  .venv/bin/python -m scripts.storage status\n"
             "  .venv/bin/python -m scripts.storage status --json\n"
             "  .venv/bin/python -m scripts.storage status --repo /path/to/checkout\n"
+            "\n"
+            "From a dispatch worktree, use the primary checkout interpreter:\n"
+            "  <primary-checkout>/.venv/bin/python -m scripts.storage status\n"
+            "Never create or use a worktree-local .venv for project commands.\n"
             "\n"
             "Outputs:\n"
             "  Human text or JSON on stdout. No files written. No cloud materialization.\n"

--- a/scripts/storage/topology.py
+++ b/scripts/storage/topology.py
@@ -274,7 +274,18 @@ def resolve_bulk_root(
     smb_candidates: Iterable[Path] | None = None,
     drive_candidates: Iterable[Path] | None = None,
 ) -> BulkRootResolution:
-    """Resolve the bulk raw-source root: override → SMB → Drive → unavailable."""
+    """Resolve the bulk raw-source root.
+
+    Precedence (fail-closed at each override step):
+
+    1. ``LU_BULK_ROOT`` — must be marker-valid or bulk is unavailable
+    2. Marker-valid SMB candidates (caller list or discovery)
+    3. ``LU_GDRIVE_DATA`` — env path is authoritative over caller
+       ``drive_candidates``; invalid/missing markers fail closed (no silent
+       fallback to auto-discovered Drive roots)
+    4. Auto / caller Drive candidates when the env override is unset
+    5. Unavailable
+    """
     environ = os.environ if env is None else env
     reports: list[CandidateReport] = []
 
@@ -328,19 +339,17 @@ def resolve_bulk_root(
             candidates=tuple(reports),
         )
 
-    drive_list = (
-        list(drive_candidates)
-        if drive_candidates is not None
-        else discover_drive_bulk_candidates(env=environ, home=home)
-    )
-    # Explicit LU_GDRIVE_DATA is never ambiguous with itself.
-    if environ.get(ENV_GDRIVE_DATA) and drive_list:
-        report = _candidate("gdrive", drive_list[0], reason="LU_GDRIVE_DATA")
+    # Explicit LU_GDRIVE_DATA always wins over caller/auto drive candidates.
+    # Invalid override is fail-closed (do not fall through to other Drive roots).
+    explicit_drive = environ.get(ENV_GDRIVE_DATA)
+    if explicit_drive:
+        path = Path(explicit_drive).expanduser()
+        report = _candidate("gdrive", path, reason="LU_GDRIVE_DATA")
         reports.append(report)
         if report.marker_valid:
             return BulkRootResolution(
                 available=True,
-                path=drive_list[0],
+                path=path,
                 source="gdrive",
                 reason="LU_GDRIVE_DATA marker-valid",
                 candidates=tuple(reports),
@@ -352,6 +361,12 @@ def resolve_bulk_root(
             reason="drive_override_not_marker_valid",
             candidates=tuple(reports),
         )
+
+    drive_list = (
+        list(drive_candidates)
+        if drive_candidates is not None
+        else discover_drive_bulk_candidates(env=environ, home=home)
+    )
 
     valid_drive: list[Path] = []
     for cand in drive_list:

--- a/scripts/storage/topology.py
+++ b/scripts/storage/topology.py
@@ -1,0 +1,637 @@
+"""Deterministic storage topology resolver for bulk sources and active SQLite.
+
+Contract (storage topology v1):
+
+- Active ``data/sources.db`` is always repository-local and never opened from
+  SMB / network filesystems.
+- Bulk raw-source root prefers a marker-valid Windows ``UkrainianData`` SMB
+  mirror, then a marker-valid Google Drive File Provider path.
+- Ambiguous or missing roots yield a structured unavailable state (no guessing).
+- Status / cache reporting is read-only and never materializes cloud-only files.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Required top-level directories that identify a learn-ukrainian bulk root.
+# Both rebuild consumers and the Windows mirror use these as presence markers.
+REQUIRED_BULK_MARKERS: tuple[str, ...] = ("literary_texts", "textbook_chunks")
+
+# Conventional share / folder names from the approved topology (not host/IP).
+SMB_SHARE_NAME = "UkrainianData"
+BULK_LEAF_NAME = "learn-ukrainian-data"
+BULK_RELATIVE_UNDER_SHARE = Path("raw-sources") / BULK_LEAF_NAME
+DRIVE_RELATIVE = Path("My Drive") / "Projects" / BULK_LEAF_NAME
+
+ENV_BULK_ROOT = "LU_BULK_ROOT"
+ENV_SMB_BULK_ROOT = "LU_SMB_BULK_ROOT"
+ENV_GDRIVE_DATA = "LU_GDRIVE_DATA"
+ENV_SOURCES_DB = "LU_SOURCES_DB"
+
+# macOS UF_DATALESS — cloud-only / File Provider stub (never open to inspect).
+_UF_DATALESS = 0x40000000
+
+_NETWORK_FS_TYPES = frozenset(
+    {
+        "smbfs",
+        "nfs",
+        "afpfs",
+        "cifs",
+        "webdav",
+        "fuse",
+        "osxfusefs",
+        "macfuse",
+        "sshfs",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    """One probed bulk-root candidate."""
+
+    kind: str
+    path: str | None
+    present: bool
+    marker_valid: bool
+    reason: str
+    missing_markers: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BulkRootResolution:
+    """Result of bulk raw-source root resolution."""
+
+    available: bool
+    path: Path | None
+    source: str
+    reason: str
+    candidates: tuple[CandidateReport, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "available": self.available,
+            "path": None if self.path is None else str(self.path),
+            "source": self.source,
+            "reason": self.reason,
+            "candidates": [c.to_dict() for c in self.candidates],
+        }
+
+
+@dataclass(frozen=True)
+class ActiveDatabaseResolution:
+    """Repository-local active sources.db (never network/SMB)."""
+
+    path: Path
+    exists: bool
+    is_local: bool
+    refused_network: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "exists": self.exists,
+            "is_local": self.is_local,
+            "refused_network": self.refused_network,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class MacCacheReport:
+    """Read-only Mac File Provider / dataless cache summary.
+
+    Never opens file contents and never triggers materialization.
+    """
+
+    applicable: bool
+    bulk_source: str
+    sampled_entries: int
+    local_or_unknown: int
+    dataless_or_cloud_only: int
+    reason: str
+    remove_download_instruction: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TopologyStatus:
+    """Full read-only topology status payload."""
+
+    schema: str
+    repository_root: str
+    active_database: ActiveDatabaseResolution
+    bulk_root: BulkRootResolution
+    mac_cache: MacCacheReport
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "repository_root": self.repository_root,
+            "active_database": self.active_database.to_dict(),
+            "bulk_root": self.bulk_root.to_dict(),
+            "mac_cache": self.mac_cache.to_dict(),
+            "notes": list(self.notes),
+        }
+
+
+class ActiveDatabaseNetworkError(ValueError):
+    """Raised when a caller tries to use a network path as active sources.db."""
+
+
+def default_repository_root(start: Path | None = None) -> Path:
+    """Resolve the repository root containing ``data/`` and ``scripts/``."""
+    cur = start.expanduser().resolve() if start is not None else Path.cwd().resolve()
+    for candidate in (cur, *cur.parents):
+        if (candidate / "scripts").is_dir() and (candidate / "data").is_dir():
+            return candidate
+        if (candidate / "scripts").is_dir() and (candidate / "AGENTS.md").is_file():
+            return candidate
+    return cur
+
+
+def _is_marker_valid(root: Path, markers: Sequence[str] = REQUIRED_BULK_MARKERS) -> tuple[bool, tuple[str, ...]]:
+    if not root.is_dir():
+        return False, tuple(markers)
+    missing = tuple(m for m in markers if not (root / m).is_dir())
+    return (not missing, missing)
+
+
+def _candidate(
+    kind: str,
+    path: Path | None,
+    *,
+    reason: str,
+    markers: Sequence[str] = REQUIRED_BULK_MARKERS,
+) -> CandidateReport:
+    if path is None:
+        return CandidateReport(
+            kind=kind,
+            path=None,
+            present=False,
+            marker_valid=False,
+            reason=reason,
+            missing_markers=tuple(markers),
+        )
+    present = path.is_dir()
+    if not present:
+        return CandidateReport(
+            kind=kind,
+            path=str(path),
+            present=False,
+            marker_valid=False,
+            reason=reason,
+            missing_markers=tuple(markers),
+        )
+    valid, missing = _is_marker_valid(path, markers)
+    return CandidateReport(
+        kind=kind,
+        path=str(path),
+        present=True,
+        marker_valid=valid,
+        reason="marker_valid" if valid else "missing_markers",
+        missing_markers=missing,
+    )
+
+
+def discover_smb_bulk_candidates(
+    *,
+    env: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> list[Path]:
+    """Return ordered SMB bulk-root candidates without validating markers."""
+    del home  # reserved for future user-level mounts; avoid unused-arg noise
+    environ = os.environ if env is None else env
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path) -> None:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            out.append(path)
+
+    explicit = environ.get(ENV_SMB_BULK_ROOT)
+    if explicit:
+        _add(Path(explicit).expanduser())
+
+    # Conventional volume mount of the UkrainianData share (share name only).
+    _add(Path("/Volumes") / SMB_SHARE_NAME / BULK_RELATIVE_UNDER_SHARE)
+    if platform.system() == "Linux":
+        _add(Path("/mnt") / SMB_SHARE_NAME / BULK_RELATIVE_UNDER_SHARE)
+        _add(Path("/media") / SMB_SHARE_NAME / BULK_RELATIVE_UNDER_SHARE)
+
+    return out
+
+
+def discover_drive_bulk_candidates(
+    *,
+    env: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> list[Path]:
+    """Return ordered Google Drive File Provider bulk-root candidates."""
+    environ = os.environ if env is None else env
+    home_path = Path.home() if home is None else home
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path) -> None:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            out.append(path)
+
+    explicit = environ.get(ENV_GDRIVE_DATA)
+    if explicit:
+        _add(Path(explicit).expanduser())
+        return out
+
+    cloudstorage = home_path / "Library" / "CloudStorage"
+    if cloudstorage.is_dir():
+        for mount in sorted(cloudstorage.glob("GoogleDrive-*")):
+            _add(mount / DRIVE_RELATIVE)
+
+    return out
+
+
+def resolve_bulk_root(
+    *,
+    env: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    smb_candidates: Iterable[Path] | None = None,
+    drive_candidates: Iterable[Path] | None = None,
+) -> BulkRootResolution:
+    """Resolve the bulk raw-source root: override → SMB → Drive → unavailable."""
+    environ = os.environ if env is None else env
+    reports: list[CandidateReport] = []
+
+    explicit = environ.get(ENV_BULK_ROOT)
+    if explicit:
+        path = Path(explicit).expanduser()
+        report = _candidate("override", path, reason="LU_BULK_ROOT")
+        reports.append(report)
+        if report.marker_valid:
+            return BulkRootResolution(
+                available=True,
+                path=path,
+                source="override",
+                reason="LU_BULK_ROOT marker-valid",
+                candidates=tuple(reports),
+            )
+        return BulkRootResolution(
+            available=False,
+            path=None,
+            source="unavailable",
+            reason="override_not_marker_valid",
+            candidates=tuple(reports),
+        )
+
+    smb_list = (
+        list(smb_candidates)
+        if smb_candidates is not None
+        else discover_smb_bulk_candidates(env=environ, home=home)
+    )
+    valid_smb: list[Path] = []
+    for cand in smb_list:
+        report = _candidate("smb", cand, reason="smb_probe")
+        reports.append(report)
+        if report.marker_valid:
+            valid_smb.append(cand)
+
+    if len(valid_smb) == 1:
+        return BulkRootResolution(
+            available=True,
+            path=valid_smb[0],
+            source="smb",
+            reason="marker_valid_smb_mirror",
+            candidates=tuple(reports),
+        )
+    if len(valid_smb) > 1:
+        return BulkRootResolution(
+            available=False,
+            path=None,
+            source="unavailable",
+            reason="ambiguous_smb_roots",
+            candidates=tuple(reports),
+        )
+
+    drive_list = (
+        list(drive_candidates)
+        if drive_candidates is not None
+        else discover_drive_bulk_candidates(env=environ, home=home)
+    )
+    # Explicit LU_GDRIVE_DATA is never ambiguous with itself.
+    if environ.get(ENV_GDRIVE_DATA) and drive_list:
+        report = _candidate("gdrive", drive_list[0], reason="LU_GDRIVE_DATA")
+        reports.append(report)
+        if report.marker_valid:
+            return BulkRootResolution(
+                available=True,
+                path=drive_list[0],
+                source="gdrive",
+                reason="LU_GDRIVE_DATA marker-valid",
+                candidates=tuple(reports),
+            )
+        return BulkRootResolution(
+            available=False,
+            path=None,
+            source="unavailable",
+            reason="drive_override_not_marker_valid",
+            candidates=tuple(reports),
+        )
+
+    valid_drive: list[Path] = []
+    for cand in drive_list:
+        report = _candidate("gdrive", cand, reason="gdrive_probe")
+        reports.append(report)
+        if report.marker_valid:
+            valid_drive.append(cand)
+
+    if len(valid_drive) == 1:
+        return BulkRootResolution(
+            available=True,
+            path=valid_drive[0],
+            source="gdrive",
+            reason="marker_valid_gdrive_fallback",
+            candidates=tuple(reports),
+        )
+    if len(valid_drive) > 1:
+        return BulkRootResolution(
+            available=False,
+            path=None,
+            source="unavailable",
+            reason="ambiguous_gdrive_roots",
+            candidates=tuple(reports),
+        )
+
+    return BulkRootResolution(
+        available=False,
+        path=None,
+        source="unavailable",
+        reason="no_marker_valid_bulk_root",
+        candidates=tuple(reports),
+    )
+
+
+def _path_looks_like_network(path: Path) -> bool:
+    """Best-effort network/SMB detection without mounting or reading content."""
+    resolved = str(path.expanduser())
+    if resolved.startswith("//") or resolved.startswith("\\\\"):
+        return True
+    lower = resolved.lower()
+    if "/volumes/ukrainiandata" in lower or "\\ukrainiandata\\" in lower:
+        return True
+    # UNC-style /Volumes/server/share is network when share is UkrainianData.
+    parts = Path(resolved).parts
+    return len(parts) >= 3 and parts[1] == "Volumes" and parts[2] == SMB_SHARE_NAME
+
+
+def _fs_type_for_path(path: Path) -> str | None:
+    """Return filesystem type for *path* when ``psutil`` is available."""
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return None
+    try:
+        parts = psutil.disk_partitions(all=True)
+    except Exception:
+        return None
+    best: str | None = None
+    best_len = -1
+    path_s = str(path.resolve()) if path.exists() else str(path)
+    for part in parts:
+        mount = part.mountpoint.rstrip("/") or part.mountpoint
+        if (
+            (path_s == mount or path_s.startswith(mount.rstrip("/") + "/"))
+            and len(mount) > best_len
+        ):
+            best = (part.fstype or "").lower()
+            best_len = len(mount)
+    return best
+
+
+def is_network_filesystem_path(path: Path) -> bool:
+    """True when *path* is on SMB/network storage or a conventional share path."""
+    if _path_looks_like_network(path):
+        return True
+    fs_type = _fs_type_for_path(path)
+    if fs_type is None:
+        return False
+    if fs_type in _NETWORK_FS_TYPES:
+        return True
+    return "smb" in fs_type or "cifs" in fs_type or "nfs" in fs_type
+
+
+def resolve_active_sources_db(
+    repository_root: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    refuse_network: bool = True,
+) -> ActiveDatabaseResolution:
+    """Resolve the active sources.db path; refuse network/SMB locations."""
+    environ = os.environ if env is None else env
+    root = default_repository_root(repository_root)
+    override = environ.get(ENV_SOURCES_DB)
+    if override:
+        path = Path(override).expanduser()
+        if refuse_network and is_network_filesystem_path(path):
+            local = root / "data" / "sources.db"
+            return ActiveDatabaseResolution(
+                path=local,
+                exists=local.is_file(),
+                is_local=True,
+                refused_network=True,
+                reason="refused_network_sources_db_override",
+            )
+        return ActiveDatabaseResolution(
+            path=path,
+            exists=path.is_file(),
+            is_local=not is_network_filesystem_path(path),
+            refused_network=False,
+            reason="LU_SOURCES_DB",
+        )
+
+    path = root / "data" / "sources.db"
+    network = is_network_filesystem_path(path)
+    if refuse_network and network:
+        return ActiveDatabaseResolution(
+            path=path,
+            exists=False,
+            is_local=False,
+            refused_network=True,
+            reason="repository_data_on_network_filesystem",
+        )
+    return ActiveDatabaseResolution(
+        path=path,
+        exists=path.is_file(),
+        is_local=not network,
+        refused_network=False,
+        reason="repository_local_data_sources_db",
+    )
+
+
+def require_local_active_sources_db(
+    repository_root: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    """Return the active DB path or raise if a network location was requested."""
+    result = resolve_active_sources_db(repository_root, env=env, refuse_network=True)
+    if result.refused_network:
+        raise ActiveDatabaseNetworkError(
+            "Active sources.db must remain on local storage; "
+            f"refused network path ({result.reason}). Use repository data/sources.db."
+        )
+    return result.path
+
+
+def _entry_is_dataless(path: Path) -> bool | None:
+    """Return True/False when dataless state is known; None when unknown.
+
+    Uses ``st_flags & UF_DATALESS`` on macOS when available. Never opens the
+    file for reading (which could trigger File Provider materialization).
+    """
+    try:
+        st = path.lstat()
+    except OSError:
+        return None
+    flags = getattr(st, "st_flags", None)
+    if flags is None:
+        return None
+    return bool(flags & _UF_DATALESS)
+
+
+def report_mac_cache(
+    bulk: BulkRootResolution,
+    *,
+    max_entries: int = 200,
+) -> MacCacheReport:
+    """Report materialized vs dataless state without materializing files."""
+    instruction = (
+        "In Finder, select cloud-only items under the Drive project folder, "
+        "then File → Remove Download. Do not run unsupported eviction CLIs; "
+        "do not delete cloud objects or the SMB mirror."
+    )
+    if not bulk.available or bulk.path is None:
+        return MacCacheReport(
+            applicable=False,
+            bulk_source=bulk.source,
+            sampled_entries=0,
+            local_or_unknown=0,
+            dataless_or_cloud_only=0,
+            reason="bulk_root_unavailable",
+            remove_download_instruction=instruction,
+        )
+    if bulk.source not in {"gdrive", "override"}:
+        return MacCacheReport(
+            applicable=False,
+            bulk_source=bulk.source,
+            sampled_entries=0,
+            local_or_unknown=0,
+            dataless_or_cloud_only=0,
+            reason="cache_report_applies_to_gdrive_file_provider_paths",
+            remove_download_instruction=instruction,
+        )
+
+    sampled = 0
+    localish = 0
+    dataless = 0
+    root = bulk.path
+    try:
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            # Do not descend into huge trees beyond the sample budget.
+            dirnames.sort()
+            filenames.sort()
+            for name in filenames:
+                if sampled >= max_entries:
+                    break
+                entry = Path(dirpath) / name
+                sampled += 1
+                state = _entry_is_dataless(entry)
+                if state is True:
+                    dataless += 1
+                else:
+                    # False or unknown — report as local_or_unknown (never open).
+                    localish += 1
+            if sampled >= max_entries:
+                break
+    except OSError as exc:
+        return MacCacheReport(
+            applicable=True,
+            bulk_source=bulk.source,
+            sampled_entries=sampled,
+            local_or_unknown=localish,
+            dataless_or_cloud_only=dataless,
+            reason=f"walk_error:{exc.__class__.__name__}",
+            remove_download_instruction=instruction,
+        )
+
+    return MacCacheReport(
+        applicable=True,
+        bulk_source=bulk.source,
+        sampled_entries=sampled,
+        local_or_unknown=localish,
+        dataless_or_cloud_only=dataless,
+        reason="read_only_dataless_flag_sample",
+        remove_download_instruction=instruction,
+    )
+
+
+def resolve_topology(
+    repository_root: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    smb_candidates: Iterable[Path] | None = None,
+    drive_candidates: Iterable[Path] | None = None,
+) -> TopologyStatus:
+    """Build a full read-only topology status object."""
+    root = default_repository_root(repository_root)
+    active = resolve_active_sources_db(root, env=env)
+    bulk = resolve_bulk_root(
+        env=env,
+        home=home,
+        smb_candidates=smb_candidates,
+        drive_candidates=drive_candidates,
+    )
+    cache = report_mac_cache(bulk)
+    notes = [
+        "Active SQLite remains repository-local; Sources MCP is unaffected by SMB outage.",
+        "Bulk consumers prefer marker-valid SMB, then marker-valid Google Drive.",
+        "Windows maintenance uses rclone copy (never sync) on local NTFS only.",
+        "Mac cache is report-only; use Finder Remove Download for eviction.",
+    ]
+    return TopologyStatus(
+        schema="storage-topology.status.v1",
+        repository_root=str(root),
+        active_database=active,
+        bulk_root=bulk,
+        mac_cache=cache,
+        notes=tuple(notes),
+    )
+
+
+def unresolved_bulk_placeholder() -> Path:
+    """Non-existent placeholder path for import-safe GDRIVE_DATA fallbacks."""
+    return (
+        Path.home()
+        / "Library"
+        / "CloudStorage"
+        / "GoogleDrive-UNSET"
+        / "My Drive"
+        / "Projects"
+        / BULK_LEAF_NAME
+    )

--- a/scripts/storage/windows/Copy-BulkSourcesFromDrive.ps1
+++ b/scripts/storage/windows/Copy-BulkSourcesFromDrive.ps1
@@ -1,0 +1,184 @@
+<#
+.SYNOPSIS
+  Non-destructive Google Drive → local NTFS bulk-source copy for UkrainianData.
+
+.DESCRIPTION
+  Runs `rclone copy` (never sync/purge/delete) from a configured Drive remote
+  into the local NTFS path that backs the UkrainianData SMB share. Destination
+  resolution uses Get-SmbShare so verification and copy never target a UNC path.
+
+  Credentials stay in the operator's private rclone config. This script never
+  prints secrets, account emails, hostnames, or absolute operator home paths.
+
+.PARAMETER RcloneRemote
+  rclone remote name that already points at Google Drive (default: gdrive).
+
+.PARAMETER RemoteSubpath
+  Path under the remote root for the project bulk folder
+  (default: Projects/learn-ukrainian-data).
+
+.PARAMETER ShareName
+  Local SMB share name whose Path is the NTFS root (default: UkrainianData).
+
+.PARAMETER DestinationRelative
+  Destination under the share's local NTFS root
+  (default: raw-sources\learn-ukrainian-data).
+
+.PARAMETER Transfers
+  rclone --transfers (default: 8).
+
+.PARAMETER Checkers
+  rclone --checkers (default: 16).
+
+.PARAMETER DryRun
+  Pass --dry-run to rclone; never write a success receipt.
+
+.PARAMETER SkipRcloneInstall
+  Do not attempt winget install when rclone is missing.
+
+.NOTES
+  Success message: BULK_COPY_COMPLETE
+  A success receipt is intentionally NOT written here — run
+  Verify-BulkSources.ps1 after copy; only verification may mint a receipt.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RcloneRemote = 'gdrive',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RemoteSubpath = 'Projects/learn-ukrainian-data',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ShareName = 'UkrainianData',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DestinationRelative = 'raw-sources\learn-ukrainian-data',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 64)]
+    [int]$Transfers = 8,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 128)]
+    [int]$Checkers = 16,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipRcloneInstall
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Get-RclonePath {
+    $cmd = Get-Command rclone.exe -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        return $cmd.Source
+    }
+    $cmd = Get-Command rclone -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        return $cmd.Source
+    }
+    if ($SkipRcloneInstall) {
+        throw 'rclone was not found on PATH'
+    }
+    Write-Output 'rclone not found; attempting Windows Package Manager install (Rclone.Rclone)...'
+    winget.exe install --id Rclone.Rclone -e `
+        --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0) {
+        throw 'rclone installation failed'
+    }
+    $cmd = Get-Command rclone.exe -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        return $cmd.Source
+    }
+    $candidate = Get-ChildItem `
+        -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages') `
+        -Filter rclone.exe -File -Recurse -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $candidate) {
+        throw 'rclone was installed but rclone.exe could not be located'
+    }
+    return $candidate.FullName
+}
+
+function Get-LocalShareRoot {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $share = Get-SmbShare -Name $Name -ErrorAction Stop
+    $shareRoot = [IO.Path]::GetFullPath([string]$share.Path)
+    if ([string]::IsNullOrWhiteSpace($shareRoot)) {
+        throw "SMB share '$Name' has an empty local Path"
+    }
+    if ($shareRoot.StartsWith('\\')) {
+        throw "SMB share '$Name' Path is UNC; refuse network destination"
+    }
+    $drive = New-Object -TypeName IO.DriveInfo -ArgumentList ([IO.Path]::GetPathRoot($shareRoot))
+    if ($drive.DriveFormat -cne 'NTFS') {
+        throw "Share '$Name' is not backed by local NTFS (format=$($drive.DriveFormat))"
+    }
+    if ($drive.DriveType -ne [IO.DriveType]::Fixed -and $drive.DriveType -ne [IO.DriveType]::Removable) {
+        # Fixed is expected for the bulk disk; still allow removable for lab disks.
+        throw "Share '$Name' is not on a local drive (DriveType=$($drive.DriveType))"
+    }
+    return $shareRoot
+}
+
+$rclonePath = Get-RclonePath
+$remotePrefix = if ($RcloneRemote.EndsWith(':')) { $RcloneRemote } else { "$RcloneRemote`:" }
+$remoteNames = @(& $rclonePath listremotes)
+if ($LASTEXITCODE -ne 0) {
+    throw 'rclone remote-list lookup failed'
+}
+if ($remoteNames -notcontains $remotePrefix) {
+    throw "rclone remote '$remotePrefix' is not configured; create it interactively with a read-only Drive scope before running this script"
+}
+
+$shareRoot = Get-LocalShareRoot -Name $ShareName
+$destination = [IO.Path]::GetFullPath((Join-Path $shareRoot $DestinationRelative))
+if (-not $destination.StartsWith($shareRoot.TrimEnd('\') + '\', [StringComparison]::OrdinalIgnoreCase) -and
+    $destination -cne $shareRoot) {
+    throw 'DestinationRelative escapes the local share root'
+}
+[void](New-Item -ItemType Directory -Path $destination -Force)
+
+$remoteSpec = "$remotePrefix$RemoteSubpath"
+$rcloneArgs = @(
+    'copy',
+    $remoteSpec,
+    $destination,
+    '--fast-list',
+    '--checksum',
+    '--transfers', "$Transfers",
+    '--checkers', "$Checkers",
+    '--create-empty-src-dirs',
+    '--retries', '10',
+    '--low-level-retries', '20',
+    '--progress'
+)
+# Explicit safety: never pass sync, delete, or purge.
+if ($DryRun) {
+    $rcloneArgs += '--dry-run'
+}
+
+Write-Output "Starting non-destructive rclone copy to local NTFS destination under share '$ShareName'..."
+& $rclonePath @rcloneArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "rclone copy failed with exit code $LASTEXITCODE"
+}
+
+if ($DryRun) {
+    Write-Output 'BULK_COPY_DRY_RUN_COMPLETE'
+    exit 0
+}
+
+Write-Output 'BULK_COPY_COMPLETE'
+Write-Output 'Next: run Verify-BulkSources.ps1 against the destination; a receipt is written only after successful verification.'
+exit 0

--- a/scripts/storage/windows/README.md
+++ b/scripts/storage/windows/README.md
@@ -1,0 +1,43 @@
+# Windows bulk-source maintenance (storage topology v1)
+
+Manual, repeatable, non-destructive maintenance for the **UkrainianData** NTFS
+mirror. These scripts are the supported Windows entrypoints for the approved
+storage topology.
+
+## Rules
+
+- Use **`rclone copy` only** — never `sync`, `purge`, or delete flags.
+- Resolve the share with **`Get-SmbShare -Name UkrainianData`** and operate on
+  the **local NTFS** `Path`. Never verify or copy through a UNC/SMB path.
+- Write a **success receipt only after verification passes**.
+- Do not put account emails, hostnames, IPs, secrets, or absolute operator home
+  paths into tracked receipts or logs committed to git.
+- Scheduled Task install is **optional and opt-in**; the default workflow is
+  manual.
+
+## Typical flow
+
+```powershell
+# 1) Copy from a pre-configured read-only Drive remote into local NTFS
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
+  .\scripts\storage\windows\Copy-BulkSourcesFromDrive.ps1
+
+# 2) Verify markers (and optional exact-file manifest)
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
+  .\scripts\storage\windows\Verify-BulkSources.ps1
+```
+
+Optional exact-file check: pass `-ManifestPath` with JSONL rows of
+`path` (posix relative), `size`, and `sha256`.
+
+Success tokens:
+
+- Copy: `BULK_COPY_COMPLETE`
+- Verify: `BULK_SOURCES_VERIFIED` plus a receipt under
+  `<share>\staging\storage-topology\receipts\`
+
+## Related
+
+- Mac/agent status CLI: `python -m scripts.storage status`
+- Runbook: `docs/runbooks/storage-topology.md`
+- Shared rule: `agents_extensions/shared/rules/storage-topology.md`

--- a/scripts/storage/windows/Verify-BulkSources.ps1
+++ b/scripts/storage/windows/Verify-BulkSources.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+  Non-destructive verification of a local NTFS bulk-source mirror.
+
+.DESCRIPTION
+  Resolves the UkrainianData share's local NTFS path via Get-SmbShare, never
+  via UNC. Verifies required marker directories and optionally an exact-file
+  JSONL manifest (relative path, size, sha256). Writes a success receipt only
+  when verification passes. Never deletes or modifies payload files.
+
+.PARAMETER PayloadRoot
+  Explicit local directory to verify. When omitted, uses
+  <share local path>\raw-sources\learn-ukrainian-data.
+
+.PARAMETER ShareName
+  SMB share name (default: UkrainianData).
+
+.PARAMETER DestinationRelative
+  Relative path under the share when PayloadRoot is omitted.
+
+.PARAMETER ManifestPath
+  Optional JSONL manifest. Each line:
+    {"path":"relative/posix/path","size":123,"sha256":"<64 hex>"}
+  Extra fields are ignored. When omitted, only marker + non-reparse checks run.
+
+.PARAMETER ReceiptPath
+  Where to write the success receipt JSON. Default:
+  <share>\staging\storage-topology\receipts\bulk-verify-<utc>.json
+
+.PARAMETER RequiredMarkers
+  Comma-separated top-level directory markers
+  (default: literary_texts,textbook_chunks).
+
+.NOTES
+  Success stdout: BULK_SOURCES_VERIFIED
+  Failure: non-zero exit; no success receipt.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$PayloadRoot = '',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ShareName = 'UkrainianData',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DestinationRelative = 'raw-sources\learn-ukrainian-data',
+
+    [Parameter(Mandatory = $false)]
+    [string]$ManifestPath = '',
+
+    [Parameter(Mandatory = $false)]
+    [string]$ReceiptPath = '',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RequiredMarkers = 'literary_texts,textbook_chunks'
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$ReceiptSchema = 'storage-topology.bulk-verify.v1'
+$TimestampUtc = [DateTime]::UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", [Globalization.CultureInfo]::InvariantCulture)
+$MismatchCounts = [ordered]@{}
+$MismatchDetails = New-Object -TypeName 'System.Collections.Generic.List[object]'
+$MaxDetails = 50
+
+function Add-Mismatch {
+    param(
+        [Parameter(Mandatory = $true)][string]$Kind,
+        [string]$CanonicalPath = '',
+        [string]$Message = ''
+    )
+    if (-not $script:MismatchCounts.Contains($Kind)) {
+        $script:MismatchCounts[$Kind] = [Int64]0
+    }
+    $script:MismatchCounts[$Kind] = [Int64]$script:MismatchCounts[$Kind] + 1
+    if ($script:MismatchDetails.Count -lt $script:MaxDetails) {
+        [void]$script:MismatchDetails.Add([ordered]@{
+            kind = $Kind
+            path = $CanonicalPath
+            message = $Message
+        })
+    }
+}
+
+function ConvertTo-LowerHex {
+    param([byte[]]$Bytes)
+    return ([BitConverter]::ToString($Bytes)).Replace('-', '').ToLowerInvariant()
+}
+
+function Get-FileSha256Lower {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    $sha = $null
+    $stream = $null
+    try {
+        $sha = [Security.Cryptography.SHA256]::Create()
+        $stream = New-Object -TypeName IO.FileStream -ArgumentList @(
+            $Path,
+            [IO.FileMode]::Open,
+            [IO.FileAccess]::Read,
+            [IO.FileShare]::Read,
+            1048576,
+            [IO.FileOptions]::SequentialScan)
+        $buffer = New-Object -TypeName byte[] -ArgumentList 1048576
+        while (($read = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            [void]$sha.TransformBlock($buffer, 0, $read, $buffer, 0)
+        }
+        [void]$sha.TransformFinalBlock((New-Object -TypeName byte[] -ArgumentList 0), 0, 0)
+        return ConvertTo-LowerHex $sha.Hash
+    }
+    finally {
+        if ($null -ne $stream) { $stream.Dispose() }
+        if ($null -ne $sha) { $sha.Dispose() }
+    }
+}
+
+function Get-LocalShareRoot {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $share = Get-SmbShare -Name $Name -ErrorAction Stop
+    $shareRoot = [IO.Path]::GetFullPath([string]$share.Path)
+    if ($shareRoot.StartsWith('\\')) {
+        throw "SMB share '$Name' Path is UNC; refuse network verification root"
+    }
+    $drive = New-Object -TypeName IO.DriveInfo -ArgumentList ([IO.Path]::GetPathRoot($shareRoot))
+    if ($drive.DriveFormat -cne 'NTFS') {
+        throw "Share '$Name' is not backed by local NTFS"
+    }
+    return $shareRoot
+}
+
+function Test-ReparsePoint {
+    param([Parameter(Mandatory = $true)][IO.FileSystemInfo]$Item)
+    return (($Item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+$shareRoot = Get-LocalShareRoot -Name $ShareName
+
+if ([string]::IsNullOrWhiteSpace($PayloadRoot)) {
+    $payloadFull = [IO.Path]::GetFullPath((Join-Path $shareRoot $DestinationRelative))
+}
+else {
+    $payloadFull = [IO.Path]::GetFullPath($PayloadRoot)
+}
+
+if ($payloadFull.StartsWith('\\')) {
+    throw 'PayloadRoot must be a local path, not UNC/SMB'
+}
+$payloadItem = Get-Item -LiteralPath $payloadFull -Force -ErrorAction Stop
+if (-not $payloadItem.PSIsContainer) {
+    throw 'PayloadRoot must be a directory'
+}
+if (Test-ReparsePoint $payloadItem) {
+    throw 'PayloadRoot must not be a reparse point'
+}
+$payloadDrive = New-Object -TypeName IO.DriveInfo -ArgumentList ([IO.Path]::GetPathRoot($payloadFull))
+if ($payloadDrive.DriveType -eq [IO.DriveType]::Network) {
+    throw 'PayloadRoot is on a network drive; verify only via local NTFS'
+}
+
+$markerList = @($RequiredMarkers.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+foreach ($marker in $markerList) {
+    $markerPath = Join-Path $payloadFull $marker
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Container)) {
+        Add-Mismatch -Kind 'missing_marker' -CanonicalPath $marker -Message 'required marker directory absent'
+    }
+}
+
+$manifestRows = [Int64]0
+$manifestChecked = [Int64]0
+if (-not [string]::IsNullOrWhiteSpace($ManifestPath)) {
+    $manifestFull = [IO.Path]::GetFullPath($ManifestPath)
+    if (-not (Test-Path -LiteralPath $manifestFull -PathType Leaf)) {
+        throw "ManifestPath not found: $manifestFull"
+    }
+    $lineNumber = 0
+    Get-Content -LiteralPath $manifestFull | ForEach-Object {
+        $lineNumber++
+        $line = $_.Trim()
+        if ([string]::IsNullOrWhiteSpace($line)) { return }
+        $manifestRows++
+        try {
+            $row = $line | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            Add-Mismatch -Kind 'manifest_parse_error' -Message "line $lineNumber"
+            return
+        }
+        $rel = [string]$row.path
+        if ([string]::IsNullOrWhiteSpace($rel) -or $rel.Contains('\') -or $rel.StartsWith('/') -or $rel.Contains('..')) {
+            Add-Mismatch -Kind 'manifest_path_error' -CanonicalPath $rel -Message "line $lineNumber"
+            return
+        }
+        $expectedSize = [Int64]$row.size
+        $expectedSha = ([string]$row.sha256).ToLowerInvariant()
+        $target = [IO.Path]::GetFullPath((Join-Path $payloadFull ($rel.Replace('/', '\'))))
+        $rootPrefix = $payloadFull.TrimEnd('\') + '\'
+        if (-not $target.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            Add-Mismatch -Kind 'manifest_path_error' -CanonicalPath $rel -Message 'escapes payload root'
+            return
+        }
+        if (-not (Test-Path -LiteralPath $target -PathType Leaf)) {
+            Add-Mismatch -Kind 'missing' -CanonicalPath $rel -Message 'file absent'
+            return
+        }
+        $item = Get-Item -LiteralPath $target -Force
+        if (Test-ReparsePoint $item) {
+            Add-Mismatch -Kind 'payload_reparse_point' -CanonicalPath $rel -Message 'reparse point'
+            return
+        }
+        if ([Int64]$item.Length -ne $expectedSize) {
+            Add-Mismatch -Kind 'size_mismatch' -CanonicalPath $rel -Message "expected=$expectedSize actual=$($item.Length)"
+            return
+        }
+        $actualSha = Get-FileSha256Lower -Path $target
+        if ($actualSha -cne $expectedSha) {
+            Add-Mismatch -Kind 'sha256_mismatch' -CanonicalPath $rel -Message 'digest mismatch'
+            return
+        }
+        $manifestChecked++
+    }
+}
+
+$totalMismatches = [Int64]0
+foreach ($key in @($MismatchCounts.Keys)) {
+    $totalMismatches += [Int64]$MismatchCounts[$key]
+}
+
+$passed = ($totalMismatches -eq 0)
+$receiptObject = [ordered]@{
+    schema = $ReceiptSchema
+    timestamp_utc = $TimestampUtc
+    share_name = $ShareName
+    payload_root = $payloadFull
+    destination_is_local_ntfs = $true
+    required_markers = $markerList
+    manifest_path = if ([string]::IsNullOrWhiteSpace($ManifestPath)) { $null } else { [IO.Path]::GetFullPath($ManifestPath) }
+    manifest_rows = $manifestRows
+    manifest_checked = $manifestChecked
+    mismatch_counts = $MismatchCounts
+    mismatch_details = @($MismatchDetails)
+    state = if ($passed) { 'BULK_SOURCES_VERIFIED' } else { 'BULK_SOURCES_VERIFY_FAILED' }
+    non_destructive = $true
+    copy_tool_constraint = 'rclone copy only; never sync/purge/delete'
+}
+
+if (-not $passed) {
+    $failJson = ($receiptObject | ConvertTo-Json -Depth 6)
+    Write-Output 'BULK_SOURCES_VERIFY_FAILED'
+    Write-Output $failJson
+    exit 1
+}
+
+# Success-only receipt on disk.
+if ([string]::IsNullOrWhiteSpace($ReceiptPath)) {
+    $receiptDir = Join-Path $shareRoot 'staging\storage-topology\receipts'
+    [void](New-Item -ItemType Directory -Path $receiptDir -Force)
+    $stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ', [Globalization.CultureInfo]::InvariantCulture)
+    $ReceiptPath = Join-Path $receiptDir "bulk-verify-$stamp.json"
+}
+else {
+    $ReceiptPath = [IO.Path]::GetFullPath($ReceiptPath)
+    $parent = Split-Path -Parent $ReceiptPath
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        [void](New-Item -ItemType Directory -Path $parent -Force)
+    }
+}
+
+($receiptObject | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $ReceiptPath -Encoding utf8
+Write-Output 'BULK_SOURCES_VERIFIED'
+Write-Output "receipt=$ReceiptPath"
+exit 0

--- a/scripts/storage/windows/Verify-BulkSources.ps1
+++ b/scripts/storage/windows/Verify-BulkSources.ps1
@@ -161,6 +161,10 @@ $payloadDrive = New-Object -TypeName IO.DriveInfo -ArgumentList ([IO.Path]::GetP
 if ($payloadDrive.DriveType -eq [IO.DriveType]::Network) {
     throw 'PayloadRoot is on a network drive; verify only via local NTFS'
 }
+$destinationIsLocalNtfs = ($payloadDrive.DriveFormat -ceq 'NTFS')
+if (-not $destinationIsLocalNtfs) {
+    throw "PayloadRoot is not backed by local NTFS (DriveFormat=$($payloadDrive.DriveFormat))"
+}
 
 $markerList = @($RequiredMarkers.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })
 foreach ($marker in $markerList) {
@@ -236,7 +240,7 @@ $receiptObject = [ordered]@{
     timestamp_utc = $TimestampUtc
     share_name = $ShareName
     payload_root = $payloadFull
-    destination_is_local_ntfs = $true
+    destination_is_local_ntfs = $destinationIsLocalNtfs
     required_markers = $markerList
     manifest_path = if ([string]::IsNullOrWhiteSpace($ManifestPath)) { $null } else { [IO.Path]::GetFullPath($ManifestPath) }
     manifest_rows = $manifestRows

--- a/scripts/wiki/config.py
+++ b/scripts/wiki/config.py
@@ -34,12 +34,13 @@ def _resolve_gdrive_data_dir() -> Path:
     Name retained as ``GDRIVE_DATA`` for call-site compatibility. The single
     source of truth is ``scripts.storage.topology.resolve_bulk_root``:
 
-    1. ``LU_BULK_ROOT`` when marker-valid
+    1. ``LU_BULK_ROOT`` when marker-valid (invalid → unavailable)
     2. Marker-valid Windows ``UkrainianData`` SMB mirror
        (``…/raw-sources/learn-ukrainian-data``)
-    3. Marker-valid Google Drive File Provider path
-       (``LU_GDRIVE_DATA`` or CloudStorage glob)
-    4. Non-existent placeholder so imports still succeed when neither root is
+    3. Explicit ``LU_GDRIVE_DATA`` when marker-valid (invalid → fail closed;
+       no silent fallback to other Drive roots)
+    4. Auto-discovered marker-valid Google Drive File Provider path
+    5. Non-existent placeholder so imports still succeed when neither root is
        present (tests/CI without mounts)
 
     Required markers: ``literary_texts/`` and ``textbook_chunks/``.

--- a/scripts/wiki/config.py
+++ b/scripts/wiki/config.py
@@ -4,7 +4,6 @@ Supports ALL tracks: core levels (A1-C2) and seminar tracks.
 Each track maps to wiki domains where its articles live.
 """
 
-import os
 from pathlib import Path
 
 # ── Paths ──────────────────────────────────────────────────────────
@@ -14,46 +13,47 @@ WIKI_STATE_DIR = WIKI_DIR / ".state"
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 
 
+def _import_resolve_bulk_root():
+    """Load the shared bulk-root resolver (project root or scripts/ on path)."""
+    try:
+        from scripts.storage.topology import (
+            resolve_bulk_root,
+            unresolved_bulk_placeholder,
+        )
+    except ImportError:  # pragma: no cover - legacy ``scripts/``-on-path imports
+        from storage.topology import (  # type: ignore
+            resolve_bulk_root,
+            unresolved_bulk_placeholder,
+        )
+    return resolve_bulk_root, unresolved_bulk_placeholder
+
+
 def _resolve_gdrive_data_dir() -> Path:
-    """Resolve the Google Drive data directory path.
+    """Resolve the bulk raw-source root for rebuild consumers.
 
-    Resolution order:
+    Name retained as ``GDRIVE_DATA`` for call-site compatibility. The single
+    source of truth is ``scripts.storage.topology.resolve_bulk_root``:
 
-    1. ``LU_GDRIVE_DATA`` env var — explicit override. Set this in
-       ``~/.bash_secrets`` (or wherever you keep per-machine env vars)
-       so the path doesn't have to be hardcoded in committed code.
-    2. Glob ``~/Library/CloudStorage/GoogleDrive-*/My Drive/Projects/learn-ukrainian-data``
-       and return the first existing match. macOS Google Drive Desktop
-       creates per-user mount points named ``GoogleDrive-<email>/``;
-       globbing avoids hardcoding the email (#1577 Phase 1 Q4 —
-       wartime contributor exposure risk).
-    3. Fall through to a placeholder Path that does not exist on disk.
-       Callers that hit the filesystem will get a clear
-       ``FileNotFoundError``; setting ``LU_GDRIVE_DATA`` fixes it.
-       Keeping this module-importable even when the mount is absent
-       matters for tests / CI that don't have a real GDrive folder.
+    1. ``LU_BULK_ROOT`` when marker-valid
+    2. Marker-valid Windows ``UkrainianData`` SMB mirror
+       (``…/raw-sources/learn-ukrainian-data``)
+    3. Marker-valid Google Drive File Provider path
+       (``LU_GDRIVE_DATA`` or CloudStorage glob)
+    4. Non-existent placeholder so imports still succeed when neither root is
+       present (tests/CI without mounts)
+
+    Required markers: ``literary_texts/`` and ``textbook_chunks/``.
+    See ``docs/runbooks/storage-topology.md``.
     """
-    explicit = os.environ.get("LU_GDRIVE_DATA")
-    if explicit:
-        return Path(explicit)
-
-    cloudstorage = Path.home() / "Library" / "CloudStorage"
-    if cloudstorage.exists():
-        for mount in sorted(cloudstorage.glob("GoogleDrive-*")):
-            candidate = mount / "My Drive" / "Projects" / "learn-ukrainian-data"
-            if candidate.exists():
-                return candidate
-
-    # Unresolved placeholder — never matches a real path. Module import
-    # still succeeds; access errors only fire on actual filesystem ops.
-    return (
-        Path.home()
-        / "Library" / "CloudStorage" / "GoogleDrive-UNSET"
-        / "My Drive" / "Projects" / "learn-ukrainian-data"
-    )
+    resolve_bulk_root, unresolved_bulk_placeholder = _import_resolve_bulk_root()
+    result = resolve_bulk_root()
+    if result.available and result.path is not None:
+        return result.path
+    # Import-safe placeholder — never a real path.
+    return unresolved_bulk_placeholder()
 
 
-# Source data on Google Drive (resolved at import; override via LU_GDRIVE_DATA)
+# Bulk raw-source root (SMB preferred, Drive fallback). Legacy name GDRIVE_DATA.
 GDRIVE_DATA = _resolve_gdrive_data_dir()
 LITERARY_DIR = GDRIVE_DATA / "literary_texts"
 TEXTBOOK_CHUNKS_DIR = GDRIVE_DATA / "textbook_chunks"

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -76,6 +76,7 @@ CLAUDE_RULE_FILES = (
     "activity-yaml.md",
     "mcp-sources-and-dictionaries.md",
     "pipeline.md",
+    "storage-topology.md",
     "ukrainian-linguistics.md",
 )
 

--- a/tests/test_storage_resolver.py
+++ b/tests/test_storage_resolver.py
@@ -1,0 +1,242 @@
+"""Hermetic tests for the storage topology bulk-root / active-DB resolver."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.storage.topology import (
+    REQUIRED_BULK_MARKERS,
+    ActiveDatabaseNetworkError,
+    is_network_filesystem_path,
+    report_mac_cache,
+    require_local_active_sources_db,
+    resolve_active_sources_db,
+    resolve_bulk_root,
+    resolve_topology,
+    unresolved_bulk_placeholder,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _project_python() -> Path:
+    local = REPO_ROOT / ".venv" / "bin" / "python"
+    if local.exists():
+        return local
+    primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    if primary.exists():
+        return primary
+    return Path(sys.executable)
+
+
+def _make_bulk_root(path: Path, *, markers: tuple[str, ...] = REQUIRED_BULK_MARKERS) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    for marker in markers:
+        (path / marker).mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_smb_preferred_when_marker_valid(tmp_path: Path) -> None:
+    smb = _make_bulk_root(tmp_path / "smb")
+    drive = _make_bulk_root(tmp_path / "drive")
+    result = resolve_bulk_root(
+        env={},
+        smb_candidates=[smb],
+        drive_candidates=[drive],
+    )
+    assert result.available is True
+    assert result.source == "smb"
+    assert result.path == smb
+
+
+def test_drive_fallback_when_smb_absent(tmp_path: Path) -> None:
+    missing_smb = tmp_path / "smb-missing"
+    drive = _make_bulk_root(tmp_path / "drive")
+    result = resolve_bulk_root(
+        env={},
+        smb_candidates=[missing_smb],
+        drive_candidates=[drive],
+    )
+    assert result.available is True
+    assert result.source == "gdrive"
+    assert result.path == drive
+
+
+def test_unavailable_when_neither_present(tmp_path: Path) -> None:
+    result = resolve_bulk_root(
+        env={},
+        smb_candidates=[tmp_path / "no-smb"],
+        drive_candidates=[tmp_path / "no-drive"],
+    )
+    assert result.available is False
+    assert result.source == "unavailable"
+    assert result.path is None
+    assert result.reason == "no_marker_valid_bulk_root"
+
+
+def test_smb_present_but_missing_markers_falls_through_to_drive(tmp_path: Path) -> None:
+    smb = tmp_path / "smb"
+    smb.mkdir()
+    (smb / "literary_texts").mkdir()
+    # textbook_chunks intentionally absent
+    drive = _make_bulk_root(tmp_path / "drive")
+    result = resolve_bulk_root(
+        env={},
+        smb_candidates=[smb],
+        drive_candidates=[drive],
+    )
+    assert result.available is True
+    assert result.source == "gdrive"
+    assert result.path == drive
+    smb_reports = [c for c in result.candidates if c.kind == "smb"]
+    assert smb_reports
+    assert smb_reports[0].marker_valid is False
+    assert "textbook_chunks" in smb_reports[0].missing_markers
+
+
+def test_ambiguous_drive_roots_unavailable(tmp_path: Path) -> None:
+    d1 = _make_bulk_root(tmp_path / "drive1")
+    d2 = _make_bulk_root(tmp_path / "drive2")
+    result = resolve_bulk_root(
+        env={},
+        smb_candidates=[],
+        drive_candidates=[d1, d2],
+    )
+    assert result.available is False
+    assert result.reason == "ambiguous_gdrive_roots"
+
+
+def test_lu_bulk_root_override(tmp_path: Path) -> None:
+    override = _make_bulk_root(tmp_path / "explicit")
+    other = _make_bulk_root(tmp_path / "smb")
+    result = resolve_bulk_root(
+        env={"LU_BULK_ROOT": str(override)},
+        smb_candidates=[other],
+        drive_candidates=[],
+    )
+    assert result.available is True
+    assert result.source == "override"
+    assert result.path == override
+
+
+def test_refuse_network_sources_db_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "data").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    (repo / "data" / "sources.db").write_bytes(b"sqlite")
+    network = Path("/Volumes/UkrainianData/raw-sources/learn-ukrainian-data/sources.db")
+    result = resolve_active_sources_db(
+        repo,
+        env={"LU_SOURCES_DB": str(network)},
+        refuse_network=True,
+    )
+    assert result.refused_network is True
+    assert result.is_local is True
+    assert result.path == repo / "data" / "sources.db"
+    with pytest.raises(ActiveDatabaseNetworkError):
+        require_local_active_sources_db(
+            repo,
+            env={"LU_SOURCES_DB": str(network)},
+        )
+
+
+def test_network_path_heuristic() -> None:
+    assert is_network_filesystem_path(Path("/Volumes/UkrainianData/raw-sources/x"))
+    assert is_network_filesystem_path(Path("//server/UkrainianData/x"))
+    assert not is_network_filesystem_path(Path("/tmp/local-only"))
+
+
+def test_mac_cache_report_only_for_gdrive(tmp_path: Path) -> None:
+    drive = _make_bulk_root(tmp_path / "drive")
+    (drive / "literary_texts" / "a.jsonl").write_text("x\n", encoding="utf-8")
+    bulk = resolve_bulk_root(env={}, smb_candidates=[], drive_candidates=[drive])
+    report = report_mac_cache(bulk, max_entries=10)
+    assert report.applicable is True
+    assert report.sampled_entries >= 1
+    assert "Remove Download" in report.remove_download_instruction
+
+    smb = resolve_bulk_root(
+        env={},
+        smb_candidates=[_make_bulk_root(tmp_path / "smb")],
+        drive_candidates=[],
+    )
+    smb_report = report_mac_cache(smb)
+    assert smb_report.applicable is False
+
+
+def test_topology_status_json_roundtrip(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "data").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    status = resolve_topology(
+        repository_root=repo,
+        env={},
+        smb_candidates=[tmp_path / "missing-smb"],
+        drive_candidates=[tmp_path / "missing-drive"],
+    )
+    payload = status.to_dict()
+    assert payload["schema"] == "storage-topology.status.v1"
+    assert payload["bulk_root"]["available"] is False
+    assert payload["active_database"]["is_local"] is True
+    # Ensure JSON serializable.
+    json.dumps(payload)
+
+
+def test_unresolved_placeholder_does_not_exist() -> None:
+    placeholder = unresolved_bulk_placeholder()
+    assert not placeholder.exists()
+
+
+def test_cli_status_json_subprocess(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "data").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    env = os.environ.copy()
+    env["LU_BULK_ROOT"] = str(tmp_path / "missing-bulk")
+    env.pop("LU_SMB_BULK_ROOT", None)
+    env.pop("LU_GDRIVE_DATA", None)
+    proc = subprocess.run(
+        [
+            str(_project_python()),
+            "-m",
+            "scripts.storage",
+            "status",
+            "--json",
+            "--repo",
+            str(repo),
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema"] == "storage-topology.status.v1"
+    assert "active_database" in payload
+    assert "bulk_root" in payload
+
+
+def test_wiki_config_uses_bulk_resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """scripts/wiki/config.py must consume the single bulk-root resolver."""
+    bulk = _make_bulk_root(tmp_path / "bulk")
+    monkeypatch.setenv("LU_BULK_ROOT", str(bulk))
+    import importlib
+
+    import scripts.wiki.config as wiki_config
+
+    importlib.reload(wiki_config)
+    try:
+        assert bulk == wiki_config.GDRIVE_DATA
+        assert bulk / "literary_texts" == wiki_config.LITERARY_DIR
+    finally:
+        monkeypatch.delenv("LU_BULK_ROOT", raising=False)
+        importlib.reload(wiki_config)

--- a/tests/test_storage_resolver.py
+++ b/tests/test_storage_resolver.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
+from scripts.common.repo_root import main_checkout_root
 from scripts.storage.topology import (
     REQUIRED_BULK_MARKERS,
     ActiveDatabaseNetworkError,
@@ -24,15 +25,33 @@ from scripts.storage.topology import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+_STORAGE_SCOPE_FILES = (
+    REPO_ROOT / "docs" / "runbooks" / "storage-topology.md",
+    REPO_ROOT / "scripts" / "storage" / "cli.py",
+    REPO_ROOT / "scripts" / "storage" / "topology.py",
+    REPO_ROOT / "scripts" / "storage" / "__init__.py",
+    REPO_ROOT / "scripts" / "storage" / "__main__.py",
+    REPO_ROOT / "scripts" / "storage" / "windows" / "Verify-BulkSources.ps1",
+    REPO_ROOT / "scripts" / "storage" / "windows" / "Copy-BulkSourcesFromDrive.ps1",
+    REPO_ROOT / "scripts" / "storage" / "windows" / "README.md",
+    REPO_ROOT / "agents_extensions" / "shared" / "rules" / "storage-topology.md",
+    REPO_ROOT / "tests" / "test_storage_resolver.py",
+    REPO_ROOT / "tests" / "test_storage_windows_scripts.py",
+)
+
 
 def _project_python() -> Path:
+    """Resolve the shared project interpreter without hardcoding operator home."""
     local = REPO_ROOT / ".venv" / "bin" / "python"
     if local.exists():
         return local
-    primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    primary = main_checkout_root(REPO_ROOT) / ".venv" / "bin" / "python"
     if primary.exists():
         return primary
-    return Path(sys.executable)
+    raise RuntimeError(
+        "Project interpreter missing from this checkout and its primary Git "
+        f"checkout: {local}, {primary}"
+    )
 
 
 def _make_bulk_root(path: Path, *, markers: tuple[str, ...] = REQUIRED_BULK_MARKERS) -> Path:
@@ -123,6 +142,61 @@ def test_lu_bulk_root_override(tmp_path: Path) -> None:
     assert result.available is True
     assert result.source == "override"
     assert result.path == override
+
+
+def test_lu_gdrive_data_override_wins_over_caller_drive_candidates(
+    tmp_path: Path,
+) -> None:
+    """LU_GDRIVE_DATA must beat caller drive_candidates (env first)."""
+    env_root = _make_bulk_root(tmp_path / "env-drive")
+    caller_root = _make_bulk_root(tmp_path / "caller-drive")
+    result = resolve_bulk_root(
+        env={"LU_GDRIVE_DATA": str(env_root)},
+        smb_candidates=[],
+        drive_candidates=[caller_root],
+    )
+    assert result.available is True
+    assert result.source == "gdrive"
+    assert result.path == env_root
+    assert result.reason == "LU_GDRIVE_DATA marker-valid"
+    # Caller candidate must not be selected when env override is set.
+    assert result.path != caller_root
+
+
+def test_invalid_lu_gdrive_data_fails_closed_no_drive_fallback(
+    tmp_path: Path,
+) -> None:
+    """Invalid LU_GDRIVE_DATA must not fall through to other Drive roots."""
+    invalid = tmp_path / "invalid-drive"
+    invalid.mkdir()
+    (invalid / "literary_texts").mkdir()
+    # textbook_chunks intentionally absent → not marker-valid
+    fallback = _make_bulk_root(tmp_path / "auto-drive")
+    result = resolve_bulk_root(
+        env={"LU_GDRIVE_DATA": str(invalid)},
+        smb_candidates=[],
+        drive_candidates=[fallback],
+    )
+    assert result.available is False
+    assert result.path is None
+    assert result.source == "unavailable"
+    assert result.reason == "drive_override_not_marker_valid"
+    gdrive_reports = [c for c in result.candidates if c.kind == "gdrive"]
+    assert len(gdrive_reports) == 1
+    assert gdrive_reports[0].path == str(invalid)
+    assert gdrive_reports[0].marker_valid is False
+
+
+def test_missing_lu_gdrive_data_path_fails_closed(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    fallback = _make_bulk_root(tmp_path / "auto-drive")
+    result = resolve_bulk_root(
+        env={"LU_GDRIVE_DATA": str(missing)},
+        smb_candidates=[],
+        drive_candidates=[fallback],
+    )
+    assert result.available is False
+    assert result.reason == "drive_override_not_marker_valid"
 
 
 def test_refuse_network_sources_db_override(tmp_path: Path) -> None:
@@ -240,3 +314,21 @@ def test_wiki_config_uses_bulk_resolver(tmp_path: Path, monkeypatch: pytest.Monk
     finally:
         monkeypatch.delenv("LU_BULK_ROOT", raising=False)
         importlib.reload(wiki_config)
+
+
+def test_storage_topology_scope_has_no_committed_operator_home_paths() -> None:
+    """Regression: do not commit absolute operator-home/project paths in scope."""
+    # Concrete username path only (not the regex character-class source text).
+    concrete = re.compile(
+        r"(?:/Users|/home)/[A-Za-z0-9._-]+/projects/learn-ukrainian(?:/|\b)"
+    )
+    offenders: list[str] = []
+    for path in _STORAGE_SCOPE_FILES:
+        assert path.is_file(), f"missing scope file: {path}"
+        text = path.read_text(encoding="utf-8")
+        for match in concrete.finditer(text):
+            line_no = text.count("\n", 0, match.start()) + 1
+            offenders.append(
+                f"{path.relative_to(REPO_ROOT)}:{line_no}:{match.group(0)}"
+            )
+    assert offenders == [], "committed operator-home paths:\n" + "\n".join(offenders)

--- a/tests/test_storage_windows_scripts.py
+++ b/tests/test_storage_windows_scripts.py
@@ -1,0 +1,104 @@
+"""Hermetic checks for Windows storage copy/verify scripts (text-level proofs)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_DIR = REPO_ROOT / "scripts" / "storage" / "windows"
+COPY_SCRIPT = WINDOWS_DIR / "Copy-BulkSourcesFromDrive.ps1"
+VERIFY_SCRIPT = WINDOWS_DIR / "Verify-BulkSources.ps1"
+
+
+@pytest.fixture(scope="module")
+def copy_text() -> str:
+    return COPY_SCRIPT.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def verify_text() -> str:
+    return VERIFY_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_scripts_exist() -> None:
+    assert COPY_SCRIPT.is_file()
+    assert VERIFY_SCRIPT.is_file()
+
+
+def test_copy_uses_rclone_copy_not_sync(copy_text: str) -> None:
+    # Primary invocation is rclone copy (first positional arg).
+    assert re.search(r"""['\"]copy['\"]""", copy_text)
+    assert "rclone" in copy_text.lower() or "Rclone" in copy_text
+    # Forbidden destructive *invocations* (comments may say "never sync/purge").
+    forbidden = [
+        r"\brclone\.exe\s+sync\b",
+        r"\brclone\s+sync\b",
+        r"""['\"]sync['\"]""",
+        r"""['\"]purge['\"]""",
+        r"--delete(?:-during|-after|-before)?\b",
+        r"\bRemove-Item\b",
+        r"\brmdir\b",
+    ]
+    for pattern in forbidden:
+        assert re.search(pattern, copy_text, flags=re.IGNORECASE) is None, pattern
+    # Documented non-destructive posture.
+    assert "never" in copy_text.lower() and "sync" in copy_text.lower()
+
+
+def test_copy_resolves_destination_via_get_smbshare_local_ntfs(copy_text: str) -> None:
+    assert "Get-SmbShare" in copy_text
+    assert "DriveFormat" in copy_text
+    assert "NTFS" in copy_text
+    assert "StartsWith('\\\\')" in copy_text or 'StartsWith("\\\\")' in copy_text
+    # Share name is conventional; no frozen Phase 3 run IDs.
+    assert "UkrainianData" in copy_text
+    assert "phase3-storage-migration" not in copy_text.lower()
+    assert "20260815" not in copy_text
+
+
+def test_copy_is_resumable_idempotent_flags(copy_text: str) -> None:
+    # checksum + copy semantics skip identical files; retries support resume.
+    assert "--checksum" in copy_text
+    assert "--retries" in copy_text
+    assert "BULK_COPY_COMPLETE" in copy_text
+    # Copy must not mint the success receipt itself.
+    assert "BULK_SOURCES_VERIFIED" not in copy_text
+    assert "Set-Content" not in copy_text or "receipt" not in copy_text.lower()
+
+
+def test_verify_receipt_only_after_success(verify_text: str) -> None:
+    assert "Get-SmbShare" in verify_text
+    assert "NTFS" in verify_text
+    assert "BULK_SOURCES_VERIFIED" in verify_text
+    assert "BULK_SOURCES_VERIFY_FAILED" in verify_text
+    # Receipt write is gated on $passed / success path.
+    assert re.search(r"if\s*\(\s*-not\s*\$passed\s*\)", verify_text)
+    assert "Set-Content" in verify_text
+    # Ensure failure path exits before success receipt language.
+    fail_idx = verify_text.index("BULK_SOURCES_VERIFY_FAILED")
+    success_write_idx = verify_text.index("Set-Content")
+    # There may be only one Set-Content (success receipt). Failure must exit 1.
+    assert "exit 1" in verify_text
+    assert fail_idx < success_write_idx
+    # No deletion of payload.
+    assert re.search(r"\bRemove-Item\b", verify_text) is None
+    assert re.search(r"\brclone\s+sync\b", verify_text, flags=re.IGNORECASE) is None
+
+
+def test_verify_rejects_unc_and_requires_markers(verify_text: str) -> None:
+    assert "literary_texts" in verify_text
+    assert "textbook_chunks" in verify_text
+    assert "not UNC" in verify_text or "refuse network" in verify_text.lower()
+    assert "reparse" in verify_text.lower()
+    assert "phase3-storage-migration" not in verify_text.lower()
+    assert "3187bdff0d41ed213e9d653e2f53b49bd46086f6f5f7daa49a47217ad71b24ec" not in verify_text
+
+
+def test_no_operator_secrets_or_hosts(copy_text: str, verify_text: str) -> None:
+    blob = copy_text + "\n" + verify_text
+    assert "kriszpc" not in blob.lower()
+    assert "@gmail.com" not in blob.lower()
+    assert re.search(r"\b\d{1,3}(\.\d{1,3}){3}\b", blob) is None

--- a/tests/test_storage_windows_scripts.py
+++ b/tests/test_storage_windows_scripts.py
@@ -97,8 +97,34 @@ def test_verify_rejects_unc_and_requires_markers(verify_text: str) -> None:
     assert "3187bdff0d41ed213e9d653e2f53b49bd46086f6f5f7daa49a47217ad71b24ec" not in verify_text
 
 
+def test_verify_destination_is_local_ntfs_derived_from_drive_format(
+    verify_text: str,
+) -> None:
+    """Receipt field must come from DriveFormat, not a hardcoded $true."""
+    assert "DriveFormat" in verify_text
+    assert re.search(
+        r"\$destinationIsLocalNtfs\s*=\s*\(\s*\$payloadDrive\.DriveFormat\s+-ceq\s*'NTFS'\s*\)",
+        verify_text,
+    )
+    assert re.search(
+        r"destination_is_local_ntfs\s*=\s*\$destinationIsLocalNtfs",
+        verify_text,
+    )
+    # Must not hardcode the receipt boolean independently of the format check.
+    assert not re.search(
+        r"destination_is_local_ntfs\s*=\s*\$true\b",
+        verify_text,
+    )
+    # Fail closed when the payload root is not NTFS.
+    assert "not backed by local NTFS" in verify_text
+
+
 def test_no_operator_secrets_or_hosts(copy_text: str, verify_text: str) -> None:
     blob = copy_text + "\n" + verify_text
     assert "kriszpc" not in blob.lower()
     assert "@gmail.com" not in blob.lower()
     assert re.search(r"\b\d{1,3}(\.\d{1,3}){3}\b", blob) is None
+    assert re.search(
+        r"(?:/Users|/home)/[A-Za-z0-9._-]+/projects/learn-ukrainian",
+        blob,
+    ) is None


### PR DESCRIPTION
## Summary

Implements the approved **storage topology v1** brief (SHA-256 `01dffe03b3c4ed7f3e0e1c8f31451a28f6d8508d4e1102db4b35adbb6825e6b7`) for #6375.

- **Active SQLite** stays repository-local (`data/sources.db`); network/SMB paths are refused.
- **Bulk raw-source root** prefers a marker-valid Windows `UkrainianData` SMB mirror (`raw-sources/learn-ukrainian-data`), then marker-valid Google Drive File Provider; ambiguous/missing → structured unavailable.
- **Status CLI:** `python -m scripts.storage status` (read-only; no cloud materialization).
- **Windows:** `rclone copy` (never sync) + verify with success-only receipt on local NTFS via `Get-SmbShare`.
- **Mac cache:** report-only + Finder Remove Download instruction.
- **Wiki rebuild path:** `scripts/wiki/config.py` `GDRIVE_DATA` is a thin consumer of the single bulk-root resolver.
- **Agent rule:** `agents_extensions/shared/rules/storage-topology.md` (+ deploy mirrors via supported deploy flow).

## Test plan

- [x] `pytest tests/test_storage_resolver.py tests/test_storage_windows_scripts.py` (20 passed)
- [x] `pytest tests/test_build_sources_db_safety.py` (29 passed; proportionate)
- [x] `ruff check` on touched Python
- [x] `scripts/check_rules_deployment.sh --tracked-mirrors-only`
- [x] Live `python -m scripts.storage status --json` (SMB preferred on operator Mac)
- [x] Byte-match of shared rule → `.claude`/`.codex`/`.gemini`/`.agent` mirrors after deploy helpers

## Residuals

- Full `scripts/deploy_prompts.sh` from this sparse dispatch worktree hits a hard-coded worktree `.venv` path at the agent-mirror reap step; mirrors were completed with the primary interpreter + the same rsync/sync helpers. CI full checkout has a local `.venv` and remains the gate.
- Windows scripts are hermetically proven by static contract tests; live Windows rclone/verify was not executed in this Mac worktree.
- No corpus move/evict/delete; Phase 3/4 product artifacts untouched.

## Substitution record

Cursor was first-choice but live routing refused it as hot; Grok selected as cooler paid lane (brief `ROUTING_CARD_V1`).