### PR TITLE
feat(atlas): tracked VPS job protocol (plan, result, restic)

### DIFF
--- a/docs/runbooks/atlas-full-reenrich-campaign.md
+++ b/docs/runbooks/atlas-full-reenrich-campaign.md
@@ -1,6 +1,7 @@
 # Atlas Full-Reenrich Campaign Runbook (#6466)
 
 This runbook documents the operator and driver procedures for the full-catalog Atlas re-enrichment campaign tooling (#6466).
+Tracked submit/status/close: [`atlas-job-protocol.md`](atlas-job-protocol.md). Default host is `atlas-runner`.
 
 ## Overview & Campaign Architecture
 
@@ -62,12 +63,13 @@ From the Mac worktree, deploy the driver and launcher to the remote VPS and laun
 
 ```bash
 # Smoke test (small limit)
-ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+# Prefer the job protocol (tracked plan + result). See atlas-job-protocol.md.
+ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --target full-catalog \
   --limit 10
 
 # Full campaign launch (detached systemd-run under 1.5G/2.0G memory limits)
-ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --target full-catalog \
   --no-poll
 ```
@@ -93,10 +95,10 @@ Check status and logs on the VPS runner:
 
 ```bash
 # Check if driver process is active
-ssh ops@runner-vps "ps aux | grep reenrich_thin_manifest_entries"
+ssh atlas-runner "ps aux | grep reenrich_thin_manifest_entries"
 
 # Inspect live log tail
-ssh ops@runner-vps "tail -n 60 /home/ops/atlas-runner/run-class-b-reenrich/reenrich.log"
+ssh atlas-runner "tail -n 60 /home/ops/atlas-runner/run-class-b-reenrich/reenrich.log"
 ```
 
 If 50 consecutive entries fail to hit any source/cache, the circuit breaker trips, returning exit code `70` (`CIRCUIT_BREAKER_EXIT_CODE`) and logging `circuit_breaker_tripped: true`.
@@ -108,7 +110,7 @@ If 50 consecutive entries fail to hit any source/cache, the circuit breaker trip
 Once complete, pull back the output manifest and run summary:
 
 ```bash
-ATLAS_RUNNER_HOST=ops@runner-vps scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --pull-only
 ```
 

--- a/docs/runbooks/atlas-job-protocol.md
+++ b/docs/runbooks/atlas-job-protocol.md
@@ -1,8 +1,11 @@
 # Atlas VPS job protocol
 
+**systemd on the host is the source of truth; the local registry is a
+journal/mirror.** Never treat a laptop JSON row as the mutex.
+
 Plan a long-running Atlas job, **register it**, run it on a named host, then
 **close it with a result**. No SSH-and-hope. No orphan systemd units. No
-“finished” without a receipt.
+“finished” without a receipt. No empty-summary success.
 
 This wraps `launch_reenrich_class_b_remote.sh`. It is not a second message bus
 and not a Hetzner snapshot.
@@ -15,7 +18,7 @@ and not a Hetzner snapshot.
 | `hramatka` | Teacher API, Caddy, CI runners | Catalog reenrich / slovnyk refetch |
 
 Default `ATLAS_RUNNER_HOST` is **`atlas-runner`**. A plan that puts `reenrich`
-on `hramatka` is rejected.
+on `hramatka` is rejected (no override).
 
 SSH aliases live in the operator `~/.ssh/config`. IAC: private
 `hramatka/ops/iac/` (merged #495).
@@ -23,25 +26,41 @@ SSH aliases live in the operator `~/.ssh/config`. IAC: private
 ## Lifecycle
 
 ```
-planned → submitted → running → {succeeded | failed | timeout | rejected}
+planned → submitted → running → {succeeded | failed | timeout | rejected | needs_finalize | crashed}
 ```
 
-`--no-poll` only detaches systemd-run. The registry row stays `running` until
-`close`. A unit that exits 0 with `consecutive_misses == targets` or a tripped
-circuit breaker is **failed**.
+- `submit` checks `systemctl --user list-units 'atlas-job-*'` over SSH before
+  accept. The **unit is the mutex**; the registry only journals.
+- `--no-poll` only detaches systemd-run. The journal row stays `running` until
+  `close` **or** `status` reconciles: unit inactive + journal `running` ⇒
+  `needs_finalize` (or `crashed` when `resume: never` and no exit-status file).
+- Units get `Restart=no`, optional `RuntimeMaxSec=` from `timeout_seconds`, and
+  `ExecStopPost=` writing `exit-status.json` next to the per-job workdir.
+- A unit that exits 0 with `consecutive_misses == targets` or a tripped
+  circuit breaker is **failed**.
+- `close` without summary evidence **and** without host exit-status ⇒
+  `needs_finalize` (non-zero). Empty `{}` is never success.
 
 Registry (gitignored, restic-covered): `batch_state/atlas-jobs/<id>.json`  
 Result: `batch_state/atlas-jobs/<id>.result.json`  
-Remote unit: `atlas-job-<id>.service` (never reuse `atlas-class-b-reenrich.service`)
+Schema-capped git receipt: `batch_state/atlas-jobs/receipts/<id>.json`  
+Remote unit: `atlas-job-<id>.service` (never reuse `atlas-class-b-reenrich.service`)  
+Remote workdir: `$ATLAS_RUN_ROOT/run-atlas-job-<id>` (per job; set via
+`ATLAS_RE_ENRICH_WORK_DIR`)
 
-`status --audit` SSH-pgreps known drivers. A matching process with **no**
-`running` registry row is exit 2 (untracked job).
+`status --audit` uses systemd MainPID / unit membership first; `pgrep` is
+secondary. A matching process with **no** tracked running unit/row is exit 2.
+Unreachable SSH is an error, never a clean empty list.
 
 ## Plan (`atlas-job.v1`)
 
 Required: `id`, `host`, `kind`, `denominator`, `pointer_write: false`,
 `result_sink` (`git` | `restic` | `both`), `success.circuit_breaker`,
-`success.min_filled`.
+`success.min_filled`, **`issue`** (one GitHub issue per campaign/kind — not
+per job).
+
+Optional: `resume` (`idempotent` | `checkpoint` | `never`, default `never`),
+`timeout_seconds` (default 86400), `args`, `slugs_file`.
 
 `pointer_write` is always false here. Publish / pointer flip is a later gate.
 
@@ -49,26 +68,48 @@ Required: `id`, `host`, `kind`, `denominator`, `pointer_write: false`,
 
 | Sink | What comes back |
 | --- | --- |
-| `git` | Small result JSON in a PR. Never commit manifests, slovnyk cache, or `sources.db`. |
-| `restic` | `durable_mirror.py snapshot` → `data/lexicon/runner-mirror/<id>/` then `backup-data.sh backup --execute` (covers `data/` + `batch_state/`). |
+| `git` | Schema-capped receipt (~10 KB allowlist). Reject absolute paths / hostnames / credential-like text. Never commit manifests, slovnyk cache, or `sources.db`. |
+| `restic` | `durable_mirror.py snapshot` → `data/lexicon/runner-mirror/<id>/` then `backup-data.sh backup --execute`. Result field: `backup: {attempted, ok, snapshot_id\|error}`. |
 | `both` | Both of the above. |
 
-If restic doctor/`#6093` fails, the result still records `restic.attempted` and
-`ok: false`. Silence is not a result.
+Backup failure policy:
+
+- Job keeps its real outcome (`succeeded` / `failed` / …).
+- Close exit is non-zero when a required restic sink fails (`delivery: failed`).
+- **Never delete** the remote workdir on backup fail.
+- Schema-capped git receipt still lands.
+- New restic-sink submits are refused until `backup-data.sh doctor` is green
+  (`.restic-sink-blocked` gate).
+
+`pulled` is true only after `pull()` actually ran successfully.
+
+## Monitor API
+
+Thin facade on the existing Monitor app (no new daemon):
+
+| Method | Path | Wraps |
+| --- | --- | --- |
+| GET | `/api/atlas-jobs` | list |
+| POST | `/api/atlas-jobs/submit` | validate + host check + submit |
+| GET | `/api/atlas-jobs/{id}` | status reconcile |
+| POST | `/api/atlas-jobs/{id}/close` | close |
 
 ## Commands
 
+Use the shared project interpreter (never bare `python`):
+
 ```bash
-python -m scripts.lexicon.runner.atlas_job validate PLAN.json
-python -m scripts.lexicon.runner.atlas_job submit PLAN.json
-python -m scripts.lexicon.runner.atlas_job status --host atlas-runner --audit
-python -m scripts.lexicon.runner.atlas_job close JOB_ID --summary-file summary.json
-python -m scripts.lexicon.runner.atlas_job pull --host atlas-runner
-python -m scripts.lexicon.runner.atlas_job list
+.venv/bin/python -m scripts.lexicon.runner.atlas_job validate PLAN.json
+.venv/bin/python -m scripts.lexicon.runner.atlas_job submit PLAN.json
+.venv/bin/python -m scripts.lexicon.runner.atlas_job status --host atlas-runner --audit
+.venv/bin/python -m scripts.lexicon.runner.atlas_job close JOB_ID --summary-file summary.json
+.venv/bin/python -m scripts.lexicon.runner.atlas_job pull --host atlas-runner --job-id JOB_ID
+.venv/bin/python -m scripts.lexicon.runner.atlas_job list
 ```
 
-`submit` refuses a second `running` job on the same host. `close` is required
-to seal a result after the unit is dead.
+`submit` refuses a second active `atlas-job-*` unit on the host. `close` seals
+a result after the unit is dead (or records `needs_finalize` when evidence is
+missing).
 
 ## Memory
 

--- a/docs/runbooks/atlas-job-protocol.md
+++ b/docs/runbooks/atlas-job-protocol.md
@@ -1,0 +1,76 @@
+# Atlas VPS job protocol
+
+Plan a long-running Atlas job, **register it**, run it on a named host, then
+**close it with a result**. No SSH-and-hope. No orphan systemd units. No
+“finished” without a receipt.
+
+This wraps `launch_reenrich_class_b_remote.sh`. It is not a second message bus
+and not a Hetzner snapshot.
+
+## Hosts
+
+| Host | Use | Never |
+| --- | --- | --- |
+| `atlas-runner` | Reenrich, later ULIF / slovnyk migrate | Teacher API, GH runners |
+| `hramatka` | Teacher API, Caddy, CI runners | Catalog reenrich / slovnyk refetch |
+
+Default `ATLAS_RUNNER_HOST` is **`atlas-runner`**. A plan that puts `reenrich`
+on `hramatka` is rejected.
+
+SSH aliases live in the operator `~/.ssh/config`. IAC: private
+`hramatka/ops/iac/` (merged #495).
+
+## Lifecycle
+
+```
+planned → submitted → running → {succeeded | failed | timeout | rejected}
+```
+
+`--no-poll` only detaches systemd-run. The registry row stays `running` until
+`close`. A unit that exits 0 with `consecutive_misses == targets` or a tripped
+circuit breaker is **failed**.
+
+Registry (gitignored, restic-covered): `batch_state/atlas-jobs/<id>.json`  
+Result: `batch_state/atlas-jobs/<id>.result.json`  
+Remote unit: `atlas-job-<id>.service` (never reuse `atlas-class-b-reenrich.service`)
+
+`status --audit` SSH-pgreps known drivers. A matching process with **no**
+`running` registry row is exit 2 (untracked job).
+
+## Plan (`atlas-job.v1`)
+
+Required: `id`, `host`, `kind`, `denominator`, `pointer_write: false`,
+`result_sink` (`git` | `restic` | `both`), `success.circuit_breaker`,
+`success.min_filled`.
+
+`pointer_write` is always false here. Publish / pointer flip is a later gate.
+
+## Result sinks
+
+| Sink | What comes back |
+| --- | --- |
+| `git` | Small result JSON in a PR. Never commit manifests, slovnyk cache, or `sources.db`. |
+| `restic` | `durable_mirror.py snapshot` → `data/lexicon/runner-mirror/<id>/` then `backup-data.sh backup --execute` (covers `data/` + `batch_state/`). |
+| `both` | Both of the above. |
+
+If restic doctor/`#6093` fails, the result still records `restic.attempted` and
+`ok: false`. Silence is not a result.
+
+## Commands
+
+```bash
+python -m scripts.lexicon.runner.atlas_job validate PLAN.json
+python -m scripts.lexicon.runner.atlas_job submit PLAN.json
+python -m scripts.lexicon.runner.atlas_job status --host atlas-runner --audit
+python -m scripts.lexicon.runner.atlas_job close JOB_ID --summary-file summary.json
+python -m scripts.lexicon.runner.atlas_job pull --host atlas-runner
+python -m scripts.lexicon.runner.atlas_job list
+```
+
+`submit` refuses a second `running` job on the same host. `close` is required
+to seal a result after the unit is dead.
+
+## Memory
+
+The existing launcher still pins `MemoryHigh=1.5G` / `MemoryMax=2G` on the
+cx33. One heavy job. Two full-catalogs need a later host or a queue.

--- a/scripts/api/atlas_jobs_router.py
+++ b/scripts/api/atlas_jobs_router.py
@@ -28,6 +28,13 @@ class CloseBody(BaseModel):
     skip_restic: bool = False
 
 
+def _require_job_id(job_id: str) -> str:
+    try:
+        return atlas_job.require_safe_job_id(job_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 @router.get("")
 def list_jobs() -> dict[str, Any]:
     rows = atlas_job.list_registry()
@@ -50,7 +57,7 @@ def submit_job(body: SubmitBody) -> dict[str, Any]:
     if errors:
         raise HTTPException(status_code=400, detail={"errors": errors})
     rc = atlas_job.submit(body.plan, dry_run=body.dry_run)
-    job_id = str(body.plan.get("id"))
+    job_id = atlas_job.require_safe_job_id(str(body.plan.get("id")))
     row = atlas_job.load_registry(job_id)
     if rc != 0:
         raise HTTPException(
@@ -62,6 +69,7 @@ def submit_job(body: SubmitBody) -> dict[str, Any]:
 
 @router.get("/{job_id}")
 def job_status(job_id: str, host: str = "atlas-runner", audit: bool = False) -> dict[str, Any]:
+    job_id = _require_job_id(job_id)
     row = atlas_job.load_registry(job_id)
     if row is None:
         raise HTTPException(status_code=404, detail=f"no registry row for {job_id}")
@@ -82,13 +90,17 @@ def job_status(job_id: str, host: str = "atlas-runner", audit: bool = False) -> 
 
 @router.post("/{job_id}/close")
 def close_job(job_id: str, body: CloseBody | None = None) -> dict[str, Any]:
+    job_id = _require_job_id(job_id)
     payload = body or CloseBody()
-    rc = atlas_job.close_job(
-        job_id,
-        summary=payload.summary,
-        skip_pull=payload.skip_pull,
-        skip_restic=payload.skip_restic,
-    )
+    try:
+        rc = atlas_job.close_job(
+            job_id,
+            summary=payload.summary,
+            skip_pull=payload.skip_pull,
+            skip_restic=payload.skip_restic,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     row = atlas_job.load_registry(job_id)
     result = None
     result_file = atlas_job.result_path(job_id)

--- a/scripts/api/atlas_jobs_router.py
+++ b/scripts/api/atlas_jobs_router.py
@@ -1,0 +1,103 @@
+"""Lightweight Monitor HTTP facade for the Atlas VPS job protocol.
+
+Wraps ``scripts.lexicon.runner.atlas_job`` — no new daemon / message bus.
+Prefix: ``/api/atlas-jobs``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from scripts.lexicon.runner import atlas_job
+
+router = APIRouter(tags=["atlas-jobs"])
+
+
+class SubmitBody(BaseModel):
+    plan: dict[str, Any]
+    dry_run: bool = False
+
+
+class CloseBody(BaseModel):
+    summary: dict[str, Any] | None = None
+    skip_pull: bool = False
+    skip_restic: bool = False
+
+
+@router.get("")
+def list_jobs() -> dict[str, Any]:
+    rows = atlas_job.list_registry()
+    return {"count": len(rows), "jobs": rows}
+
+
+@router.get("/health")
+def atlas_jobs_health() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema": atlas_job.SCHEMA,
+        "restic_sink_blocked": atlas_job.restic_sink_blocked(),
+        "registry": str(atlas_job.registry_dir()),
+    }
+
+
+@router.post("/submit")
+def submit_job(body: SubmitBody) -> dict[str, Any]:
+    errors = atlas_job.validate_plan(body.plan)
+    if errors:
+        raise HTTPException(status_code=400, detail={"errors": errors})
+    rc = atlas_job.submit(body.plan, dry_run=body.dry_run)
+    job_id = str(body.plan.get("id"))
+    row = atlas_job.load_registry(job_id)
+    if rc != 0:
+        raise HTTPException(
+            status_code=409,
+            detail={"exit_code": rc, "job": row, "message": "submit refused or launch failed"},
+        )
+    return {"exit_code": rc, "job": row, "dry_run": body.dry_run}
+
+
+@router.get("/{job_id}")
+def job_status(job_id: str, host: str = "atlas-runner", audit: bool = False) -> dict[str, Any]:
+    row = atlas_job.load_registry(job_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"no registry row for {job_id}")
+    # Reconcile the journal against host systemd truth.
+    rc = atlas_job.status(host=host, audit=audit)
+    row = atlas_job.load_registry(job_id) or row
+    result = None
+    result_file = atlas_job.result_path(job_id)
+    if result_file.is_file():
+        result = json.loads(result_file.read_text(encoding="utf-8"))
+    return {
+        "job": row,
+        "result": result,
+        "status_exit_code": rc,
+        "restic_sink_blocked": atlas_job.restic_sink_blocked(),
+    }
+
+
+@router.post("/{job_id}/close")
+def close_job(job_id: str, body: CloseBody | None = None) -> dict[str, Any]:
+    payload = body or CloseBody()
+    rc = atlas_job.close_job(
+        job_id,
+        summary=payload.summary,
+        skip_pull=payload.skip_pull,
+        skip_restic=payload.skip_restic,
+    )
+    row = atlas_job.load_registry(job_id)
+    result = None
+    result_file = atlas_job.result_path(job_id)
+    if result_file.is_file():
+        result = json.loads(result_file.read_text(encoding="utf-8"))
+    if rc == 2:
+        raise HTTPException(status_code=404, detail={"exit_code": rc, "message": "no registry row"})
+    response = {"exit_code": rc, "job": row, "result": result}
+    if rc != 0:
+        # Fail-closed: non-success still returns the receipt under 409.
+        raise HTTPException(status_code=409, detail=response)
+    return response

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -50,6 +50,7 @@ from .admin_router import router as admin_router
 from .agent_monitor_router import router as agent_monitor_router
 from .agent_router import router as agent_router
 from .artifacts_router import router as artifacts_router
+from .atlas_jobs_router import router as atlas_jobs_router
 from .blue_router import router as blue_router
 from .build_events_router import router as build_events_router
 from .codexbar_usage import scheduler_status, start_periodic_refresh, stop_periodic_refresh
@@ -174,6 +175,7 @@ app.include_router(admin_router, prefix="/api/admin")
 app.include_router(agent_router, prefix="/api/agent", tags=["agent"])
 app.include_router(agent_monitor_router, prefix="/api/agent-monitor")
 app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
+app.include_router(atlas_jobs_router, prefix="/api/atlas-jobs", tags=["atlas-jobs"])
 app.include_router(blue_router, prefix="/api/blue")
 app.include_router(comms_router, prefix="/api/comms")
 app.include_router(fleet_router, prefix="/api/fleet", tags=["fleet"])

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -231,14 +231,27 @@ def require_safe_job_id(job_id: object) -> str:
     """Reject non-token job ids before any filesystem path join.
 
     Raises ValueError when ``job_id`` is not a str matching ``_SAFE_ID``.
+    Returns the matched token (``Match.group(0)``), never the raw argument,
+    so path joins are not fed a CodeQL-tainted string.
     """
-    if not isinstance(job_id, str) or not _SAFE_ID.match(job_id):
+    if not isinstance(job_id, str):
         raise ValueError("job_id must be a filesystem/systemd-safe token")
-    return job_id
+    matched = _SAFE_ID.fullmatch(job_id)
+    if matched is None:
+        raise ValueError("job_id must be a filesystem/systemd-safe token")
+    return matched.group(0)
 
 
 def _run_root() -> Path:
     return Path(os.environ.get("ATLAS_RUN_ROOT", DEFAULT_RUN_ROOT))
+
+
+def _safe_id_token(part: str) -> str:
+    """Return ``_SAFE_ID`` match text for a path segment, or raise."""
+    matched = _SAFE_ID.fullmatch(part)
+    if matched is None:
+        raise ValueError("workdir must be a safe token path")
+    return matched.group(0)
 
 
 def require_safe_workdir(workdir: object) -> str:
@@ -246,6 +259,9 @@ def require_safe_workdir(workdir: object) -> str:
 
     Rejects ``..``, absolute paths outside ``ATLAS_RUN_ROOT`` / default run
     root, and any path whose segments are not ``_SAFE_ID`` tokens.
+    Returns a newly constructed path from validated tokens (or
+    ``str(resolved)`` for absolute paths under the run root), never the
+    original relative ``workdir`` string.
     """
     if not isinstance(workdir, str) or not workdir:
         raise ValueError("workdir must be a non-empty safe token path")
@@ -263,14 +279,14 @@ def require_safe_workdir(workdir: object) -> str:
             raise ValueError("workdir must be under ATLAS_RUN_ROOT") from exc
         if not rel.parts:
             raise ValueError("workdir must be a subdirectory of ATLAS_RUN_ROOT")
-        for part in rel.parts:
-            if not _SAFE_ID.match(part):
-                raise ValueError("workdir must be a safe token path")
-        return str(resolved)
+        safe_rel = [_safe_id_token(part) for part in rel.parts]
+        return str(run_root.joinpath(*safe_rel))
+    safe_parts: list[str] = []
     for part in raw.parts:
-        if part in {".", ""} or not _SAFE_ID.match(part):
+        if part in {".", ""}:
             raise ValueError("workdir must be a safe token path")
-    return workdir
+        safe_parts.append(_safe_id_token(part))
+    return str(Path(*safe_parts))
 
 
 def registry_path(job_id: str) -> Path:
@@ -327,7 +343,7 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     if plan.get("schema") != SCHEMA:
         errors.append(f"schema must be {SCHEMA}")
     job_id = plan.get("id")
-    if not isinstance(job_id, str) or not _SAFE_ID.match(job_id):
+    if not isinstance(job_id, str) or _SAFE_ID.fullmatch(job_id) is None:
         errors.append("id must be a filesystem/systemd-safe token")
     host = plan.get("host")
     if host not in {"atlas-runner", "hramatka"}:

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -1,0 +1,395 @@
+"""Atlas VPS job protocol: plan → submit → status → close (always a result).
+
+Batch kinds run on atlas-runner only. Registry lives under batch_state/atlas-jobs/
+(restic-covered). Close writes a result receipt; large artifacts go through
+durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "atlas-job.v1"
+BATCH_KINDS = frozenset({"reenrich"})
+ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"})}
+HRAMATKA_ALIASES = frozenset({"hramatka", "vps"})
+RESULT_SINKS = frozenset({"git", "restic", "both"})
+DRIVER_NEEDLES = (
+    "reenrich_thin_manifest_entries",
+    "migrate_slovnyk",
+    "enrich_offline_20k",
+)
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def registry_dir() -> Path:
+    override = os.environ.get("ATLAS_JOB_REGISTRY")
+    if override:
+        return Path(override)
+    return repo_root() / "batch_state" / "atlas-jobs"
+
+
+def registry_path(job_id: str) -> Path:
+    return registry_dir() / f"{job_id}.json"
+
+
+def result_path(job_id: str) -> Path:
+    return registry_dir() / f"{job_id}.result.json"
+
+
+def unit_name(job_id: str) -> str:
+    return f"atlas-job-{job_id}.service"
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("plan must be a JSON object")
+    return data
+
+
+def validate_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if plan.get("schema") != SCHEMA:
+        errors.append(f"schema must be {SCHEMA}")
+    job_id = plan.get("id")
+    if not isinstance(job_id, str) or not _SAFE_ID.match(job_id):
+        errors.append("id must be a filesystem/systemd-safe token")
+    host = plan.get("host")
+    if host not in {"atlas-runner", "hramatka"}:
+        errors.append("host must be atlas-runner or hramatka")
+    kind = plan.get("kind")
+    if kind not in BATCH_KINDS:
+        errors.append(f"kind must be one of {sorted(BATCH_KINDS)}")
+    elif host is not None and host not in ALLOWED_HOSTS[kind]:
+        errors.append(f"kind {kind} cannot run on {host}")
+    if host in HRAMATKA_ALIASES and kind in BATCH_KINDS:
+        errors.append("batch kinds must not target hramatka/vps")
+    if plan.get("pointer_write") is not False:
+        errors.append("pointer_write must be false (publish is a separate gate)")
+    sink = plan.get("result_sink")
+    if sink not in RESULT_SINKS:
+        errors.append("result_sink must be git, restic, or both")
+    denom = plan.get("denominator")
+    if not isinstance(denom, int) or denom < 0:
+        errors.append("denominator must be an integer >= 0")
+    success = plan.get("success")
+    if not isinstance(success, dict):
+        errors.append("success must be an object")
+    else:
+        if "circuit_breaker" not in success:
+            errors.append("success.circuit_breaker is required")
+        if "min_filled" not in success:
+            errors.append("success.min_filled is required")
+    args = plan.get("args", [])
+    if args is not None and not (
+        isinstance(args, list) and all(isinstance(a, str) for a in args)
+    ):
+        errors.append("args must be a list of strings")
+    slugs = plan.get("slugs_file")
+    if slugs is not None and not isinstance(slugs, str):
+        errors.append("slugs_file must be a string path when set")
+    return errors
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def save_registry(row: dict[str, Any]) -> Path:
+    registry_dir().mkdir(parents=True, exist_ok=True)
+    path = registry_path(str(row["id"]))
+    path.write_text(json.dumps(row, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def load_registry(job_id: str) -> dict[str, Any] | None:
+    path = registry_path(job_id)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"corrupt registry row: {path}")
+    return data
+
+
+def list_registry() -> list[dict[str, Any]]:
+    root = registry_dir()
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(root.glob("*.json")):
+        if path.name.endswith(".result.json"):
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            rows.append(data)
+    return rows
+
+
+def running_on_host(host: str) -> list[dict[str, Any]]:
+    return [r for r in list_registry() if r.get("host") == host and r.get("state") == "running"]
+
+
+def interpret_summary(summary: dict[str, Any], plan: dict[str, Any]) -> str:
+    """Map a launcher summary onto succeeded|failed."""
+    if summary.get("circuit_breaker_tripped"):
+        return "failed"
+    targets = summary.get("targets")
+    misses = summary.get("consecutive_misses")
+    if isinstance(targets, int) and isinstance(misses, int) and targets > 0 and misses == targets:
+        return "failed"
+    filled = summary.get("filled_translation")
+    min_filled = (plan.get("success") or {}).get("min_filled", 0)
+    if isinstance(filled, int) and isinstance(min_filled, int) and filled < min_filled:
+        return "failed"
+    want_cb = (plan.get("success") or {}).get("circuit_breaker", False)
+    if want_cb is False and summary.get("circuit_breaker_tripped"):
+        return "failed"
+    return "succeeded"
+
+
+def audit_processes(pgrep_lines: list[str], running_ids: list[str]) -> list[str]:
+    """Return untracked driver command lines."""
+    tracked = bool(running_ids)
+    orphans: list[str] = []
+    for line in pgrep_lines:
+        text = line.strip()
+        if not text or text == "none":
+            continue
+        if not any(needle in text for needle in DRIVER_NEEDLES):
+            continue
+        if "pgrep" in text:
+            continue
+        if not tracked:
+            orphans.append(text)
+            continue
+        if not any(job_id in text or f"atlas-job-{job_id}" in text for job_id in running_ids):
+            orphans.append(text)
+    return orphans
+
+
+def _launcher() -> Path:
+    return repo_root() / "scripts" / "lexicon" / "runner" / "launch_reenrich_class_b_remote.sh"
+
+
+def submit(plan: dict[str, Any], *, dry_run: bool = False) -> int:
+    errors = validate_plan(plan)
+    if errors:
+        print("invalid plan:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 2
+    job_id = str(plan["id"])
+    host = str(plan["host"])
+    existing = load_registry(job_id)
+    if existing and existing.get("state") == "running":
+        print(f"job {job_id} is already running", file=sys.stderr)
+        return 2
+    busy = running_on_host(host)
+    if busy and not dry_run:
+        print(f"host {host} already has running job {busy[0].get('id')}", file=sys.stderr)
+        return 2
+    unit = unit_name(job_id)
+    args = list(plan.get("args") or [])
+    if "--no-poll" not in args:
+        args.append("--no-poll")
+    env = os.environ.copy()
+    env["ATLAS_RUNNER_HOST"] = host
+    env["ATLAS_RE_ENRICH_UNIT"] = unit
+    slugs = plan.get("slugs_file")
+    if isinstance(slugs, str) and slugs:
+        env["ATLAS_RE_ENRICH_RESIDUAL"] = slugs
+    cmd = ["bash", str(_launcher()), *args]
+    plan_blob = json.dumps(plan, sort_keys=True).encode()
+    row = {
+        "id": job_id,
+        "state": "submitted" if dry_run else "running",
+        "host": host,
+        "kind": plan["kind"],
+        "unit": unit,
+        "plan_sha256": hashlib.sha256(plan_blob).hexdigest(),
+        "denominator": plan["denominator"],
+        "result_sink": plan["result_sink"],
+        "pointer_write": False,
+        "submitted_at": _now(),
+        "plan": plan,
+    }
+    if dry_run:
+        print("host", host)
+        print("unit", unit)
+        print("cmd", " ".join(cmd))
+        if slugs:
+            print("slugs_file", slugs)
+        return 0
+    save_registry(row)
+    rc = subprocess.call(cmd, cwd=str(repo_root()), env=env)
+    if rc != 0:
+        row["state"] = "rejected"
+        row["submit_exit"] = rc
+        save_registry(row)
+    return rc
+
+
+def close_job(
+    job_id: str,
+    *,
+    summary: dict[str, Any] | None = None,
+    skip_pull: bool = False,
+    skip_restic: bool = False,
+) -> int:
+    row = load_registry(job_id)
+    if row is None:
+        print(f"no registry row for {job_id}", file=sys.stderr)
+        return 2
+    plan = row.get("plan") if isinstance(row.get("plan"), dict) else {}
+    if summary is None:
+        summary = {}
+    state = interpret_summary(summary, plan)
+    receipt = {
+        "schema": "atlas-job-result.v1",
+        "id": job_id,
+        "state": state,
+        "host": row.get("host"),
+        "unit": row.get("unit"),
+        "closed_at": _now(),
+        "summary": summary,
+        "pulled": not skip_pull,
+        "mirror_dir": None,
+        "restic": {"attempted": False, "ok": False, "receipt": None},
+        "git_pr": None,
+    }
+    sink = row.get("result_sink") or plan.get("result_sink")
+    if sink in {"restic", "both"} and not skip_restic:
+        receipt["restic"]["attempted"] = True
+        doctor = subprocess.call(
+            ["bash", str(repo_root() / "scripts" / "backup-data.sh"), "doctor"],
+            cwd=str(repo_root()),
+        )
+        receipt["restic"]["ok"] = doctor == 0
+        receipt["restic"]["receipt"] = "backup-data.sh doctor"
+    result_file = result_path(job_id)
+    result_file.parent.mkdir(parents=True, exist_ok=True)
+    result_file.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    row["state"] = state
+    row["closed_at"] = receipt["closed_at"]
+    row["result"] = str(result_file)
+    save_registry(row)
+    print(state, job_id, result_file)
+    return 0 if state == "succeeded" else 1
+
+
+def status(*, host: str, audit: bool = False) -> int:
+    if host in HRAMATKA_ALIASES:
+        print("status for batch jobs must use atlas-runner", file=sys.stderr)
+        return 2
+    rows = [r for r in list_registry() if r.get("host") == host]
+    for row in rows:
+        print(row.get("state"), row.get("id"), row.get("unit"))
+    if not audit:
+        return 0
+    remote = "pgrep -af 'reenrich_thin_manifest_entries|migrate_slovnyk|enrich_offline_20k' || true"
+    proc = subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=12", host, remote],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    lines = (proc.stdout or "").splitlines()
+    running_ids = [str(r["id"]) for r in rows if r.get("state") == "running"]
+    orphans = audit_processes(lines, running_ids)
+    if orphans:
+        print("untracked driver process:", file=sys.stderr)
+        for line in orphans:
+            print(f"  {line}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def pull(*, host: str) -> int:
+    if host in HRAMATKA_ALIASES:
+        print("pull for batch jobs must use atlas-runner", file=sys.stderr)
+        return 2
+    env = os.environ.copy()
+    env["ATLAS_RUNNER_HOST"] = host
+    return subprocess.call(
+        ["bash", str(_launcher()), "--pull-only"],
+        cwd=str(repo_root()),
+        env=env,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_val = sub.add_parser("validate", help="Validate a plan JSON")
+    p_val.add_argument("plan", type=Path)
+
+    p_sub = sub.add_parser("submit", help="Validate, register, and launch")
+    p_sub.add_argument("plan", type=Path)
+    p_sub.add_argument("--dry-run", action="store_true")
+
+    p_st = sub.add_parser("status", help="List registry rows; optional untracked audit")
+    p_st.add_argument("--host", default="atlas-runner")
+    p_st.add_argument("--audit", action="store_true")
+
+    p_close = sub.add_parser("close", help="Seal a result receipt for a registered job")
+    p_close.add_argument("job_id")
+    p_close.add_argument("--summary-file", type=Path)
+    p_close.add_argument("--skip-pull", action="store_true")
+    p_close.add_argument("--skip-restic", action="store_true")
+
+    sub.add_parser("list", help="List registry rows")
+
+    p_pull = sub.add_parser("pull", help="Pull work-dir artifacts (no pointer flip)")
+    p_pull.add_argument("--host", default="atlas-runner")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "validate":
+        plan = load_plan(args.plan)
+        errors = validate_plan(plan)
+        if errors:
+            for err in errors:
+                print(err, file=sys.stderr)
+            return 2
+        print("ok", plan.get("id"), plan.get("host"), plan.get("kind"))
+        return 0
+    if args.cmd == "submit":
+        return submit(load_plan(args.plan), dry_run=args.dry_run)
+    if args.cmd == "status":
+        return status(host=args.host, audit=args.audit)
+    if args.cmd == "close":
+        summary = None
+        if args.summary_file:
+            summary = json.loads(args.summary_file.read_text(encoding="utf-8"))
+        return close_job(
+            args.job_id,
+            summary=summary,
+            skip_pull=args.skip_pull,
+            skip_restic=args.skip_restic,
+        )
+    if args.cmd == "list":
+        for row in list_registry():
+            print(row.get("state"), row.get("id"), row.get("host"))
+        return 0
+    if args.cmd == "pull":
+        return pull(host=args.host)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -227,16 +227,65 @@ def registry_dir() -> Path:
     return repo_root() / "batch_state" / "atlas-jobs"
 
 
+def require_safe_job_id(job_id: object) -> str:
+    """Reject non-token job ids before any filesystem path join.
+
+    Raises ValueError when ``job_id`` is not a str matching ``_SAFE_ID``.
+    """
+    if not isinstance(job_id, str) or not _SAFE_ID.match(job_id):
+        raise ValueError("job_id must be a filesystem/systemd-safe token")
+    return job_id
+
+
+def _run_root() -> Path:
+    return Path(os.environ.get("ATLAS_RUN_ROOT", DEFAULT_RUN_ROOT))
+
+
+def require_safe_workdir(workdir: object) -> str:
+    """Fail closed for plan/registry workdirs used in path and SSH contexts.
+
+    Rejects ``..``, absolute paths outside ``ATLAS_RUN_ROOT`` / default run
+    root, and any path whose segments are not ``_SAFE_ID`` tokens.
+    """
+    if not isinstance(workdir, str) or not workdir:
+        raise ValueError("workdir must be a non-empty safe token path")
+    if "\0" in workdir:
+        raise ValueError("workdir must not contain null bytes")
+    raw = Path(workdir)
+    if ".." in raw.parts:
+        raise ValueError("workdir must not contain ..")
+    run_root = _run_root().resolve()
+    if raw.is_absolute():
+        resolved = raw.resolve()
+        try:
+            rel = resolved.relative_to(run_root)
+        except ValueError as exc:
+            raise ValueError("workdir must be under ATLAS_RUN_ROOT") from exc
+        if not rel.parts:
+            raise ValueError("workdir must be a subdirectory of ATLAS_RUN_ROOT")
+        for part in rel.parts:
+            if not _SAFE_ID.match(part):
+                raise ValueError("workdir must be a safe token path")
+        return str(resolved)
+    for part in raw.parts:
+        if part in {".", ""} or not _SAFE_ID.match(part):
+            raise ValueError("workdir must be a safe token path")
+    return workdir
+
+
 def registry_path(job_id: str) -> Path:
-    return registry_dir() / f"{job_id}.json"
+    safe = require_safe_job_id(job_id)
+    return registry_dir() / f"{safe}.json"
 
 
 def result_path(job_id: str) -> Path:
-    return registry_dir() / f"{job_id}.result.json"
+    safe = require_safe_job_id(job_id)
+    return registry_dir() / f"{safe}.result.json"
 
 
 def git_receipt_path(job_id: str) -> Path:
-    return registry_dir() / "receipts" / f"{job_id}.json"
+    safe = require_safe_job_id(job_id)
+    return registry_dir() / "receipts" / f"{safe}.json"
 
 
 def restic_block_path() -> Path:
@@ -244,22 +293,26 @@ def restic_block_path() -> Path:
 
 
 def unit_name(job_id: str) -> str:
-    return f"atlas-job-{job_id}.service"
+    safe = require_safe_job_id(job_id)
+    return f"atlas-job-{safe}.service"
 
 
 def work_dir_for(job_id: str, plan: dict[str, Any] | None = None) -> str:
+    safe = require_safe_job_id(job_id)
     if plan and isinstance(plan.get("workdir"), str) and plan["workdir"]:
-        return str(plan["workdir"])
-    run_root = os.environ.get("ATLAS_RUN_ROOT", DEFAULT_RUN_ROOT)
-    return f"{run_root.rstrip('/')}/run-atlas-job-{job_id}"
+        return require_safe_workdir(plan["workdir"])
+    run_root = str(_run_root()).rstrip("/")
+    return f"{run_root}/run-atlas-job-{safe}"
 
 
 def local_pull_dir(job_id: str) -> Path:
-    return registry_dir() / "pulled" / job_id
+    safe = require_safe_job_id(job_id)
+    return registry_dir() / "pulled" / safe
 
 
 def mirror_dir_for(job_id: str) -> Path:
-    return repo_root() / "data" / "lexicon" / "runner-mirror" / job_id
+    safe = require_safe_job_id(job_id)
+    return repo_root() / "data" / "lexicon" / "runner-mirror" / safe
 
 
 def load_plan(path: Path) -> dict[str, Any]:
@@ -319,6 +372,12 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     timeout = plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
     if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
         errors.append("timeout_seconds must be a positive integer")
+    workdir = plan.get("workdir")
+    if workdir is not None:
+        try:
+            require_safe_workdir(workdir)
+        except ValueError as exc:
+            errors.append(str(exc))
     return errors
 
 
@@ -336,7 +395,7 @@ def save_registry(row: dict[str, Any]) -> Path:
 
 
 def load_registry(job_id: str) -> dict[str, Any] | None:
-    path = registry_path(job_id)
+    path = registry_path(require_safe_job_id(job_id))
     if not path.is_file():
         return None
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -741,6 +800,7 @@ def close_job(
     skip_restic: bool = False,
     host_adapter: HostAdapter | None = None,
 ) -> int:
+    job_id = require_safe_job_id(job_id)
     row = load_registry(job_id)
     if row is None:
         print(f"no registry row for {job_id}", file=sys.stderr)
@@ -1018,6 +1078,10 @@ def pull(
     if host in HRAMATKA_ALIASES:
         print("pull for batch jobs must use atlas-runner", file=sys.stderr)
         return 2
+    if job_id is not None:
+        job_id = require_safe_job_id(job_id)
+    if workdir:
+        workdir = require_safe_workdir(workdir)
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
     if workdir:
@@ -1078,23 +1142,33 @@ def main(argv: list[str] | None = None) -> int:
         summary = None
         if args.summary_file:
             summary = json.loads(args.summary_file.read_text(encoding="utf-8"))
-        return close_job(
-            args.job_id,
-            summary=summary,
-            skip_pull=args.skip_pull,
-            skip_restic=args.skip_restic,
-        )
+        try:
+            return close_job(
+                args.job_id,
+                summary=summary,
+                skip_pull=args.skip_pull,
+                skip_restic=args.skip_restic,
+            )
+        except ValueError as exc:
+            print(exc, file=sys.stderr)
+            return 2
     if args.cmd == "list":
         for row in list_registry():
             print(row.get("state"), row.get("id"), row.get("host"))
         return 0
     if args.cmd == "pull":
-        workdir = None
-        if args.job_id:
-            row = load_registry(args.job_id)
-            if row:
-                workdir = str(row.get("workdir") or "")
-        return pull(host=args.host, job_id=args.job_id, workdir=workdir or None)
+        try:
+            if args.job_id:
+                require_safe_job_id(args.job_id)
+            workdir = None
+            if args.job_id:
+                row = load_registry(args.job_id)
+                if row:
+                    workdir = str(row.get("workdir") or "")
+            return pull(host=args.host, job_id=args.job_id, workdir=workdir or None)
+        except ValueError as exc:
+            print(exc, file=sys.stderr)
+            return 2
     return 2
 
 

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -1,8 +1,10 @@
 """Atlas VPS job protocol: plan → submit → status → close (always a result).
 
+**systemd on the host is truth; the local registry is a journal/mirror.**
+
 Batch kinds run on atlas-runner only. Registry lives under batch_state/atlas-jobs/
-(restic-covered). Close writes a result receipt; large artifacts go through
-durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
+(restic-covered). Close writes a fail-closed result receipt; large artifacts go
+through durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
 """
 
 from __future__ import annotations
@@ -14,21 +16,204 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 SCHEMA = "atlas-job.v1"
+RESULT_SCHEMA = "atlas-job-result.v1"
 BATCH_KINDS = frozenset({"reenrich"})
 ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"})}
 HRAMATKA_ALIASES = frozenset({"hramatka", "vps"})
 RESULT_SINKS = frozenset({"git", "restic", "both"})
+RESUME_MODES = frozenset({"idempotent", "checkpoint", "never"})
 DRIVER_NEEDLES = (
     "reenrich_thin_manifest_entries",
     "migrate_slovnyk",
     "enrich_offline_20k",
 )
+SUMMARY_REQUIRED_KEYS = frozenset(
+    {
+        "targets",
+        "consecutive_misses",
+        "filled_translation",
+        "circuit_breaker_tripped",
+    }
+)
+GIT_RECEIPT_ALLOWLIST = frozenset(
+    {
+        "schema",
+        "id",
+        "state",
+        "host",
+        "unit",
+        "kind",
+        "closed_at",
+        "summary",
+        "pulled",
+        "backup",
+        "delivery",
+        "issue",
+        "git_pr",
+        "workdir",
+        "plan_sha256",
+        "denominator",
+        "exit_status",
+    }
+)
+GIT_RECEIPT_MAX_BYTES = 10_240
 _SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
+_ABS_PATH = re.compile(r"(^|[\s\"'])/(?:Users|home|var|tmp|opt|etc)/")
+_CRED_HINT = re.compile(
+    r"(?i)(password|secret|api[_-]?key|token|authorization|private[_-]?key)\s*[:=]"
+)
+_HOSTNAME_HINT = re.compile(
+    r"(?i)\b(?:[a-z0-9-]+\.)+(?:internal|local|lan|corp|example)\b|\b\d{1,3}(?:\.\d{1,3}){3}\b"
+)
+DEFAULT_TIMEOUT_SECONDS = 86400
+DEFAULT_RUN_ROOT = "/home/ops/atlas-runner"
+
+_HOST = None  # set via set_host_adapter(); typed as HostAdapter | None
+
+
+class HostAdapter(Protocol):
+    """Host-side truth for atlas-job-* units (injectable for hermetic tests)."""
+
+    def list_atlas_job_units(self, host: str) -> list[dict[str, Any]]:
+        """Return unit rows: name, active, sub, main_pid."""
+
+    def read_exit_status(self, host: str, work_dir: str) -> dict[str, Any] | None:
+        """Read work_dir/exit-status.json from the host, if present."""
+
+    def pgrep_drivers(self, host: str) -> list[str]:
+        """Secondary orphan signal: pgrep driver command lines."""
+
+    def reachable(self, host: str) -> bool:
+        """True when SSH (or fake) host checks can run."""
+
+
+@dataclass
+class FakeHostAdapter:
+    """In-memory host adapter for unit tests (fail-closed by default)."""
+
+    units: list[dict[str, Any]] = field(default_factory=list)
+    exit_status_by_workdir: dict[str, dict[str, Any]] = field(default_factory=dict)
+    pgrep_lines: list[str] = field(default_factory=list)
+    online: bool = True
+
+    def list_atlas_job_units(self, host: str) -> list[dict[str, Any]]:
+        del host
+        if not self.online:
+            raise ConnectionError("host unreachable")
+        return list(self.units)
+
+    def read_exit_status(self, host: str, work_dir: str) -> dict[str, Any] | None:
+        del host
+        if not self.online:
+            raise ConnectionError("host unreachable")
+        return self.exit_status_by_workdir.get(work_dir)
+
+    def pgrep_drivers(self, host: str) -> list[str]:
+        del host
+        if not self.online:
+            raise ConnectionError("host unreachable")
+        return list(self.pgrep_lines)
+
+    def reachable(self, host: str) -> bool:
+        del host
+        return self.online
+
+
+class SshHostAdapter:
+    """Production adapter: BatchMode SSH to the named host alias."""
+
+    def list_atlas_job_units(self, host: str) -> list[dict[str, Any]]:
+        remote = (
+            "systemctl --user list-units 'atlas-job-*.service' --all --no-legend --no-pager "
+            "2>/dev/null || true"
+        )
+        proc = _ssh(host, remote)
+        if proc.returncode not in {0, 1}:
+            raise ConnectionError(f"systemctl list-units failed on {host}: rc={proc.returncode}")
+        rows: list[dict[str, Any]] = []
+        for line in (proc.stdout or "").splitlines():
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            name, _load, active, sub = parts[0], parts[1], parts[2], parts[3]
+            if not name.startswith("atlas-job-"):
+                continue
+            main_pid = self._main_pid(host, name)
+            rows.append(
+                {
+                    "name": name,
+                    "active": active,
+                    "sub": sub,
+                    "main_pid": main_pid,
+                }
+            )
+        return rows
+
+    def _main_pid(self, host: str, unit: str) -> int | None:
+        proc = _ssh(
+            host,
+            f"systemctl --user show {unit} --property=MainPID --value 2>/dev/null || true",
+        )
+        text = (proc.stdout or "").strip()
+        if text.isdigit() and int(text) > 0:
+            return int(text)
+        return None
+
+    def read_exit_status(self, host: str, work_dir: str) -> dict[str, Any] | None:
+        remote = (
+            "python3 - <<'PY'\n"
+            "from pathlib import Path\n"
+            f"p = Path({work_dir!r}) / 'exit-status.json'\n"
+            "print(p.read_text() if p.is_file() else '')\n"
+            "PY"
+        )
+        proc = _ssh(host, remote)
+        if proc.returncode != 0:
+            raise ConnectionError(f"exit-status read failed on {host}: rc={proc.returncode}")
+        text = (proc.stdout or "").strip()
+        if not text:
+            return None
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("exit-status.json must be an object")
+        return data
+
+    def pgrep_drivers(self, host: str) -> list[str]:
+        remote = (
+            "pgrep -af 'reenrich_thin_manifest_entries|migrate_slovnyk|enrich_offline_20k' || true"
+        )
+        proc = _ssh(host, remote)
+        if proc.returncode not in {0, 1}:
+            raise ConnectionError(f"pgrep failed on {host}: rc={proc.returncode}")
+        return (proc.stdout or "").splitlines()
+
+    def reachable(self, host: str) -> bool:
+        proc = _ssh(host, "true")
+        return proc.returncode == 0
+
+
+def _ssh(host: str, remote: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=12", host, remote],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def get_host_adapter() -> HostAdapter:
+    return _HOST if _HOST is not None else SshHostAdapter()
+
+
+def set_host_adapter(adapter: HostAdapter | None) -> None:
+    global _HOST
+    _HOST = adapter
 
 
 def repo_root() -> Path:
@@ -50,8 +235,31 @@ def result_path(job_id: str) -> Path:
     return registry_dir() / f"{job_id}.result.json"
 
 
+def git_receipt_path(job_id: str) -> Path:
+    return registry_dir() / "receipts" / f"{job_id}.json"
+
+
+def restic_block_path() -> Path:
+    return registry_dir() / ".restic-sink-blocked"
+
+
 def unit_name(job_id: str) -> str:
     return f"atlas-job-{job_id}.service"
+
+
+def work_dir_for(job_id: str, plan: dict[str, Any] | None = None) -> str:
+    if plan and isinstance(plan.get("workdir"), str) and plan["workdir"]:
+        return str(plan["workdir"])
+    run_root = os.environ.get("ATLAS_RUN_ROOT", DEFAULT_RUN_ROOT)
+    return f"{run_root.rstrip('/')}/run-atlas-job-{job_id}"
+
+
+def local_pull_dir(job_id: str) -> Path:
+    return registry_dir() / "pulled" / job_id
+
+
+def mirror_dir_for(job_id: str) -> Path:
+    return repo_root() / "data" / "lexicon" / "runner-mirror" / job_id
 
 
 def load_plan(path: Path) -> dict[str, Any]:
@@ -102,6 +310,15 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     slugs = plan.get("slugs_file")
     if slugs is not None and not isinstance(slugs, str):
         errors.append("slugs_file must be a string path when set")
+    issue = plan.get("issue")
+    if not isinstance(issue, int) or issue <= 0:
+        errors.append("issue must be a positive GitHub campaign/kind issue number")
+    resume = plan.get("resume", "never")
+    if resume not in RESUME_MODES:
+        errors.append(f"resume must be one of {sorted(RESUME_MODES)}")
+    timeout = plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    if not isinstance(timeout, int) or timeout <= 0:
+        errors.append("timeout_seconds must be a positive integer")
     return errors
 
 
@@ -112,7 +329,9 @@ def _now() -> str:
 def save_registry(row: dict[str, Any]) -> Path:
     registry_dir().mkdir(parents=True, exist_ok=True)
     path = registry_path(str(row["id"]))
-    path.write_text(json.dumps(row, indent=2) + "\n", encoding="utf-8")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(row, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
     return path
 
 
@@ -140,8 +359,43 @@ def list_registry() -> list[dict[str, Any]]:
     return rows
 
 
+def restic_sink_blocked() -> bool:
+    return restic_block_path().is_file()
+
+
+def set_restic_sink_blocked(reason: str) -> None:
+    registry_dir().mkdir(parents=True, exist_ok=True)
+    restic_block_path().write_text(
+        json.dumps({"blocked_at": _now(), "reason": reason}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def clear_restic_sink_blocked() -> None:
+    path = restic_block_path()
+    if path.is_file():
+        path.unlink()
+
+
 def running_on_host(host: str) -> list[dict[str, Any]]:
     return [r for r in list_registry() if r.get("host") == host and r.get("state") == "running"]
+
+
+def active_host_units(host: str, adapter: HostAdapter | None = None) -> list[dict[str, Any]]:
+    host_adapter = adapter or get_host_adapter()
+    units = host_adapter.list_atlas_job_units(host)
+    return [
+        u
+        for u in units
+        if u.get("active") in {"active", "activating", "reloading"}
+        or str(u.get("sub", "")).startswith("running")
+    ]
+
+
+def summary_has_evidence(summary: dict[str, Any] | None) -> bool:
+    if not isinstance(summary, dict) or not summary:
+        return False
+    return SUMMARY_REQUIRED_KEYS.issubset(summary.keys())
 
 
 def interpret_summary(summary: dict[str, Any], plan: dict[str, Any]) -> str:
@@ -162,9 +416,20 @@ def interpret_summary(summary: dict[str, Any], plan: dict[str, Any]) -> str:
     return "succeeded"
 
 
-def audit_processes(pgrep_lines: list[str], running_ids: list[str]) -> list[str]:
-    """Return untracked driver command lines."""
-    tracked = bool(running_ids)
+def audit_processes(
+    pgrep_lines: list[str],
+    running_ids: list[str] | None = None,
+    *,
+    tracked: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    """Return untracked driver command lines.
+
+    Prefer systemd MainPID / workdir / unit markers. ``running_ids`` alone is
+    retained for back-compat but is not enough when the cmdline omits the job id.
+    """
+    tracked_rows = list(tracked or [])
+    if running_ids and not tracked_rows:
+        tracked_rows = [{"id": job_id} for job_id in running_ids]
     orphans: list[str] = []
     for line in pgrep_lines:
         text = line.strip()
@@ -174,19 +439,200 @@ def audit_processes(pgrep_lines: list[str], running_ids: list[str]) -> list[str]
             continue
         if "pgrep" in text:
             continue
-        if not tracked:
-            orphans.append(text)
+        if _line_matches_tracked(text, tracked_rows):
             continue
-        if not any(job_id in text or f"atlas-job-{job_id}" in text for job_id in running_ids):
-            orphans.append(text)
+        orphans.append(text)
     return orphans
+
+
+def _line_matches_tracked(text: str, tracked_rows: list[dict[str, Any]]) -> bool:
+    if not tracked_rows:
+        return False
+    for row in tracked_rows:
+        job_id = str(row.get("id") or "")
+        unit = str(row.get("unit") or "")
+        workdir = str(row.get("workdir") or "")
+        main_pid = row.get("main_pid")
+        if job_id and (job_id in text or f"atlas-job-{job_id}" in text):
+            return True
+        if unit and unit in text:
+            return True
+        if workdir and workdir in text:
+            return True
+        if isinstance(main_pid, int) and main_pid > 0:
+            first = text.split(None, 1)[0]
+            if first.isdigit() and int(first) == main_pid:
+                return True
+    return False
 
 
 def _launcher() -> Path:
     return repo_root() / "scripts" / "lexicon" / "runner" / "launch_reenrich_class_b_remote.sh"
 
 
-def submit(plan: dict[str, Any], *, dry_run: bool = False) -> int:
+def _python_bin() -> str:
+    override = os.environ.get("ATLAS_RE_ENRICH_PYTHON")
+    if override:
+        return override
+    # Resolve primary checkout .venv via shared git common dir (layout A).
+    try:
+        common = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=str(repo_root()),
+            text=True,
+        ).strip()
+        common_path = Path(common)
+        if not common_path.is_absolute():
+            common_path = (repo_root() / common_path).resolve()
+        primary = common_path.parent
+        candidate = primary / ".venv" / "bin" / "python"
+        if candidate.is_file():
+            return str(candidate)
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    fallback = repo_root() / ".venv" / "bin" / "python"
+    return str(fallback)
+
+
+def _run_backup_doctor() -> int:
+    return subprocess.call(
+        ["bash", str(repo_root() / "scripts" / "backup-data.sh"), "doctor"],
+        cwd=str(repo_root()),
+    )
+
+
+def validate_git_receipt(receipt: dict[str, Any]) -> list[str]:
+    """Reject (don't warn) receipts that violate the public-repo schema cap."""
+    errors: list[str] = []
+    unknown = sorted(set(receipt) - GIT_RECEIPT_ALLOWLIST)
+    if unknown:
+        errors.append(f"disallowed fields: {unknown}")
+    blob = json.dumps(receipt, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    if len(blob) > GIT_RECEIPT_MAX_BYTES:
+        errors.append(f"receipt exceeds {GIT_RECEIPT_MAX_BYTES} bytes ({len(blob)})")
+
+    def walk(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                walk(child, f"{path}.{key}" if path else key)
+            return
+        if isinstance(value, list):
+            for idx, child in enumerate(value):
+                walk(child, f"{path}[{idx}]")
+            return
+        if not isinstance(value, str):
+            return
+        if _ABS_PATH.search(value):
+            errors.append(f"absolute path at {path}")
+        if _CRED_HINT.search(value):
+            errors.append(f"credential-like text at {path}")
+        if _HOSTNAME_HINT.search(value):
+            errors.append(f"hostname/IP at {path}")
+
+    walk(receipt, "")
+    return errors
+
+
+def build_git_receipt(full: dict[str, Any]) -> dict[str, Any]:
+    capped = {key: full[key] for key in GIT_RECEIPT_ALLOWLIST if key in full}
+    # Never embed remote absolute workdirs in the public receipt.
+    if isinstance(capped.get("workdir"), str) and capped["workdir"].startswith("/"):
+        capped["workdir"] = f"run-atlas-job-{capped.get('id', 'job')}"
+    errors = validate_git_receipt(capped)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return capped
+
+
+def write_git_receipt(job_id: str, receipt: dict[str, Any]) -> Path:
+    capped = build_git_receipt(receipt)
+    path = git_receipt_path(job_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(capped, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _receipt_locator(path: Path, job_id: str) -> str:
+    try:
+        return str(path.relative_to(repo_root()))
+    except ValueError:
+        return f"batch_state/atlas-jobs/receipts/{job_id}.json"
+
+
+def run_restic_sink(
+    job_id: str,
+    *,
+    source_dir: Path,
+    skip: bool = False,
+) -> dict[str, Any]:
+    """Run durable_mirror snapshot then backup-data.sh backup --execute."""
+    backup: dict[str, Any] = {"attempted": False, "ok": False, "snapshot_id": None, "error": None}
+    if skip:
+        backup["error"] = "skipped"
+        return backup
+    backup["attempted"] = True
+    doctor = _run_backup_doctor()
+    if doctor != 0:
+        backup["error"] = "backup-data.sh doctor failed"
+        set_restic_sink_blocked(backup["error"])
+        return backup
+    mirror = mirror_dir_for(job_id)
+    mirror.parent.mkdir(parents=True, exist_ok=True)
+    py = os.environ.get("ATLAS_RE_ENRICH_PYTHON") or _python_bin()
+    snap = subprocess.run(
+        [
+            py,
+            str(repo_root() / "scripts" / "lexicon" / "runner" / "durable_mirror.py"),
+            "snapshot",
+            "--source",
+            str(source_dir),
+            "--mirror-dir",
+            str(mirror),
+        ],
+        cwd=str(repo_root()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if snap.returncode != 0:
+        backup["error"] = (snap.stderr or snap.stdout or "durable_mirror snapshot failed").strip()[
+            :500
+        ]
+        set_restic_sink_blocked(str(backup["error"]))
+        return backup
+    backup_proc = subprocess.run(
+        ["bash", str(repo_root() / "scripts" / "backup-data.sh"), "backup", "--execute"],
+        cwd=str(repo_root()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if backup_proc.returncode != 0:
+        backup["error"] = (backup_proc.stderr or backup_proc.stdout or "backup --execute failed").strip()[
+            :500
+        ]
+        set_restic_sink_blocked(str(backup["error"]))
+        return backup
+    snapshot_id = _extract_snapshot_id(backup_proc.stdout or "")
+    if not snapshot_id:
+        snapshot_id = _extract_snapshot_id(backup_proc.stderr or "")
+    if not snapshot_id:
+        backup["error"] = "backup completed without snapshot_id"
+        set_restic_sink_blocked(str(backup["error"]))
+        return backup
+    backup["ok"] = True
+    backup["snapshot_id"] = snapshot_id
+    backup["error"] = None
+    clear_restic_sink_blocked()
+    return backup
+
+
+def _extract_snapshot_id(text: str) -> str | None:
+    match = re.search(r"\b([0-9a-f]{64})\b", text)
+    return match.group(1) if match else None
+
+
+def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAdapter | None = None) -> int:
     errors = validate_plan(plan)
     if errors:
         print("invalid plan:", file=sys.stderr)
@@ -195,21 +641,59 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False) -> int:
         return 2
     job_id = str(plan["id"])
     host = str(plan["host"])
+    sink = plan.get("result_sink")
+    if sink in {"restic", "both"} and restic_sink_blocked() and not dry_run:
+        print(
+            "restic sink blocked until backup-data.sh doctor is green "
+            f"({restic_block_path()})",
+            file=sys.stderr,
+        )
+        return 2
     existing = load_registry(job_id)
     if existing and existing.get("state") == "running":
         print(f"job {job_id} is already running", file=sys.stderr)
         return 2
-    busy = running_on_host(host)
-    if busy and not dry_run:
-        print(f"host {host} already has running job {busy[0].get('id')}", file=sys.stderr)
-        return 2
+    adapter = host_adapter or get_host_adapter()
+    if not dry_run:
+        try:
+            if not adapter.reachable(host):
+                print(f"host {host} unreachable", file=sys.stderr)
+                return 2
+            busy_units = active_host_units(host, adapter)
+        except (ConnectionError, OSError, ValueError) as exc:
+            print(f"host unit check failed: {exc}", file=sys.stderr)
+            return 2
+        if busy_units:
+            print(
+                f"host {host} already has active unit {busy_units[0].get('name')} "
+                "(systemd is the mutex; registry is journal only)",
+                file=sys.stderr,
+            )
+            return 2
+        journal_busy = running_on_host(host)
+        if journal_busy:
+            # Journal says running but host has no unit — reconcile hole; still refuse.
+            print(
+                f"registry journal has running job {journal_busy[0].get('id')} "
+                "with no active host unit; close/reconcile before submit",
+                file=sys.stderr,
+            )
+            return 2
     unit = unit_name(job_id)
+    workdir = work_dir_for(job_id, plan)
     args = list(plan.get("args") or [])
     if "--no-poll" not in args:
         args.append("--no-poll")
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
     env["ATLAS_RE_ENRICH_UNIT"] = unit
+    env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
+    env["ATLAS_RE_ENRICH_OUT_DIR"] = str(local_pull_dir(job_id))
+    env["ATLAS_JOB_EXIT_STATUS_FILE"] = f"{workdir}/exit-status.json"
+    env["ATLAS_RE_ENRICH_RUNTIME_MAX_SEC"] = str(
+        plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    )
+    env["ATLAS_RE_ENRICH_RESTART"] = "no"
     slugs = plan.get("slugs_file")
     if isinstance(slugs, str) and slugs:
         env["ATLAS_RE_ENRICH_RESIDUAL"] = slugs
@@ -221,16 +705,21 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False) -> int:
         "host": host,
         "kind": plan["kind"],
         "unit": unit,
+        "workdir": workdir,
+        "issue": plan["issue"],
         "plan_sha256": hashlib.sha256(plan_blob).hexdigest(),
         "denominator": plan["denominator"],
         "result_sink": plan["result_sink"],
         "pointer_write": False,
+        "resume": plan.get("resume", "never"),
+        "timeout_seconds": plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS),
         "submitted_at": _now(),
         "plan": plan,
     }
     if dry_run:
         print("host", host)
         print("unit", unit)
+        print("workdir", workdir)
         print("cmd", " ".join(cmd))
         if slugs:
             print("slugs_file", slugs)
@@ -250,67 +739,268 @@ def close_job(
     summary: dict[str, Any] | None = None,
     skip_pull: bool = False,
     skip_restic: bool = False,
+    host_adapter: HostAdapter | None = None,
 ) -> int:
     row = load_registry(job_id)
     if row is None:
         print(f"no registry row for {job_id}", file=sys.stderr)
         return 2
     plan = row.get("plan") if isinstance(row.get("plan"), dict) else {}
-    if summary is None:
-        summary = {}
-    state = interpret_summary(summary, plan)
-    receipt = {
-        "schema": "atlas-job-result.v1",
+    host = str(row.get("host") or plan.get("host") or "atlas-runner")
+    workdir = str(row.get("workdir") or work_dir_for(job_id, plan))
+    adapter = host_adapter or get_host_adapter()
+
+    exit_status: dict[str, Any] | None = None
+    try:
+        exit_status = adapter.read_exit_status(host, workdir)
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"exit-status read failed: {exc}", file=sys.stderr)
+
+    has_summary = summary_has_evidence(summary)
+    if not has_summary and not exit_status:
+        receipt = _base_receipt(row, job_id, plan, workdir)
+        receipt["state"] = "needs_finalize"
+        receipt["summary"] = summary if isinstance(summary, dict) else {}
+        receipt["pulled"] = False
+        receipt["backup"] = {"attempted": False, "ok": False, "snapshot_id": None, "error": "not attempted"}
+        receipt["delivery"] = "failed"
+        _seal_receipt(job_id, row, receipt, registry_state="needs_finalize")
+        print("needs_finalize", job_id, "missing summary evidence and exit-status", file=sys.stderr)
+        return 1
+
+    if has_summary:
+        assert summary is not None
+        job_state = interpret_summary(summary, plan)
+    else:
+        # Exit status alone cannot prove success.
+        job_state = "failed"
+        if _exit_status_ok(exit_status):
+            job_state = "needs_finalize"
+        summary = summary if isinstance(summary, dict) else {}
+
+    if exit_status and not _exit_status_ok(exit_status) and job_state == "succeeded":
+        job_state = "failed"
+
+    pulled = False
+    pull_error: str | None = None
+    if not skip_pull:
+        pull_rc = pull(host=host, job_id=job_id, workdir=workdir)
+        pulled = pull_rc == 0
+        if not pulled:
+            pull_error = f"pull failed rc={pull_rc}"
+    else:
+        pull_error = "skipped"
+
+    sink = row.get("result_sink") or plan.get("result_sink")
+    backup = {"attempted": False, "ok": False, "snapshot_id": None, "error": "not required"}
+    if sink in {"restic", "both"}:
+        source = local_pull_dir(job_id)
+        if not source.is_dir():
+            source.mkdir(parents=True, exist_ok=True)
+            # Minimal local evidence so mirror has something when pull was skipped in tests.
+            (source / "close-marker.json").write_text(
+                json.dumps({"id": job_id, "closed_at": _now()}) + "\n",
+                encoding="utf-8",
+            )
+        backup = run_restic_sink(job_id, source_dir=source, skip=skip_restic)
+
+    receipt = _base_receipt(row, job_id, plan, workdir)
+    receipt["state"] = job_state
+    receipt["summary"] = summary if isinstance(summary, dict) else {}
+    receipt["pulled"] = pulled
+    if pull_error:
+        receipt["pull_error"] = pull_error
+    receipt["exit_status"] = exit_status
+    receipt["backup"] = backup
+    # Keep legacy key as alias for older readers (same object).
+    receipt["restic"] = {
+        "attempted": backup.get("attempted"),
+        "ok": backup.get("ok"),
+        "receipt": backup.get("snapshot_id") or backup.get("error"),
+    }
+
+    delivery_ok = True
+    if sink in {"restic", "both"} and not skip_restic and not backup.get("ok"):
+        delivery_ok = False
+    if sink in {"git", "both"}:
+        try:
+            git_path = write_git_receipt(job_id, receipt)
+            receipt["git_pr"] = _receipt_locator(git_path, job_id)
+        except ValueError as exc:
+            delivery_ok = False
+            receipt["git_pr"] = None
+            receipt["git_error"] = str(exc)
+            print(f"git receipt rejected: {exc}", file=sys.stderr)
+    else:
+        # Even for restic-only, land a schema-capped local receipt for visibility.
+        try:
+            git_path = write_git_receipt(job_id, receipt)
+            receipt["git_pr"] = _receipt_locator(git_path, job_id)
+        except ValueError as exc:
+            receipt["git_pr"] = None
+            receipt["git_error"] = str(exc)
+            delivery_ok = False
+
+    receipt["delivery"] = "ok" if delivery_ok else "failed"
+    # Never delete remote workdir — especially on backup failure.
+    receipt["workdir_retained"] = True
+
+    registry_state = job_state
+    _seal_receipt(job_id, row, receipt, registry_state=registry_state)
+    print(registry_state, job_id, result_path(job_id))
+    if job_state == "succeeded" and delivery_ok:
+        return 0
+    return 1
+
+
+def _base_receipt(
+    row: dict[str, Any], job_id: str, plan: dict[str, Any], workdir: str
+) -> dict[str, Any]:
+    return {
+        "schema": RESULT_SCHEMA,
         "id": job_id,
-        "state": state,
+        "state": "failed",
         "host": row.get("host"),
         "unit": row.get("unit"),
+        "kind": row.get("kind") or plan.get("kind"),
+        "issue": row.get("issue") or plan.get("issue"),
+        "workdir": workdir,
+        "plan_sha256": row.get("plan_sha256"),
+        "denominator": row.get("denominator") or plan.get("denominator"),
         "closed_at": _now(),
-        "summary": summary,
-        "pulled": not skip_pull,
+        "summary": {},
+        "pulled": False,
         "mirror_dir": None,
-        "restic": {"attempted": False, "ok": False, "receipt": None},
+        "backup": {"attempted": False, "ok": False, "snapshot_id": None, "error": None},
+        "delivery": "failed",
         "git_pr": None,
+        "exit_status": None,
     }
-    sink = row.get("result_sink") or plan.get("result_sink")
-    if sink in {"restic", "both"} and not skip_restic:
-        receipt["restic"]["attempted"] = True
-        doctor = subprocess.call(
-            ["bash", str(repo_root() / "scripts" / "backup-data.sh"), "doctor"],
-            cwd=str(repo_root()),
-        )
-        receipt["restic"]["ok"] = doctor == 0
-        receipt["restic"]["receipt"] = "backup-data.sh doctor"
+
+
+def _seal_receipt(
+    job_id: str, row: dict[str, Any], receipt: dict[str, Any], *, registry_state: str
+) -> None:
     result_file = result_path(job_id)
     result_file.parent.mkdir(parents=True, exist_ok=True)
-    result_file.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-    row["state"] = state
+    tmp = result_file.with_suffix(result_file.suffix + ".tmp")
+    tmp.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(result_file)
+    row["state"] = registry_state
     row["closed_at"] = receipt["closed_at"]
     row["result"] = str(result_file)
     save_registry(row)
-    print(state, job_id, result_file)
-    return 0 if state == "succeeded" else 1
 
 
-def status(*, host: str, audit: bool = False) -> int:
+def _exit_status_ok(exit_status: dict[str, Any] | None) -> bool:
+    if not exit_status:
+        return False
+    code = exit_status.get("exit_status", exit_status.get("exit_code"))
+    if code in {0, "0"}:
+        return True
+    return exit_status.get("service_result") == "success"
+
+
+def reconcile_row(
+    row: dict[str, Any],
+    *,
+    host_units: list[dict[str, Any]],
+    host_adapter: HostAdapter | None = None,
+) -> dict[str, Any]:
+    """Reconcile journal row against host units. Mutates and persists when needed."""
+    if row.get("state") != "running":
+        return row
+    unit = str(row.get("unit") or "")
+    active_names = {str(u.get("name")) for u in host_units if _unit_is_active(u)}
+    if unit in active_names:
+        return row
+    # Unit inactive while journal says running.
+    adapter = host_adapter or get_host_adapter()
+    workdir = str(row.get("workdir") or work_dir_for(str(row["id"]), row.get("plan") or {}))
+    host = str(row.get("host") or "atlas-runner")
+    exit_status = None
+    try:
+        exit_status = adapter.read_exit_status(host, workdir)
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError):
+        exit_status = None
+    resume = row.get("resume") or (row.get("plan") or {}).get("resume") or "never"
+    new_state = "crashed" if exit_status is None and resume == "never" else "needs_finalize"
+    row["state"] = new_state
+    row["reconciled_at"] = _now()
+    if exit_status is not None:
+        row["exit_status"] = exit_status
+    save_registry(row)
+    return row
+
+
+def _unit_is_active(unit: dict[str, Any]) -> bool:
+    return unit.get("active") in {"active", "activating", "reloading"} or str(
+        unit.get("sub", "")
+    ).startswith("running")
+
+
+def status(*, host: str, audit: bool = False, host_adapter: HostAdapter | None = None) -> int:
     if host in HRAMATKA_ALIASES:
         print("status for batch jobs must use atlas-runner", file=sys.stderr)
         return 2
+    adapter = host_adapter or get_host_adapter()
+    try:
+        if not adapter.reachable(host):
+            print(f"host {host} unreachable", file=sys.stderr)
+            return 2
+        host_units = adapter.list_atlas_job_units(host)
+    except (ConnectionError, OSError, ValueError) as exc:
+        print(f"host status failed: {exc}", file=sys.stderr)
+        return 2
+
     rows = [r for r in list_registry() if r.get("host") == host]
     for row in rows:
-        print(row.get("state"), row.get("id"), row.get("unit"))
+        if row.get("state") == "running":
+            row = reconcile_row(row, host_units=host_units, host_adapter=adapter)
+        print(row.get("state"), row.get("id"), row.get("unit"), row.get("workdir"))
+
+    if restic_sink_blocked():
+        print("restic-sink-blocked", restic_block_path(), file=sys.stderr)
+
     if not audit:
         return 0
-    remote = "pgrep -af 'reenrich_thin_manifest_entries|migrate_slovnyk|enrich_offline_20k' || true"
-    proc = subprocess.run(
-        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=12", host, remote],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    lines = (proc.stdout or "").splitlines()
-    running_ids = [str(r["id"]) for r in rows if r.get("state") == "running"]
-    orphans = audit_processes(lines, running_ids)
+
+    # Primary orphan test: systemd MainPID / unit membership.
+    tracked: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("state") != "running":
+            continue
+        unit = str(row.get("unit") or "")
+        main_pid = None
+        for host_unit in host_units:
+            if host_unit.get("name") == unit:
+                main_pid = host_unit.get("main_pid")
+                break
+        tracked.append(
+            {
+                "id": row.get("id"),
+                "unit": unit,
+                "workdir": row.get("workdir"),
+                "main_pid": main_pid,
+            }
+        )
+
+    try:
+        lines = adapter.pgrep_drivers(host)
+    except (ConnectionError, OSError) as exc:
+        print(f"audit pgrep failed: {exc}", file=sys.stderr)
+        return 2
+
+    orphans = audit_processes(lines, tracked=tracked)
+    # Also flag active host units with no journal row.
+    journal_units = {str(r.get("unit")) for r in rows if r.get("state") == "running"}
+    for host_unit in host_units:
+        if not _unit_is_active(host_unit):
+            continue
+        name = str(host_unit.get("name") or "")
+        if name and name not in journal_units:
+            orphans.append(f"untracked-unit:{name}")
+
     if orphans:
         print("untracked driver process:", file=sys.stderr)
         for line in orphans:
@@ -319,12 +1009,23 @@ def status(*, host: str, audit: bool = False) -> int:
     return 0
 
 
-def pull(*, host: str) -> int:
+def pull(
+    *,
+    host: str,
+    job_id: str | None = None,
+    workdir: str | None = None,
+) -> int:
     if host in HRAMATKA_ALIASES:
         print("pull for batch jobs must use atlas-runner", file=sys.stderr)
         return 2
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
+    if workdir:
+        env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
+    if job_id:
+        env["ATLAS_RE_ENRICH_OUT_DIR"] = str(local_pull_dir(job_id))
+        unit = unit_name(job_id)
+        env["ATLAS_RE_ENRICH_UNIT"] = unit
     return subprocess.call(
         ["bash", str(_launcher()), "--pull-only"],
         cwd=str(repo_root()),
@@ -357,6 +1058,7 @@ def main(argv: list[str] | None = None) -> int:
 
     p_pull = sub.add_parser("pull", help="Pull work-dir artifacts (no pointer flip)")
     p_pull.add_argument("--host", default="atlas-runner")
+    p_pull.add_argument("--job-id")
 
     args = parser.parse_args(argv)
     if args.cmd == "validate":
@@ -387,7 +1089,12 @@ def main(argv: list[str] | None = None) -> int:
             print(row.get("state"), row.get("id"), row.get("host"))
         return 0
     if args.cmd == "pull":
-        return pull(host=args.host)
+        workdir = None
+        if args.job_id:
+            row = load_registry(args.job_id)
+            if row:
+                workdir = str(row.get("workdir") or "")
+        return pull(host=args.host, job_id=args.job_id, workdir=workdir or None)
     return 2
 
 

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -131,7 +131,7 @@ class SshHostAdapter:
     def list_atlas_job_units(self, host: str) -> list[dict[str, Any]]:
         remote = (
             "systemctl --user list-units 'atlas-job-*.service' --all --no-legend --no-pager "
-            "2>/dev/null || true"
+            "--plain 2>/dev/null || true"
         )
         proc = _ssh(host, remote)
         if proc.returncode not in {0, 1}:
@@ -292,7 +292,7 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     if sink not in RESULT_SINKS:
         errors.append("result_sink must be git, restic, or both")
     denom = plan.get("denominator")
-    if not isinstance(denom, int) or denom < 0:
+    if not isinstance(denom, int) or isinstance(denom, bool) or denom < 0:
         errors.append("denominator must be an integer >= 0")
     success = plan.get("success")
     if not isinstance(success, dict):
@@ -311,13 +311,13 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     if slugs is not None and not isinstance(slugs, str):
         errors.append("slugs_file must be a string path when set")
     issue = plan.get("issue")
-    if not isinstance(issue, int) or issue <= 0:
+    if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
         errors.append("issue must be a positive GitHub campaign/kind issue number")
     resume = plan.get("resume", "never")
     if resume not in RESUME_MODES:
         errors.append(f"resume must be one of {sorted(RESUME_MODES)}")
     timeout = plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
-    if not isinstance(timeout, int) or timeout <= 0:
+    if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
         errors.append("timeout_seconds must be a positive integer")
     return errors
 

--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -184,10 +184,34 @@ WRAPPED="cd $(printf '%q' "$REPO") && PYTHONPATH=$(printf '%q' "$CODE_ROOT"):\$P
 
 if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run >/dev/null 2>&1; then
   rm -f "$PID_FILE" "$WRAPPER_PID_FILE"
+  # Protocol path (atlas_job): Restart=no, optional RuntimeMaxSec, ExecStopPost
+  # writes exit-status.json next to the per-job workdir. Default class-b runs
+  # keep prior memory caps and also default Restart=no (no double-processing).
+  EXIT_STATUS_FILE="${ATLAS_JOB_EXIT_STATUS_FILE:-$WORK_DIR/exit-status.json}"
+  cat > "$WORK_DIR/write-exit-status.sh" <<'EOS'
+#!/bin/bash
+set -eu
+out="${ATLAS_JOB_EXIT_STATUS_FILE:-}"
+if [[ -z "$out" ]]; then
+  exit 0
+fi
+printf '{"service_result":"%s","exit_code":"%s","exit_status":"%s"}\n' \
+  "${SERVICE_RESULT:-}" "${EXIT_CODE:-}" "${EXIT_STATUS:-}" > "$out"
+EOS
+  chmod +x "$WORK_DIR/write-exit-status.sh"
+  SYSTEMD_PROPS=(
+    --property=MemoryHigh=1536M
+    --property=MemoryMax=2048M
+    --property=Restart="${ATLAS_RE_ENRICH_RESTART:-no}"
+    --property="Environment=ATLAS_JOB_EXIT_STATUS_FILE=${EXIT_STATUS_FILE}"
+    --property="ExecStopPost=${WORK_DIR}/write-exit-status.sh"
+  )
+  if [[ -n "${ATLAS_RE_ENRICH_RUNTIME_MAX_SEC:-}" ]]; then
+    SYSTEMD_PROPS+=(--property="RuntimeMaxSec=${ATLAS_RE_ENRICH_RUNTIME_MAX_SEC}")
+  fi
   nohup systemd-run --user --wait --collect --unit="${UNIT%.service}" \
     --working-directory="$REPO" \
-    --property=MemoryHigh=1536M \
-    --property=MemoryMax=2048M \
+    "${SYSTEMD_PROPS[@]}" \
     /bin/bash -c "$WRAPPED" >> "$LOG" 2>&1 &
   wrapper_pid=$!
   printf '%s\n' "$wrapper_pid" > "$WRAPPER_PID_FILE"
@@ -195,7 +219,8 @@ if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run 
     driver_pid=$(systemctl --user show "$UNIT" --property=MainPID --value 2>/dev/null || true)
     if [[ "$driver_pid" =~ ^[1-9][0-9]*$ ]]; then
       printf '%s\n' "$driver_pid" > "$PID_FILE"
-      printf 'pid=%s wrapper_pid=%s unit=%s log=%s\n' "$driver_pid" "$wrapper_pid" "$UNIT" "$LOG"
+      printf 'pid=%s wrapper_pid=%s unit=%s log=%s workdir=%s\n' \
+        "$driver_pid" "$wrapper_pid" "$UNIT" "$LOG" "$WORK_DIR"
       exit 0
     fi
     if ! kill -0 "$wrapper_pid" 2>/dev/null; then

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -280,6 +280,17 @@ if [[ "$do_sync_and_launch" == "1" ]]; then
   if [[ -n "${ATLAS_RE_ENRICH_UNIT:-}" ]]; then
     remote_cmd+=" ATLAS_RE_ENRICH_UNIT=$(printf '%q' "$ATLAS_RE_ENRICH_UNIT")"
   fi
+  # Forward atlas_job.submit() protocol env so remote systemd gets RuntimeMaxSec,
+  # exit-status file path, and Restart=no (same printf %q style as UNIT).
+  if [[ -n "${ATLAS_RE_ENRICH_RUNTIME_MAX_SEC:-}" ]]; then
+    remote_cmd+=" ATLAS_RE_ENRICH_RUNTIME_MAX_SEC=$(printf '%q' "$ATLAS_RE_ENRICH_RUNTIME_MAX_SEC")"
+  fi
+  if [[ -n "${ATLAS_JOB_EXIT_STATUS_FILE:-}" ]]; then
+    remote_cmd+=" ATLAS_JOB_EXIT_STATUS_FILE=$(printf '%q' "$ATLAS_JOB_EXIT_STATUS_FILE")"
+  fi
+  if [[ -n "${ATLAS_RE_ENRICH_RESTART:-}" ]]; then
+    remote_cmd+=" ATLAS_RE_ENRICH_RESTART=$(printf '%q' "$ATLAS_RE_ENRICH_RESTART")"
+  fi
   remote_cmd+=" bash $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
   # macOS ships bash 3.2, where "${arr[@]}" on a zero-element array throws
   # "unbound variable" under `set -u` (fixed upstream in bash 4.4+) — guard

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -20,7 +20,7 @@
 #   scripts/lexicon/runner/launch_reenrich_class_b_remote.sh --pull-only  # just pull artifacts back
 #
 # Env overrides:
-#   ATLAS_RUNNER_HOST (default vps), ATLAS_RUN_ROOT, ATLAS_REPO,
+#   ATLAS_RUNNER_HOST (default atlas-runner), ATLAS_RUN_ROOT, ATLAS_REPO,
 #   ATLAS_PRIMARY_ROOT (default: primary checkout from shared .git common dir),
 #   ATLAS_RE_ENRICH_WORK_DIR, ATLAS_RE_ENRICH_RESIDUAL (local slugs dump),
 #   ATLAS_LOCAL_VESUM_DB, ATLAS_LOCAL_SLOVNYK_CACHE
@@ -50,7 +50,7 @@ esac
 PRIMARY_ROOT="${ATLAS_PRIMARY_ROOT:-$(cd "$_primary_common_dir/.." && pwd)}"
 PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-$PRIMARY_ROOT/.venv/bin/python}"
 
-HOST="${ATLAS_RUNNER_HOST:-vps}"
+HOST="${ATLAS_RUNNER_HOST:-atlas-runner}"
 RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
 REMOTE_REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 REMOTE_WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
@@ -276,7 +276,11 @@ if [[ "$do_sync_and_launch" == "1" ]]; then
   echo "launching on $HOST"
   # ATLAS_RE_ENRICH_DRIVER pins the work-dir copy explicitly so a stale
   # in-repo checkout on the VPS can never win the launcher's auto-detection.
-  remote_cmd="ATLAS_RUN_ROOT=$(printf '%q' "$RUN_ROOT") ATLAS_REPO=$(printf '%q' "$REMOTE_REPO") ATLAS_RE_ENRICH_WORK_DIR=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_CODE_ROOT=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_DRIVER=$(printf '%q' "$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py") bash $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
+  remote_cmd="ATLAS_RUN_ROOT=$(printf '%q' "$RUN_ROOT") ATLAS_REPO=$(printf '%q' "$REMOTE_REPO") ATLAS_RE_ENRICH_WORK_DIR=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_CODE_ROOT=$(printf '%q' "$REMOTE_WORK_DIR") ATLAS_RE_ENRICH_DRIVER=$(printf '%q' "$REMOTE_WORK_DIR/reenrich_thin_manifest_entries.py")"
+  if [[ -n "${ATLAS_RE_ENRICH_UNIT:-}" ]]; then
+    remote_cmd+=" ATLAS_RE_ENRICH_UNIT=$(printf '%q' "$ATLAS_RE_ENRICH_UNIT")"
+  fi
+  remote_cmd+=" bash $(printf '%q' "$REMOTE_WORK_DIR/launch_reenrich_class_b.sh")"
   # macOS ships bash 3.2, where "${arr[@]}" on a zero-element array throws
   # "unbound variable" under `set -u` (fixed upstream in bash 4.4+) — guard
   # the iteration instead of relying on the expansion alone.

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from scripts.api.main import app
@@ -110,3 +111,38 @@ def test_status_reconciles(
     resp = client.get(f"/api/atlas-jobs/{plan['id']}")
     assert resp.status_code == 200
     assert resp.json()["job"]["state"] == "needs_finalize"
+
+
+def test_api_rejects_path_injection_job_id(
+    tmp_path, _isolate: atlas_job.FakeHostAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsafe job_id must 400 before any Path join; no writes outside registry."""
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    outside = tmp_path.parent / "escape-marker"
+    if outside.exists():
+        outside.unlink()
+
+    # Single-segment unsafe tokens reach the atlas-jobs handler (encoded
+    # ``../`` is often normalized by the ASGI stack before routing).
+    for bad in ("..escape", ".hidden", "-leading-dash", "has%20space"):
+        get_resp = client.get(f"/api/atlas-jobs/{bad}")
+        assert get_resp.status_code == 400, (bad, get_resp.status_code, get_resp.text)
+        close_resp = client.post(
+            f"/api/atlas-jobs/{bad}/close",
+            json={"summary": {}, "skip_pull": True, "skip_restic": True},
+        )
+        assert close_resp.status_code == 400, (bad, close_resp.status_code, close_resp.text)
+
+    # Explicit path-param values that CodeQL flags (handler-level, not URL routing).
+    from scripts.api import atlas_jobs_router as router_mod
+
+    for bad in ("../../tmp", "../escape", "/etc/passwd"):
+        with pytest.raises(HTTPException) as excinfo:
+            router_mod.job_status(bad)
+        assert excinfo.value.status_code == 400
+        with pytest.raises(HTTPException) as excinfo:
+            router_mod.close_job(bad, router_mod.CloseBody(skip_pull=True, skip_restic=True))
+        assert excinfo.value.status_code == 400
+
+    assert not outside.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -1,0 +1,112 @@
+"""Tests for /api/atlas-jobs Monitor facade."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.api.main import app
+from scripts.lexicon.runner import atlas_job
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _plan(**overrides: object) -> dict:
+    base: dict = {
+        "schema": "atlas-job.v1",
+        "id": "api-job-example",
+        "host": "atlas-runner",
+        "kind": "reenrich",
+        "args": ["--target", "missing-translation"],
+        "pointer_write": False,
+        "result_sink": "git",
+        "denominator": 3,
+        "issue": 6867,
+        "success": {"circuit_breaker": False, "min_filled": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    yield fake
+    atlas_job.set_host_adapter(None)
+
+
+def test_list_and_health(_isolate: atlas_job.FakeHostAdapter) -> None:
+    health = client.get("/api/atlas-jobs/health")
+    assert health.status_code == 200
+    assert health.json()["ok"] is True
+    listed = client.get("/api/atlas-jobs")
+    assert listed.status_code == 200
+    assert listed.json()["count"] == 0
+
+
+def test_submit_dry_run_via_api(_isolate: atlas_job.FakeHostAdapter) -> None:
+    resp = client.post("/api/atlas-jobs/submit", json={"plan": _plan(), "dry_run": True})
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+
+def test_submit_rejects_hramatka(_isolate: atlas_job.FakeHostAdapter) -> None:
+    resp = client.post(
+        "/api/atlas-jobs/submit",
+        json={"plan": _plan(host="hramatka"), "dry_run": True},
+    )
+    assert resp.status_code == 400
+
+
+def test_close_empty_summary_fail_closed(_isolate: atlas_job.FakeHostAdapter) -> None:
+    plan = _plan()
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": atlas_job.work_dir_for(plan["id"], plan),
+            "result_sink": "git",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+    resp = client.post(
+        f"/api/atlas-jobs/{plan['id']}/close",
+        json={"summary": {}, "skip_pull": True, "skip_restic": True},
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["result"]["state"] == "needs_finalize"
+
+
+def test_status_reconciles(
+    _isolate: atlas_job.FakeHostAdapter,
+) -> None:
+    plan = _plan()
+    workdir = atlas_job.work_dir_for(plan["id"], plan)
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": workdir,
+            "resume": "checkpoint",
+            "result_sink": "git",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+    _isolate.exit_status_by_workdir[workdir] = {
+        "service_result": "success",
+        "exit_status": "0",
+    }
+    resp = client.get(f"/api/atlas-jobs/{plan['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["job"]["state"] == "needs_finalize"

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -372,6 +372,7 @@ def test_require_safe_job_id_rejects_traversal_and_bool() -> None:
         with pytest.raises(ValueError):
             atlas_job.require_safe_job_id(bad)  # type: ignore[arg-type]
     assert atlas_job.require_safe_job_id("missing-tr-example") == "missing-tr-example"
+    assert atlas_job.require_safe_job_id("ab") == "ab"
 
 
 def test_path_builders_reject_unsafe_job_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -1,0 +1,123 @@
+"""Hermetic tests for the Atlas VPS job protocol."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner import atlas_job
+
+
+def _plan(**overrides: object) -> dict:
+    base: dict = {
+        "schema": "atlas-job.v1",
+        "id": "missing-tr-example",
+        "host": "atlas-runner",
+        "kind": "reenrich",
+        "args": ["--target", "missing-translation"],
+        "pointer_write": False,
+        "result_sink": "restic",
+        "denominator": 10,
+        "success": {"circuit_breaker": False, "min_filled": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_plan_is_ok() -> None:
+    assert atlas_job.validate_plan(_plan()) == []
+
+
+def test_rejects_hramatka_for_reenrich() -> None:
+    errors = atlas_job.validate_plan(_plan(host="hramatka"))
+    assert any("cannot run" in e or "must not target" in e for e in errors)
+
+
+def test_rejects_pointer_write() -> None:
+    errors = atlas_job.validate_plan(_plan(pointer_write=True))
+    assert any("pointer_write" in e for e in errors)
+
+
+def test_rejects_unknown_kind() -> None:
+    errors = atlas_job.validate_plan(_plan(kind="scrape-web"))
+    assert any("kind" in e for e in errors)
+
+
+def test_submit_dry_run_sets_host(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = atlas_job.submit(_plan(), dry_run=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "atlas-runner" in out
+    assert "launch_reenrich_class_b_remote.sh" in out
+    assert "--no-poll" in out
+    assert "atlas-job-missing-tr-example.service" in out
+
+
+def test_submit_invalid_plan_exits_2() -> None:
+    assert atlas_job.submit(_plan(host="hramatka"), dry_run=True) == 2
+
+
+def test_close_without_registry_exits_2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    assert atlas_job.close_job("no-such-job", skip_pull=True, skip_restic=True) == 2
+
+
+def test_consecutive_misses_equal_targets_is_failed() -> None:
+    summary = {
+        "targets": 43,
+        "consecutive_misses": 43,
+        "filled_translation": 0,
+        "circuit_breaker_tripped": False,
+    }
+    assert atlas_job.interpret_summary(summary, _plan()) == "failed"
+
+
+def test_close_writes_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    plan = _plan()
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "result_sink": "restic",
+            "plan": plan,
+        }
+    )
+    rc = atlas_job.close_job(
+        plan["id"],
+        summary={
+            "targets": 10,
+            "consecutive_misses": 0,
+            "filled_translation": 4,
+            "circuit_breaker_tripped": False,
+        },
+        skip_pull=True,
+        skip_restic=True,
+    )
+    assert rc == 0
+    receipt = json.loads((tmp_path / f"{plan['id']}.result.json").read_text(encoding="utf-8"))
+    assert receipt["state"] == "succeeded"
+    row = atlas_job.load_registry(plan["id"])
+    assert row is not None
+    assert row["state"] == "succeeded"
+
+
+def test_audit_flags_untracked_driver() -> None:
+    lines = [
+        "1234 /opt/x/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py --local"
+    ]
+    orphans = atlas_job.audit_processes(lines, running_ids=[])
+    assert orphans
+    assert atlas_job.audit_processes(["pgrep -af reenrich"], running_ids=[]) == []
+
+
+def test_cli_validate_and_dry_submit(tmp_path: Path) -> None:
+    path = tmp_path / "job.json"
+    path.write_text(json.dumps(_plan()), encoding="utf-8")
+    assert atlas_job.main(["validate", str(path)]) == 0
+    assert atlas_job.main(["submit", str(path), "--dry-run"]) == 0

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -20,10 +20,28 @@ def _plan(**overrides: object) -> dict:
         "pointer_write": False,
         "result_sink": "restic",
         "denominator": 10,
+        "issue": 6867,
         "success": {"circuit_breaker": False, "min_filled": 0},
     }
     base.update(overrides)
     return base
+
+
+def _good_summary() -> dict:
+    return {
+        "targets": 10,
+        "consecutive_misses": 0,
+        "filled_translation": 4,
+        "circuit_breaker_tripped": False,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_host(monkeypatch: pytest.MonkeyPatch) -> atlas_job.FakeHostAdapter:
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    yield fake
+    atlas_job.set_host_adapter(None)
 
 
 def test_valid_plan_is_ok() -> None:
@@ -45,7 +63,12 @@ def test_rejects_unknown_kind() -> None:
     assert any("kind" in e for e in errors)
 
 
-def test_submit_dry_run_sets_host(capsys: pytest.CaptureFixture[str]) -> None:
+def test_requires_campaign_issue() -> None:
+    errors = atlas_job.validate_plan(_plan(issue=None))
+    assert any("issue" in e for e in errors)
+
+
+def test_submit_dry_run_sets_host_and_workdir(capsys: pytest.CaptureFixture[str]) -> None:
     rc = atlas_job.submit(_plan(), dry_run=True)
     assert rc == 0
     out = capsys.readouterr().out
@@ -53,15 +76,58 @@ def test_submit_dry_run_sets_host(capsys: pytest.CaptureFixture[str]) -> None:
     assert "launch_reenrich_class_b_remote.sh" in out
     assert "--no-poll" in out
     assert "atlas-job-missing-tr-example.service" in out
+    assert "run-atlas-job-missing-tr-example" in out
 
 
 def test_submit_invalid_plan_exits_2() -> None:
     assert atlas_job.submit(_plan(host="hramatka"), dry_run=True) == 2
 
 
+def test_submit_checks_host_units(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    _isolate_host.units = [
+        {
+            "name": "atlas-job-other.service",
+            "active": "active",
+            "sub": "running",
+            "main_pid": 99,
+        }
+    ]
+    rc = atlas_job.submit(_plan(id="new-job"), dry_run=False, host_adapter=_isolate_host)
+    assert rc == 2
+
+
 def test_close_without_registry_exits_2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
     assert atlas_job.close_job("no-such-job", skip_pull=True, skip_restic=True) == 2
+
+
+def test_close_empty_summary_is_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    plan = _plan()
+    workdir = atlas_job.work_dir_for(plan["id"], plan)
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": workdir,
+            "result_sink": "restic",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+    rc = atlas_job.close_job(plan["id"], summary={}, skip_pull=True, skip_restic=True)
+    assert rc == 1
+    receipt = json.loads((tmp_path / f"{plan['id']}.result.json").read_text(encoding="utf-8"))
+    assert receipt["state"] == "needs_finalize"
+    assert receipt["pulled"] is False
 
 
 def test_consecutive_misses_equal_targets_is_failed() -> None:
@@ -84,27 +150,98 @@ def test_close_writes_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
             "host": "atlas-runner",
             "kind": "reenrich",
             "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": atlas_job.work_dir_for(plan["id"], plan),
             "result_sink": "restic",
+            "issue": plan["issue"],
             "plan": plan,
         }
     )
     rc = atlas_job.close_job(
         plan["id"],
-        summary={
-            "targets": 10,
-            "consecutive_misses": 0,
-            "filled_translation": 4,
-            "circuit_breaker_tripped": False,
-        },
+        summary=_good_summary(),
         skip_pull=True,
         skip_restic=True,
     )
     assert rc == 0
     receipt = json.loads((tmp_path / f"{plan['id']}.result.json").read_text(encoding="utf-8"))
     assert receipt["state"] == "succeeded"
+    assert receipt["pulled"] is False
+    assert receipt["backup"]["ok"] is False
+    assert receipt["issue"] == 6867
     row = atlas_job.load_registry(plan["id"])
     assert row is not None
     assert row["state"] == "succeeded"
+
+
+def test_restic_doctor_fail_blocks_success_via_sink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    plan = _plan()
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": atlas_job.work_dir_for(plan["id"], plan),
+            "result_sink": "restic",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+
+    def fake_doctor() -> int:
+        return 3
+
+    monkeypatch.setattr(atlas_job, "_run_backup_doctor", fake_doctor)
+    rc = atlas_job.close_job(
+        plan["id"],
+        summary=_good_summary(),
+        skip_pull=True,
+        skip_restic=False,
+    )
+    assert rc == 1
+    receipt = json.loads((tmp_path / f"{plan['id']}.result.json").read_text(encoding="utf-8"))
+    assert receipt["state"] == "succeeded"  # real job outcome kept
+    assert receipt["backup"]["attempted"] is True
+    assert receipt["backup"]["ok"] is False
+    assert receipt["delivery"] == "failed"
+    assert receipt["workdir_retained"] is True
+    assert atlas_job.restic_sink_blocked()
+
+
+def test_pulled_true_only_after_pull(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    plan = _plan(result_sink="git")
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": atlas_job.work_dir_for(plan["id"], plan),
+            "result_sink": "git",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+    calls: list[dict] = []
+
+    def fake_pull(**kwargs: object) -> int:
+        calls.append(dict(kwargs))
+        return 0
+
+    monkeypatch.setattr(atlas_job, "pull", fake_pull)
+    rc = atlas_job.close_job(plan["id"], summary=_good_summary(), skip_pull=False, skip_restic=True)
+    assert rc == 0
+    assert calls
+    receipt = json.loads((tmp_path / f"{plan['id']}.result.json").read_text(encoding="utf-8"))
+    assert receipt["pulled"] is True
 
 
 def test_audit_flags_untracked_driver() -> None:
@@ -114,6 +251,68 @@ def test_audit_flags_untracked_driver() -> None:
     orphans = atlas_job.audit_processes(lines, running_ids=[])
     assert orphans
     assert atlas_job.audit_processes(["pgrep -af reenrich"], running_ids=[]) == []
+
+
+def test_audit_with_running_id_matches_main_pid() -> None:
+    lines = [
+        "4242 /opt/x/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py --local"
+    ]
+    tracked = [
+        {
+            "id": "missing-tr-example",
+            "unit": "atlas-job-missing-tr-example.service",
+            "workdir": "/home/ops/atlas-runner/run-atlas-job-missing-tr-example",
+            "main_pid": 4242,
+        }
+    ]
+    assert atlas_job.audit_processes(lines, tracked=tracked) == []
+    # True orphan still flagged while a tracked job exists.
+    other = [
+        "9999 /opt/x/.venv/bin/python scripts/lexicon/reenrich_thin_manifest_entries.py --local"
+    ]
+    assert atlas_job.audit_processes(other, tracked=tracked)
+
+
+def test_status_reconciles_inactive_unit_to_needs_finalize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    plan = _plan()
+    workdir = atlas_job.work_dir_for(plan["id"], plan)
+    atlas_job.save_registry(
+        {
+            "id": plan["id"],
+            "state": "running",
+            "host": "atlas-runner",
+            "kind": "reenrich",
+            "unit": atlas_job.unit_name(plan["id"]),
+            "workdir": workdir,
+            "resume": "checkpoint",
+            "result_sink": "restic",
+            "issue": plan["issue"],
+            "plan": plan,
+        }
+    )
+    _isolate_host.exit_status_by_workdir[workdir] = {
+        "service_result": "success",
+        "exit_status": "0",
+    }
+    rc = atlas_job.status(host="atlas-runner", host_adapter=_isolate_host)
+    assert rc == 0
+    row = atlas_job.load_registry(plan["id"])
+    assert row is not None
+    assert row["state"] == "needs_finalize"
+
+
+def test_git_receipt_rejects_absolute_paths() -> None:
+    bad = {
+        "schema": "atlas-job-result.v1",
+        "id": "x",
+        "state": "succeeded",
+        "summary": {"note": "/Users/secret/path"},
+    }
+    errors = atlas_job.validate_git_receipt(bad)
+    assert any("absolute path" in e for e in errors)
 
 
 def test_cli_validate_and_dry_submit(tmp_path: Path) -> None:

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -365,3 +365,61 @@ def test_cli_validate_and_dry_submit(tmp_path: Path) -> None:
     path.write_text(json.dumps(_plan()), encoding="utf-8")
     assert atlas_job.main(["validate", str(path)]) == 0
     assert atlas_job.main(["submit", str(path), "--dry-run"]) == 0
+
+
+def test_require_safe_job_id_rejects_traversal_and_bool() -> None:
+    for bad in ("../escape", "/etc/passwd", True, False, "", "a/b", "job id", None, 12):
+        with pytest.raises(ValueError):
+            atlas_job.require_safe_job_id(bad)  # type: ignore[arg-type]
+    assert atlas_job.require_safe_job_id("missing-tr-example") == "missing-tr-example"
+
+
+def test_path_builders_reject_unsafe_job_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    for bad in ("../escape", "/etc/passwd", "true/../x"):
+        with pytest.raises(ValueError):
+            atlas_job.registry_path(bad)
+        with pytest.raises(ValueError):
+            atlas_job.result_path(bad)
+        with pytest.raises(ValueError):
+            atlas_job.git_receipt_path(bad)
+        with pytest.raises(ValueError):
+            atlas_job.local_pull_dir(bad)
+        with pytest.raises(ValueError):
+            atlas_job.mirror_dir_for(bad)
+        with pytest.raises(ValueError):
+            atlas_job.unit_name(bad)
+        with pytest.raises(ValueError):
+            atlas_job.work_dir_for(bad)
+        with pytest.raises(ValueError):
+            atlas_job.load_registry(bad)
+    # No files created outside the registry root for a traversal id attempt.
+    assert list(tmp_path.iterdir()) == []
+    assert not (tmp_path / "escape.json").exists()
+    assert not (tmp_path.parent / "escape.json").exists()
+
+
+def test_workdir_honored_only_when_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_RUN_ROOT", str(tmp_path / "runs"))
+    job = "safe-job"
+    nested = tmp_path / "runs" / "run-atlas-job-safe-job"
+    assert atlas_job.work_dir_for(job, {"workdir": str(nested)}) == str(nested.resolve())
+    assert atlas_job.work_dir_for(job, {"workdir": "run-atlas-job-safe-job"}) == (
+        "run-atlas-job-safe-job"
+    )
+    for bad in ("../escape", "/etc/passwd", "/tmp/evil", "foo/../../etc", "has space"):
+        with pytest.raises(ValueError):
+            atlas_job.work_dir_for(job, {"workdir": bad})
+        errors = atlas_job.validate_plan(_plan(workdir=bad))
+        assert errors, bad
+
+
+def test_close_and_cli_reject_unsafe_job_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    with pytest.raises(ValueError):
+        atlas_job.close_job("../escape", skip_pull=True, skip_restic=True)
+    assert atlas_job.main(["close", "../escape", "--skip-pull", "--skip-restic"]) == 2
+    assert atlas_job.main(["pull", "--job-id", "../escape"]) == 2
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -68,6 +68,51 @@ def test_requires_campaign_issue() -> None:
     assert any("issue" in e for e in errors)
 
 
+def test_rejects_bool_for_numeric_fields() -> None:
+    """bool is a subclass of int; plans must not accept true/false as numbers."""
+    for field, value in (
+        ("issue", True),
+        ("issue", False),
+        ("denominator", True),
+        ("denominator", False),
+        ("timeout_seconds", True),
+        ("timeout_seconds", False),
+    ):
+        errors = atlas_job.validate_plan(_plan(**{field: value}))
+        assert any(field in e for e in errors), (field, value, errors)
+
+
+def test_remote_launcher_forwards_protocol_env() -> None:
+    """atlas_job.submit sets protocol env; remote_cmd must forward them over SSH."""
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "lexicon"
+        / "runner"
+        / "launch_reenrich_class_b_remote.sh"
+    ).read_text(encoding="utf-8")
+    # Each var must be appended to remote_cmd with the same printf %q style as UNIT.
+    for var in (
+        "ATLAS_RE_ENRICH_RUNTIME_MAX_SEC",
+        "ATLAS_JOB_EXIT_STATUS_FILE",
+        "ATLAS_RE_ENRICH_RESTART",
+    ):
+        assert f'if [[ -n "${{{var}:-}}" ]]; then' in source
+        assert f'remote_cmd+=" {var}=$(printf \'%q\' "${var}")"' in source
+    # UNIT already forwarded; protocol vars must appear after that block.
+    unit_fwd = source.index('remote_cmd+=" ATLAS_RE_ENRICH_UNIT=$(printf')
+    runtime_fwd = source.index("ATLAS_RE_ENRICH_RUNTIME_MAX_SEC=$(printf")
+    assert runtime_fwd > unit_fwd
+
+
+def test_ssh_host_adapter_list_units_uses_plain() -> None:
+    import inspect
+
+    src = inspect.getsource(atlas_job.SshHostAdapter.list_atlas_job_units)
+    assert "--plain" in src
+    assert "list-units" in src
+
+
 def test_submit_dry_run_sets_host_and_workdir(capsys: pytest.CaptureFixture[str]) -> None:
     rc = atlas_job.submit(_plan(), dry_run=True)
     assert rc == 0


### PR DESCRIPTION
## Summary

Protocol for long Atlas jobs on `atlas-runner`: validate a plan, register the job, submit via the existing remote launcher (per-job systemd unit + per-job workdir), then **close** with a fail-closed result receipt. Large artifacts go through `durable_mirror` + `backup-data.sh`. Small receipts are schema-capped under `batch_state/atlas-jobs/receipts/`. Publish/pointer flip is out of scope.

**systemd on the host is truth; the local registry is a journal.**

- Host policy: reenrich cannot run on `hramatka` (no override)
- Default `ATLAS_RUNNER_HOST=atlas-runner`
- `consecutive_misses == targets` is **failed**
- `close` without summary evidence / exit-status ⇒ `needs_finalize` (never empty-`{}` success)
- `submit` checks host `systemctl list-units 'atlas-job-*'` before accept
- `status` reconciles inactive unit + journal `running` ⇒ `needs_finalize` / `crashed`
- Restic path actually runs snapshot + `backup --execute`; doctor/backup fail ≠ delivery success; workdir retained; restic-sink submits blocked until doctor green
- `pulled` is true only after `pull()` runs
- Monitor facade: `GET/POST /api/atlas-jobs` (list/submit/status/close)
- Campaign `issue` required on plan; one GH issue per campaign/kind

## Test plan

- [x] `pytest tests/test_atlas_job_protocol.py tests/api/test_atlas_jobs_router.py`
- [x] `pytest tests/test_launch_reenrich_target_detection.py`
- [x] `ruff check` on touched files

## Residuals (honest)

- Live SSH against atlas-runner is exercised via injectable `HostAdapter` / `FakeHostAdapter` in unit tests — not a live host fixture in CI.
- `durable_mirror` of a full remote workdir with symlinks is still incompatible; close mirrors the **local pull dir** (or a close-marker stub when pull is skipped in recovery tooling). Curated export inventory per Sol finding #8 remains a follow-up for production artifact sets.
- Auto-finalize daemon / scheduled reconciler is not a separate process: reconciliation runs on `status` / API GET. Operator or Monitor poll still required for liveness without a close call.
- `git_pr` writes a schema-capped receipt file ready for a dispatch PR; it does not open a GitHub PR automatically.
- Free-disk preflight on submit (Fable finding 3 tail) not implemented in this recut.

Do **not** merge until cross-family re-review of this head.