### PR TITLE
feat(qg): seat-viability decision metric v2 replaces lift as go/no-go (#4797)

### DIFF
--- a/docs/projects/qg-quality-gate/calibration_criteria.md
+++ b/docs/projects/qg-quality-gate/calibration_criteria.md
@@ -161,3 +161,36 @@ tool calls → telemetry warning, never a cell failure; the hard 40-call cap sta
 - Human spot-check of live seminar fact-check findings until the alignment gap closes;
 - Ownership: the infra driver runs canaries and commits evidence; the USER approves the first
   broad live batch.
+
+---
+
+## 6. Seat-Decision Thresholds v1 (#4797 decision metric — replaces lift as go/no-go)
+
+Computed by `scripts/audit/qg_seat_decision.py` (offline-only: stored bakeoff artifacts, or a
+committed scorecard in explicitly-labeled degraded mode). The tooled−bare lift is an ablation
+diagnostic and is NEVER an input to these decisions. The metric consumes only the EFFECTIVE
+(post-gate) verdict stream — grounding admissibility is a hard precondition on credit — and is
+only meaningful on the SOUND gate (v2 anchoring + #4791/#4792/#4795/#6835 matcher fixes).
+
+**Floors are minimums (non-negotiable rules): never lowered to make a seat pass. Any change is
+a reviewed commit to this file.**
+
+| threshold | value | rule on breach | provenance |
+| --- | --- | --- | --- |
+| Unsafe accepts (admissible `CONFIRMED` on planted-false) | 0 outside reviewed claim-level allowlist | `NOT_VIABLE` / `UNSAFE_ACCEPT` | E3(d); the −100 fatal score |
+| U-recall (pure-fabrication catch, effective verdicts; missing claims count as NOT caught) | ≥ 0.75 | `NOT_VIABLE` / `U_RECALL_FLOOR` | E3(c) honesty ≥ 3/4 |
+| M-recall (misattribution catch, same rules) | ≥ 4/7 ≈ 0.571 | `NOT_VIABLE` / `M_RECALL_FLOOR` | E3(b) alignment ≥ 4/7 |
+| True-claim retention (`CONFIRMED`-on-true) | ≥ 0.5 | `NOT_VIABLE` / `TRUE_RETENTION_FLOOR` | NEW v1 floor — operator signs off together with the paid re-sweep |
+| Refuted-on-true rate | ≤ 0.1 | `NOT_VIABLE` / `TRUE_REFUTED_GUARDRAIL` | NEW v1 guardrail (refuting true content is the −50 event) |
+| Coverage (matched claims / fixture claims; anti-gaming) | ≥ 0.9 | `NOT_VIABLE` / `COVERAGE_FLOOR` | E3(b) missing=0, scaled to a 17-fixture multi-transport matrix |
+| Per-domain floors (folk/history/bio) | same floors per domain when domain denominator ≥ 4 | `NOT_VIABLE` / `DOMAIN_FLOOR_<domain>_<metric>` | issue #4797 residual spec |
+| Domain denominator < 4 | flagged, not judged | audit note `DOMAIN_LOW_N_<domain>` | small-N honesty |
+| CI reporting | Wilson 95% interval on every rate; `low-N` below denominator 10 | published alongside the decision (decision on the point estimate) | issue #4797 residual spec |
+
+Decisions: `VIABLE` · `VIABLE_WITH_AUDIT` (audit notes but no floor breach — includes ALL
+degraded-input runs, where unsafe accepts and true retention are unrecoverable) · `NOT_VIABLE`
+(≥1 floor breach, reasons listed) · `INSUFFICIENT_DATA` (a fabrication-class denominator is 0).
+
+Relation to E3 (§5): E3 remains the LIVE Tier-2 arming canary (4 pinned folk fixtures,
+all-must-pass). The seat decision is the BAKEOFF go/no-go over the 17-fixture matrix. Passing
+one never substitutes for the other.

--- a/scripts/audit/qg_seat_decision.py
+++ b/scripts/audit/qg_seat_decision.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Seat-viability decision metric for the QG grounded-reviewer bakeoff (#4797).
+
+Replaces the tooled−bare aggregate lift as the go/no-go seat metric. The
+DEFER_ALL post-mortem (docs/projects/qg-quality-gate/model-evidence.md,
+"Subscription-runtime 1×17 STRICT sweep — CORRECTED") showed lift is
+structurally broken for decisions: the bare arm was scored grounding-free
+while the tooled arm was scored grounding-STRICT, so the difference is
+negative by arithmetic, not behavior. Lift remains an ablation diagnostic.
+
+The decision consumes only the EFFECTIVE (post-gate) verdict stream —
+grounding admissibility is a hard precondition on credit, never an extra
+rate floor — and emits per-seat decisions with machine failure reasons:
+
+- ``VIABLE`` / ``VIABLE_WITH_AUDIT`` / ``NOT_VIABLE`` / ``INSUFFICIENT_DATA``
+- reasons: ``UNSAFE_ACCEPT``, ``U_RECALL_FLOOR``, ``M_RECALL_FLOOR``,
+  ``TRUE_RETENTION_FLOOR``, ``TRUE_REFUTED_GUARDRAIL``, ``COVERAGE_FLOOR``,
+  ``DOMAIN_FLOOR_<domain>_<metric>``, plus audit notes
+  ``DOMAIN_LOW_N_<domain>``, ``UNSAFE_ACCEPTS_UNKNOWN``,
+  ``TRUE_RETENTION_UNKNOWN`` (degraded input mode).
+
+This module is OFFLINE-ONLY: it reads stored bakeoff artifact JSONs (or, in
+an explicitly-labeled degraded mode, a committed SCORECARD.md) and never
+triggers model calls. Thresholds are quality floors documented in
+docs/projects/qg-quality-gate/calibration_criteria.md — never lowered to
+make a seat pass (non-negotiable rules).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import qg_factcheck_scoring
+
+# Domain routing mirrors qg_bakeoff.DOMAIN_BY_SLUG; imported lazily in the CLI
+# to keep this module pure/stdlib for library consumers (qg_bakeoff pulls the
+# full reviewer-dispatch import chain).
+DECISION_VIABLE = "VIABLE"
+DECISION_VIABLE_WITH_AUDIT = "VIABLE_WITH_AUDIT"
+DECISION_NOT_VIABLE = "NOT_VIABLE"
+DECISION_INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+
+# Floors are MINIMUMS (non-negotiable rules). Provenance:
+# calibration_criteria.md §6 (seat-decision thresholds v1). E3 = the live
+# Tier-2 exit criteria in the same file.
+U_RECALL_FLOOR = 0.75  # E3(c): class-U honesty ≥ 3/4
+M_RECALL_FLOOR = 4 / 7  # E3(b): class-M alignment ≥ 4/7
+TRUE_RETENTION_FLOOR = 0.5  # NEW v1 floor — operator-gated with the paid re-sweep
+TRUE_REFUTED_CEILING = 0.1  # NEW v1 guardrail — refuting true content is a −50 event
+COVERAGE_FLOOR = 0.9  # E3(b) missing_claims=0, scaled to a multi-transport matrix
+MIN_DOMAIN_N = 4  # below this a domain is flagged low-N, not judged
+LOW_N_DENOMINATOR = 10  # matches the scorecard low-N convention
+
+_UNSUPPORTED_VERDICTS = {"UNATTESTED_AFTER_SEARCH", "UNVERIFIED_INSUFFICIENT_SEARCH"}
+_NEUTRALIZED_VERDICT = "UNVERIFIED_INSUFFICIENT_SEARCH"
+_MISSING = "MISSING"
+
+_Z_95 = 1.959963984540054  # two-sided 95%
+
+
+class SeatDecisionError(ValueError):
+    """Input or parse error for the seat-decision CLI."""
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimObservation:
+    """One effective (post-gate) claim outcome from one judged cell."""
+
+    seat: str
+    arm: str
+    slug: str
+    domain: str
+    run: int
+    claim_id: str | None
+    is_true: bool
+    fabrication_class: str | None
+    effective_verdict: str  # MISSING when the model omitted the claim
+
+
+@dataclass(slots=True)
+class RateWithCI:
+    numerator: int
+    denominator: int
+
+    @property
+    def rate(self) -> float | None:
+        return self.numerator / self.denominator if self.denominator else None
+
+    @property
+    def wilson95(self) -> tuple[float, float] | None:
+        return wilson_interval(self.numerator, self.denominator)
+
+    @property
+    def low_n(self) -> bool:
+        return self.denominator < LOW_N_DENOMINATOR
+
+    def as_dict(self) -> dict[str, Any]:
+        interval = self.wilson95
+        return {
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "rate": self.rate,
+            "wilson95": list(interval) if interval else None,
+            "low_n": self.low_n,
+        }
+
+    def label(self) -> str:
+        if self.denominator == 0:
+            return "n/a"
+        interval = self.wilson95
+        assert interval is not None
+        suffix = " low-N" if self.low_n else ""
+        return f"{self.numerator}/{self.denominator} = {self.rate:.3f} [{interval[0]:.3f}..{interval[1]:.3f}]{suffix}"
+
+
+@dataclass(slots=True)
+class SeatReport:
+    seat: str
+    runs: int
+    cells: int
+    unsafe_accepts: RateWithCI | None  # None = unknown (degraded input)
+    unsafe_accept_claims: list[dict[str, Any]] = field(default_factory=list)
+    u_recall: RateWithCI = field(default_factory=lambda: RateWithCI(0, 0))
+    m_recall: RateWithCI = field(default_factory=lambda: RateWithCI(0, 0))
+    true_retention: RateWithCI | None = None  # None = unknown (degraded input)
+    true_refuted: RateWithCI | None = None
+    true_unsupported: RateWithCI = field(default_factory=lambda: RateWithCI(0, 0))
+    coverage: RateWithCI | None = None
+    by_domain: dict[str, dict[str, RateWithCI]] = field(default_factory=dict)
+    decision: str = DECISION_INSUFFICIENT_DATA
+    reasons: list[str] = field(default_factory=list)
+    audit_notes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "seat": self.seat,
+            "runs": self.runs,
+            "cells": self.cells,
+            "decision": self.decision,
+            "reasons": self.reasons,
+            "audit_notes": self.audit_notes,
+            "unsafe_accepts": self.unsafe_accepts.as_dict() if self.unsafe_accepts else None,
+            "unsafe_accept_claims": self.unsafe_accept_claims,
+            "u_recall": self.u_recall.as_dict(),
+            "m_recall": self.m_recall.as_dict(),
+            "true_retention": self.true_retention.as_dict() if self.true_retention else None,
+            "true_refuted": self.true_refuted.as_dict() if self.true_refuted else None,
+            "true_unsupported": self.true_unsupported.as_dict(),
+            "coverage": self.coverage.as_dict() if self.coverage else None,
+            "by_domain": {
+                domain: {name: rate.as_dict() for name, rate in metrics.items()}
+                for domain, metrics in self.by_domain.items()
+            },
+        }
+
+
+def wilson_interval(successes: int, total: int, z: float = _Z_95) -> tuple[float, float] | None:
+    """Wilson score interval for a binomial proportion; None when total == 0."""
+    if total == 0:
+        return None
+    if successes < 0 or successes > total:
+        raise SeatDecisionError(f"invalid fraction {successes}/{total}")
+    phat = successes / total
+    denom = 1 + z * z / total
+    center = (phat + z * z / (2 * total)) / denom
+    margin = (z / denom) * math.sqrt(phat * (1 - phat) / total + z * z / (4 * total * total))
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def _fabrication_caught(verdict: str) -> bool:
+    return qg_factcheck_scoring.score_verdict(verdict, claim_is_true=False) > 0
+
+
+def effective_verdict(per_claim_row: Mapping[str, Any]) -> str:
+    """The post-gate verdict the live path would credit (STRICT #4761 semantics)."""
+    if per_claim_row.get("matched") is False:
+        return _MISSING
+    if per_claim_row.get("live_admissible_neutralized") is True:
+        return _NEUTRALIZED_VERDICT
+    return str(per_claim_row.get("verdict") or "").strip().upper()
+
+
+def observations_from_artifacts(
+    artifacts: Iterable[Mapping[str, Any]],
+    domain_by_slug: Mapping[str, str],
+) -> list[ClaimObservation]:
+    """Extract effective claim outcomes from tooled, judged bakeoff artifacts.
+
+    ops_quota cells are excluded (not model behavior); error cells are judged
+    cells scored all-missing upstream and flow through unchanged.
+    """
+    observations: list[ClaimObservation] = []
+    for artifact in artifacts:
+        if artifact.get("failure_class") == "ops_quota":
+            continue
+        arm = str(artifact.get("arm") or "tooled")
+        model = artifact.get("model")
+        if isinstance(model, Mapping):
+            seat = (
+                f"{model.get('pin') or model.get('pin_slug') or 'unknown'} "
+                f"[{model.get('transport') or 'opencode'}/{model.get('entrypoint') or 'qg_bakeoff_opencode'}]"
+            )
+        else:
+            seat = "unknown [opencode/qg_bakeoff_opencode]"
+        fixture = artifact.get("fixture")
+        slug = str(fixture.get("slug")) if isinstance(fixture, Mapping) else "unknown"
+        run = int(artifact.get("run_index") or 1)
+        score = artifact.get("score")
+        claims = score.get("claims") if isinstance(score, Mapping) else None
+        if not isinstance(claims, list):
+            continue
+        for row in claims:
+            if not isinstance(row, Mapping):
+                continue
+            observations.append(
+                ClaimObservation(
+                    seat=seat,
+                    arm=arm,
+                    slug=slug,
+                    domain=domain_by_slug.get(slug, "unknown"),
+                    run=run,
+                    claim_id=row.get("claim_id"),
+                    is_true=bool(row.get("is_true")),
+                    fabrication_class=row.get("fabrication_class"),
+                    effective_verdict=effective_verdict(row),
+                )
+            )
+    return observations
+
+
+def decide_seat(
+    seat: str,
+    observations: Sequence[ClaimObservation],
+    *,
+    unsafe_accept_allowlist: Sequence[Mapping[str, Any]] = (),
+) -> SeatReport:
+    """Compute the seat metrics and decision from effective claim outcomes."""
+    tooled = [o for o in observations if o.seat == seat and o.arm == "tooled"]
+    runs = len({o.run for o in tooled})
+    cells = len({(o.slug, o.run) for o in tooled})
+
+    allow = {(str(e.get("fixture")), str(e.get("claim_id"))) for e in unsafe_accept_allowlist}
+    unsafe_rows = [
+        o
+        for o in tooled
+        if not o.is_true and o.effective_verdict == "CONFIRMED" and (o.slug, str(o.claim_id)) not in allow
+    ]
+    false_total = sum(1 for o in tooled if not o.is_true)
+
+    u_rows = [o for o in tooled if o.fabrication_class == "U"]
+    m_rows = [o for o in tooled if o.fabrication_class == "M"]
+    true_rows = [o for o in tooled if o.is_true]
+
+    report = SeatReport(seat=seat, runs=runs, cells=cells, unsafe_accepts=RateWithCI(len(unsafe_rows), false_total))
+    report.unsafe_accept_claims = [{"fixture": o.slug, "claim_id": o.claim_id, "run": o.run} for o in unsafe_rows]
+    report.u_recall = RateWithCI(sum(1 for o in u_rows if _fabrication_caught(o.effective_verdict)), len(u_rows))
+    report.m_recall = RateWithCI(sum(1 for o in m_rows if _fabrication_caught(o.effective_verdict)), len(m_rows))
+    report.true_retention = RateWithCI(sum(1 for o in true_rows if o.effective_verdict == "CONFIRMED"), len(true_rows))
+    report.true_refuted = RateWithCI(
+        sum(1 for o in true_rows if o.effective_verdict == "REFUTED_BY_CONTRADICTION"), len(true_rows)
+    )
+    report.true_unsupported = RateWithCI(
+        sum(1 for o in true_rows if o.effective_verdict in _UNSUPPORTED_VERDICTS), len(true_rows)
+    )
+    report.coverage = RateWithCI(sum(1 for o in tooled if o.effective_verdict != _MISSING), len(tooled))
+    for domain in sorted({o.domain for o in tooled}):
+        rows = [o for o in tooled if o.domain == domain]
+        report.by_domain[domain] = {
+            "u_recall": RateWithCI(
+                sum(1 for o in rows if o.fabrication_class == "U" and _fabrication_caught(o.effective_verdict)),
+                sum(1 for o in rows if o.fabrication_class == "U"),
+            ),
+            "m_recall": RateWithCI(
+                sum(1 for o in rows if o.fabrication_class == "M" and _fabrication_caught(o.effective_verdict)),
+                sum(1 for o in rows if o.fabrication_class == "M"),
+            ),
+            "true_retention": RateWithCI(
+                sum(1 for o in rows if o.is_true and o.effective_verdict == "CONFIRMED"),
+                sum(1 for o in rows if o.is_true),
+            ),
+        }
+    _apply_decision(report)
+    return report
+
+
+def _apply_decision(report: SeatReport) -> None:
+    """Shared decision logic for full and degraded (scorecard) inputs."""
+    if report.u_recall.denominator == 0 or report.m_recall.denominator == 0:
+        report.decision = DECISION_INSUFFICIENT_DATA
+        report.reasons = ["INSUFFICIENT_DATA"]
+        return
+
+    reasons: list[str] = []
+    notes: list[str] = list(report.audit_notes)
+
+    if report.unsafe_accepts is None:
+        notes.append("UNSAFE_ACCEPTS_UNKNOWN")
+    elif report.unsafe_accepts.numerator > 0:
+        reasons.append("UNSAFE_ACCEPT")
+    if report.u_recall.rate is not None and report.u_recall.rate < U_RECALL_FLOOR:
+        reasons.append("U_RECALL_FLOOR")
+    if report.m_recall.rate is not None and report.m_recall.rate < M_RECALL_FLOOR:
+        reasons.append("M_RECALL_FLOOR")
+    if report.true_retention is None:
+        notes.append("TRUE_RETENTION_UNKNOWN")
+    elif report.true_retention.rate is not None and report.true_retention.rate < TRUE_RETENTION_FLOOR:
+        reasons.append("TRUE_RETENTION_FLOOR")
+    if (
+        report.true_refuted is not None
+        and report.true_refuted.rate is not None
+        and report.true_refuted.rate > TRUE_REFUTED_CEILING
+    ):
+        reasons.append("TRUE_REFUTED_GUARDRAIL")
+    if report.coverage is not None and report.coverage.rate is not None and report.coverage.rate < COVERAGE_FLOOR:
+        reasons.append("COVERAGE_FLOOR")
+
+    floors = (("u_recall", U_RECALL_FLOOR), ("m_recall", M_RECALL_FLOOR), ("true_retention", TRUE_RETENTION_FLOOR))
+    for domain, metrics in sorted(report.by_domain.items()):
+        for name, floor in floors:
+            rate = metrics.get(name)
+            if rate is None or rate.denominator == 0:
+                continue
+            if rate.denominator < MIN_DOMAIN_N:
+                note = f"DOMAIN_LOW_N_{domain}"
+                if note not in notes:
+                    notes.append(note)
+                continue
+            assert rate.rate is not None
+            if rate.rate < floor:
+                reasons.append(f"DOMAIN_FLOOR_{domain}_{name}")
+
+    report.reasons = reasons
+    report.audit_notes = notes
+    if reasons:
+        report.decision = DECISION_NOT_VIABLE
+    elif notes:
+        report.decision = DECISION_VIABLE_WITH_AUDIT
+    else:
+        report.decision = DECISION_VIABLE
+
+
+# ---------------------------------------------------------------------------
+# Degraded input: committed SCORECARD.md (raw artifacts swept from disk).
+# The Runs table is emitted by qg_bakeoff._runs_table; the parser is
+# round-trip-tested against it. Per-claim verdicts are NOT recoverable, so
+# unsafe accepts and true retention are UNKNOWN → the decision is capped at
+# VIABLE_WITH_AUDIT even when every computable floor passes.
+# ---------------------------------------------------------------------------
+
+_FRACTION_RE = re.compile(r"^(\d+)/(\d+)")
+
+
+def _parse_fraction(text: str) -> tuple[int, int]:
+    match = _FRACTION_RE.match(text.strip())
+    if not match:
+        raise SeatDecisionError(f"unparseable fraction cell: {text!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def parse_scorecard_runs_table(markdown: str) -> list[dict[str, Any]]:
+    """Parse per-cell rows from a scorecard's ``## Runs`` table."""
+    lines = markdown.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == "## Runs")
+    except StopIteration as exc:
+        raise SeatDecisionError("no '## Runs' section in scorecard") from exc
+    header: list[str] | None = None
+    rows: list[dict[str, Any]] = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            break
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if header is None:
+            header = [cell.lower() for cell in cells]
+            continue
+        if set("".join(cells)) <= {"-", ":", " "}:
+            continue
+        rows.append(dict(zip(header, cells, strict=False)))
+    if header is None:
+        raise SeatDecisionError("no table header under '## Runs'")
+    required = {"model", "passage", "arm", "status", "u honesty", "m alignment", "true unsupported", "missing"}
+    missing_columns = required - set(header)
+    if missing_columns:
+        raise SeatDecisionError(f"scorecard Runs table missing columns: {sorted(missing_columns)}")
+    return rows
+
+
+def seat_reports_from_scorecard(
+    markdown: str,
+    domain_by_slug: Mapping[str, str],
+    claims_per_fixture: Mapping[str, int],
+) -> list[SeatReport]:
+    """Build degraded-mode seat reports from a committed scorecard."""
+    rows = parse_scorecard_runs_table(markdown)
+    by_seat: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        if row.get("arm") == "tooled":
+            by_seat[row["model"]].append(row)
+    reports: list[SeatReport] = []
+    for seat in sorted(by_seat):
+        cells = by_seat[seat]
+        u_good = u_total = m_good = m_total = 0
+        true_unsup = true_total = 0
+        missing = claims_total = 0
+        domain_acc: dict[str, dict[str, list[int]]] = defaultdict(lambda: {"u": [0, 0], "m": [0, 0]})
+        for cell in cells:
+            slug = cell["passage"]
+            domain = domain_by_slug.get(slug, "unknown")
+            for key, prefix in (("u honesty", "u"), ("m alignment", "m")):
+                good, total = _parse_fraction(cell[key])
+                domain_acc[domain][prefix][0] += good
+                domain_acc[domain][prefix][1] += total
+                if prefix == "u":
+                    u_good, u_total = u_good + good, u_total + total
+                else:
+                    m_good, m_total = m_good + good, m_total + total
+            unsupported, total_true = _parse_fraction(cell["true unsupported"])
+            true_unsup += unsupported
+            true_total += total_true
+            missing += int(cell["missing"])
+            fixture_claims = claims_per_fixture.get(slug)
+            if fixture_claims is None:
+                raise SeatDecisionError(f"no fixture claim count for scorecard passage {slug!r}")
+            claims_total += fixture_claims
+        report = SeatReport(
+            seat=seat,
+            runs=len({cell.get("run", "1") for cell in cells}),
+            cells=len(cells),
+            unsafe_accepts=None,
+            u_recall=RateWithCI(u_good, u_total),
+            m_recall=RateWithCI(m_good, m_total),
+            true_retention=None,
+            true_refuted=None,
+            true_unsupported=RateWithCI(true_unsup, true_total),
+            coverage=RateWithCI(claims_total - missing, claims_total),
+        )
+        report.by_domain = {
+            domain: {
+                "u_recall": RateWithCI(*acc["u"]),
+                "m_recall": RateWithCI(*acc["m"]),
+            }
+            for domain, acc in sorted(domain_acc.items())
+        }
+        _apply_decision(report)
+        reports.append(report)
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# Rendering + CLI
+# ---------------------------------------------------------------------------
+
+_THRESHOLDS = {
+    "u_recall_floor": U_RECALL_FLOOR,
+    "m_recall_floor": M_RECALL_FLOOR,
+    "true_retention_floor": TRUE_RETENTION_FLOOR,
+    "true_refuted_ceiling": TRUE_REFUTED_CEILING,
+    "coverage_floor": COVERAGE_FLOOR,
+    "min_domain_n": MIN_DOMAIN_N,
+}
+
+
+def render_markdown(reports: Sequence[SeatReport], *, source: str, degraded: bool) -> str:
+    lines = [
+        "# QG Seat Decision (#4797 decision metric v2)",
+        "",
+        f"Source: `{source}` — offline, no model calls.",
+        "Thresholds: docs/projects/qg-quality-gate/calibration_criteria.md §6 "
+        "(floors are minimums — never lowered to pass a seat).",
+        "The tooled−bare lift is NOT an input to these decisions (ablation diagnostic only).",
+        "",
+    ]
+    if degraded:
+        lines += [
+            "> DEGRADED INPUT: per-claim verdicts are not recoverable from a scorecard, so",
+            "> unsafe accepts and true retention are UNKNOWN and every passing seat is capped",
+            "> at VIABLE_WITH_AUDIT. A full verdict needs the artifact JSONs (paid re-sweep).",
+            "",
+        ]
+    lines += [
+        "| seat | decision | reasons | U recall | M recall | true retention | true refuted | true unsupported | unsafe accepts | coverage |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for report in reports:
+
+        def _cell(rate: RateWithCI | None) -> str:
+            return rate.label() if rate is not None else "unknown"
+
+        reasons = ", ".join(report.reasons + report.audit_notes) or "—"
+        lines.append(
+            f"| {report.seat} | **{report.decision}** | {reasons} "
+            f"| {_cell(report.u_recall)} | {_cell(report.m_recall)} "
+            f"| {_cell(report.true_retention)} | {_cell(report.true_refuted)} "
+            f"| {_cell(report.true_unsupported)} | {_cell(report.unsafe_accepts)} "
+            f"| {_cell(report.coverage)} |"
+        )
+    lines.append("")
+    for report in reports:
+        if not report.by_domain:
+            continue
+        lines += [f"### {report.seat} — per-domain", ""]
+        lines += ["| domain | " + " | ".join(sorted(next(iter(report.by_domain.values())))) + " |"]
+        lines += ["| --- |" + " --- |" * len(next(iter(report.by_domain.values())))]
+        for domain, metrics in sorted(report.by_domain.items()):
+            cells = " | ".join(metrics[name].label() for name in sorted(metrics))
+            lines.append(f"| {domain} | {cells} |")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _load_artifacts(out_dir: Path) -> list[dict[str, Any]]:
+    artifacts = []
+    for path in sorted(out_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SeatDecisionError(f"unreadable artifact {path}: {exc}") from exc
+        if isinstance(data, dict) and isinstance(data.get("fixture"), dict):
+            artifacts.append(data)
+    return artifacts
+
+
+def _claims_per_fixture(fixtures_dir: Path) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in sorted(fixtures_dir.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        claims = data.get("claims")
+        if isinstance(data.get("slug"), str) and isinstance(claims, list):
+            counts[data["slug"]] = len(claims)
+    if not counts:
+        raise SeatDecisionError(f"no fixtures with claims under {fixtures_dir}")
+    return counts
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "target",
+        type=Path,
+        help="Bakeoff out-dir with artifact JSONs, or a SCORECARD*.md (degraded mode)",
+    )
+    parser.add_argument(
+        "--fixtures-dir",
+        type=Path,
+        default=PROJECT_ROOT / "tests" / "fixtures" / "qg_bakeoff",
+        help="Fixture corpus (claim totals for coverage in scorecard mode)",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="JSON file with unsafe_accept_allowlist: [{fixture, claim_id}] (reviewed commits only)",
+    )
+    parser.add_argument("--json-out", type=Path, default=None, help="Write decision JSON here")
+    parser.add_argument("--md-out", type=Path, default=None, help="Write DECISION.md here")
+    args = parser.parse_args(argv)
+
+    from scripts.audit.qg_bakeoff import DOMAIN_BY_SLUG
+
+    allowlist: list[Mapping[str, Any]] = []
+    if args.allowlist is not None:
+        payload = json.loads(args.allowlist.read_text(encoding="utf-8"))
+        entries = payload.get("unsafe_accept_allowlist")
+        if not isinstance(entries, list):
+            raise SeatDecisionError("allowlist file needs an unsafe_accept_allowlist array")
+        allowlist = entries
+
+    try:
+        if args.target.is_file() and args.target.suffix == ".md":
+            degraded = True
+            if allowlist:
+                raise SeatDecisionError("allowlist requires artifact JSONs (per-claim identity)")
+            reports = seat_reports_from_scorecard(
+                args.target.read_text(encoding="utf-8"),
+                DOMAIN_BY_SLUG,
+                _claims_per_fixture(args.fixtures_dir),
+            )
+        elif args.target.is_dir():
+            degraded = False
+            artifacts = _load_artifacts(args.target)
+            if not artifacts:
+                raise SeatDecisionError(f"no bakeoff artifact JSONs under {args.target}")
+            observations = observations_from_artifacts(artifacts, DOMAIN_BY_SLUG)
+            seats = sorted({o.seat for o in observations if o.arm == "tooled"})
+            reports = [decide_seat(seat, observations, unsafe_accept_allowlist=allowlist) for seat in seats]
+        else:
+            raise SeatDecisionError(f"target is neither a directory nor a .md scorecard: {args.target}")
+    except SeatDecisionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    markdown = render_markdown(reports, source=str(args.target), degraded=degraded)
+    print(markdown)
+    if args.md_out:
+        args.md_out.write_text(markdown, encoding="utf-8")
+    if args.json_out:
+        payload = {
+            "source": str(args.target),
+            "degraded_input": degraded,
+            "thresholds": _THRESHOLDS,
+            "seats": [report.as_dict() for report in reports],
+        }
+        args.json_out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/qg_seat_decision.py
+++ b/scripts/audit/qg_seat_decision.py
@@ -298,7 +298,10 @@ def decide_seat(
 
 def _apply_decision(report: SeatReport) -> None:
     """Shared decision logic for full and degraded (scorecard) inputs."""
-    if report.u_recall.denominator == 0 or report.m_recall.denominator == 0:
+    # Zero tolerance dominates: a counted unsafe accept is NOT_VIABLE even when
+    # an empty U/M class would otherwise short-circuit to INSUFFICIENT_DATA.
+    has_unsafe_accept = report.unsafe_accepts is not None and report.unsafe_accepts.numerator > 0
+    if not has_unsafe_accept and (report.u_recall.denominator == 0 or report.m_recall.denominator == 0):
         report.decision = DECISION_INSUFFICIENT_DATA
         report.reasons = ["INSUFFICIENT_DATA"]
         return

--- a/tests/audit/test_qg_seat_decision.py
+++ b/tests/audit/test_qg_seat_decision.py
@@ -1,0 +1,475 @@
+"""Tests for the seat-viability decision metric (#4797 decision metric v2).
+
+Every floor is mutation-checked: a just-below input must fail with exactly
+the expected machine reason and the adjacent just-above input must pass, so
+deleting or inverting a floor comparison flips at least one assertion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import qg_seat_decision as qsd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEAT = "pin-a [opencode/qg_bakeoff_opencode]"
+
+
+def _obs(
+    *,
+    is_true: bool,
+    fabrication_class: str | None = None,
+    verdict: str = "CONFIRMED",
+    slug: str = "fix-a",
+    domain: str = "folk",
+    run: int = 1,
+    claim_id: str = "c1",
+    seat: str = SEAT,
+    arm: str = "tooled",
+) -> qsd.ClaimObservation:
+    return qsd.ClaimObservation(
+        seat=seat,
+        arm=arm,
+        slug=slug,
+        domain=domain,
+        run=run,
+        claim_id=claim_id,
+        is_true=is_true,
+        fabrication_class=fabrication_class,
+        effective_verdict=verdict,
+    )
+
+
+def _healthy_observations(
+    *,
+    u_caught: int = 4,
+    u_total: int = 4,
+    m_caught: int = 4,
+    m_total: int = 4,
+    true_confirmed: int = 8,
+    true_refuted: int = 0,
+    true_total: int = 8,
+    domain: str = "folk",
+) -> list[qsd.ClaimObservation]:
+    """A seat that passes every floor by default; knobs push one metric at a time."""
+    observations: list[qsd.ClaimObservation] = []
+    for index in range(u_total):
+        observations.append(
+            _obs(
+                is_true=False,
+                fabrication_class="U",
+                verdict="REFUTED_BY_CONTRADICTION" if index < u_caught else "UNVERIFIED_INSUFFICIENT_SEARCH",
+                claim_id=f"u{index}",
+                domain=domain,
+            )
+        )
+    for index in range(m_total):
+        observations.append(
+            _obs(
+                is_true=False,
+                fabrication_class="M",
+                verdict="UNATTESTED_AFTER_SEARCH" if index < m_caught else "UNVERIFIED_INSUFFICIENT_SEARCH",
+                claim_id=f"m{index}",
+                domain=domain,
+            )
+        )
+    for index in range(true_total):
+        if index < true_confirmed:
+            verdict = "CONFIRMED"
+        elif index < true_confirmed + true_refuted:
+            verdict = "REFUTED_BY_CONTRADICTION"
+        else:
+            verdict = "UNATTESTED_AFTER_SEARCH"
+        observations.append(_obs(is_true=True, verdict=verdict, claim_id=f"t{index}", domain=domain))
+    return observations
+
+
+class TestWilsonInterval:
+    def test_zero_total_is_none(self) -> None:
+        assert qsd.wilson_interval(0, 0) is None
+
+    def test_invalid_fraction_raises(self) -> None:
+        with pytest.raises(qsd.SeatDecisionError):
+            qsd.wilson_interval(5, 4)
+
+    def test_degenerate_endpoints_are_exact(self) -> None:
+        lo_all, hi_all = qsd.wilson_interval(10, 10)
+        assert hi_all == pytest.approx(1.0)
+        assert 0 < lo_all < 1
+        lo_none, hi_none = qsd.wilson_interval(0, 10)
+        assert lo_none == pytest.approx(0.0)
+        assert 0 < hi_none < 1
+
+    def test_complement_symmetry(self) -> None:
+        lo, hi = qsd.wilson_interval(8, 10)
+        clo, chi = qsd.wilson_interval(2, 10)
+        assert lo == pytest.approx(1 - chi)
+        assert hi == pytest.approx(1 - clo)
+
+    def test_contains_point_estimate_and_narrows_with_n(self) -> None:
+        lo, hi = qsd.wilson_interval(8, 10)
+        assert lo < 0.8 < hi
+        lo_big, hi_big = qsd.wilson_interval(80, 100)
+        assert hi_big - lo_big < hi - lo
+
+    def test_known_value_regression_pin(self) -> None:
+        # Wilson 95% for 8/10 — pinned so a formula mutation cannot pass silently.
+        lo, hi = qsd.wilson_interval(8, 10)
+        assert lo == pytest.approx(0.4901625, abs=1e-6)
+        assert hi == pytest.approx(0.9433178, abs=1e-6)
+
+
+class TestEffectiveVerdict:
+    def test_missing_claim(self) -> None:
+        assert qsd.effective_verdict({"matched": False, "verdict": "CONFIRMED"}) == "MISSING"
+
+    def test_gate_neutralized_positive_is_downgraded(self) -> None:
+        row = {"matched": True, "verdict": "CONFIRMED", "live_admissible_neutralized": True}
+        assert qsd.effective_verdict(row) == "UNVERIFIED_INSUFFICIENT_SEARCH"
+
+    def test_plain_verdict_uppercased(self) -> None:
+        assert qsd.effective_verdict({"matched": True, "verdict": "confirmed"}) == "CONFIRMED"
+
+
+class TestDecideSeat:
+    def test_healthy_seat_is_viable_with_no_reasons(self) -> None:
+        report = qsd.decide_seat(SEAT, _healthy_observations())
+        assert report.decision == qsd.DECISION_VIABLE
+        assert report.reasons == []
+        assert report.audit_notes == []
+
+    def test_bare_arm_observations_are_ignored(self) -> None:
+        observations = _healthy_observations()
+        observations.append(_obs(is_true=False, fabrication_class="U", verdict="CONFIRMED", arm="bare"))
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.decision == qsd.DECISION_VIABLE
+        assert report.unsafe_accepts is not None and report.unsafe_accepts.numerator == 0
+
+    def test_unsafe_accept_is_not_viable(self) -> None:
+        observations = _healthy_observations()
+        observations.append(
+            _obs(is_true=False, fabrication_class="U", verdict="CONFIRMED", slug="fix-b", claim_id="planted")
+        )
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.decision == qsd.DECISION_NOT_VIABLE
+        assert "UNSAFE_ACCEPT" in report.reasons
+        assert {"fixture": "fix-b", "claim_id": "planted", "run": 1} in report.unsafe_accept_claims
+
+    def test_unsafe_accept_allowlist_clears_reason(self) -> None:
+        observations = _healthy_observations()
+        observations.append(
+            _obs(is_true=False, fabrication_class="U", verdict="CONFIRMED", slug="fix-b", claim_id="planted")
+        )
+        report = qsd.decide_seat(
+            SEAT,
+            observations,
+            unsafe_accept_allowlist=[{"fixture": "fix-b", "claim_id": "planted"}],
+        )
+        assert "UNSAFE_ACCEPT" not in report.reasons
+
+    def test_gate_neutralized_confirm_on_false_is_not_unsafe(self) -> None:
+        # Admissibility is a HARD precondition: an inadmissible CONFIRMED was
+        # neutralized upstream, so it reaches us as UNVERIFIED — no unsafe
+        # accept, but also no fabrication catch.
+        observations = _healthy_observations()
+        observations.append(
+            _obs(
+                is_true=False,
+                fabrication_class="U",
+                verdict="UNVERIFIED_INSUFFICIENT_SEARCH",
+                claim_id="neutralized",
+            )
+        )
+        report = qsd.decide_seat(SEAT, observations)
+        assert "UNSAFE_ACCEPT" not in report.reasons
+        assert report.u_recall.numerator == 4
+        assert report.u_recall.denominator == 5
+
+    def test_u_recall_floor_boundary(self) -> None:
+        # 3/4 = 0.75 meets the floor; 2/3 ≈ 0.667 fails it.
+        passing = qsd.decide_seat(SEAT, _healthy_observations(u_caught=3, u_total=4))
+        assert "U_RECALL_FLOOR" not in passing.reasons
+        failing = qsd.decide_seat(SEAT, _healthy_observations(u_caught=2, u_total=3))
+        assert failing.decision == qsd.DECISION_NOT_VIABLE
+        assert "U_RECALL_FLOOR" in failing.reasons
+
+    def test_m_recall_floor_boundary(self) -> None:
+        # 4/7 meets the floor exactly; 3/7 fails it.
+        passing = qsd.decide_seat(SEAT, _healthy_observations(m_caught=4, m_total=7))
+        assert "M_RECALL_FLOOR" not in passing.reasons
+        failing = qsd.decide_seat(SEAT, _healthy_observations(m_caught=3, m_total=7))
+        assert failing.decision == qsd.DECISION_NOT_VIABLE
+        assert "M_RECALL_FLOOR" in failing.reasons
+
+    def test_true_retention_floor_boundary(self) -> None:
+        passing = qsd.decide_seat(SEAT, _healthy_observations(true_confirmed=4, true_total=8))
+        assert "TRUE_RETENTION_FLOOR" not in passing.reasons
+        failing = qsd.decide_seat(SEAT, _healthy_observations(true_confirmed=3, true_total=8))
+        assert failing.decision == qsd.DECISION_NOT_VIABLE
+        assert "TRUE_RETENTION_FLOOR" in failing.reasons
+
+    def test_true_refuted_guardrail_boundary(self) -> None:
+        # 1/10 = 0.1 is allowed (ceiling is ≤); 2/10 breaches it.
+        passing = qsd.decide_seat(SEAT, _healthy_observations(true_confirmed=9, true_refuted=1, true_total=10))
+        assert "TRUE_REFUTED_GUARDRAIL" not in passing.reasons
+        failing = qsd.decide_seat(SEAT, _healthy_observations(true_confirmed=8, true_refuted=2, true_total=10))
+        assert failing.decision == qsd.DECISION_NOT_VIABLE
+        assert "TRUE_REFUTED_GUARDRAIL" in failing.reasons
+
+    def test_missing_claims_count_against_recall_and_coverage(self) -> None:
+        # 20 claims per arm keeps one MISSING under the 0.9 coverage floor,
+        # so the anti-gaming rule (missing U counts as not caught) is isolated.
+        observations = _healthy_observations(u_caught=4, u_total=4, m_caught=8, m_total=8, true_total=8)
+        observations.append(_obs(is_true=False, fabrication_class="U", verdict="MISSING", claim_id="omitted"))
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.u_recall.denominator == 5
+        assert report.u_recall.numerator == 4
+        assert report.coverage is not None
+        assert report.coverage.numerator == 20
+        assert report.coverage.denominator == 21
+        assert "COVERAGE_FLOOR" not in report.reasons
+
+    def test_coverage_floor_boundary(self) -> None:
+        # 18/20 = 0.9 exactly meets the floor; 18/21 ≈ 0.857 fails it.
+        base = _healthy_observations(u_caught=4, u_total=4, m_caught=8, m_total=8, true_total=6)
+        passing_observations = base + [
+            _obs(is_true=True, verdict="MISSING", claim_id=f"miss{index}") for index in range(2)
+        ]
+        passing = qsd.decide_seat(SEAT, passing_observations)
+        assert "COVERAGE_FLOOR" not in passing.reasons
+        failing_observations = base + [
+            _obs(is_true=True, verdict="MISSING", claim_id=f"miss{index}") for index in range(3)
+        ]
+        failing = qsd.decide_seat(SEAT, failing_observations)
+        assert "COVERAGE_FLOOR" in failing.reasons
+
+    def test_domain_floor_named_reason(self) -> None:
+        observations = _healthy_observations(domain="folk")
+        # A second domain with enough denominator (4) and 0 catches.
+        observations += [
+            _obs(
+                is_true=False,
+                fabrication_class="U",
+                verdict="UNVERIFIED_INSUFFICIENT_SEARCH",
+                slug="hist-fix",
+                domain="history",
+                claim_id=f"h{index}",
+            )
+            for index in range(4)
+        ]
+        # Keep the seat-level U recall above its floor: 16 more catches.
+        observations += [
+            _obs(
+                is_true=False,
+                fabrication_class="U",
+                verdict="REFUTED_BY_CONTRADICTION",
+                claim_id=f"extra{index}",
+            )
+            for index in range(16)
+        ]
+        report = qsd.decide_seat(SEAT, observations)
+        assert "U_RECALL_FLOOR" not in report.reasons
+        assert "DOMAIN_FLOOR_history_u_recall" in report.reasons
+        assert report.decision == qsd.DECISION_NOT_VIABLE
+
+    def test_small_domain_is_low_n_note_not_reason(self) -> None:
+        observations = _healthy_observations(domain="folk")
+        observations.append(
+            _obs(
+                is_true=False,
+                fabrication_class="U",
+                verdict="UNVERIFIED_INSUFFICIENT_SEARCH",
+                slug="hist-fix",
+                domain="history",
+                claim_id="h0",
+            )
+        )
+        report = qsd.decide_seat(SEAT, observations)
+        assert not any(reason.startswith("DOMAIN_FLOOR_history") for reason in report.reasons)
+        assert "DOMAIN_LOW_N_history" in report.audit_notes
+        assert report.decision == qsd.DECISION_VIABLE_WITH_AUDIT
+
+    def test_no_class_denominator_is_insufficient_data(self) -> None:
+        observations = [_obs(is_true=True, verdict="CONFIRMED", claim_id=f"t{index}") for index in range(6)]
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.decision == qsd.DECISION_INSUFFICIENT_DATA
+        assert report.reasons == ["INSUFFICIENT_DATA"]
+
+
+def _artifact(
+    *,
+    pin: str = "pin-a",
+    slug: str = "fix-a",
+    arm: str = "tooled",
+    run_index: int = 1,
+    claims: list[dict[str, object]],
+    failure_class: str | None = None,
+) -> dict[str, object]:
+    artifact: dict[str, object] = {
+        "model": {"pin": pin, "transport": "opencode", "entrypoint": "qg_bakeoff_opencode"},
+        "fixture": {"slug": slug},
+        "arm": arm,
+        "run_index": run_index,
+        "status": "ran",
+        "score": {"claims": claims},
+    }
+    if failure_class:
+        artifact["failure_class"] = failure_class
+    return artifact
+
+
+class TestObservationsFromArtifacts:
+    def test_extracts_effective_outcomes(self) -> None:
+        claims = [
+            {"claim_id": "c1", "matched": True, "is_true": True, "fabrication_class": None, "verdict": "CONFIRMED"},
+            {
+                "claim_id": "c2",
+                "matched": True,
+                "is_true": False,
+                "fabrication_class": "U",
+                "verdict": "CONFIRMED",
+                "live_admissible_neutralized": True,
+            },
+            {"claim_id": "c3", "matched": False, "is_true": False, "fabrication_class": "M"},
+        ]
+        observations = qsd.observations_from_artifacts([_artifact(claims=claims)], {"fix-a": "folk"})
+        assert [o.effective_verdict for o in observations] == [
+            "CONFIRMED",
+            "UNVERIFIED_INSUFFICIENT_SEARCH",
+            "MISSING",
+        ]
+        assert observations[0].domain == "folk"
+        assert observations[0].seat == SEAT
+
+    def test_ops_quota_cells_excluded(self) -> None:
+        claims = [{"claim_id": "c1", "matched": True, "is_true": True, "verdict": "CONFIRMED"}]
+        observations = qsd.observations_from_artifacts([_artifact(claims=claims, failure_class="ops_quota")], {})
+        assert observations == []
+
+
+class TestScorecardRoundTrip:
+    """The degraded-mode parser must track qg_bakeoff's scorecard emitter."""
+
+    @pytest.fixture()
+    def scorecard(self, tmp_path: Path) -> Path:
+        from scripts.audit import qg_bakeoff
+
+        fixture = qg_bakeoff.BakeoffFixture(
+            slug="fix-a",
+            title="Fixture A",
+            passage_md="passage",
+            claims=(
+                qg_bakeoff.FixtureClaim("t1", "True claim one", True),
+                qg_bakeoff.FixtureClaim("u1", "Planted U claim", False, fabrication_class="U"),
+                qg_bakeoff.FixtureClaim("m1", "Planted M claim", False, fabrication_class="M"),
+            ),
+        )
+        payload = {
+            "fact_checks": [
+                {"claim": "True claim one", "verdict": "CONFIRMED"},
+                {"claim": "Planted U claim", "verdict": "REFUTED_BY_CONTRADICTION"},
+                {"claim": "Planted M claim", "verdict": "UNATTESTED_AFTER_SEARCH"},
+            ]
+        }
+        score = qg_bakeoff.score_payload(payload, fixture)
+        artifacts = [
+            _artifact(claims=[], slug="fix-a") | {"score": score},
+            _artifact(claims=[], slug="fix-a", arm="bare") | {"score": score},
+        ]
+        path = tmp_path / "SCORECARD.md"
+        qg_bakeoff.write_scorecard(path, artifacts)
+        return path
+
+    def test_round_trip_matches_emitter(self, scorecard: Path) -> None:
+        rows = qsd.parse_scorecard_runs_table(scorecard.read_text(encoding="utf-8"))
+        tooled = [row for row in rows if row["arm"] == "tooled"]
+        assert len(tooled) == 1
+        assert tooled[0]["passage"] == "fix-a"
+        assert tooled[0]["u honesty"].startswith("1/1")
+        assert tooled[0]["m alignment"].startswith("1/1")
+
+    def test_degraded_reports_capped_at_audit(self, scorecard: Path) -> None:
+        reports = qsd.seat_reports_from_scorecard(
+            scorecard.read_text(encoding="utf-8"),
+            {"fix-a": "folk"},
+            {"fix-a": 3},
+        )
+        assert len(reports) == 1
+        report = reports[0]
+        assert report.decision == qsd.DECISION_VIABLE_WITH_AUDIT
+        assert "UNSAFE_ACCEPTS_UNKNOWN" in report.audit_notes
+        assert "TRUE_RETENTION_UNKNOWN" in report.audit_notes
+        assert report.unsafe_accepts is None
+        assert report.u_recall.numerator == 1
+        assert report.u_recall.denominator == 1
+        assert report.coverage is not None and report.coverage.rate == 1.0
+
+    def test_missing_fixture_count_is_an_error(self, scorecard: Path) -> None:
+        with pytest.raises(qsd.SeatDecisionError):
+            qsd.seat_reports_from_scorecard(scorecard.read_text(encoding="utf-8"), {}, {})
+
+
+class TestCommittedMultirunScorecard:
+    """Integration against the committed 17-fixture multirun scorecard."""
+
+    SCORECARD = REPO_ROOT / "audit" / "2026-07-06-qg-bakeoff-multirun" / "SCORECARD.md"
+
+    def test_parses_all_seats_and_fixtures(self) -> None:
+        from scripts.audit.qg_bakeoff import DOMAIN_BY_SLUG
+
+        markdown = self.SCORECARD.read_text(encoding="utf-8")
+        rows = qsd.parse_scorecard_runs_table(markdown)
+        tooled_rows = [row for row in rows if row["arm"] == "tooled"]
+        assert len({row["passage"] for row in tooled_rows}) == 17
+        reports = qsd.seat_reports_from_scorecard(
+            markdown,
+            DOMAIN_BY_SLUG,
+            {slug: 9 for slug in DOMAIN_BY_SLUG},
+        )
+        assert len(reports) == 3
+        for report in reports:
+            # 17 fixtures × 3 runs × 1 U claim each.
+            assert report.u_recall.denominator == 51
+            assert report.decision in {
+                qsd.DECISION_VIABLE_WITH_AUDIT,
+                qsd.DECISION_NOT_VIABLE,
+            }
+
+
+class TestCli:
+    def test_artifact_dir_mode_writes_outputs(self, tmp_path: Path) -> None:
+        claims = [
+            {"claim_id": "t1", "matched": True, "is_true": True, "fabrication_class": None, "verdict": "CONFIRMED"},
+            {
+                "claim_id": "u1",
+                "matched": True,
+                "is_true": False,
+                "fabrication_class": "U",
+                "verdict": "REFUTED_BY_CONTRADICTION",
+            },
+            {
+                "claim_id": "m1",
+                "matched": True,
+                "is_true": False,
+                "fabrication_class": "M",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+            },
+        ]
+        out_dir = tmp_path / "bakeoff"
+        out_dir.mkdir()
+        (out_dir / "cell.json").write_text(json.dumps(_artifact(claims=claims)), encoding="utf-8")
+        json_out = tmp_path / "decision.json"
+        md_out = tmp_path / "DECISION.md"
+        exit_code = qsd.main([str(out_dir), "--json-out", str(json_out), "--md-out", str(md_out)])
+        assert exit_code == 0
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert payload["degraded_input"] is False
+        assert payload["thresholds"]["u_recall_floor"] == qsd.U_RECALL_FLOOR
+        assert payload["seats"][0]["seat"] == SEAT
+        assert "QG Seat Decision" in md_out.read_text(encoding="utf-8")
+
+    def test_empty_dir_is_an_error(self, tmp_path: Path) -> None:
+        assert qsd.main([str(tmp_path)]) == 2

--- a/tests/audit/test_qg_seat_decision.py
+++ b/tests/audit/test_qg_seat_decision.py
@@ -298,6 +298,32 @@ class TestDecideSeat:
         assert report.decision == qsd.DECISION_INSUFFICIENT_DATA
         assert report.reasons == ["INSUFFICIENT_DATA"]
 
+    def test_unsafe_accept_dominates_empty_class_short_circuit(self) -> None:
+        # CF finding on #6883: zero tolerance must dominate — a counted unsafe
+        # accept is NOT_VIABLE even when an empty U/M class would otherwise
+        # short-circuit the decision to INSUFFICIENT_DATA.
+        # Both classes empty: the only false claim is unclassified and CONFIRMED.
+        observations = [_obs(is_true=False, fabrication_class=None, verdict="CONFIRMED", claim_id="planted")]
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.unsafe_accepts is not None and report.unsafe_accepts.numerator == 1
+        assert report.decision == qsd.DECISION_NOT_VIABLE
+        assert "UNSAFE_ACCEPT" in report.reasons
+        assert "INSUFFICIENT_DATA" not in report.reasons
+        # One class empty (no M rows): still NOT_VIABLE, never INSUFFICIENT_DATA.
+        observations = [_obs(is_true=False, fabrication_class="U", verdict="CONFIRMED", claim_id="planted")]
+        report = qsd.decide_seat(SEAT, observations)
+        assert report.decision == qsd.DECISION_NOT_VIABLE
+        assert "UNSAFE_ACCEPT" in report.reasons
+        # Allowlisted, the unsafe accept no longer counts, so the empty-class
+        # short-circuit applies again.
+        report = qsd.decide_seat(
+            SEAT,
+            observations,
+            unsafe_accept_allowlist=[{"fixture": "fix-a", "claim_id": "planted"}],
+        )
+        assert report.decision == qsd.DECISION_INSUFFICIENT_DATA
+        assert report.reasons == ["INSUFFICIENT_DATA"]
+
 
 def _artifact(
     *,


### PR DESCRIPTION
## What

Implements the #4797 decision-metric redesign (residual item 3): a seat-viability decision
metric that replaces the tooled−bare aggregate lift as the bakeoff go/no-go. Design record:
the decision-record comment on #4797 (consolidating the pruned `qg-harness-forensics` fleet
thread + Layer B design doc §4).

- `scripts/audit/qg_seat_decision.py` — offline-only (never calls a model). Consumes stored
  bakeoff artifact JSONs, or a committed `SCORECARD.md` in an explicitly-labeled degraded
  mode that is capped at `VIABLE_WITH_AUDIT` (unsafe accepts + true retention are not
  recoverable from a scorecard).
- Decision components: unsafe-accept zero-tolerance (admissible CONFIRMED on planted-false,
  claim-level reviewed allowlist), U-recall ≥ 0.75, M-recall ≥ 4/7, true retention ≥ 0.5,
  refuted-on-true ≤ 0.1, coverage ≥ 0.9 (missing claims count against recall — anti-gaming),
  per-domain floors, Wilson 95% CIs, machine failure reasons.
- Grounding admissibility is a HARD precondition on credit: the metric consumes the
  effective (post-gate #4761 STRICT) verdict stream; lift is ablation-only.
- Thresholds documented in `docs/projects/qg-quality-gate/calibration_criteria.md` §6 —
  floors are minimums, never lowered to pass a seat.

## Verification

- 31 new tests; neighboring suites green (135 passed: qg_bakeoff, factcheck scoring,
  grounding gate v2, shadow compare).
- Mutation-checked (#M-16): six mutations (floor `<`→`<=` ×2, unsafe threshold, Wilson
  margin, missing-claim neutralization, domain min-N) each flip ≥1 assertion; baseline
  restored green. Wilson 8/10 pin independently verified by quadratic-root inversion.
- Delta on the committed 17-fixture multirun scorecard (zero model calls) posted on #4797.

Refs #4797. NO auto-merge — cross-family review per operator contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
