### PR TITLE
feat(runtime): mid-dispatch primary-tree write tripwire for the agy escape class (#6818)

### DIFF
--- a/scripts/agent_runtime/primary_tree_watch.py
+++ b/scripts/agent_runtime/primary_tree_watch.py
@@ -1,0 +1,319 @@
+"""Mid-dispatch primary-checkout tracked-write detector (#6818).
+
+The spawn-time guard (``runner._ensure_write_cwd_isolated``, #4444/#4446)
+proves a write-capable child STARTS in an isolated dispatch worktree, but has
+no visibility afterwards. #6818's recurrence showed why that matters: during
+dispatch ``work-6849-projection-health`` the agy harness executed
+model-supplied absolute paths that resolved to the PRIMARY checkout —
+``replace_file_content`` wrote the primary's ``scripts/api/fleet_router.py``
+mid-run, then the worker itself reverted it minutes later. The escape window
+was invisible to every existing probe: the post-exit integrity sweep only
+alerts on detachment, and the transient dirty state had self-corrected by
+finalize time.
+
+Per the #5803 design-panel conclusion ("git-layer enforcement against a
+same-UID process is categorically impossible"), this module is **detection +
+attribution, not prevention**:
+
+- BASELINE: at spawn, snapshot the primary checkout's tracked-dirty path set
+  (``git status --porcelain -uno``) so a human already working in the primary
+  never produces a false alert.
+- DETECT: while the child runs (and once after it exits), re-probe and diff.
+  Any tracked path that went dirty AFTER the baseline, while a write-capable
+  dispatch child is running, is recorded.
+- RECORD: append a ``primary_tree_write_during_dispatch`` event to the same
+  attribution JSONL the primary-integrity watchdog uses
+  (``<primary>/data/telemetry/primary-integrity/events.jsonl``) with the
+  agent, task id, and offending paths — enough to attribute the writer even
+  when the dirty state later self-corrects.
+- ENFORCE (operator-gated, default OFF): ``LU_PRIMARY_TREE_WATCH_ENFORCE=1``
+  lets the runner kill the child on detection. Enabling it is an operator
+  decision on #6818, not a default — untracked new files at the repo root are
+  already covered by the #6866 root-entry canary, and a kill mid-write can
+  strand worse states than the write itself.
+
+Untracked files are intentionally out of scope (``-uno``): this watch is for
+tracked-file writes, the probe must stay cheap enough to run inside the
+runner's 1s poll loop (throttled to ``LU_PRIMARY_TREE_WATCH_INTERVAL_S``,
+default 20s), and the untracked class has its own canary (#6866).
+
+Every failure path is fail-open: a broken probe disables the watch, never the
+dispatch.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Dual-flavor import, same rationale as runner._load_worktree_containment:
+# ``scripts.*`` resolves under pytest/module runs; the delegate worker puts
+# only ``scripts/`` on sys.path.
+try:
+    from scripts.common.git_context import sanitized_git_env
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.git_context import sanitized_git_env  # type: ignore[no-redef]
+
+_logger = logging.getLogger(__name__)
+
+# Must stay equal to runner._WRITE_CAPABLE_MODES; a drift tripwire test pins
+# the two sets together (tests/test_primary_tree_watch.py).
+WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+
+_INTERVAL_ENV = "LU_PRIMARY_TREE_WATCH_INTERVAL_S"
+_ENFORCE_ENV = "LU_PRIMARY_TREE_WATCH_ENFORCE"
+_DEFAULT_INTERVAL_S = 20.0
+# Consecutive probe failures before the watch disables itself (fail-open
+# without log spam on a persistently broken primary).
+_MAX_PROBE_FAILURES = 3
+
+EVENT_NAME = "primary_tree_write_during_dispatch"
+
+
+def _interval_from_env() -> float:
+    raw = os.environ.get(_INTERVAL_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_S
+    try:
+        return float(raw)
+    except ValueError:
+        return _DEFAULT_INTERVAL_S
+
+
+def _load_containment():
+    for candidate in ("scripts.guardrails.worktree_containment", "guardrails.worktree_containment"):
+        try:
+            import importlib
+
+            return importlib.import_module(candidate)
+        except ImportError:
+            continue
+    return None
+
+
+def _tracked_dirty_paths(main_root: Path) -> set[str] | None:
+    """Tracked paths currently dirty in ``main_root``; None if unprobeable.
+
+    ``-uno`` skips untracked files entirely — cheap, and untracked pollution
+    is the #6866 canary's job. Rename/copy entries carry a second NUL token
+    (the source path); the destination token is sufficient for attribution.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(main_root), "status", "--porcelain=v1", "-z", "-uno"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=sanitized_git_env(),
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    paths: set[str] = set()
+    parts = proc.stdout.split("\0")
+    index = 0
+    while index < len(parts):
+        raw = parts[index]
+        index += 1
+        if not raw:
+            continue
+        xy = raw[:2]
+        path = raw[3:] if len(raw) > 3 else ""
+        if path:
+            paths.add(path)
+        if xy[:1] in {"R", "C"} or xy[1:2] in {"R", "C"}:
+            index += 1
+    return paths
+
+
+class PrimaryTreeWatch:
+    """Watches the primary checkout for tracked writes during one dispatch."""
+
+    def __init__(
+        self,
+        *,
+        main_root: Path,
+        baseline: set[str],
+        agent_name: str,
+        mode: str,
+        task_id: str | None,
+        worktree: Path,
+        interval_s: float,
+        event_sink: Callable[..., None] | None,
+        state_dir: Path | None = None,
+    ) -> None:
+        self.main_root = main_root
+        self.baseline = baseline
+        self.agent_name = agent_name
+        self.mode = mode
+        self.task_id = task_id
+        self.worktree = worktree
+        self.interval_s = interval_s
+        self.event_sink = event_sink
+        # Same location the primary-integrity watchdog records to, so one
+        # events.jsonl carries the full escape-class forensic trail.
+        self.state_dir = state_dir or (main_root / "data" / "telemetry" / "primary-integrity")
+        self._reported: set[str] = set()
+        self._next_check = time.monotonic() + interval_s
+        self._probe_failures = 0
+
+    # ------------------------------------------------------------------
+    # construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        cwd: Path,
+        mode: str,
+        agent_name: str,
+        task_id: str | None,
+        event_sink: Callable[..., None] | None,
+        repo_tree: Path,
+        interval_s: float | None = None,
+        state_dir: Path | None = None,
+    ) -> PrimaryTreeWatch | None:
+        """Build a watch for one spawn, or None when not applicable.
+
+        Applicable only to write-capable spawns whose cwd is a dispatch
+        worktree of ``repo_tree``'s repository. Never raises: any resolution
+        or probe failure returns None (fail-open — the watch is a tripwire,
+        not a gate; the spawn-time guard already did the fail-closed part).
+        """
+        try:
+            if mode not in WRITE_CAPABLE_MODES:
+                return None
+            interval = _interval_from_env() if interval_s is None else interval_s
+            if interval <= 0:
+                return None
+            wc = _load_containment()
+            if wc is None:
+                return None
+            resolved = wc.canonicalize(cwd)
+            # Same cheap pre-filter as the spawn-time guard: only a cwd inside
+            # this checkout's own tree can be one of its dispatch worktrees.
+            if not resolved.is_relative_to(wc.canonicalize(repo_tree)):
+                return None
+            if wc.classify_repo_path(resolved, cwd=resolved) != "dispatch_worktree":
+                return None
+            main_root = wc.resolve_main_root(resolved)
+            baseline = _tracked_dirty_paths(main_root)
+            if baseline is None:
+                return None
+            return cls(
+                main_root=main_root,
+                baseline=baseline,
+                agent_name=agent_name,
+                mode=mode,
+                task_id=task_id,
+                worktree=resolved,
+                interval_s=interval,
+                event_sink=event_sink,
+                state_dir=state_dir,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "primary-tree watch unavailable for %s (%s: %s) — dispatch continues unwatched",
+                agent_name,
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # probing
+    # ------------------------------------------------------------------
+
+    @property
+    def enforce(self) -> bool:
+        """Operator-gated kill switch (#6818 decision list). Default OFF."""
+        return os.environ.get(_ENFORCE_ENV, "").strip() == "1"
+
+    def maybe_check(self, *, force: bool = False) -> list[str]:
+        """Probe (throttled) and return newly-escaped tracked paths.
+
+        Returns only paths not in the spawn baseline and not yet reported this
+        dispatch, so each escape is recorded exactly once. Never raises.
+        """
+        try:
+            now = time.monotonic()
+            if not force and now < self._next_check:
+                return []
+            self._next_check = now + self.interval_s
+            if self._probe_failures >= _MAX_PROBE_FAILURES:
+                return []
+            current = _tracked_dirty_paths(self.main_root)
+            if current is None:
+                self._probe_failures += 1
+                if self._probe_failures == _MAX_PROBE_FAILURES:
+                    _logger.warning(
+                        "primary-tree watch: %d consecutive probe failures on %s — watch disabled for this dispatch",
+                        self._probe_failures,
+                        self.main_root,
+                    )
+                return []
+            self._probe_failures = 0
+            new_paths = sorted(current - self.baseline - self._reported)
+            if not new_paths:
+                return []
+            self._reported.update(new_paths)
+            self._record(new_paths)
+            return new_paths
+        except Exception as exc:  # pragma: no cover - defensive fail-open
+            _logger.warning(
+                "primary-tree watch check failed (%s: %s)", type(exc).__name__, exc
+            )
+            return []
+
+    def final_check(self) -> list[str]:
+        """One unthrottled probe after the child exits (last-interval writes)."""
+        return self.maybe_check(force=True)
+
+    # ------------------------------------------------------------------
+    # recording
+    # ------------------------------------------------------------------
+
+    def _record(self, new_paths: list[str]) -> None:
+        fields = {
+            "agent": self.agent_name,
+            "task_id": self.task_id,
+            "mode": self.mode,
+            "worktree": str(self.worktree),
+            "main_root": str(self.main_root),
+            "paths": new_paths,
+            "baseline_dirty_count": len(self.baseline),
+            "enforce": self.enforce,
+        }
+        _logger.error(
+            "PRIMARY-TREE WRITE DURING DISPATCH: agent=%s task=%s wrote tracked "
+            "primary path(s) %s while its worktree is %s — recorded to %s (#6818)",
+            self.agent_name,
+            self.task_id,
+            ", ".join(new_paths),
+            self.worktree,
+            self.state_dir / "events.jsonl",
+        )
+        payload = {"ts": datetime.now(UTC).isoformat(), "event": EVENT_NAME, **fields}
+        try:
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            with open(self.state_dir / "events.jsonl", "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+        except OSError as exc:
+            _logger.warning(
+                "primary-tree watch: failed to append event (%s: %s)",
+                type(exc).__name__,
+                exc,
+            )
+        if self.event_sink is not None:
+            with contextlib.suppress(Exception):
+                self.event_sink(EVENT_NAME, **fields)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -91,6 +91,7 @@ from .failover import (
     substitution_for_route,
     tool_config_with_route,
 )
+from .primary_tree_watch import PrimaryTreeWatch
 from .registry import AGENTS, get_agent_entry
 from .result import ParseResult, Result
 from .telemetry import InvocationTelemetry, resolve_invocation_telemetry
@@ -164,6 +165,7 @@ _SAFE_ACP_FAILURE_CODES = frozenset(
         "acp_turn_limit",
         "github_secondary_rate_limited",
         "adapter_refused",
+        "primary_tree_write",
         "protocol_output_limit",
         "provider_unavailable",
         "rate_limited",
@@ -197,6 +199,23 @@ class AgentOutputLimitError(AgentRuntimeError):
         super().__init__(
             f"{agent} exceeded streamed_output_limit={limit_bytes} bytes "
             f"(observed={observed_bytes})"
+        )
+
+
+class PrimaryTreeWriteError(AgentRuntimeError):
+    """A dispatch child wrote tracked files in the protected primary checkout.
+
+    Raised only when the operator-gated enforcement switch
+    (``LU_PRIMARY_TREE_WATCH_ENFORCE=1``) is on; the default posture is
+    detect + record without killing (#6818).
+    """
+
+    def __init__(self, agent: str, paths: list[str]):
+        self.agent = agent
+        self.paths = list(paths)
+        super().__init__(
+            f"{agent} wrote tracked primary-checkout path(s) during dispatch: "
+            f"{', '.join(self.paths)} (#6818)"
         )
 
 
@@ -987,6 +1006,9 @@ class _ExecutionOutcome:
     isolation_capability_digest: str | None = None
     isolation_prompt_digest: str | None = None
     isolation_prompt_transport: str | None = None
+    # Tracked primary-checkout paths the child dirtied mid-dispatch (#6818);
+    # empty unless the PrimaryTreeWatch tripwire fired.
+    escaped_primary_paths: tuple[str, ...] = ()
 
 
 @dataclass
@@ -1332,6 +1354,20 @@ def _execute_invocation_plan(
     streamed_output_bytes = 0
     fleet_capture: FleetCapture | None = None
     kill_reason: str | None = None
+    escaped_primary: list[str] = []
+    # Mid-dispatch primary-tree tripwire (#6818): the spawn-time guard above
+    # proved cwd isolation, but a child can still resolve absolute paths into
+    # the primary checkout while running (the agy escape class). Baseline is
+    # taken BEFORE the spawn so nothing the child does hides in it. None when
+    # not applicable (read-only, non-dispatch cwd) — always fail-open.
+    tree_watch = PrimaryTreeWatch.start(
+        cwd=review_cwd,
+        mode=mode,
+        agent_name=agent_name,
+        task_id=task_id,
+        event_sink=event_sink,
+        repo_tree=_RUNNER_REPO_TREE,
+    )
 
     try:
         try:
@@ -1498,9 +1534,25 @@ def _execute_invocation_plan(
                     break
                 _kill_process_tree(proc)
                 break
+
+            if tree_watch is not None:
+                escaped_primary.extend(tree_watch.maybe_check())
+                if escaped_primary and tree_watch.enforce:
+                    kill_reason = "primary_tree_write"
+                    returncode = proc.poll()
+                    if returncode is None:
+                        _kill_process_tree(proc)
+                    break
+
             time.sleep(_POLL_INTERVAL_S)
 
         duration_s = time.monotonic() - start_time
+        if tree_watch is not None:
+            # Unthrottled sweep now that the child is done: catches writes from
+            # the last poll interval and fast exits that beat the first check.
+            # (final_check dedupes, so the finally-block safety call is a no-op
+            # after this.)
+            escaped_primary.extend(tree_watch.final_check())
         assert watchdog_state is not None
 
         # ``poll()`` is the authoritative completion observation.  Most
@@ -1603,11 +1655,19 @@ def _execute_invocation_plan(
             isolation_capability_digest=isolation_capability_digest,
             isolation_prompt_digest=isolation_prompt_digest,
             isolation_prompt_transport=isolation_prompt_transport,
+            escaped_primary_paths=tuple(escaped_primary),
         )
     finally:
         if proc is not None and proc.poll() is None:
             with contextlib.suppress(Exception):
                 _kill_process_tree(proc)
+
+        # Post-exit sweep for the tripwire (#6818): catches a write landed
+        # inside the last poll interval, and the common fast-exit case where
+        # the child finished before the first throttled check ever ran.
+        if tree_watch is not None:
+            with contextlib.suppress(Exception):
+                tree_watch.final_check()
 
         if fleet_capture is not None:
             actual_model, route_metadata = resolved_route(
@@ -1713,6 +1773,36 @@ def _raise_for_kill_reason(
         )
         write_record(record)
         raise AgentOutputLimitError(agent_name, limit_bytes, observed_bytes)
+    if kill_reason == "primary_tree_write":
+        # Operator-gated enforcement fired (#6818): the child wrote tracked
+        # primary-checkout files mid-dispatch. Paths were already recorded to
+        # the primary-integrity events JSONL by PrimaryTreeWatch._record.
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            duration_s=execution.duration_s,
+            input_chars=len(prompt),
+            output_chars=len(execution.stdout_text),
+            returncode=execution.returncode,
+            outcome="error",
+            rate_limited=False,
+            stalled=False,
+            stderr_excerpt=(
+                "primary_tree_write: child wrote tracked primary-checkout "
+                f"files during dispatch ({', '.join(execution.escaped_primary_paths)}); "
+                "see data/telemetry/primary-integrity/events.jsonl (#6818)"
+            )[:500],
+            tokens=None,
+            substitution=record_substitution,
+            failure_code="primary_tree_write",
+        )
+        write_record(record)
+        raise PrimaryTreeWriteError(agent_name, list(execution.escaped_primary_paths))
     if kill_reason == "stdout_silence_timeout":
         record = _build_usage_record(
             agent=agent_name,

--- a/tests/test_primary_tree_watch.py
+++ b/tests/test_primary_tree_watch.py
@@ -1,0 +1,428 @@
+"""Guard tests for the mid-dispatch primary-tree tripwire (#6818).
+
+The agy escape class: a write-capable dispatch child starts in an isolated
+worktree (passing the spawn-time #4444 guard) and then resolves absolute paths
+into the PRIMARY checkout while running. These tests build a real primary
+repo + registered dispatch worktree and prove the watch detects a tracked
+primary write DURING the dispatch, records attribution, and (only when the
+operator gate is on) kills the child.
+
+Mutation contract (#M-16): neutering detection — e.g. making
+``PrimaryTreeWatch.maybe_check`` return ``[]`` or dropping the runner loop
+wiring — must fail ``test_end_to_end_runner_detects_primary_write`` and
+``test_detects_new_tracked_write``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime import primary_tree_watch as ptw
+from agent_runtime import runner as runner_mod
+from agent_runtime.primary_tree_watch import PrimaryTreeWatch
+from agent_runtime.result import ParseResult
+from agent_runtime.runner import (
+    PrimaryTreeWriteError,
+    _execute_invocation_plan,
+    _raise_for_kill_reason,
+)
+
+_GIT_SCRUB = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG_GLOBAL",
+}
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_SCRUB}
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> SimpleNamespace:
+    """Primary checkout on main + a registered dispatch worktree."""
+    main = tmp_path / "main"
+    main.mkdir()
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_SCRUB}
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(main)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    _git(main, "config", "user.email", "t@example.com")
+    _git(main, "config", "user.name", "T")
+    (main / ".gitignore").write_text(".worktrees/\n")
+    (main / "tracked.txt").write_text("original\n")
+    (main / "pkg").mkdir()
+    (main / "pkg" / "module.py").write_text("x = 1\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-q", "-m", "init")
+    dispatch_wt = main / ".worktrees" / "dispatch" / "agy" / "task-1"
+    _git(main, "worktree", "add", "-q", "-b", "agy/task-1", str(dispatch_wt))
+    return SimpleNamespace(main=main.resolve(), dispatch_wt=dispatch_wt.resolve())
+
+
+def _start(repo, **overrides) -> PrimaryTreeWatch | None:
+    kwargs = dict(
+        cwd=repo.dispatch_wt,
+        mode="workspace-write",
+        agent_name="agy",
+        task_id="task-1",
+        event_sink=None,
+        repo_tree=repo.main,
+        interval_s=0.01,
+    )
+    kwargs.update(overrides)
+    return PrimaryTreeWatch.start(**kwargs)
+
+
+def _events(repo) -> list[dict]:
+    path = repo.main / "data" / "telemetry" / "primary-integrity" / "events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# applicability
+# ---------------------------------------------------------------------------
+
+
+def test_mode_sets_do_not_drift():
+    # The watch and the spawn-time guard must agree on what "write-capable" is.
+    assert ptw.WRITE_CAPABLE_MODES == runner_mod._WRITE_CAPABLE_MODES
+
+
+def test_start_returns_none_for_read_only_mode(repo):
+    assert _start(repo, mode="read-only") is None
+
+
+def test_start_returns_none_for_primary_checkout_cwd(repo):
+    # The spawn-time guard refuses this spawn anyway; the watch must not
+    # double-report a cwd that is itself the primary.
+    assert _start(repo, cwd=repo.main) is None
+
+
+def test_start_returns_none_outside_repo_tree(repo, tmp_path):
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    assert _start(repo, cwd=outside) is None
+
+
+def test_start_returns_none_when_disabled_by_interval(repo):
+    assert _start(repo, interval_s=0) is None
+
+
+def test_start_builds_watch_for_dispatch_worktree(repo):
+    watch = _start(repo)
+    assert watch is not None
+    assert watch.main_root == repo.main
+    assert watch.baseline == set()
+
+
+# ---------------------------------------------------------------------------
+# detection
+# ---------------------------------------------------------------------------
+
+
+def test_no_writes_no_events(repo):
+    watch = _start(repo)
+    assert watch.maybe_check(force=True) == []
+    assert _events(repo) == []
+
+
+def test_detects_new_tracked_write(repo):
+    watch = _start(repo)
+    (repo.main / "tracked.txt").write_text("ESCAPED\n")
+    assert watch.maybe_check(force=True) == ["tracked.txt"]
+    events = _events(repo)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == ptw.EVENT_NAME
+    assert event["agent"] == "agy"
+    assert event["task_id"] == "task-1"
+    assert event["paths"] == ["tracked.txt"]
+    assert event["worktree"] == str(repo.dispatch_wt)
+    # Reported exactly once: the same escape never duplicates.
+    assert watch.maybe_check(force=True) == []
+    assert len(_events(repo)) == 1
+
+
+def test_baseline_dirty_paths_are_not_reported(repo):
+    # A human already mid-edit in the primary is baseline, not an escape.
+    (repo.main / "tracked.txt").write_text("human edit\n")
+    watch = _start(repo)
+    assert watch.baseline == {"tracked.txt"}
+    assert watch.maybe_check(force=True) == []
+    # A DIFFERENT tracked file going dirty afterwards still fires.
+    (repo.main / "pkg" / "module.py").write_text("x = 2\n")
+    assert watch.maybe_check(force=True) == ["pkg/module.py"]
+
+
+def test_untracked_files_are_out_of_scope(repo):
+    # Untracked pollution belongs to the #6866 root-entry canary; this watch
+    # stays cheap with -uno.
+    watch = _start(repo)
+    (repo.main / "junk.tmp").write_text("junk\n")
+    assert watch.maybe_check(force=True) == []
+
+
+def test_worktree_writes_are_not_reported(repo):
+    watch = _start(repo)
+    (repo.dispatch_wt / "tracked.txt").write_text("legit worker edit\n")
+    assert watch.maybe_check(force=True) == []
+
+
+def test_throttle_skips_until_interval_and_force_bypasses(repo):
+    watch = _start(repo, interval_s=3600)
+    (repo.main / "tracked.txt").write_text("ESCAPED\n")
+    # Non-forced check inside the interval: no probe yet.
+    assert watch.maybe_check() == []
+    assert _events(repo) == []
+    # Forced probe (the post-exit sweep) sees it.
+    assert watch.maybe_check(force=True) == ["tracked.txt"]
+
+
+def test_event_sink_receives_the_event(repo):
+    seen: list[tuple[str, dict]] = []
+    watch = _start(repo, event_sink=lambda name, **fields: seen.append((name, fields)))
+    (repo.main / "tracked.txt").write_text("ESCAPED\n")
+    watch.maybe_check(force=True)
+    assert len(seen) == 1
+    name, fields = seen[0]
+    assert name == ptw.EVENT_NAME
+    assert fields["paths"] == ["tracked.txt"]
+
+
+def test_probe_failures_fail_open_and_self_disable(repo, monkeypatch):
+    watch = _start(repo)
+    monkeypatch.setattr(ptw, "_tracked_dirty_paths", lambda _root: None)
+    for _ in range(5):
+        assert watch.maybe_check(force=True) == []
+    # Self-disabled after repeated failures: even a real escape stays silent
+    # rather than crashing the dispatch (fail-open by design).
+    assert watch._probe_failures == ptw._MAX_PROBE_FAILURES
+
+
+def test_enforce_gate_defaults_off(repo, monkeypatch):
+    monkeypatch.delenv("LU_PRIMARY_TREE_WATCH_ENFORCE", raising=False)
+    watch = _start(repo)
+    assert watch.enforce is False
+    monkeypatch.setenv("LU_PRIMARY_TREE_WATCH_ENFORCE", "1")
+    assert watch.enforce is True
+
+
+# ---------------------------------------------------------------------------
+# runner wiring
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Plan:
+    cmd: list[str]
+    cwd: Path
+    stdin_payload: str = ""
+    output_file: Path | None = None
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    env_unsets: tuple[str, ...] = ()
+    liveness_paths: tuple[Path, ...] = ()
+
+
+class _Adapter:
+    def liveness_signal_paths(self, _plan: _Plan) -> tuple[Path, ...]:
+        return ()
+
+    def parse_response(self, *, stdout: str, **_kwargs: object) -> ParseResult:
+        return ParseResult(ok=True, response=stdout)
+
+
+def _run_plan(plan: _Plan, *, mode: str = "workspace-write", task_id: str = "task-1"):
+    return _execute_invocation_plan(
+        agent_name="agy",
+        adapter=_Adapter(),
+        plan=plan,
+        prompt="tripwire test",
+        mode=mode,
+        cwd=plan.cwd,
+        model="test-model",
+        task_id=task_id,
+        session_id=None,
+        entrypoint="runtime-test",
+        hard_timeout=30,
+        stall_timeout=30,
+    )
+
+
+def _disable_fleet_capture(monkeypatch):
+    monkeypatch.setattr(
+        runner_mod.FleetCapture,
+        "start",
+        classmethod(lambda cls, **_kw: (_ for _ in ()).throw(RuntimeError("off"))),
+    )
+
+
+def test_runner_starts_watch_and_final_checks(monkeypatch, tmp_path):
+    calls = SimpleNamespace(start_kwargs=None, final_checks=0)
+
+    class _StubWatch:
+        enforce = False
+
+        def maybe_check(self, *, force: bool = False):
+            return []
+
+        def final_check(self):
+            calls.final_checks += 1
+            return []
+
+    def _stub_start(cls=None, **kwargs):
+        calls.start_kwargs = kwargs
+        return _StubWatch()
+
+    monkeypatch.setattr(
+        runner_mod.PrimaryTreeWatch, "start", classmethod(lambda cls, **kw: _stub_start(**kw))
+    )
+    _disable_fleet_capture(monkeypatch)
+    plan = _Plan(cmd=[sys.executable, "-c", "print('hi')"], cwd=tmp_path)
+    outcome = _run_plan(plan)
+    assert outcome.parse.ok is True
+    assert calls.start_kwargs["cwd"] == tmp_path
+    assert calls.start_kwargs["mode"] == "workspace-write"
+    assert calls.start_kwargs["agent_name"] == "agy"
+    assert calls.start_kwargs["task_id"] == "task-1"
+    # Post-exit sweep always runs (once in the normal path, once as the
+    # finally safety net — both are required to be reachable).
+    assert calls.final_checks >= 1
+    assert outcome.kill_reason is None
+
+
+def test_runner_kills_on_escape_only_when_enforced(monkeypatch, tmp_path):
+    class _StubWatch:
+        enforce = True
+
+        def __init__(self):
+            self._fired = False
+
+        def maybe_check(self, *, force: bool = False):
+            if self._fired:
+                return []
+            self._fired = True
+            return ["scripts/api/fleet_router.py"]
+
+        def final_check(self):
+            return []
+
+    monkeypatch.setattr(
+        runner_mod.PrimaryTreeWatch, "start", classmethod(lambda cls, **kw: _StubWatch())
+    )
+    monkeypatch.setattr(runner_mod, "_POLL_INTERVAL_S", 0.05)
+    _disable_fleet_capture(monkeypatch)
+    plan = _Plan(cmd=[sys.executable, "-c", "import time; time.sleep(30)"], cwd=tmp_path)
+    started = time.monotonic()
+    outcome = _run_plan(plan)
+    assert outcome.kill_reason == "primary_tree_write"
+    assert outcome.escaped_primary_paths == ("scripts/api/fleet_router.py",)
+    assert time.monotonic() - started < 20
+
+
+def test_end_to_end_runner_detects_primary_write(monkeypatch, repo):
+    """THE guard test: a child that writes a tracked primary file mid-dispatch
+    is detected and attributed, without being killed (enforce off)."""
+    monkeypatch.setattr(runner_mod, "_RUNNER_REPO_TREE", repo.main)
+    monkeypatch.setattr(runner_mod, "_POLL_INTERVAL_S", 0.05)
+    monkeypatch.setenv("LU_PRIMARY_TREE_WATCH_INTERVAL_S", "0.05")
+    monkeypatch.delenv("LU_PRIMARY_TREE_WATCH_ENFORCE", raising=False)
+    _disable_fleet_capture(monkeypatch)
+    target = repo.main / "tracked.txt"
+    script = (
+        "import pathlib, time; "
+        f"pathlib.Path({str(target)!r}).write_text('ESCAPED'); "
+        "time.sleep(1.0)"
+    )
+    plan = _Plan(cmd=[sys.executable, "-c", script], cwd=repo.dispatch_wt)
+    outcome = _run_plan(plan)
+    assert outcome.kill_reason is None  # detection only — the gate is off
+    assert outcome.returncode == 0
+    assert "tracked.txt" in outcome.escaped_primary_paths
+    events = _events(repo)
+    assert len(events) == 1
+    assert events[0]["paths"] == ["tracked.txt"]
+    assert events[0]["agent"] == "agy"
+    assert events[0]["task_id"] == "task-1"
+
+
+def test_end_to_end_clean_child_records_nothing(monkeypatch, repo):
+    monkeypatch.setattr(runner_mod, "_RUNNER_REPO_TREE", repo.main)
+    monkeypatch.setenv("LU_PRIMARY_TREE_WATCH_INTERVAL_S", "0.05")
+    _disable_fleet_capture(monkeypatch)
+    # The child edits its own worktree — the sanctioned flow must stay silent.
+    target = repo.dispatch_wt / "tracked.txt"
+    script = f"import pathlib; pathlib.Path({str(target)!r}).write_text('legit')"
+    plan = _Plan(cmd=[sys.executable, "-c", script], cwd=repo.dispatch_wt)
+    outcome = _run_plan(plan)
+    assert outcome.parse.ok is True
+    assert outcome.escaped_primary_paths == ()
+    assert _events(repo) == []
+
+
+def test_raise_for_kill_reason_maps_primary_tree_write(monkeypatch, tmp_path):
+    records: list[dict] = []
+    monkeypatch.setattr(runner_mod, "write_record", records.append)
+    execution = runner_mod._ExecutionOutcome(
+        parse=ParseResult(ok=False, response=""),
+        duration_s=1.0,
+        returncode=-15,
+        kill_reason="primary_tree_write",
+        stdout_text="",
+        stderr_text="",
+        liveness_paths=(),
+        escaped_primary_paths=("scripts/api/fleet_router.py",),
+    )
+    with pytest.raises(PrimaryTreeWriteError) as exc_info:
+        _raise_for_kill_reason(
+            agent_name="agy",
+            kill_reason="primary_tree_write",
+            execution=execution,
+            prompt="p",
+            entrypoint="runtime-test",
+            model="m",
+            mode="workspace-write",
+            task_id="task-1",
+            cwd=tmp_path,
+            session_id=None,
+            stdout_silence_timeout=None,
+            initial_response_timeout=None,
+            stall_timeout=30,
+            hard_timeout=30,
+        )
+    assert exc_info.value.paths == ["scripts/api/fleet_router.py"]
+    assert len(records) == 1
+    assert records[0]["failure_code"] == "primary_tree_write"


### PR DESCRIPTION
## Summary

Root-causes the #6818 recurrence (transient primary-checkout write during agy dispatch `work-6849-projection-health`) and lands the in-repo containment at the layer the incident actually needs: mid-dispatch detection + attribution, not spawn-time-only classification.

### Mechanism (tool-backed, from agy's own persisted transcript)

`~/.gemini/antigravity-cli/brain/56e8b62e-…/transcript.jsonl` for the incident conversation shows:

- Every `run_command` ran with `Cwd` = the dispatch worktree (the harness handed agy the correct cwd; the spawn-time #4444 guard passed correctly).
- From 10:40:39Z to 10:44:27Z, the model emitted **primary-checkout absolute paths** in `view_file`/`replace_file_content` calls, and agy executed them without any workspace containment — including two `replace_file_content` writes to the primary's `scripts/api/fleet_router.py` at 10:44:23Z/10:44:27Z (exactly the `M scripts/api/fleet_router.py` transient dirty observed live).
- The "self-correction": the worker itself noticed (`fr.__file__` probe at 10:44:46Z resolved the worktree copy), ran `git -C <primary> checkout -- scripts/api/fleet_router.py` at 10:45:10Z, and redid all edits with worktree-rooted paths from 10:45:15Z onward.

The defect is **provably external** (agy's file tools accept out-of-workspace absolute paths; same class as the #5803 panel conclusion that same-UID prevention is impossible), and condition-dependent on model path construction — which is why the concurrent `work-6850` dispatch never escaped. Full mechanism + recommendations on #6818.

### Change

- **`scripts/agent_runtime/primary_tree_watch.py`** — `PrimaryTreeWatch`: baselines the primary's tracked-dirty set (`git status --porcelain -z -uno`) before the spawn, re-probes inside the runner wait loop (throttled, `LU_PRIMARY_TREE_WATCH_INTERVAL_S`, default 20s) and once unthrottled post-exit, and RECORDs new tracked-path dirtiness to the primary-integrity attribution JSONL (`data/telemetry/primary-integrity/events.jsonl`) with agent/task/paths — so a transient, self-corrected escape leaves a durable attributed trail. Untracked files stay out of scope (#6866 canary owns that class). Fail-open everywhere.
- **`scripts/agent_runtime/runner.py`** — wires the watch into `_execute_invocation_plan` (write-capable dispatch-worktree spawns only), threads escaped paths through `_ExecutionOutcome`, and adds the **operator-gated** enforcement path (`LU_PRIMARY_TREE_WATCH_ENFORCE=1` → kill + `PrimaryTreeWriteError`). Default posture is detect + record; the gate stays OFF per the #6818 decision list.

### Evidence (#M-4 / #M-16)

- 20 new tests; **10/10 consecutive green runs** (5.6–6.0s each).
- **Mutation-checked**: neutering detection fails 5 guard tests; removing the runner wiring fails 3 (incl. the end-to-end test where a real child writes a tracked primary file mid-dispatch and is detected + attributed without being killed).
- Happy path intact: 306 passed across `test_agent_runtime*`, `test_agy_integration`, `test_gemini_fallback_agy`, `test_worktree_containment`, `test_check_primary_integrity`, `test_delegate_primary_integrity`.
- Ruff clean.

NO auto-merge — cross-family review per the #6818 routing card.

Closes nothing on its own; #6818 remains open for the operator decisions (enforce gate, node pin sequencing, provisioning-level prevention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
