### PR TITLE
fix(bridge): align inbox banner with live-pending store (#6864)

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -1881,30 +1881,106 @@ def pending_deliveries_for(agent: str) -> list[dict[str, Any]]:
         conn.close()
 
 
-def bridge_pending_summary(now: str | None = None) -> dict[str, dict[str, float | int]]:
-    """Return per-agent pending counts and oldest pending age in hours."""
-    current = _parse_iso(now) if now else datetime.now(UTC)
+def live_pending_by_agent(now: str | None = None) -> list[dict[str, Any]]:
+    """Return per-agent live pending counts (authority query for banner + show).
+
+    Counts only ``status='pending'`` rows that would *remain* after
+    ``expire_stale_deliveries`` — i.e. still within their effective TTL.
+    Read-only: never mutates rows. Shared by the CLI backlog banner and
+    ``inbox show`` so the two surfaces cannot disagree (#6864).
+    """
+    current = now or _now_iso()
     conn = get_db()
     try:
         rows = conn.execute(
-            """
-            SELECT d.to_agent, COUNT(*) AS count, MIN(cm.created_at) AS oldest_created_at
+            f"""
+            SELECT d.to_agent AS to_agent,
+                   COUNT(*) AS count,
+                   MIN(cm.created_at) AS oldest_created_at
             FROM deliveries d
             JOIN channel_messages cm ON cm.message_id = d.message_id
+            JOIN channels c ON c.name = cm.channel
             WHERE d.status = 'pending'
+              AND (
+                    julianday(:now) - julianday(cm.created_at)
+                  ) * 24.0 <= {_effective_ttl_hours_sql()}
             GROUP BY d.to_agent
             ORDER BY d.to_agent ASC
-            """
+            """,
+            {"now": current, "action_ttl": DEFAULT_ACTION_REQUIRED_TTL_HOURS},
         ).fetchall()
     finally:
         conn.close()
 
+    return [
+        {
+            "agent": str(row["to_agent"]),
+            "count": int(row["count"]),
+            "oldest_created_at": (
+                str(row["oldest_created_at"]) if row["oldest_created_at"] else None
+            ),
+        }
+        for row in rows
+        if row["oldest_created_at"]
+    ]
+
+
+def live_pending_for_agent(agent: str, now: str | None = None) -> dict[str, Any]:
+    """Return live pending count + oldest timestamp for one agent (#6864)."""
+    for row in live_pending_by_agent(now=now):
+        if row["agent"] == agent:
+            return row
+    return {"agent": agent, "count": 0, "oldest_created_at": None}
+
+
+def oldest_live_pending_preview(
+    agent: str, now: str | None = None
+) -> dict[str, Any] | None:
+    """Return channel/body preview for the oldest live pending delivery."""
+    current = now or _now_iso()
+    conn = get_db()
+    try:
+        row = conn.execute(
+            f"""
+            SELECT cm.channel, cm.thread_id, cm.from_agent, cm.body
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            JOIN channels c ON c.name = cm.channel
+            WHERE d.to_agent = :agent AND d.status = 'pending'
+              AND (
+                    julianday(:now) - julianday(cm.created_at)
+                  ) * 24.0 <= {_effective_ttl_hours_sql()}
+            ORDER BY cm.created_at ASC, d.delivery_id ASC
+            LIMIT 1
+            """,
+            {
+                "agent": agent,
+                "now": current,
+                "action_ttl": DEFAULT_ACTION_REQUIRED_TTL_HOURS,
+            },
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    body = str(row["body"]).replace("\n", " ").strip()
+    return {
+        "channel": str(row["channel"]),
+        "thread_id": str(row["thread_id"]),
+        "from_agent": str(row["from_agent"]),
+        "body": body[:60] + ("..." if len(body) > 60 else ""),
+    }
+
+
+def bridge_pending_summary(now: str | None = None) -> dict[str, dict[str, float | int]]:
+    """Return per-agent pending counts and oldest pending age in hours."""
+    current = _parse_iso(now) if now else datetime.now(UTC)
     summary: dict[str, dict[str, float | int]] = {}
-    for row in rows:
+    for row in live_pending_by_agent(now=current.isoformat()):
         oldest = row["oldest_created_at"]
         if not oldest:
             continue
-        summary[str(row["to_agent"])] = {
+        summary[row["agent"]] = {
             "count": int(row["count"]),
             "oldest_hours": round(_age_hours(str(oldest), now=current), 1),
         }

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -807,25 +807,24 @@ def _print_inbox_run_summary(summary: Any, *, duration_s: float) -> None:
 
 
 def _query_inbox_show(agent: str) -> dict[str, Any]:
-    """Return read-only inbox status details for one agent."""
+    """Return inbox status details for one agent.
+
+    Pending counts use the same live-pending authority query as the
+    backlog banner (#6864). TTL-elapsed rows are expired first so the
+    janitor side effect still runs on show; the count itself is the
+    post-TTL live set either way.
+    """
     from ._db import get_db
 
     _channels.expire_stale_deliveries()
 
     now = _now_utc()
     failed_cutoff = (now - timedelta(hours=24)).isoformat()
+    live = _channels.live_pending_for_agent(agent, now=now.isoformat())
+    preview = _channels.oldest_live_pending_preview(agent, now=now.isoformat())
 
     conn = get_db()
     try:
-        pending = conn.execute(
-            """
-            SELECT COUNT(*) AS count, MIN(cm.created_at) AS oldest_created_at
-            FROM deliveries d
-            JOIN channel_messages cm ON cm.message_id = d.message_id
-            WHERE d.to_agent = ? AND d.status = 'pending'
-            """,
-            (agent,),
-        ).fetchone()
         processing = conn.execute(
             """
             SELECT COUNT(*) AS count, MIN(d.lease_until) AS lease_until
@@ -845,37 +844,12 @@ def _query_inbox_show(agent: str) -> dict[str, Any]:
             """,
             (agent, failed_cutoff),
         ).fetchone()
-        oldest = conn.execute(
-            """
-            SELECT cm.channel, cm.thread_id, cm.from_agent, cm.body
-            FROM deliveries d
-            JOIN channel_messages cm ON cm.message_id = d.message_id
-            WHERE d.to_agent = ? AND d.status = 'pending'
-            ORDER BY cm.created_at ASC, d.delivery_id ASC
-            LIMIT 1
-            """,
-            (agent,),
-        ).fetchone()
     finally:
         conn.close()
 
-    preview = None
-    if oldest is not None:
-        body = str(oldest["body"]).replace("\n", " ").strip()
-        preview = {
-            "channel": str(oldest["channel"]),
-            "thread_id": str(oldest["thread_id"]),
-            "from_agent": str(oldest["from_agent"]),
-            "body": body[:60] + ("..." if len(body) > 60 else ""),
-        }
-
     return {
-        "pending_count": int(pending["count"]) if pending else 0,
-        "oldest_created_at": (
-            str(pending["oldest_created_at"])
-            if pending and pending["oldest_created_at"]
-            else None
-        ),
+        "pending_count": int(live["count"]),
+        "oldest_created_at": live["oldest_created_at"],
         "processing_count": int(processing["count"]) if processing else 0,
         "processing_lease_until": (
             str(processing["lease_until"])
@@ -888,55 +862,43 @@ def _query_inbox_show(agent: str) -> dict[str, Any]:
 
 
 def _pending_backlog_rows() -> list[dict[str, Any]]:
-    """Return pending-delivery backlog rows used for the warning banner.
+    """Return live pending-delivery backlog rows for the warning banner.
 
-    Dead lanes (e.g. retired ``gemini`` → ``agy``) are excluded: they never
-    get drained by ``ab inbox run``, and nagging every CLI invocation is
-    pure noise (#5113). Expire them via ``ab cleanup --expire`` instead.
+    Uses the same authority query as ``inbox show``
+    (``_channels.live_pending_by_agent``): only within-TTL ``pending``
+    rows. Dead lanes are excluded (#5113) — expire them via
+    ``cleanup --expire`` instead of nagging every CLI invocation.
     """
-    from ._db import get_db
-
     dead = _channels.dead_lane_agents()
-    conn = get_db()
-    try:
-        rows = conn.execute(
-            """
-            SELECT d.to_agent, COUNT(*) AS count, MIN(cm.created_at) AS oldest_created_at
-            FROM deliveries d
-            JOIN channel_messages cm ON cm.message_id = d.message_id
-            WHERE d.status = 'pending'
-            GROUP BY d.to_agent
-            ORDER BY d.to_agent ASC
-            """
-        ).fetchall()
-    finally:
-        conn.close()
-
     return [
         {
-            "agent": str(row["to_agent"]),
+            "agent": row["agent"],
             "count": int(row["count"]),
             "oldest_created_at": str(row["oldest_created_at"]),
         }
-        for row in rows
-        if row["oldest_created_at"] and str(row["to_agent"]) not in dead
+        for row in _channels.live_pending_by_agent()
+        if row["oldest_created_at"] and row["agent"] not in dead
     ]
 
 
 def _maybe_print_backlog_warnings() -> None:
     """Emit one stderr warning per *live* agent with stale pending deliveries.
 
-    Intentionally read-only — see ``run_delivery_expiry_cleanup`` (``ab
-    cleanup --expire``) and the Monitor API server's periodic sweep
+    Intentionally read-only — see ``run_delivery_expiry_cleanup``
+    (``cleanup --expire``) and the Monitor API server's periodic sweep
     (``scripts/api/comms_router.py``) for where the TTL policy actually
     mutates rows (#4837 item 4). This function only warns; a print-a-
     warning helper mutating the DB on every single CLI invocation —
-    including e.g. ``ab cleanup --dry-run`` — would be a surprising,
+    including e.g. ``cleanup --dry-run`` — would be a surprising,
     hard-to-predict side effect and would break dry-run's no-mutation
     contract.
 
+    Counts match ``inbox show`` via ``live_pending_by_agent`` (#6864).
+    The hint names the live driver-session drain (drive-epic §0a); never
+    recommend the retired ``inbox run`` path or the bare ``ab`` alias.
+
     Dead-lane queues are never warned here (#5113); run
-    ``ab cleanup --expire`` (or the Monitor sweep) to bulk-expire them.
+    ``cleanup --expire`` (or the Monitor sweep) to bulk-expire them.
     """
     threshold = timedelta(hours=_parse_backlog_warn_hours())
     now = _now_utc()
@@ -946,7 +908,8 @@ def _maybe_print_backlog_warnings() -> None:
         age = _format_age(row["oldest_created_at"], now=now)
         print(
             f"⚠️  {row['agent']} has {row['count']} pending deliveries "
-            f"(oldest {age}). Run 'ab inbox run {row['agent']}' to drain.",
+            f"(oldest {age}). Drain in the live driver session "
+            f"(drive-epic §0a).",
             file=sys.stderr,
         )
 

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -504,7 +504,14 @@ def test_backlog_banner_triggers_for_old_pending_delivery(monkeypatch, capsys):
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "⚠️  codex has 1 pending deliveries (oldest 6h12m)." in captured.err
-    assert "Run 'ab inbox run codex' to drain." in captured.err
+    assert "Drain in the live driver session (drive-epic §0a)." in captured.err
+    # #6864: never recommend retired inbox run or bare `ab` alias
+    assert "inbox run" not in captured.err
+    assert " ab " not in f" {captured.err} "
+    assert not any(
+        token == "ab" or token.startswith("ab ")
+        for token in captured.err.replace(".", " ").split()
+    )
 
 
 def test_backlog_banner_does_not_trigger_for_fresh_pending_delivery(monkeypatch, capsys):
@@ -516,6 +523,51 @@ def test_backlog_banner_does_not_trigger_for_fresh_pending_delivery(monkeypatch,
     assert exit_code == 0
     captured = capsys.readouterr()
     assert captured.err == ""
+
+
+def test_backlog_banner_count_matches_inbox_show_excluding_ttl_elapsed(
+    monkeypatch, capsys
+):
+    """#6864: banner live-pending count equals inbox show (not raw pending).
+
+    Seed one within-TTL pending + one past channel TTL. Banner must report
+    only the live row (1), matching inbox show after expire, not the raw
+    pending total (2).
+    """
+    monkeypatch.setenv("AB_BACKLOG_WARN_HOURS", "2")
+    _channels.create_channel("topic", description="ttl fixture")
+    _channels.set_channel_ttl("topic", 24)
+
+    live = _channels.post(
+        "topic", "user", "still live", to_agents=["codex"], auto_snapshot=False
+    )
+    stale = _channels.post(
+        "topic", "user", "past ttl", to_agents=["codex"], auto_snapshot=False
+    )
+    live_ts = (datetime.now(UTC) - timedelta(hours=6, minutes=12)).isoformat()
+    stale_ts = (datetime.now(UTC) - timedelta(hours=30)).isoformat()
+    _set_message_created_at(str(live["message_id"]), live_ts)
+    _set_message_created_at(str(stale["message_id"]), stale_ts)
+
+    # Authority query (shared) already excludes TTL-elapsed before show mutates.
+    live_rows = {
+        row["agent"]: row for row in _channels.live_pending_by_agent()
+    }
+    assert live_rows["codex"]["count"] == 1
+
+    exit_code = _run_cli(["inbox", "show", "codex"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "⚠️  codex has 1 pending deliveries (oldest 6h12m)." in captured.err
+    assert "pending:    1 (oldest 6h12m ago)" in captured.out
+    assert "inbox run" not in captured.err
+    assert "ab inbox" not in captured.err
+    # Stale row expired by show janitor; live row remains pending.
+    statuses = {
+        row["body"]: row["status"] for row in _delivery_statuses() if row["to_agent"] == "codex"
+    }
+    assert statuses["still live"] == "pending"
+    assert statuses["past ttl"] == "expired"
 
 
 def test_post_model_flag_stores_delivery_target_model(capsys):

--- a/tests/test_reply_sidecar.py
+++ b/tests/test_reply_sidecar.py
@@ -182,7 +182,8 @@ def test_pending_backlog_skips_dead_lane(monkeypatch):
         def close(self):
             return None
 
-    with patch("scripts.ai_agent_bridge._db.get_db", return_value=_Conn()):
+    # live_pending_by_agent binds get_db on the _channels module (#6864).
+    with patch("scripts.ai_agent_bridge._channels.get_db", return_value=_Conn()):
         rows = _channels_cli._pending_backlog_rows()
     agents = {r["agent"] for r in rows}
     assert "gemini" not in agents


### PR DESCRIPTION
## Summary

Fixes #6864 — the legacy inbox backlog banner reported a wrong pending count, ever-growing age, and a retired `ab inbox run` drain hint.

**Root cause:** the banner counted *all* `pending` deliveries, while `inbox show` runs `expire_stale_deliveries()` first and then counts. On one invocation that printed e.g. 20 then showed 8; ages kept growing on TTL-elapsed rows the banner still counted.

**Fix:**
- Shared authority query `live_pending_by_agent` / `live_pending_for_agent` — within-TTL pending only (same set show would report after expire), used by both banner and show
- Banner hint: drain in the live driver session (drive-epic §0a); no retired `inbox run`, no bare `ab`
- Operational: expired 8 live `test-*` harness pending deliveries for grok-infra via `mark_delivery(..., "expired")` so test traffic stops aging into scary numbers

## Test plan

- [x] `pytest` banner / live-pending fixtures:
  - `test_backlog_banner_triggers_for_old_pending_delivery`
  - `test_backlog_banner_count_matches_inbox_show_excluding_ttl_elapsed` (mutation: seed 1 live + 1 past-TTL → both surfaces report 1)
  - related pending/expire bridge tests (21 passed)
- [x] ruff clean on touched files
- [x] live: `inbox show grok-infra` pending 0; no grok-infra banner on `channel list`

## Residual

- Fleet-comms `authority_deliveries` backlog for other agents is a separate surface (`fleet_comms backlog`); this PR only fixes the legacy channel-delivery banner that `ai_agent_bridge` prints.
- No auto-merge (dispatch instruction).