### PR TITLE
fix(runner): fail closed when runner venv lacks yaml/jsonschema (#6876)

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -31,7 +31,7 @@
 #
 # Env overrides:
 #   ATLAS_RUN_ROOT, ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
-#   ATLAS_RE_ENRICH_CODE_ROOT,
+#   ATLAS_RE_ENRICH_CODE_ROOT, ATLAS_RE_ENRICH_RUNNER_PYTHON,
 #   ATLAS_RE_ENRICH_UNIT, ATLAS_RE_ENRICH_DRIVER, ATLAS_RE_ENRICH_SLUGS_FILE,
 #   ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON, ATLAS_LIVE_MANIFEST
 set -euo pipefail
@@ -123,8 +123,25 @@ if [[ ! -f "$SOURCES_DB" ]]; then
   echo "sources.db not found: $SOURCES_DB" >&2
   exit 1
 fi
-if [[ ! -f "$REPO/.venv/bin/python" ]]; then
-  echo "repo venv python not found: $REPO/.venv/bin/python" >&2
+# Fail closed (#6876): the driver imports yaml + jsonschema. A runner venv
+# missing them dies mid-run with ModuleNotFoundError *after* systemd-run has
+# already reported success, so verify the imports up front, before any
+# filesystem/systemd side effect. Prefer the project .venv on the runner:
+# $REPO first (its hydrated data sits next to it), then the work-dir overlay.
+RUNNER_PYTHON="${ATLAS_RE_ENRICH_RUNNER_PYTHON:-}"
+if [[ -z "$RUNNER_PYTHON" ]]; then
+  if [[ -x "$REPO/.venv/bin/python" ]]; then
+    RUNNER_PYTHON="$REPO/.venv/bin/python"
+  elif [[ -x "$CODE_ROOT/.venv/bin/python" ]]; then
+    RUNNER_PYTHON="$CODE_ROOT/.venv/bin/python"
+  fi
+fi
+if [[ -z "$RUNNER_PYTHON" || ! -x "$RUNNER_PYTHON" ]]; then
+  echo "runner venv python not found (tried $REPO/.venv/bin/python and $CODE_ROOT/.venv/bin/python)" >&2
+  exit 1
+fi
+if ! "$RUNNER_PYTHON" -c 'import yaml, jsonschema' >/dev/null 2>&1; then
+  echo "runner venv $RUNNER_PYTHON cannot import yaml/jsonschema; install with: $RUNNER_PYTHON -m pip install pyyaml jsonschema" >&2
   exit 1
 fi
 
@@ -172,7 +189,7 @@ fi
 # inherit the launching shell's exports), so this must be set inside the
 # wrapped command, not via `export` before systemd-run.
 run_cmd() {
-  printf '%q ' "$REPO/.venv/bin/python" "$DRIVER" "${COMMON_ARGS[@]}"
+  printf '%q ' "$RUNNER_PYTHON" "$DRIVER" "${COMMON_ARGS[@]}"
   # Bash <4.4 (e.g. macOS's stock /bin/bash 3.2) throws "unbound variable"
   # on "${arr[@]}" for a zero-element array under `set -u` — guard rather
   # than rely on the expansion, in case this script is ever invoked there.

--- a/tests/test_launch_reenrich_venv_preflight.py
+++ b/tests/test_launch_reenrich_venv_preflight.py
@@ -1,0 +1,151 @@
+"""Runner-venv preflight regression test for the #6876 campaign launcher.
+
+Root cause covered: an atlas-runner job died with ``ModuleNotFoundError:
+yaml`` mid-run, *after* systemd-run had already reported success -- the
+launcher only checked that ``$REPO/.venv/bin/python`` existed, never that it
+could import the driver's hard dependencies. The launcher must now fail
+closed before systemd-run unless the resolved runner venv (``$REPO/.venv``
+preferred, ``$CODE_ROOT/.venv`` fallback) can ``import yaml`` and
+``import jsonschema``, printing a one-line pip install recipe otherwise.
+
+Like the target-detection suite, this drives the real launcher via subprocess
+against a fully stubbed tmp tree (stub venv python, stub driver/data files),
+so no systemd or SSH side effect is possible: on a host without systemctl the
+launcher falls through to its nohup path, and the stub python exits 0
+immediately when invoked as the "driver".
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_LAUNCHER = ROOT / "scripts" / "lexicon" / "runner" / "launch_reenrich_class_b.sh"
+
+# Stub venv pythons: invoked by the preflight as `-c 'import yaml, jsonschema'`.
+# The "broken" one fails exactly that probe (simulating a venv without the
+# deps) and succeeds otherwise so the launcher's own resolution order is the
+# only variable under test.
+_STUB_OK = "#!/bin/bash\nexit 0\n"
+_STUB_BROKEN = (
+    "#!/bin/bash\n"
+    'for a in "$@"; do\n'
+    '  if [[ "$a" == *"import yaml"* ]]; then exit 1; fi\n'
+    "done\n"
+    "exit 0\n"
+)
+
+
+def _build_fixture(tmp_path: Path, *, repo_stub: str | None, code_stub: str | None = None) -> dict[str, str]:
+    """Materialize the minimal tmp tree the launcher checks before its venv
+    preflight: driver with --slugs-file, synced enrichment package, residual
+    slugs, sources.db, and a work-dir manifest."""
+    repo = tmp_path / "repo"
+    work = tmp_path / "work"
+    code = tmp_path / "code"
+
+    driver = repo / "scripts" / "lexicon" / "reenrich_thin_manifest_entries.py"
+    driver.parent.mkdir(parents=True)
+    driver.write_text("# driver\n# supports --slugs-file\n", encoding="utf-8")
+
+    pkg = code / "scripts" / "lexicon"
+    pkg.mkdir(parents=True)
+    (pkg / "enrich_manifest.py").write_text("# synced package\n", encoding="utf-8")
+
+    (repo / "data").mkdir(parents=True)
+    (repo / "data" / "sources.db").write_bytes(b"stub")
+
+    work.mkdir(parents=True)
+    (work / "class-b-no-en.json").write_text("[]\n", encoding="utf-8")
+    (work / "manifest.json").write_text("{}\n", encoding="utf-8")
+
+    def _write_venv(base: Path, stub: str) -> None:
+        py = base / ".venv" / "bin" / "python"
+        py.parent.mkdir(parents=True)
+        py.write_text(stub, encoding="utf-8")
+        py.chmod(0o755)
+
+    if repo_stub is not None:
+        _write_venv(repo, repo_stub)
+    if code_stub is not None:
+        _write_venv(code, code_stub)
+
+    return {
+        "PATH": "/usr/bin:/bin",
+        "ATLAS_RUN_ROOT": str(tmp_path),
+        "ATLAS_REPO": str(repo),
+        "ATLAS_RE_ENRICH_WORK_DIR": str(work),
+        "ATLAS_RE_ENRICH_CODE_ROOT": str(code),
+    }
+
+
+def _run_launcher(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(LOCAL_LAUNCHER)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+        env=env,
+    )
+
+
+def test_fails_closed_when_venv_cannot_import_yaml_jsonschema(tmp_path: Path) -> None:
+    env = _build_fixture(tmp_path, repo_stub=_STUB_BROKEN)
+    proc = _run_launcher(env)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "pip install pyyaml jsonschema" in proc.stderr
+    # One-line recipe naming the resolved interpreter, and no launch happened.
+    assert ".venv/bin/python" in proc.stderr
+    assert "pid=" not in proc.stdout
+
+
+def test_fails_closed_when_no_runner_venv_exists(tmp_path: Path) -> None:
+    env = _build_fixture(tmp_path, repo_stub=None)
+    proc = _run_launcher(env)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "runner venv python not found" in proc.stderr
+    assert "pid=" not in proc.stdout
+
+
+def test_launches_when_repo_venv_imports_ok(tmp_path: Path) -> None:
+    env = _build_fixture(tmp_path, repo_stub=_STUB_OK)
+    proc = _run_launcher(env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "pid=" in proc.stdout
+
+
+def test_falls_back_to_code_root_venv(tmp_path: Path) -> None:
+    """$REPO/.venv missing -> the work-dir ($CODE_ROOT) .venv is used."""
+    env = _build_fixture(tmp_path, repo_stub=None, code_stub=_STUB_OK)
+    proc = _run_launcher(env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "pid=" in proc.stdout
+
+
+def test_prefers_repo_venv_over_code_root_venv(tmp_path: Path) -> None:
+    """A broken $REPO/.venv must NOT be skipped in favor of a healthy
+    $CODE_ROOT/.venv -- preference order is part of the contract."""
+    env = _build_fixture(tmp_path, repo_stub=_STUB_BROKEN, code_stub=_STUB_OK)
+    proc = _run_launcher(env)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "pip install pyyaml jsonschema" in proc.stderr
+
+
+def test_runner_python_override_wins(tmp_path: Path) -> None:
+    env = _build_fixture(tmp_path, repo_stub=_STUB_BROKEN)
+    override = tmp_path / "override" / ".venv" / "bin" / "python"
+    override.parent.mkdir(parents=True)
+    override.write_text(_STUB_OK, encoding="utf-8")
+    override.chmod(0o755)
+    env["ATLAS_RE_ENRICH_RUNNER_PYTHON"] = str(override)
+    proc = _run_launcher(env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_launcher_invokes_resolved_runner_python() -> None:
+    """The systemd/nohup command must use the preflight-resolved interpreter,
+    not a hardcoded $REPO/.venv path that could diverge from the check."""
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    assert 'printf \'%q \' "$RUNNER_PYTHON" "$DRIVER"' in source
+    assert 'import yaml, jsonschema' in source


### PR DESCRIPTION
## Summary

Campaign #6876. The last atlas-runner job died with `ModuleNotFoundError: yaml` **after** systemd-run had already reported success, because `launch_reenrich_class_b.sh` only checked that `$REPO/.venv/bin/python` existed — never that it could import the driver's hard deps.

## Changes

- `scripts/lexicon/runner/launch_reenrich_class_b.sh`
  - New preflight before any filesystem/systemd side effect: resolves the runner interpreter — `$REPO/.venv/bin/python` preferred, `$CODE_ROOT/.venv/bin/python` fallback, `ATLAS_RE_ENRICH_RUNNER_PYTHON` override — then runs `$RUNNER_PYTHON -c 'import yaml, jsonschema'`.
  - On failure: prints a one-line install recipe (`<py> -m pip install pyyaml jsonschema`) and exits 1. No apt-get, no silent success.
  - The wrapped driver command (`run_cmd`) now uses the preflight-resolved `$RUNNER_PYTHON` instead of a hardcoded `$REPO/.venv/bin/python`, so the check and the launch can never diverge.
- `launch_reenrich_class_b_remote.sh` — **no change needed**: it invokes the launcher over ssh under `set -euo pipefail`, so the remote exit 1 propagates and the wrapper already fails closed.
- `tests/test_launch_reenrich_venv_preflight.py` (new, 7 tests): drives the real launcher against a fully stubbed tmp tree (stub venv pythons, stub driver/data) — fail-closed on missing imports, fail-closed on missing venv, happy path, `$CODE_ROOT` fallback, preference order, override, and a source contract tying `run_cmd` to `$RUNNER_PYTHON`.

## Verification

- `.venv/bin/python -m pytest tests/test_launch_reenrich_venv_preflight.py tests/test_launch_reenrich_target_detection.py -v` → **27 passed**
- `ruff check` on the new test → clean; `bash -n` on the launcher → clean

## Out of scope (per dispatch)

No changes to `atlas_job.py` (AGY owns free-disk) or `atlas_jobs_router.py` (GLM reviewing). No merges, no pointer flips.

Refs #6876
