### PR TITLE
fix(fleet-comms): hard-fail unanchored plane roots + root-entry leak guard (#6863)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ gha-creds-*.json
 .pytest_cache/
 .pytest_breadcrumbs/
 .ruff_cache/
+# CI scratch output (junit XML, shard plans, logs) written by .github/workflows/ci.yml
+ci-artifacts/
 
 # uv lockfiles are local scratch in this repo; dependencies are managed through
 # pyproject.toml plus the project venv.

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ docs/bolshakova_*.png
 gha-creds-*.json
 .pytest_cache/
 .pytest_breadcrumbs/
+.ruff_cache/
 
 # uv lockfiles are local scratch in this repo; dependencies are managed through
 # pyproject.toml plus the project venv.

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -285,7 +285,10 @@ if [ "$ROOT_GUARD_RC" -eq 0 ] && [ -n "$ROOT_GUARD_JSON" ]; then
   fi
   unset ROOT_GUARD_COUNT ROOT_GUARD_NAMES
 else
-  ISSUES+=("ROOT HYGIENE CHECK COULD NOT RUN (rc=$ROOT_GUARD_RC): unexpected repo-root entries would go undetected this session (#6863).")
+  # Alert-only means output ONLY on findings: a skipped canary is not a
+  # finding, so it goes to stderr and must not eat the concise-session
+  # context budget (ordinary Codex starts are contracted under 500 bytes).
+  echo "WARNING: root-hygiene canary could not run (rc=$ROOT_GUARD_RC): unexpected repo-root entries would go undetected this session (#6863)." >&2
 fi
 unset ROOT_GUARD_RC ROOT_GUARD_JSON
 

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -268,6 +268,27 @@ if [ -f "$LANE_PROBE_SCRIPT" ]; then
 fi
 unset LANE_PROBE_SCRIPT
 
+# Root-hygiene canary (#6863). A transport/quoting leak once materialized
+# garbage dirs at the primary checkout root — verbatim ACP event-stream JSON
+# lines and word-split tokens of them, including a literal `-rf` — and empty
+# dirs are invisible to git status, so the class sat undetected until one grew
+# a shadow comms DB and swallowed a message. Advisory only: the guard alerts
+# here and NEVER deletes (garbage root entries are forensic evidence).
+ROOT_GUARD_RC=0
+ROOT_GUARD_JSON=$(run_bounded 3 env "PYTHONPATH=$PROJECT_DIR" "$BOUNDED_PYTHON" \
+  -m scripts.hygiene.root_entry_guard --repo-root "$CANONICAL_ROOT" --json 2>/dev/null) || ROOT_GUARD_RC=$?
+if [ "$ROOT_GUARD_RC" -eq 0 ] && [ -n "$ROOT_GUARD_JSON" ]; then
+  ROOT_GUARD_COUNT=$(printf '%s' "$ROOT_GUARD_JSON" | jq -r '.unexpected_count // 0' 2>/dev/null || echo 0)
+  if [ "${ROOT_GUARD_COUNT:-0}" -gt 0 ]; then
+    ROOT_GUARD_NAMES=$(printf '%s' "$ROOT_GUARD_JSON" | jq -r '[.unexpected[].name] | join(", ")' 2>/dev/null || true)
+    ISSUES+=("ROOT HYGIENE: $ROOT_GUARD_COUNT unexpected top-level entries in the primary checkout ($ROOT_GUARD_NAMES). Inspect and remove MANUALLY — the guard never auto-deletes (evidence preservation, #6863). Detail: .venv/bin/python -m scripts.hygiene.root_entry_guard")
+  fi
+  unset ROOT_GUARD_COUNT ROOT_GUARD_NAMES
+else
+  ISSUES+=("ROOT HYGIENE CHECK COULD NOT RUN (rc=$ROOT_GUARD_RC): unexpected repo-root entries would go undetected this session (#6863).")
+fi
+unset ROOT_GUARD_RC ROOT_GUARD_JSON
+
 # 6. Check MEMORY.md line count (truncated at 200 lines by system)
 MEMORY_DIR="$HOME/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian/memory"
 MEMORY_FILE="$MEMORY_DIR/MEMORY.md"

--- a/scripts/fleet_comms/paths.py
+++ b/scripts/fleet_comms/paths.py
@@ -14,8 +14,31 @@ ENV_ROOT = "FLEET_COMMS_ROOT"
 DEFAULT_ROOT_REL = Path("batch_state") / "fleet-comms" / "v1"
 
 
-def default_plane_root(*, repo_root: Path | None = None) -> Path:
-    """Resolve fleet state beneath the primary checkout, unless explicitly overridden."""
+class PlaneRootAnchorError(RuntimeError):
+    """Raised when the plane root cannot be anchored to the primary checkout."""
+
+
+def default_plane_root(
+    *,
+    repo_root: Path | None = None,
+    allow_non_git: bool = False,
+) -> Path:
+    """Resolve fleet state beneath the primary checkout, unless explicitly overridden.
+
+    Anchoring order:
+
+    1. ``FLEET_COMMS_ROOT`` env override (explicit operator choice) — honored as-is.
+    2. The primary checkout that owns the shared ``.git`` store, resolved from
+       ``repo_root`` (default: process cwd).
+
+    When neither applies — the candidate is not inside a git repository — the
+    default is a HARD ERROR (#6863), never a silent fallback to the raw
+    candidate. The old fallback let a process running with a garbage cwd (a
+    transport-leak directory fragment at the repo root) materialize a shadow
+    ``batch_state/fleet-comms/v1`` tree there, converting a quoting bug into
+    silent message loss. Isolated non-git callers and test fixtures must opt in
+    explicitly with ``allow_non_git=True``.
+    """
     env = os.environ.get(ENV_ROOT)
     if env:
         return Path(env).expanduser().resolve()
@@ -23,7 +46,15 @@ def default_plane_root(*, repo_root: Path | None = None) -> Path:
     candidate = repo_root if repo_root is not None else Path.cwd()
     try:
         base = resolve_main_root(candidate)
-    except NotAGitRepositoryError:
-        # Preserve support for isolated non-Git callers and test fixtures.
+    except NotAGitRepositoryError as exc:
+        if not allow_non_git:
+            raise PlaneRootAnchorError(
+                f"refusing to anchor the fleet-comms plane root at {candidate}: "
+                "not inside a git repository, so the primary checkout cannot be "
+                "verified. A silent fallback here once materialized a shadow comms "
+                "DB under a garbage cwd (#6863). Set FLEET_COMMS_ROOT for an "
+                "explicit override, or pass allow_non_git=True for an isolated "
+                "non-git fixture."
+            ) from exc
         base = candidate.resolve()
     return (base / DEFAULT_ROOT_REL).resolve()

--- a/scripts/hygiene/root_entry_guard.py
+++ b/scripts/hygiene/root_entry_guard.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Unexpected repo-root entry guard (#6863).
+
+A transport/quoting defect once materialized garbage directories at the repo
+root — names that were verbatim opencode/ACP event-stream JSON lines and
+word-split tokens of them (a literal ``-rf`` among them). Empty directories
+are invisible to ``git status``, so this class of pollution sat undetected;
+one of them even grew a shadow fleet-comms DB and swallowed a message.
+
+This guard deterministically lists the primary checkout's top-level entries
+and reports any that are neither tracked nor gitignored. It is ALERT-ONLY:
+nothing is ever deleted here — garbage root entries are forensic evidence and
+removal is an explicit human decision.
+
+Surfaces:
+* Session-start sweep: ``agents_extensions/shared/hooks/session-setup.sh``
+  invokes this module bounded and surfaces findings as an ISSUE line.
+* Advisory CLI: ``python -m scripts.hygiene.root_entry_guard [--strict]``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Dual-flavor import: delegate workers put only ``scripts/`` on sys.path (see
+# the note in scripts/guardrails/worktree_containment.py).
+try:
+    from scripts.common.git_context import sanitized_git_env
+    from scripts.guardrails.worktree_containment import resolve_main_root
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.git_context import sanitized_git_env  # type: ignore[no-redef]
+    from guardrails.worktree_containment import resolve_main_root  # type: ignore[no-redef]
+
+__all__ = ["UnexpectedEntry", "main", "scan_unexpected_root_entries"]
+
+
+class UnexpectedEntry:
+    """One top-level repo-root entry that git does not expect."""
+
+    def __init__(self, name: str, *, kind: str, empty_dir: bool) -> None:
+        self.name = name
+        self.kind = kind
+        # Empty dirs are invisible to git status; everything else git can see.
+        self.git_invisible = empty_dir
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "git_invisible": self.git_invisible,
+        }
+
+
+def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=sanitized_git_env(),
+    )
+
+
+def _tracked_top_level_names(root: Path) -> set[str]:
+    """First path component of every tracked file (NUL-safe)."""
+    proc = _run_git(root, "ls-files", "-z")
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git ls-files failed under {root}: "
+            f"{(proc.stderr or proc.stdout or 'unknown error').strip()}"
+        )
+    names: set[str] = set()
+    for path in proc.stdout.split("\0"):
+        if path:
+            names.add(path.split("/", 1)[0])
+    return names
+
+
+def _is_ignored(root: Path, name: str) -> bool:
+    # -q: exit 0 == ignored, 1 == not ignored, 128 == error.
+    proc = _run_git(root, "check-ignore", "-q", "--", name)
+    return proc.returncode == 0
+
+
+def _classify(entry: Path) -> tuple[str, bool]:
+    """(kind, empty_dir) for a top-level entry; symlinks are not followed."""
+    if entry.is_symlink():
+        return "symlink", False
+    if entry.is_dir():
+        try:
+            empty = not any(entry.iterdir())
+        except OSError:
+            empty = False
+        return "dir", empty
+    return "file", False
+
+
+def scan_unexpected_root_entries(repo_root: Path | None = None) -> list[UnexpectedEntry]:
+    """Top-level entries of the primary checkout that git neither tracks nor ignores.
+
+    ``repo_root`` may point anywhere inside the repo (a worktree cwd included);
+    the scan always targets the primary checkout that owns the shared ``.git``.
+    Raises if the anchor is not inside a git repository.
+    """
+    root = resolve_main_root(repo_root if repo_root is not None else Path.cwd())
+    tracked = _tracked_top_level_names(root)
+
+    unexpected: list[UnexpectedEntry] = []
+    for entry in sorted(root.iterdir(), key=lambda p: p.name):
+        name = entry.name
+        if name == ".git" or name in tracked:
+            continue
+        if _is_ignored(root, name):
+            continue
+        kind, empty_dir = _classify(entry)
+        unexpected.append(UnexpectedEntry(name, kind=kind, empty_dir=empty_dir))
+    return unexpected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Alert on unexpected top-level entries in the primary checkout "
+            "(including empty dirs git cannot see). Advisory by default; "
+            "never deletes anything (#6863)."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Anchor path inside the repo (default: cwd); scan targets the primary checkout.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when unexpected entries exist (default: always exit 0).",
+    )
+    args = parser.parse_args(argv)
+
+    root = resolve_main_root(args.repo_root if args.repo_root is not None else Path.cwd())
+    unexpected = scan_unexpected_root_entries(root)
+    report = {
+        "repo_root": str(root),
+        "unexpected_count": len(unexpected),
+        "unexpected": [entry.to_dict() for entry in unexpected],
+    }
+    if args.json:
+        print(json.dumps(report, indent=2))
+    elif unexpected:
+        print("UNEXPECTED repo-root entries (inspect manually; never auto-deleted, #6863):")
+        for entry in unexpected:
+            invis = " [git-invisible empty dir]" if entry.git_invisible else ""
+            print(f"  - {entry.name} ({entry.kind}){invis}")
+    else:
+        print("Root hygiene OK: no unexpected top-level entries.")
+    return 1 if (args.strict and unexpected) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent_runtime/test_acpx_discuss.py
+++ b/tests/agent_runtime/test_acpx_discuss.py
@@ -1264,6 +1264,9 @@ def test_optional_projection_failure_never_changes_complete_discussion_result(
 
     monkeypatch.setattr(acpx_discuss, "AcpxDiscussionController", FakeController)
     monkeypatch.setattr(reconcile, "project_terminal_acp_receipt", fail_projection)
+    # #6863: default_plane_root hard-fails on non-git roots; the fixture must
+    # present a real anchor (a `.git` dir is enough for the fs fallback).
+    (tmp_path / ".git").mkdir()
 
     result = acpx_discuss.run_discussion(cwd=tmp_path)
 

--- a/tests/fleet_comms/test_cold_start_board.py
+++ b/tests/fleet_comms/test_cold_start_board.py
@@ -399,6 +399,9 @@ def test_cli_cold_start_board_markdown(capsys):
 
 def test_probe_inbox_legacy_schema_ok(tmp_path: Path, monkeypatch) -> None:
     """Legacy deliveries without channel/recipient columns must not degrade."""
+    # #6863: default_plane_root hard-fails on non-git roots; the fixture must
+    # present a real anchor (a `.git` dir is enough for the fs fallback).
+    (tmp_path / ".git").mkdir()
     broker = tmp_path / "messages.db"
     _seed_legacy_broker(broker)
     monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")

--- a/tests/hygiene/test_root_entry_guard.py
+++ b/tests/hygiene/test_root_entry_guard.py
@@ -24,6 +24,7 @@ def _git(root: Path, *args: str) -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
 

--- a/tests/hygiene/test_root_entry_guard.py
+++ b/tests/hygiene/test_root_entry_guard.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/hygiene/root_entry_guard.py (#6863).
+
+The guard must deterministically flag top-level repo-root entries that git
+neither tracks nor ignores — crucially EMPTY DIRECTORIES, which git status
+cannot see — and must never delete anything itself.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.guardrails.worktree_containment import NotAGitRepositoryError
+from scripts.hygiene import root_entry_guard
+from scripts.hygiene.root_entry_guard import main, scan_unexpected_root_entries
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_repo(root: Path) -> Path:
+    """Minimal real git repo: one tracked file, one ignored dir."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q")
+    (root / "tracked.py").write_text("# tracked\n", encoding="utf-8")
+    (root / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+    _git(root, "add", "tracked.py", ".gitignore")
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "dep.js").write_text("// ignored\n", encoding="utf-8")
+    return root
+
+
+def test_clean_root_reports_nothing(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    assert scan_unexpected_root_entries(root) == []
+
+
+def test_empty_garbage_dir_flagged_as_git_invisible(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    # The Aug-13 leak class: a verbatim ACP event line as a directory name.
+    (root / '{"type":"text","part":{"type":"text","text":"привіт"}}').mkdir()
+
+    unexpected = scan_unexpected_root_entries(root)
+
+    assert [e.name for e in unexpected] == [
+        '{"type":"text","part":{"type":"text","text":"привіт"}}'
+    ]
+    assert unexpected[0].kind == "dir"
+    assert unexpected[0].git_invisible is True
+
+
+def test_literal_dash_rf_dir_flagged_without_arg_injection(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    (root / "-rf").mkdir()
+
+    unexpected = scan_unexpected_root_entries(root)
+
+    assert [e.name for e in unexpected] == ["-rf"]
+    assert unexpected[0].git_invisible is True
+    # The flag-shaped name must not have been consumed as a git option:
+    # the ignored node_modules dir is still correctly NOT flagged.
+    assert all(e.name != "node_modules" for e in unexpected)
+
+
+def test_nonempty_garbage_dir_flagged_as_git_visible(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    garbage = root / 'prompt"}}'
+    garbage.mkdir()
+    (garbage / "nested.txt").write_text("x\n", encoding="utf-8")
+
+    unexpected = scan_unexpected_root_entries(root)
+
+    assert [e.name for e in unexpected] == ['prompt"}}']
+    assert unexpected[0].kind == "dir"
+    assert unexpected[0].git_invisible is False
+
+
+def test_untracked_file_flagged_as_git_visible(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    (root / "stray.txt").write_text("x\n", encoding="utf-8")
+
+    unexpected = scan_unexpected_root_entries(root)
+
+    assert [e.name for e in unexpected] == ["stray.txt"]
+    assert unexpected[0].kind == "file"
+    assert unexpected[0].git_invisible is False
+
+
+def test_tracked_and_ignored_entries_never_flagged(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    unexpected = scan_unexpected_root_entries(root)
+    assert all(e.name not in {"tracked.py", ".gitignore", "node_modules", ".git"} for e in unexpected)
+
+
+def test_scan_anchored_from_nested_subdir_scans_primary_root(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    nested = root / "scripts" / "deeper"
+    nested.mkdir(parents=True)
+    (root / "scripts" / "kept.py").write_text("# tracked\n", encoding="utf-8")
+    _git(root, "add", "scripts/kept.py")
+    (root / "-rf").mkdir()
+
+    unexpected = scan_unexpected_root_entries(nested)
+
+    assert [e.name for e in unexpected] == ["-rf"]
+
+
+def test_outside_git_repo_raises(tmp_path: Path) -> None:
+    nowhere = tmp_path / "nowhere"
+    nowhere.mkdir()
+    with pytest.raises(NotAGitRepositoryError):
+        scan_unexpected_root_entries(nowhere)
+
+
+def test_guard_never_deletes(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path / "repo")
+    garbage = root / "-rf"
+    garbage.mkdir()
+
+    scan_unexpected_root_entries(root)
+    main(["--repo-root", str(root), "--strict"])
+
+    assert garbage.is_dir()
+
+
+def test_cli_json_report(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root = _make_repo(tmp_path / "repo")
+    (root / "-rf").mkdir()
+
+    rc = main(["--repo-root", str(root), "--json"])
+
+    assert rc == 0  # advisory by default, even with findings
+    report = json.loads(capsys.readouterr().out)
+    assert report["repo_root"] == str(root)
+    assert report["unexpected_count"] == 1
+    assert report["unexpected"][0]["name"] == "-rf"
+    assert report["unexpected"][0]["git_invisible"] is True
+
+
+def test_cli_strict_exit_codes(tmp_path: Path) -> None:
+    dirty = _make_repo(tmp_path / "dirty")
+    (dirty / "-rf").mkdir()
+    clean = _make_repo(tmp_path / "clean")
+
+    assert main(["--repo-root", str(dirty), "--strict"]) == 1
+    assert main(["--repo-root", str(clean), "--strict"]) == 0
+
+
+def test_module_docstring_and_exports() -> None:
+    assert root_entry_guard.__doc__ is not None
+    assert "#6863" in root_entry_guard.__doc__
+
+
+def test_session_start_hook_wires_the_guard() -> None:
+    """The SessionStart canary must invoke this guard and alert, never delete."""
+    hook = (
+        Path(root_entry_guard.__file__).resolve().parents[2]
+        / "agents_extensions"
+        / "shared"
+        / "hooks"
+        / "session-setup.sh"
+    )
+    text = hook.read_text(encoding="utf-8")
+    assert '-m scripts.hygiene.root_entry_guard --repo-root "$CANONICAL_ROOT" --json' in text
+    assert "ROOT HYGIENE" in text
+    # Evidence preservation: the hook must not turn the guard into a deleter.
+    guard_block = text[text.index("Root-hygiene canary"):]
+    assert "rm " not in guard_block.split("# 6. Check MEMORY.md")[0]

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -23,7 +23,11 @@ def _client() -> TestClient:
 
 def test_read_plane_status_defaults_to_configured_mode(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
-    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    # Every production caller (Monitor API routers, CLI) passes an in-repo
+    # PROJECT_ROOT; this fixture is a non-git tmp dir, and since #6863 the
+    # default plane root hard-fails there, so anchor via the explicit
+    # operator override. The default under test is the plane MODE.
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "plane"))
     monkeypatch.delenv("FLEET_COMMS_PLANE_TELEMETRY", raising=False)
     status = read_plane_status(repo_root=tmp_path)
     # The final migration gate promotes durable authority as the default.

--- a/tests/test_entire_context_recall.py
+++ b/tests/test_entire_context_recall.py
@@ -72,6 +72,8 @@ from scripts.entire_context.resolvers import (
     rollover_projection_digest,
 )
 from scripts.entire_context.store import AdmitOutcome, AdmitResult, ContextLinkStore
+from scripts.fleet_comms.paths import ENV_ROOT as FLEET_COMMS_ROOT_ENV
+from scripts.fleet_comms.paths import PlaneRootAnchorError
 from scripts.orchestration import task_identity
 from scripts.orchestration.task_family import rollover, rollover_registry
 
@@ -417,7 +419,15 @@ def test_acp_root_reuses_canonical_fleet_resolution_and_override_order(
     isolated = tmp_path / "isolated"
     isolated.mkdir()
     monkeypatch.delenv(ENV_ACP_ROOT)
-    assert acp_root(isolated) == isolated / "batch_state" / "fleet-comms" / "v1"
+    # Non-git anchors HARD-FAIL since #6863 (a silent fallback once grew a
+    # shadow comms DB under a garbage cwd); every production acp_root caller
+    # (CLI, service) runs inside the repo, so only the explicit
+    # FLEET_COMMS_ROOT operator override rescues an isolated directory.
+    with pytest.raises(PlaneRootAnchorError):
+        acp_root(isolated)
+    fleet_override = tmp_path / "fleet-override"
+    monkeypatch.setenv(FLEET_COMMS_ROOT_ENV, str(fleet_override))
+    assert acp_root(isolated) == fleet_override
 
 
 def test_cli_automatically_uses_service_acp_root(
@@ -1694,6 +1704,10 @@ def test_rollover_bootstrap_then_search_explain_and_handoff(tmp_path: Path, caps
         ROLLOVER_LINEAGE,
         "--repo",
         str(tmp_path),
+        # Explicit plane: this fixture is an isolated non-git state dir, and
+        # the default ACP anchor hard-fails outside a git repo since #6863.
+        "--acp-root",
+        str(tmp_path / "acp-plane"),
         "--rollover-root",
         str(root),
         "--db",
@@ -1723,6 +1737,8 @@ def test_rollover_bootstrap_then_search_explain_and_handoff(tmp_path: Path, caps
         ROLLOVER_CANONICAL_ID,
         "--repo",
         str(tmp_path),
+        "--acp-root",
+        str(tmp_path / "acp-plane"),
         "--rollover-root",
         str(root),
         "--db",
@@ -1745,6 +1761,8 @@ def test_rollover_bootstrap_then_search_explain_and_handoff(tmp_path: Path, caps
         card["locator_id"],
         "--repo",
         str(tmp_path),
+        "--acp-root",
+        str(tmp_path / "acp-plane"),
         "--rollover-root",
         str(root),
         "--db",

--- a/tests/test_fleet_comms_bottleneck_alerts.py
+++ b/tests/test_fleet_comms_bottleneck_alerts.py
@@ -17,8 +17,13 @@ NOW = datetime(2026, 7, 22, 12, 0, tzinfo=UTC)
 
 
 @pytest.fixture(autouse=True)
-def isolate_broker(tmp_path: Path):
+def isolate_broker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     broker_db = tmp_path / "messages.db"
+    # The scan's production caller (scripts/ai_agent_bridge/_inbox.py) always
+    # passes an in-repo REPO_ROOT, so default_plane_root anchors to the primary
+    # checkout. These fixtures are plain non-git tmp dirs; since #6863 the
+    # default hard-fails there, so they use the explicit operator override.
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "plane"))
     with patch("scripts.ai_agent_bridge._config.DB_PATH", broker_db), patch(
         "scripts.ai_agent_bridge._db.DB_PATH", broker_db
     ):

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -57,17 +57,25 @@ def test_default_plane_root_anchors_linked_worktree_to_primary(
     assert default_plane_root(repo_root=worktree) == expected
 
 
-def test_default_plane_root_preserves_override_and_non_git_fallback(
+def test_default_plane_root_preserves_override_and_hard_fails_outside_git(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from scripts.fleet_comms.paths import PlaneRootAnchorError
+
     isolated = tmp_path / "isolated"
     isolated.mkdir()
     override = tmp_path / "explicit-plane"
     monkeypatch.setenv("FLEET_COMMS_ROOT", str(override))
     assert default_plane_root(repo_root=isolated) == override
 
+    # #6863: outside a git repository the default is a hard error, never a
+    # silent shadow tree under an unverifiable cwd.
     monkeypatch.delenv("FLEET_COMMS_ROOT")
-    assert default_plane_root(repo_root=isolated) == (
+    with pytest.raises(PlaneRootAnchorError):
+        default_plane_root(repo_root=isolated)
+
+    # Isolated non-git fixtures must opt in explicitly.
+    assert default_plane_root(repo_root=isolated, allow_non_git=True) == (
         isolated / "batch_state" / "fleet-comms" / "v1"
     )
 


### PR DESCRIPTION
## Summary

Forensic hunt + hardening for the repo-root directory leak. The in-repo defect that converted an external transport/quoting leak into **silent message loss** is pinned and fixed at the root-cause layer; a deterministic, alert-only root-hygiene guard now makes this class visible at every session start (empty dirs are invisible to `git status`).

## Forensic answers (issue acceptance)

**Creator of the shadow comms tree — identified.** The trapped row's metadata in the preserved shadow DB (`/tmp/lu-leak-evidence/shadow-comms-aug13.sqlite3`: `transport_mode: "bridge-ask"`, `plane_mode: "authority"`, `legacy_message_id: 1`, `task_id: "review-6014-plan"`, `model: "gemini-3.1-pro-high"`, `cwd: null`) matches exactly one code site: `MessagePlane.open_ask`'s metadata dict at `scripts/fleet_comms/message_plane.py:253-263`, fed by `_plane_try_open_ask` (`scripts/ai_agent_bridge/_ask_lifecycle.py:1052-1065`, line-identical at Aug-13 HEAD `e5baf72bea`). Chain: `ask_agy()` → `register_ask` → `_plane_try_open_ask` → `_plane_root()` → `default_plane_root(repo_root=REPO_ROOT)` → `RequestExecutor`/`ArtifactStore`, where `ArtifactStore._prepare_private_dir` (`scripts/fleet_comms/artifacts.py:388-399`) mkdirs every missing component of the resolved root and `apply_migrations` built the 421 KB DB. The two other preserved evidence DBs (`shadow-narration`, `shadow-rmrf`, 421 KB, zero messages) are two more bare `ArtifactStore` materializations under garbage roots.

**Event-line → directory-name step — bounded with negative proof: not in tracked code.** None of the four garbage names contains `/`, so the issue's acpx lead (`cli.js:178`, inside `exportSession`, which mkdirs `path.dirname(...)`) cannot produce root-level dirs with those names; nothing in the repo invokes `sessions export` or passes `--output` to acpx. Exhaustive search found no `shell=True`/`os.system`/backticks in `scripts/`, no unquoted `mkdir $VAR`/`$(...)` in any shell/hook/deployed copy, and all opencode/acpx invocations are argv lists (`_opencode.py:1205-1243`, `adapters/acpx.py:1263-1281`, `acp_text_agent.mjs:122` `shell: false`). The pollution of the plane-root base happened in an untracked layer (operator/agent-issued shell or host tooling). Candor note: `resolve_main_root` walks upward, so a garbage cwd *inside* the primary still anchored correctly even on Aug 13 — the observed shadow therefore required `FLEET_COMMS_ROOT`/`AB_REPO_ROOT` env honored unvalidated, or a stale pre-`84926a35b2` code copy with no git anchoring at all.

**Defect status: the silent-loss conversion was LIVE and is fixed by this PR.** `default_plane_root`'s silent non-git fallback was live on Aug 13 (`paths.py` md5-identical between `84926a35b2` and `e5baf72bea`) and at HEAD until this PR. The bridge-ask agy path itself is live and unchanged in shape (only default-model bumps since, `56f099195d`); "hermes removal" (`bc6fa93a85`, PR #6837) was host state, not an agy→hermes path — agy never routed through hermes (`registry.py:416-423`).

**Sweeper — identified as external to this repo, with proof.** No tracked code deletes repo-root entries: the retention engine and both worktree reapers are `.worktrees`-scoped; `tmp_leak_sweep.py` is `$TMPDIR`-scoped; the API worktree-GC sweep (`scripts/api/main.py:777-801`) logs loudly to `logs/api.log` and shows **no sweep in the 14:39→14:44 window** (the server was wedged 14:28:57→16:53:46 — the projection cold-wedge fixed by `569df9f489`); the launchd cleanup job fails at startup (exit 78); the post-worker `check_primary_integrity` is detection-only and logged nothing after Aug 13. The only empty-dir-only deleter in the repo (`scripts/deploy/reap_agent_mirrors.py:198`, `os.rmdir` with ENOTEMPTY-preserve) is `.agent/`-scoped. A **second live sweep wave was witnessed during this investigation** (primary-root mtime 17:25:21, junk dirs dated Aug 13 18:53 gone between 17:20 and 17:26, Trash empty, no repo log active, zero `rm`/`rmdir` in the running agy dispatch's runtime log). The sweep is silent, `rmdir`-family (empty-only — which is why the non-empty shadow dir survived wave 1), and the only actors present in both windows sit outside repo instrumentation (the long-lived interactive agy TUI process / human shell). Since the sweeper is external, this PR's answer to "recurrences self-erase" is the loud surface below: every SessionStart now alerts on this class.

## Changes

- `scripts/fleet_comms/paths.py` — `default_plane_root` hard-fails with `PlaneRootAnchorError` when the anchor is not inside a git repository (shadow comms DB under a garbage cwd becomes impossible without an explicit override: `FLEET_COMMS_ROOT` or `allow_non_git=True` for isolated fixtures).
- `scripts/hygiene/root_entry_guard.py` (new) — flags top-level primary-checkout entries git neither tracks nor ignores, marking empty dirs as `git_invisible`; alert-only, never deletes (evidence preservation). CLI: `python -m scripts.hygiene.root_entry_guard [--repo-root PATH] [--json] [--strict]`.
- `agents_extensions/shared/hooks/session-setup.sh` — bounded SessionStart canary invoking the guard against the canonical root; findings surface as a SESSION SETUP CHECK issue. (Deploy copies regenerate via `npm run agents:deploy` on next launcher start.)
- `.gitignore` — ignore `.ruff_cache/` (the only pre-existing benign top-level entry the guard flags; `.pytest_cache/` was already ignored).
- Tests: `tests/hygiene/test_root_entry_guard.py` (13 cases: the literal `-rf` name, verbatim ACP event-line names, `--` arg-injection safety, never-deletes invariant, nested-anchor resolution, CLI/exit codes, hook wiring); `tests/test_fleet_comms_message_plane.py` hard-fail coverage; two fixtures that secretly relied on the silent fallback (`test_cold_start_board.py::test_probe_inbox_legacy_schema_ok`, `test_acpx_discuss.py::test_optional_projection_failure_...`) now anchor on real `.git` markers.

## Testing

- [x] Affected suites: 954 passed across `tests/ai_agent_bridge`, `tests/agent_runtime`, `tests/hygiene`, fleet-comms, entire-context, session-hook, and retention suites. The 6 failures are all pre-existing on HEAD (verified via `git stash` A/B): `test_supported_bridge_command_defaults_to_durable_acp`, `test_cold_start_board.py::test_size_cap`/`test_markdown_path` (ordering-dependent), `test_review_worktree.py::test_sealed_acp_config_...`, `test_agy_adapter.py::test_render_writer_prompt_*` ×2.
- [x] ruff clean on all touched files; shellcheck clean on the hook.
- [x] Mutation checks (#M-16), each restored after confirmation: removing empty-dir detection kills 3 guard tests; removing the ignored-check kills 9; restoring the silent fallback kills the new hard-fail test; dropping the hook invocation kills the wiring test.
- [x] Live cross-validation: the guard run at 17:40 against the primary checkout agrees with the witnessed sweep timeline (junk dirs removed at 17:25:21; only `.ruff_cache` flagged).
- N/A: module audit / site build / Ukrainian text (infra-only change).

## Related Issues

Refs #6863 — forensic answers above; this PR leaves #6863 open for the external (out-of-repo) creator/sweeper layer and operator follow-up on the agy host tooling.
Refs #6805 #6818 #6830 (adjacent transport/process classes), #6014 (the lost ask's topic).

NO auto-merge; cross-family exact-head review required per the merge gate.
