### PR TITLE
fix(work): retired formal-review rows never drive OFF_TRACK/REQUEST_CF_REVIEW

### DIFF
--- a/scripts/work/attention.py
+++ b/scripts/work/attention.py
@@ -112,14 +112,15 @@ def derive_health(item: dict[str, Any], *, source_ok: bool) -> str:
         return "UNKNOWN"
 
     if kind == "review":
+        # formal_review_jobs is the retired sealed-CF era dataset (operator
+        # 2026-08-07); the current direct ask-<lane> CF flow writes nothing
+        # there. Only rows still in flight can be attention-driving — every
+        # terminal state (failed/rejected/error/complete/completed/published),
+        # sealed or not, is historical and must read neutral, never OFF_TRACK
+        # (issue #6862).
         state = str(item.get("lifecycle") or "")
-        sealed = bool(review.get("sealed_verdict_available"))
-        if state in {"failed", "rejected", "error"}:
-            return "OFF_TRACK"
         if state in {"running", "queued", "pending"}:
             return "AT_RISK"
-        if sealed or state in {"complete", "completed", "published"}:
-            return "ON_TRACK"
         return "UNKNOWN"
 
     return "UNKNOWN"
@@ -182,7 +183,11 @@ def derive_safe_next_action(item: dict[str, Any]) -> dict[str, Any]:
             return {"code": "WAIT_REVIEW", "reason_codes": ["formal_review_pending"]}
         if review.get("sealed_verdict_available"):
             return {"code": "NONE", "reason_codes": ["sealed_verdict_available"]}
-        return {"code": "REQUEST_CF_REVIEW", "reason_codes": ["formal_review_open"]}
+        # Retired sealed-CF era rows (terminal or unresolved "open" jobs the
+        # dead pipeline never sealed) never ask for a CF review themselves —
+        # that ask belongs to the PR row under the current direct ask-<lane>
+        # flow (issue #6862).
+        return {"code": "NONE", "reason_codes": ["formal_review_terminal_historical"]}
 
     if item.get("health") == "UNKNOWN":
         return {"code": "INSPECT_UNKNOWN", "reason_codes": ["unknown_health"]}

