### PR TITLE
fix(drive-epic): fold in five follow-up review findings from PR #6855

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -28,9 +28,11 @@ verifiable claim is tool-backed (deterministic-over-hallucination).
 
 **Work-board orientation surface:** `GET http://127.0.0.1:8765/api/work/v1/projection`
 returns the merged work board — issues, PRs, dispatch tasks, and reviews — with each item
-carrying a rule-derived `health` (`ON_TRACK` / `AT_RISK` / `OFF_TRACK`), an `attention_rank`,
-and a `safe_next_action`. Query it at orient and again when picking the next unblocked action
-(§2); it is a queue INPUT alongside your stream/GH/issue sources, never a replacement for them.
+carrying a rule-derived `health` (`ON_TRACK` / `AT_RISK` / `OFF_TRACK` / `UNKNOWN` — authority
+missing/stale, pairs with the `INSPECT_UNKNOWN` safe action; see `HEALTH_RANK` in
+`scripts/work/attention.py`), an `attention_rank`, and a `safe_next_action`. Query it at orient
+and again when picking the next unblocked action (§2); it is a queue INPUT alongside your
+stream/GH/issue sources, never a replacement for them.
 
 ---
 
@@ -40,6 +42,7 @@ and a `safe_next_action`. Query it at orient and again when picking the next unb
 
 ```bash
 curl -sS --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true" || true
+curl -sS --max-time 2 "http://127.0.0.1:8765/api/work/v1/projection" || true  # best-effort: local server, degraded/absent sources are normal
 .venv/bin/python -m scripts.fleet_comms plane-status        # message-plane mode/parity
 ```
 Know your `SESSION_EPIC`, your stream, and your handoff slot (the launcher already

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -503,7 +503,7 @@ launcher_bind_drive_epic() {
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     fleet_clause="$(fleet_comms_cold_clause)"
   else
-    fleet_clause='Fleet-comms: run plane-status and review-pr; authority mode is durable state and ACP is provider transport.'
+    fleet_clause='Fleet-comms: run plane-status; cross-family review is direct ask-<lane> per the skill (§6) — verdict posted on the PR, merge when CI green, sealed formal CF is retired; authority mode is durable state and ACP is provider transport.'
   fi
   LC_DRIVER_PROMPT="Load agents_extensions/shared/skills/drive-epic/SKILL.md before acting. The launcher already claimed the ${LC_EPIC} lease and ran its provider canary; do not claim, renew, or reopen the lease. ${fleet_clause} Consult the Work API projection (http://127.0.0.1:8765/api/work/v1/projection) for orientation and treat grok-bot QA-observer issues as a queue input — the skill covers both. Obtain independent cross-family review."
   LC_FORWARD_ARGS+=("$LC_DRIVER_PROMPT")

--- a/tests/test_driver_work_api_onboarding.py
+++ b/tests/test_driver_work_api_onboarding.py
@@ -10,27 +10,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.test_launcher_contract import PUBLIC as PUBLIC_LAUNCHERS
+
 REPO = Path(__file__).resolve().parents[1]
 LAUNCHER_CORE = REPO / "scripts/lib/launcher_core.sh"
 SKILL = REPO / "agents_extensions/shared/skills/drive-epic/SKILL.md"
 
-# All 12 start-*.sh launchers source launcher_core.sh (verified by
-# test_launcher_contract.py's PUBLIC tuple); this test guards the one
-# LC_DRIVER_PROMPT string they all forward.
-PUBLIC_LAUNCHERS = (
-    "start-claude.sh",
-    "start-claude-driver.sh",
-    "start-codex.sh",
-    "start-codex-driver.sh",
-    "start-gemini.sh",
-    "start-gemini-driver.sh",
-    "start-grok.sh",
-    "start-grok-driver.sh",
-    "start-kimi.sh",
-    "start-kimicc.sh",
-    "start-glm.sh",
-    "start-glmcc.sh",
-)
+# All 12 start-*.sh launchers source launcher_core.sh; PUBLIC_LAUNCHERS is
+# imported from test_launcher_contract.py's PUBLIC tuple (the allowlist SSOT,
+# guarded there by test_root_launcher_allowlist_is_exact) so the two lists
+# cannot silently drift. This test guards the one LC_DRIVER_PROMPT string
+# they all forward.
 
 
 def test_all_public_launchers_source_launcher_core() -> None:
@@ -71,3 +61,27 @@ def test_skill_teaches_grok_bot_with_hard_exclusions() -> None:
     assert "ask-grok-bot" in body
     assert "never" in body.lower() and "dispatch target" in body
     assert "same-family Grok must not CF" in body
+
+
+def test_skill_teaches_the_full_health_enum() -> None:
+    from scripts.work.attention import HEALTH_RANK
+
+    body = SKILL.read_text(encoding="utf-8")
+    # The taught enum must match HEALTH_RANK exactly, not a stale 3-state subset
+    # (UNKNOWN is authority-missing/stale, pairs with the INSPECT_UNKNOWN safe
+    # action) — assert against the source of truth so this cannot silently drift.
+    for state in HEALTH_RANK:
+        assert f"`{state}`" in body, f"skill must teach health state {state!r}"
+    assert "INSPECT_UNKNOWN" in body
+
+
+def test_no_launcher_prompt_branch_names_review_pr() -> None:
+    # Sealed formal review-pr is retired (operator 2026-08-07; the CLI fails
+    # closed) — no LC_DRIVER_PROMPT / fleet_clause branch a driver could be
+    # launched down may still instruct it.
+    core = LAUNCHER_CORE.read_text(encoding="utf-8")
+    cold_start = (REPO / "scripts/lib/fleet_comms_cold_start.sh").read_text(encoding="utf-8")
+    assert "review-pr" not in core
+    # The richer clause is allowed to name the retired command only to say
+    # "do not use" — never as an instruction to run it.
+    assert "RETIRED — do not use" in cold_start


### PR DESCRIPTION
## Summary
Follow-up to merged PR #6855 (issue #6851). Folds in all five non-blocking
findings from the PR's cross-family review (kimi, APPROVE) and the driver
observations.

1. Wired the `/api/work/v1/projection` curl into §0 Orient's command block
   so "query it at orient" is executable, and fixed the dangling `(§0)`
   cross-reference in §2.
2. `PUBLIC_LAUNCHERS` in `test_driver_work_api_onboarding.py` now imports
   `PUBLIC` from `test_launcher_contract.py` instead of duplicating it
   (silent-drift guard).
3. Added a one-line best-effort note on the projection query (degraded
   sources are normal; it's a local-server input).
4. Taught the full health enum in the skill — added `UNKNOWN`
   (authority-missing, pairs with `INSPECT_UNKNOWN`) — verified against
   `HEALTH_RANK` in `scripts/work/attention.py`.
5. Removed the retired `review-pr` instruction from the `fleet_clause`
   else-branch in `scripts/lib/launcher_core.sh`, replaced with the current
   direct `ask-<lane>` CF wording consistent with the skill's §6. Added a
   regression test asserting no launcher prompt branch names `review-pr`.

## Testing
```
$ .venv/bin/python -m pytest tests/test_driver_work_api_onboarding.py tests/test_launcher_contract.py -q
```
6/6 new+existing tests in `test_driver_work_api_onboarding.py` pass. The 7
pre-existing failures in `test_launcher_contract.py` (missing `.venv/bin/python`
inside this dispatch worktree, per project policy) reproduce identically on
`origin/main` before this change — unrelated to this PR.

Both new guard tests (health-enum, no-review-pr) mutation-checked: reverting
the corresponding source edit makes each fail.

`shellcheck` on the edited `launcher_core.sh` line: no new warnings (only
pre-existing SC1091 info notes for `source` lines elsewhere in the file).
`ruff check tests/test_driver_work_api_onboarding.py`: all checks passed.

Refs #6851, PR #6855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
