### PR TITLE
feat(atlas): host free-disk preflight on submit (#6876)

### DIFF
--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -4,7 +4,8 @@
 
 Batch kinds run on atlas-runner only. Registry lives under batch_state/atlas-jobs/
 (restic-covered). Close writes a fail-closed result receipt; large artifacts go
-through durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
+through durable_mirror + backup-data.sh. Publish/pointer flip is never this module. Submit enforces a host free-disk
+floor (default 5 GiB, ATLAS_MIN_FREE_DISK_BYTES / ATLAS_MIN_FREE_DISK_GIB).
 """
 
 from __future__ import annotations
@@ -73,8 +74,36 @@ _HOSTNAME_HINT = re.compile(
 )
 DEFAULT_TIMEOUT_SECONDS = 86400
 DEFAULT_RUN_ROOT = "/home/ops/atlas-runner"
+DEFAULT_MIN_FREE_DISK_BYTES = 5 * 1024 * 1024 * 1024  # 5 GiB host floor
 
 _HOST = None  # set via set_host_adapter(); typed as HostAdapter | None
+
+
+def min_free_disk_bytes() -> int:
+    """Return the configured host free disk floor in bytes (default 5 GiB).
+
+    Overridable via ATLAS_MIN_FREE_DISK_BYTES (raw integer bytes) or
+    ATLAS_MIN_FREE_DISK_GIB / ATLAS_MIN_FREE_DISK_GB (in GiB / GB).
+    """
+    override = os.environ.get("ATLAS_MIN_FREE_DISK_BYTES")
+    if override:
+        try:
+            val = int(override)
+            if val >= 0:
+                return val
+        except ValueError:
+            pass
+    gib_override = os.environ.get("ATLAS_MIN_FREE_DISK_GIB") or os.environ.get(
+        "ATLAS_MIN_FREE_DISK_GB"
+    )
+    if gib_override:
+        try:
+            val_f = float(gib_override)
+            if val_f >= 0:
+                return int(val_f * 1024 * 1024 * 1024)
+        except ValueError:
+            pass
+    return DEFAULT_MIN_FREE_DISK_BYTES
 
 
 class HostAdapter(Protocol):
@@ -92,6 +121,9 @@ class HostAdapter(Protocol):
     def reachable(self, host: str) -> bool:
         """True when SSH (or fake) host checks can run."""
 
+    def free_disk_bytes(self, host: str, path: str | None = None) -> int:
+        """Return available free disk space in bytes on the host for path (or run root)."""
+
 
 @dataclass
 class FakeHostAdapter:
@@ -101,6 +133,8 @@ class FakeHostAdapter:
     exit_status_by_workdir: dict[str, dict[str, Any]] = field(default_factory=dict)
     pgrep_lines: list[str] = field(default_factory=list)
     online: bool = True
+    free_disk_bytes_value: int = 50 * 1024 * 1024 * 1024  # 50 GiB default healthy
+    free_disk_by_path: dict[str, int] = field(default_factory=dict)
 
     def list_atlas_job_units(self, host: str) -> list[dict[str, Any]]:
         del host
@@ -123,6 +157,14 @@ class FakeHostAdapter:
     def reachable(self, host: str) -> bool:
         del host
         return self.online
+
+    def free_disk_bytes(self, host: str, path: str | None = None) -> int:
+        del host
+        if not self.online:
+            raise ConnectionError("host unreachable")
+        if path is not None and path in self.free_disk_by_path:
+            return self.free_disk_by_path[path]
+        return self.free_disk_bytes_value
 
 
 class SshHostAdapter:
@@ -196,6 +238,26 @@ class SshHostAdapter:
     def reachable(self, host: str) -> bool:
         proc = _ssh(host, "true")
         return proc.returncode == 0
+
+    def free_disk_bytes(self, host: str, path: str | None = None) -> int:
+        target = path or str(_run_root())
+        remote = (
+            "python3 - <<'PY'\n"
+            "import shutil\n"
+            "from pathlib import Path\n"
+            f"p = Path({target!r})\n"
+            "while not p.exists() and p != p.parent:\n"
+            "    p = p.parent\n"
+            "print(shutil.disk_usage(str(p)).free)\n"
+            "PY"
+        )
+        proc = _ssh(host, remote)
+        if proc.returncode != 0:
+            raise ConnectionError(f"free-disk check failed on {host}: rc={proc.returncode}")
+        text = (proc.stdout or "").strip()
+        if not text.isdigit():
+            raise ValueError(f"invalid free disk output from {host}: {text!r}")
+        return int(text)
 
 
 def _ssh(host: str, remote: str) -> subprocess.CompletedProcess[str]:
@@ -717,62 +779,8 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
     job_id = str(plan["id"])
     host = str(plan["host"])
     sink = plan.get("result_sink")
-    if sink in {"restic", "both"} and restic_sink_blocked() and not dry_run:
-        print(
-            "restic sink blocked until backup-data.sh doctor is green "
-            f"({restic_block_path()})",
-            file=sys.stderr,
-        )
-        return 2
-    existing = load_registry(job_id)
-    if existing and existing.get("state") == "running":
-        print(f"job {job_id} is already running", file=sys.stderr)
-        return 2
-    adapter = host_adapter or get_host_adapter()
-    if not dry_run:
-        try:
-            if not adapter.reachable(host):
-                print(f"host {host} unreachable", file=sys.stderr)
-                return 2
-            busy_units = active_host_units(host, adapter)
-        except (ConnectionError, OSError, ValueError) as exc:
-            print(f"host unit check failed: {exc}", file=sys.stderr)
-            return 2
-        if busy_units:
-            print(
-                f"host {host} already has active unit {busy_units[0].get('name')} "
-                "(systemd is the mutex; registry is journal only)",
-                file=sys.stderr,
-            )
-            return 2
-        journal_busy = running_on_host(host)
-        if journal_busy:
-            # Journal says running but host has no unit — reconcile hole; still refuse.
-            print(
-                f"registry journal has running job {journal_busy[0].get('id')} "
-                "with no active host unit; close/reconcile before submit",
-                file=sys.stderr,
-            )
-            return 2
     unit = unit_name(job_id)
     workdir = work_dir_for(job_id, plan)
-    args = list(plan.get("args") or [])
-    if "--no-poll" not in args:
-        args.append("--no-poll")
-    env = os.environ.copy()
-    env["ATLAS_RUNNER_HOST"] = host
-    env["ATLAS_RE_ENRICH_UNIT"] = unit
-    env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
-    env["ATLAS_RE_ENRICH_OUT_DIR"] = str(local_pull_dir(job_id))
-    env["ATLAS_JOB_EXIT_STATUS_FILE"] = f"{workdir}/exit-status.json"
-    env["ATLAS_RE_ENRICH_RUNTIME_MAX_SEC"] = str(
-        plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
-    )
-    env["ATLAS_RE_ENRICH_RESTART"] = "no"
-    slugs = plan.get("slugs_file")
-    if isinstance(slugs, str) and slugs:
-        env["ATLAS_RE_ENRICH_RESIDUAL"] = slugs
-    cmd = ["bash", str(_launcher()), *args]
     plan_blob = json.dumps(plan, sort_keys=True).encode()
     row = {
         "id": job_id,
@@ -791,6 +799,108 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
         "submitted_at": _now(),
         "plan": plan,
     }
+
+    if sink in {"restic", "both"} and restic_sink_blocked() and not dry_run:
+        print(
+            "restic sink blocked until backup-data.sh doctor is green "
+            f"({restic_block_path()})",
+            file=sys.stderr,
+        )
+        row["state"] = "rejected"
+        row["refusal_reason"] = f"restic sink blocked ({restic_block_path()})"
+        save_registry(row)
+        return 2
+    existing = load_registry(job_id)
+    if existing and existing.get("state") == "running":
+        print(f"job {job_id} is already running", file=sys.stderr)
+        return 2
+    adapter = host_adapter or get_host_adapter()
+    if not dry_run:
+        try:
+            if not adapter.reachable(host):
+                print(f"host {host} unreachable", file=sys.stderr)
+                row["state"] = "rejected"
+                row["refusal_reason"] = f"host {host} unreachable"
+                save_registry(row)
+                return 2
+            busy_units = active_host_units(host, adapter)
+        except (ConnectionError, OSError, ValueError) as exc:
+            print(f"host unit check failed: {exc}", file=sys.stderr)
+            row["state"] = "rejected"
+            row["refusal_reason"] = f"host unit check failed: {exc}"
+            save_registry(row)
+            return 2
+        if busy_units:
+            print(
+                f"host {host} already has active unit {busy_units[0].get('name')} "
+                "(systemd is the mutex; registry is journal only)",
+                file=sys.stderr,
+            )
+            row["state"] = "rejected"
+            row["refusal_reason"] = (
+                f"host {host} already has active unit {busy_units[0].get('name')}"
+            )
+            save_registry(row)
+            return 2
+        journal_busy = running_on_host(host)
+        if journal_busy:
+            # Journal says running but host has no unit — reconcile hole; still refuse.
+            print(
+                f"registry journal has running job {journal_busy[0].get('id')} "
+                "with no active host unit; close/reconcile before submit",
+                file=sys.stderr,
+            )
+            row["state"] = "rejected"
+            row["refusal_reason"] = (
+                f"registry journal has running job {journal_busy[0].get('id')} with no active host unit"
+            )
+            save_registry(row)
+            return 2
+
+        # Free disk preflight check: refuse when host free disk is below floor.
+        min_free = min_free_disk_bytes()
+        try:
+            free_bytes = adapter.free_disk_bytes(host, workdir)
+        except (ConnectionError, OSError, ValueError) as exc:
+            print(f"host free disk check failed: {exc}", file=sys.stderr)
+            row["state"] = "rejected"
+            row["refusal_reason"] = f"host free disk check failed: {exc}"
+            save_registry(row)
+            return 2
+
+        if free_bytes < min_free:
+            print(
+                f"refusing submit: host {host} free disk ({free_bytes} bytes) "
+                f"is below required floor ({min_free} bytes)",
+                file=sys.stderr,
+            )
+            row["state"] = "rejected"
+            row["refusal_reason"] = (
+                f"insufficient host free disk: {free_bytes} bytes < {min_free} bytes floor"
+            )
+            row["free_disk_bytes"] = free_bytes
+            row["min_free_disk_bytes"] = min_free
+            save_registry(row)
+            return 2
+
+    args = list(plan.get("args") or [])
+    if "--no-poll" not in args:
+        args.append("--no-poll")
+    env = os.environ.copy()
+    env["ATLAS_RUNNER_HOST"] = host
+    env["ATLAS_RE_ENRICH_UNIT"] = unit
+    env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
+    env["ATLAS_RE_ENRICH_OUT_DIR"] = str(local_pull_dir(job_id))
+    env["ATLAS_JOB_EXIT_STATUS_FILE"] = f"{workdir}/exit-status.json"
+    env["ATLAS_RE_ENRICH_RUNTIME_MAX_SEC"] = str(
+        plan.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    )
+    env["ATLAS_RE_ENRICH_RESTART"] = "no"
+    slugs = plan.get("slugs_file")
+    if isinstance(slugs, str) and slugs:
+        env["ATLAS_RE_ENRICH_RESIDUAL"] = slugs
+    cmd = ["bash", str(_launcher()), *args]
+    plan_blob = json.dumps(plan, sort_keys=True).encode()
     if dry_run:
         print("host", host)
         print("unit", unit)

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -424,3 +424,162 @@ def test_close_and_cli_reject_unsafe_job_id(
     assert atlas_job.main(["close", "../escape", "--skip-pull", "--skip-restic"]) == 2
     assert atlas_job.main(["pull", "--job-id", "../escape"]) == 2
     assert list(tmp_path.iterdir()) == []
+
+
+def test_min_free_disk_bytes_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_BYTES", raising=False)
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_GIB", raising=False)
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_GB", raising=False)
+    assert atlas_job.min_free_disk_bytes() == atlas_job.DEFAULT_MIN_FREE_DISK_BYTES
+    assert atlas_job.min_free_disk_bytes() == 5 * 1024 * 1024 * 1024
+
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_BYTES", "10737418240")
+    assert atlas_job.min_free_disk_bytes() == 10 * 1024 * 1024 * 1024
+
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_BYTES")
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_GIB", "2.5")
+    assert atlas_job.min_free_disk_bytes() == int(2.5 * 1024 * 1024 * 1024)
+
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_GIB")
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_GB", "4")
+    assert atlas_job.min_free_disk_bytes() == 4 * 1024 * 1024 * 1024
+
+    # Invalid string fallbacks to default when other env vars are unset.
+    monkeypatch.delenv("ATLAS_MIN_FREE_DISK_GB")
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_BYTES", "invalid")
+    assert atlas_job.min_free_disk_bytes() == atlas_job.DEFAULT_MIN_FREE_DISK_BYTES
+
+
+def test_submit_refuses_when_host_free_disk_below_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    # 1 GiB free disk is below the 5 GiB default floor.
+    _isolate_host.free_disk_bytes_value = 1 * 1024 * 1024 * 1024
+
+    plan = _plan(id="low-disk-job")
+    rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 2
+
+    # Journal records the refusal fail-closed.
+    row = atlas_job.load_registry("low-disk-job")
+    assert row is not None
+    assert row["state"] == "rejected"
+    assert "insufficient host free disk" in row["refusal_reason"]
+    assert row["free_disk_bytes"] == 1 * 1024 * 1024 * 1024
+    assert row["min_free_disk_bytes"] == atlas_job.DEFAULT_MIN_FREE_DISK_BYTES
+
+
+def test_submit_honors_env_override_min_free_disk_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    # Override floor to 100 MB.
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_BYTES", str(100 * 1024 * 1024))
+    _isolate_host.free_disk_bytes_value = 200 * 1024 * 1024
+
+    launched: list[list[str]] = []
+
+    def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
+        launched.append(cmd)
+        return 0
+
+    monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
+
+    plan = _plan(id="override-ok-job")
+    rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 0
+    assert len(launched) == 1
+
+    row = atlas_job.load_registry("override-ok-job")
+    assert row is not None
+    assert row["state"] == "running"
+
+
+def test_submit_honors_env_override_min_free_disk_gib(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    # Higher override via GIB causes refusal.
+    monkeypatch.setenv("ATLAS_MIN_FREE_DISK_GIB", "10")
+    _isolate_host.free_disk_bytes_value = 6 * 1024 * 1024 * 1024
+    plan_refused = _plan(id="override-refused-job")
+    rc_refused = atlas_job.submit(plan_refused, dry_run=False, host_adapter=_isolate_host)
+    assert rc_refused == 2
+    row_refused = atlas_job.load_registry("override-refused-job")
+    assert row_refused is not None
+    assert row_refused["state"] == "rejected"
+    assert row_refused["min_free_disk_bytes"] == 10 * 1024 * 1024 * 1024
+
+
+def test_submit_refuses_when_free_disk_check_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+
+    def fake_free_disk_err(host: str, path: str | None = None) -> int:
+        raise ConnectionError("host disk probe failed")
+
+    monkeypatch.setattr(_isolate_host, "free_disk_bytes", fake_free_disk_err)
+
+    plan = _plan(id="disk-err-job")
+    rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 2
+
+    row = atlas_job.load_registry("disk-err-job")
+    assert row is not None
+    assert row["state"] == "rejected"
+    assert "host free disk check failed" in row["refusal_reason"]
+
+
+def test_submit_refuses_restic_sink_when_restic_sink_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    atlas_job.set_restic_sink_blocked("doctor failed")
+
+    # sink='restic' is refused
+    plan_restic = _plan(id="restic-job", result_sink="restic")
+    rc = atlas_job.submit(plan_restic, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 2
+    row = atlas_job.load_registry("restic-job")
+    assert row is not None
+    assert row["state"] == "rejected"
+    assert "restic sink blocked" in row["refusal_reason"]
+
+    # sink='both' is refused
+    plan_both = _plan(id="both-job", result_sink="both")
+    rc_both = atlas_job.submit(plan_both, dry_run=False, host_adapter=_isolate_host)
+    assert rc_both == 2
+    row_both = atlas_job.load_registry("both-job")
+    assert row_both is not None
+    assert row_both["state"] == "rejected"
+    assert "restic sink blocked" in row_both["refusal_reason"]
+
+
+def test_submit_allows_git_sink_when_restic_sink_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    atlas_job.set_restic_sink_blocked("doctor failed")
+
+    def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
+
+    # sink='git' is NOT blocked by restic sink block
+    plan_git = _plan(id="git-job", result_sink="git")
+    rc = atlas_job.submit(plan_git, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 0
+    row = atlas_job.load_registry("git-job")
+    assert row is not None
+    assert row["state"] == "running"
+
+
+def test_ssh_host_adapter_free_disk_bytes_source() -> None:
+    import inspect
+
+    src = inspect.getsource(atlas_job.SshHostAdapter.free_disk_bytes)
+    assert "shutil.disk_usage" in src
+    assert "while not p.exists()" in src


### PR DESCRIPTION
## Summary
`atlas_job.submit()` refuses when host free disk is below 5GiB (env-overridable) or when restic sink is blocked. No unit start; journal records the refusal.

## Campaign
#6876 (first protocol-tracked job / protocol residuals after #6867)

## Verify
- pytest tests/test_atlas_job_protocol.py: 34 passed (worker)
- ruff clean on touched files

X-Agent: agy/6876-freedisk

Do not merge until independent CF (not AGY/Gemini).