--- a/tests/test_work_contract.py
+++ b/tests/test_work_contract.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.work.attention import derive_health, derive_safe_next_action
+from scripts.work.attention import apply_health_and_actions, derive_health, derive_safe_next_action
 from scripts.work.normalize import _match_dispatch, build_projection
 from scripts.work.relations import (
     detect_dependency_cycles,
@@ -1869,6 +1869,86 @@ def test_health_never_uses_activity_and_pr_rules():
     assert derive_safe_next_action(orphan)["code"] == "TRIAGE_ORPHAN"
 
     assert derive_health(orphan, source_ok=False) == "UNKNOWN"
+
+
+def _is_actionable(item: dict) -> bool:
+    """Mirror dashboards/work.html's isActionable() for a Python-side check."""
+    if item["health"] in {"OFF_TRACK", "AT_RISK"}:
+        return True
+    code = item.get("safe_next_action", {}).get("code") or ""
+    return bool(code) and code not in {"INSPECT_UNKNOWN", "OPEN_GITHUB", "NONE"}
+
+
+def _review_item(lifecycle: str, *, sealed: bool = False) -> dict:
+    return {
+        "work_id": f"review:{lifecycle}:{sealed}",
+        "resource_kind": "review",
+        "lifecycle": lifecycle,
+        "flags": {},
+        "projections": {
+            "stream": {},
+            "dispatch": {},
+            "review": {"sealed_verdict_available": sealed},
+            "verification": {},
+        },
+    }
+
+
+def test_historical_review_rows_never_off_track_or_request_cf_review():
+    """Issue #6862: retired sealed-CF era rows (formal_review_jobs) must read
+    as history, never as attention-driving work. Terminal rows (failed /
+    complete / rejected, sealed or not) get neutral health, safe action NONE,
+    and are excluded from the actionable default view. No review row emits
+    REQUEST_CF_REVIEW, including the one still-open row (that ask belongs to
+    the PR row under the current direct ask-<lane> flow)."""
+    items = [
+        _review_item("failed"),
+        _review_item("rejected"),
+        _review_item("error"),
+        _review_item("complete", sealed=False),
+        _review_item("complete", sealed=True),
+        _review_item("completed", sealed=True),
+        _review_item("published", sealed=True),
+        _review_item("open", sealed=False),
+        _review_item("running"),
+        _review_item("queued"),
+        _review_item("pending"),
+    ]
+    # apply_health_and_actions mutates `items` in place (sets health/
+    # safe_next_action) and returns a stripped attention-list projection that
+    # drops lifecycle; assert against the mutated originals instead.
+    apply_health_and_actions(items, source_ok=True)
+    resolved = items
+
+    terminal_lifecycles = {
+        "failed",
+        "rejected",
+        "error",
+        "complete",
+        "completed",
+        "published",
+        "open",
+    }
+    in_flight_lifecycles = {"running", "queued", "pending"}
+
+    for item in resolved:
+        code = item["safe_next_action"]["code"]
+        assert code != "REQUEST_CF_REVIEW", item
+        if item["lifecycle"] in terminal_lifecycles:
+            assert item["health"] != "OFF_TRACK", item
+            assert code == "NONE", item
+            assert not _is_actionable(item), item
+        elif item["lifecycle"] in in_flight_lifecycles:
+            assert item["health"] == "AT_RISK"
+            assert code == "WAIT_REVIEW"
+
+    off_track_reviews = [i for i in resolved if i["health"] == "OFF_TRACK"]
+    request_cf_review_reviews = [
+        i for i in resolved if i["safe_next_action"]["code"] == "REQUEST_CF_REVIEW"
+    ]
+    assert off_track_reviews == []
+    assert request_cf_review_reviews == []
+    assert not any(_is_actionable(i) for i in resolved if i["lifecycle"] in terminal_lifecycles)
 
 
 def test_build_projection_joins_sources_deterministically():


### PR DESCRIPTION
## Summary
Fixes #6862. Terminal `formal_review_jobs` rows (the retired sealed-CF era dataset — operator decision 2026-08-07) were still driving board attention: `derive_health` mapped `failed/rejected/error` unconditionally to `OFF_TRACK`, and every terminal-or-unsealed review row fell through `derive_safe_next_action` to `REQUEST_CF_REVIEW`.

Live probe quoted on the issue (2026-08-16): `OFF_TRACK by kind: {issue: 1, review: 196}`, `REQUEST_CF_REVIEW by kind: {pr: 1, review: 198}` out of 498 review rows (`{complete: 301, failed: 196, open: 1}`).

## Semantic direction (binding, from the issue)
- Terminal review rows (failed/complete/rejected, sealed or not) → health neutral, safe action `NONE`, excluded from the actionable default view.
- No review row emits `REQUEST_CF_REVIEW` — that ask belongs to PR rows only under the current direct ask-`<lane>` flow.
- Rows stay queryable under `kind=review` for audit.

## Changes
- `scripts/work/attention.py::derive_health` — `kind=review`: only `running/queued/pending` stay `AT_RISK`; every other state (terminal, or the sole unsealed `open` row) reads `UNKNOWN`.
- `scripts/work/attention.py::derive_safe_next_action` — drop the `REQUEST_CF_REVIEW` fallback for review rows; retired-era rows get `NONE` (`formal_review_terminal_historical`).
- No dashboard change: `NONE` was already in `dashboards/work.html`'s `NON_ACTIONABLE_ACTION_CODES`, and non-`OFF_TRACK`/`AT_RISK` health already falls out of `isActionable()`.

## Tests
Added `test_historical_review_rows_never_off_track_or_request_cf_review` in `tests/test_work_contract.py`: fixture covering failed/rejected/error/complete(sealed+unsealed)/open/running/queued/pending review rows, asserting the new health/action codes and that no terminal row is actionable (mirrors the dashboard's `isActionable()` predicate in Python).

Mutation-checked (#M-16): reverting `scripts/work/attention.py` alone fails the new test on both the `OFF_TRACK` health assertion and the `REQUEST_CF_REVIEW` assertion.

```
tests/test_work_contract.py ...................................  [100%]  (35 passed)
tests/test_work_privacy.py tests/test_driver_work_api_onboarding.py tests/test_work_api.py — 19 passed
ruff check scripts/work/ tests/test_work_contract.py — All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
