### PR TITLE
fix(venv): close manifest debt, fix recovery runbook, add venv-integrity canary (#6830)

### DIFF
--- a/docs/runbooks/recovery.md
+++ b/docs/runbooks/recovery.md
@@ -42,14 +42,55 @@ git pull --ff-only
 
 PYTHON_CONFIGURE_OPTS="--enable-loadable-sqlite-extensions" pyenv install 3.12.8
 pyenv local 3.12.8
-python -m venv .venv
+uv venv --python 3.12.8 .venv
 .venv/bin/python -m pip install --upgrade pip
-.venv/bin/python -m pip install -e .
+uv pip install --python .venv/bin/python -r requirements.txt -r requirements-dev.txt
 ```
 
 If `pyenv install` reports that 3.12.8 already exists, retain that interpreter;
-do not substitute another Python version. Add any project dependencies required
-by the checked-out revision using its tracked installation instructions.
+do not substitute another Python version.
+
+**`pip install -e .` does NOT work on this tree — do not use it.** `pyproject.toml`
+declares no `[build-system]`/`[tool.setuptools]` table, so an editable install
+falls back to setuptools flat-layout auto-discovery, which refuses to guess a
+single top-level package when the repo root holds multiple top-level
+directories (`scripts/`, `wiki/`, `docs/`, …) — the install fails outright.
+`uv pip install -r requirements.txt` (a plain dependency install, not a
+project install) is the working replacement — but it was NOT sufficient on
+its own until #6830 closed a manifest-debt gap: `psutil`, `filelock`,
+`rapidfuzz`, `lxml`, `pypdf`, `PyMuPDF`, and `ruamel.yaml` were previously
+only pulled in transitively, so a from-scratch `requirements.txt`-only
+install left `pytest --collect-only` unable to collect 17 test modules (see
+`requirements.txt`).
+
+### The `.pth` story
+
+Neither `requirements.txt` nor an editable install puts this repo's own code
+on `sys.path` — there is no `scripts` distribution to install. Two internal
+import spellings are both live in the tree: `scripts.audit.foo` (repo root on
+`sys.path`, what `tests/conftest.py` sets up for pytest) and bare `audit.foo`
+(`scripts/` itself on `sys.path`, used by scripts invoked directly and by
+tools that shell out to a script's own directory — see the dual-identity
+note in `check_node_modules_integrity.py` and #6812). Outside pytest — a
+direct venv `python -c "import ..."`, an MCP server subprocess, a cron job —
+nothing sets either path up. A `.pth` file in site-packages is the standard
+mechanism for adding paths to every interpreter start in a venv:
+
+```bash
+cat > .venv/lib/python3.12/site-packages/learn-ukrainian-paths.pth <<'EOF'
+/absolute/path/to/clean/learn-ukrainian
+/absolute/path/to/clean/learn-ukrainian/scripts
+EOF
+```
+
+Use the venv's actual `python3.NN` directory name (`ls .venv/lib/`) and the
+clone's real absolute path — a `.pth` is not portable across clones or Python
+minor versions; regenerate it, don't copy it from another checkout. #6812
+tracks retiring the bare `scripts/`-rooted identity, which will let this file
+shrink to the repo-root line only.
+
+Add any further project dependencies required by the checked-out revision
+using its tracked installation instructions.
 
 ## 2. Restore data databases from the release
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,23 @@ ruff>=0.15.21
 # Database
 aiosqlite>=0.22
 
+# Process / file-locking / fuzzy-match utilities (#6830 manifest-debt fix —
+# these were installed transitively and worked until a from-scratch venv
+# rebuild had nothing to reinstall them from; declare them directly).
+psutil>=7.2      # scripts/agent_runtime/{livenessprobe,watchdog}.py, agent_monitor_router.py
+filelock>=3.24   # scripts/pipeline/{stress_annotator,state}.py, curriculum_coordinator.py
+rapidfuzz>=3.14  # .mcp/servers/sources/server.py (handle_verify_quote), scripts/build/linear_pipeline.py
+
+# Document parsing (#6830 import-scan sweep — same restore-gap class as
+# above: unconditionally imported by production scripts/, only ever pulled
+# in transitively before, so pytest collection itself breaks on a
+# from-scratch `requirements.txt`-only install: `test_esum_abbyy_parser.py`,
+# `test_plan_latin_fix.py`, and 15 `test_open_model_phase3_*` modules).
+lxml>=6.1         # scripts/ingest/esum_abbyy_parser.py
+pypdf>=6.15       # scripts/projects/open_model_data/*.py, scripts/rag/scrape_diasporiana.py
+PyMuPDF>=1.28     # scripts/rag/{extract_images,annotate_images,poc_pair_page}.py, scripts/tools/analyze_textbook_pages.py
+ruamel.yaml>=0.19 # scripts/tools/{fix_plan_latin_refs,convert_seminar_plans_v6}.py
+
 # MCP protocol (sources + trails MCP servers ported to 2.0 API)
 mcp>=2,<3
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -1048,6 +1048,33 @@ def _node_modules_integrity_canary() -> bool:
     return ok
 
 
+def _venv_integrity_canary() -> bool:
+    """Read-only diagnostic for an empty/broken primary venv.
+
+    #6830 follow-up: a mid-session venv rebuild left `.venv` with no
+    site-packages, and separately, console-script launchers
+    (`pytest`/`py.test`/`cbor2`) were found pointing at a deleted worktree
+    venv. ALERT-only, same posture as `_node_modules_integrity_canary` —
+    detects and records, never repairs. Never raises: the canary must not
+    break health collection.
+    """
+    try:
+        from scripts.audit.check_venv_integrity import check_venv_integrity  # noqa: PLC0415 — script-path fallback
+    except ImportError:  # path-flavoured import for test/script contexts
+        from audit.check_venv_integrity import check_venv_integrity  # noqa: PLC0415 — script-path fallback
+    try:
+        ok, message = check_venv_integrity(
+            PROJECT_ROOT,
+            tasks_dir=PROJECT_ROOT / "batch_state" / "tasks",
+        )
+    except Exception:
+        logger.exception("venv-integrity canary failed to run")
+        return True  # fail-open: don't raise a false alarm on canary error
+    if not ok:
+        logger.warning("venv-integrity canary: %s", message)
+    return ok
+
+
 def _collect_health_orient_data() -> dict:
     return {
         "api": True,
@@ -1058,6 +1085,7 @@ def _collect_health_orient_data() -> dict:
         "node_modules_symlinks_ok": _self_symlink_canary(),
         "primary_integrity_ok": _primary_integrity_canary(),
         "node_modules_integrity_ok": _node_modules_integrity_canary(),
+        "venv_integrity_ok": _venv_integrity_canary(),
     }
 
 

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -45,6 +45,8 @@ PRELOAD_MODULES = [
     "audit.check_primary_integrity",
     "scripts.audit.check_node_modules_integrity",
     "audit.check_node_modules_integrity",
+    "scripts.audit.check_venv_integrity",
+    "audit.check_venv_integrity",
     "scripts.build.phase_constants",
     "agent_runtime.adapters.gemini",
     "research_quality",

--- a/scripts/audit/check_venv_integrity.py
+++ b/scripts/audit/check_venv_integrity.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Primary-venv integrity probe: DETECT an empty/broken venv (#6830).
+
+Follow-up to #6830 (#6818 comment). Two live incidents motivate this:
+
+1. **Empty venv.** A mid-session `uv` venv rebuild (2026-08-15 18:47) left the
+   primary `.venv` with no site-packages; every consumer (`ModuleNotFoundError:
+   No module named 'yaml'`) failed until an operator ran
+   ``uv pip install -r requirements.txt`` by hand. The restore itself then
+   surfaced manifest debt: ``requirements.txt`` was missing ``psutil``,
+   ``filelock``, and ``rapidfuzz`` (pulled in only transitively before), so a
+   from-scratch reinstall from that file alone still left three modules
+   missing (three ``TestVerifyQuoteHandler`` tests silently red).
+2. **Broken console-script shebangs.** ``.venv/bin/pytest`` (and ``py.test``,
+   ``cbor2``) use pip's long-path launcher trick — ``#!/bin/sh`` followed by
+   a ``'''exec' '<python path>' "$0" "$@"`` line — and that embedded
+   interpreter path pointed at a DELETED dispatch worktree's own venv
+   (``.../.worktrees/dispatch/codex/465-.../.venv/bin/python3``). Verbatim
+   ``pytest`` on the primary hard-fails while ``python -m pytest`` still
+   works, because module invocation never execs the broken launcher script.
+   Pollution class: some install/reinstall ran with ``sys.executable``
+   resolving into a worktree venv instead of the primary one.
+
+This module is DETECTION ONLY, mirroring ``check_primary_integrity.py`` /
+``check_node_modules_integrity.py``'s posture:
+
+- DETECT (a): a curated set of lightweight, always-required modules
+  (``requirements.txt``'s non-ML core — deliberately excludes torch/
+  sentence-transformers/qdrant-client, which are legitimately expensive to
+  import and would make this unsuitable for a session-start hook) fail to
+  import under the primary venv's own interpreter. One subprocess, not one
+  per module — cheap (<1s warm) and catches "the venv is empty" as reliably
+  as importing everything, without the heavy-ML import tax.
+- DETECT (b): every non-symlink entry in ``.venv/bin/`` that is a pip
+  console-script launcher (``#!`` first line) whose embedded interpreter path
+  does not realpath-resolve to the SAME interpreter as the venv's own
+  ``bin/python`` (a healthy venv's own ``bin/python`` is itself normally a
+  symlink out to the base interpreter, so "inside the venv directory" is the
+  wrong test — see ``find_broken_console_scripts``'s docstring).
+- RECORD: every detection appends a JSONL event (mirrors the sibling
+  watchdogs' RECORD contract) with the missing modules / broken scripts and
+  the dispatches running at the time.
+- ALERT ONLY, never repairs. Reinstalling packages or console scripts is a
+  package-mutation, not a read, and the primary venv is off-limits to
+  dispatch-worktree writes by convention — repair is an explicit operator
+  action; this probe prints the command to run, it never runs it.
+
+Usage::
+
+    python scripts/audit/check_venv_integrity.py
+
+Wire-up (matches ``check_node_modules_integrity``'s three call sites): the
+``cmd_dispatch`` pre-dispatch gate, the post-worker sweep (both in
+``scripts/delegate.py``), and the Monitor API health-orient canary
+(``scripts/api/main.py``). Callers fail open on any probe exception —
+consistent with the existing watchdogs, a probe bug must never itself block
+or crash a dispatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_sibling(module_name: str, filename: str):
+    """Load a sibling module by FILE PATH — see the identical helper (and its
+    docstring explaining why) in ``check_node_modules_integrity.py``."""
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, Path(__file__).resolve().parent / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_check_primary_integrity = _load_sibling("_venv_integrity_check_primary_integrity", "check_primary_integrity.py")
+_append_event = _check_primary_integrity._append_event
+_resolve_main_root = _check_primary_integrity._resolve_main_root
+_running_dispatches = _check_primary_integrity._running_dispatches
+
+# Lightweight, always-required modules from requirements.txt/requirements-dev.txt
+# (import-name -> the distribution that declares it). Deliberately excludes
+# torch, sentence-transformers, transformers, qdrant-client and other
+# ML/network-heavy deps: importing those costs real seconds and would make
+# this probe unfit for a session-start hook. This set exists to answer one
+# question cheaply — "is site-packages populated at all" — which the
+# 2026-08-15 incident (every import failing, starting with `yaml`) shows a
+# handful of cheap sentinels answers just as reliably as importing everything.
+CORE_SENTINEL_MODULES: dict[str, str] = {
+    "yaml": "pyyaml",
+    "jsonschema": "jsonschema",
+    "fastapi": "fastapi",
+    "uvicorn": "uvicorn",
+    "httpx": "httpx",
+    "ahocorasick": "pyahocorasick",
+    "pymorphy3": "pymorphy3",
+    "jinja2": "jinja2",
+    "aiosqlite": "aiosqlite",
+    "mcp": "mcp",
+    "bs4": "beautifulsoup4",
+    "requests": "requests",
+    "pytest": "pytest",
+    "ruff": "ruff",
+    "psutil": "psutil",
+    "filelock": "filelock",
+    "rapidfuzz": "rapidfuzz",
+    "ukrainian_word_stress": "ukrainian-word-stress",
+    "zeroconf": "zeroconf",
+}
+
+# Console-script launcher name -> owning distribution, for the (rare) cases
+# where they differ. Any script not listed here is assumed to share its
+# distribution's name (true for the overwhelming majority of pip packages,
+# e.g. `cbor2` -> `cbor2`).
+_SCRIPT_PACKAGE_ALIASES: dict[str, str] = {"py.test": "pytest"}
+
+# pip's long-path console-script launcher: `#!/bin/sh` followed by a
+# tri-quoted `exec` line naming the real interpreter, so shells this long
+# path length limit still find a working shebang. See PYTHONPATH/venv
+# launcher docs; every modern pip build emits this form when the venv path
+# is long enough that a direct `#!/abs/path/python` would overflow the
+# kernel's shebang line limit (macOS default: 512 bytes).
+_SHEBANG_EXEC_RE = re.compile(r"^'''exec' '(?P<path>[^']+)' \"\$0\" \"\$@\"$")
+
+
+def _iter_console_scripts(bin_dir: Path):
+    """Regular (non-symlink) files directly under a venv's ``bin/``.
+
+    Skips the interpreter symlinks (``python``, ``python3``, ``python3.12``,
+    …) — those are not pip console-script launchers, they're the venv's own
+    interpreter identity and are checked separately by the primary-integrity
+    watchdog's Python-version drift detection, not here.
+    """
+    if not bin_dir.is_dir():
+        return
+    for entry in sorted(bin_dir.iterdir()):
+        if entry.is_symlink() or not entry.is_file():
+            continue
+        yield entry
+
+
+def _extract_interpreter_path(script: Path) -> str | None:
+    """The interpreter path a pip console-script launcher execs, or ``None``
+    if ``script`` isn't a text launcher (binary tool, activation script,
+    data file, …)."""
+    try:
+        with script.open(encoding="utf-8", errors="strict") as fh:
+            first_line = fh.readline().rstrip("\n")
+            if not first_line.startswith("#!"):
+                return None
+            shebang_target = first_line[2:].strip()
+            if shebang_target != "/bin/sh":
+                # Direct shebang: the interpreter path was short enough to
+                # embed as-is (the common case for a short venv path).
+                parts = shebang_target.split()
+                return parts[0] if parts else None
+            second_line = fh.readline().rstrip("\n")
+    except (OSError, UnicodeDecodeError):
+        return None
+    match = _SHEBANG_EXEC_RE.match(second_line)
+    return match.group("path") if match else None
+
+
+def find_broken_console_scripts(venv_dir: Path) -> list[dict[str, Any]]:
+    """Console-script launchers under ``venv_dir/bin`` whose embedded
+    interpreter is not THIS venv's own interpreter.
+
+    A healthy venv's ``bin/python`` is itself normally a symlink OUT to the
+    base interpreter (pyenv, system, …) — so "resolves inside ``venv_dir``"
+    is the wrong test; it would flag every launcher in a normal venv, since
+    following any of them ends outside ``venv_dir`` too. The right invariant
+    is identity with the venv's own interpreter: a launcher is healthy iff
+    its embedded path's realpath equals ``venv_dir/bin/python``'s realpath —
+    i.e. both ultimately name the same base interpreter. ``realpath`` works
+    on a nonexistent path too (pure normalization, no symlink to follow), so
+    a launcher pointing at a deleted venv still compares cleanly unequal.
+
+    Returns a list of ``{"script", "interpreter", "exists"}`` dicts, one per
+    offending launcher. Empty when every launcher agrees with the venv's own
+    interpreter (the healthy case).
+    """
+    venv_python = Path(os.path.realpath(venv_dir / "bin" / "python"))
+    broken: list[dict[str, Any]] = []
+    for script in _iter_console_scripts(venv_dir / "bin"):
+        interpreter = _extract_interpreter_path(script)
+        if interpreter is None:
+            continue
+        interpreter_path = Path(interpreter)
+        exists = interpreter_path.exists()
+        resolved = Path(os.path.realpath(interpreter_path))
+        if resolved != venv_python:
+            broken.append({"script": script.name, "interpreter": interpreter, "exists": exists})
+    return broken
+
+
+def check_sentinel_imports(python_exe: Path, *, timeout: float = 30.0) -> tuple[list[str], str | None]:
+    """Try importing every ``CORE_SENTINEL_MODULES`` key under ``python_exe``.
+
+    One subprocess for the whole set (not one per module) — a cold Python
+    start dominates the cost of importing any single lightweight module, so
+    batching keeps this cheap. Returns ``(missing_modules, error)``; ``error``
+    is set only when the probe itself couldn't run (interpreter missing,
+    timed out, crashed) — that is also a venv-health signal, surfaced
+    separately from "these specific modules are missing".
+    """
+    if not python_exe.exists():
+        return [], f"interpreter does not exist: {python_exe}"
+    probe = (
+        "import importlib, json, sys\n"
+        f"mods = {sorted(CORE_SENTINEL_MODULES)!r}\n"
+        "missing = []\n"
+        "for m in mods:\n"
+        "    try:\n"
+        "        importlib.import_module(m)\n"
+        "    except Exception as exc:\n"
+        "        missing.append(f'{m}: {type(exc).__name__}: {exc}')\n"
+        "print(json.dumps(missing))\n"
+    )
+    try:
+        proc = subprocess.run(
+            [str(python_exe), "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return [], f"{type(exc).__name__}: {exc}"
+    if proc.returncode != 0:
+        return [], f"probe subprocess exited {proc.returncode}: {proc.stderr.strip()[-500:]}"
+    try:
+        return json.loads(proc.stdout.strip() or "[]"), None
+    except json.JSONDecodeError as exc:
+        return [], f"probe produced unparseable output: {exc}"
+
+
+def check_venv_integrity(
+    repo: Path,
+    *,
+    tasks_dir: Path | None = None,
+    state_dir: Path | None = None,
+    python_exe: Path | None = None,
+) -> tuple[bool, str]:
+    """Detect (never repair) an empty or shebang-broken primary venv.
+
+    Returns ``(ok, message)``. ``ok`` is False when a sentinel module fails
+    to import or a console-script launcher is broken; this is an ALERT
+    signal only — callers must never block or auto-repair on it (repairing a
+    venv is a package mutation, gated to an explicit operator command).
+    """
+    main_root = _resolve_main_root(Path(repo))
+    venv_dir = main_root / ".venv"
+    exe = python_exe or (venv_dir / "bin" / "python")
+    sdir = state_dir or (main_root / "data" / "telemetry" / "venv-integrity")
+
+    missing, probe_error = check_sentinel_imports(exe)
+    broken_scripts = find_broken_console_scripts(venv_dir)
+
+    if not missing and not probe_error and not broken_scripts:
+        return True, f"venv integrity ok ({venv_dir})"
+
+    evidence: dict[str, Any] = {
+        "missing_modules": missing,
+        "probe_error": probe_error,
+        "broken_console_scripts": broken_scripts,
+        "running_dispatches": _running_dispatches(tasks_dir),
+        "venv_dir": str(venv_dir),
+    }
+    _append_event(sdir, "venv_integrity_alert", **evidence)
+
+    reasons = []
+    if probe_error:
+        reasons.append(f"sentinel-import probe failed: {probe_error}")
+    if missing:
+        reasons.append(f"{len(missing)} sentinel module(s) fail to import: {'; '.join(missing)}")
+    if broken_scripts:
+        detail = ", ".join(f"{b['script']} -> {b['interpreter']}" for b in broken_scripts)
+        packages = sorted({_SCRIPT_PACKAGE_ALIASES.get(b["script"], b["script"]) for b in broken_scripts})
+        reasons.append(
+            f"{len(broken_scripts)} console-script launcher(s) don't match the venv's own interpreter: "
+            f"{detail}. Repair (operator-run, never automated against the primary): "
+            f"{exe} -m pip install --force-reinstall {' '.join(packages)}"
+        )
+    return False, (
+        f"ALERT: venv integrity issue(s) — {'; '.join(reasons)}. "
+        f"NOT repaired (detection only); evidence preserved under {sdir}/events.jsonl."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect an empty or shebang-broken primary venv (#6830).",
+    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="suppress the OK message (alerts still print)")
+    parser.add_argument(
+        "--repo", type=Path, default=Path(__file__).resolve().parents[2], help="repo path to check (default: this project root)"
+    )
+    parser.add_argument(
+        "--python-exe",
+        type=Path,
+        default=None,
+        help="interpreter to run the sentinel-import probe under (default: <main_root>/.venv/bin/python)",
+    )
+    parser.add_argument(
+        "--tasks-dir", type=Path, default=None, help="dispatch tasks dir for attribution (default: <root>/batch_state/tasks)"
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help="watchdog state/log dir (default: <main_root>/data/telemetry/venv-integrity)",
+    )
+    args = parser.parse_args(argv)
+
+    tasks_dir = args.tasks_dir
+    if tasks_dir is None:
+        try:
+            tasks_dir = _resolve_main_root(args.repo) / "batch_state" / "tasks"
+        except Exception:
+            tasks_dir = None
+
+    ok, message = check_venv_integrity(
+        args.repo,
+        tasks_dir=tasks_dir,
+        state_dir=args.state_dir,
+        python_exe=args.python_exe,
+    )
+    if not ok:
+        print(f"❌ {message}", file=sys.stderr)
+        return 1
+    if not args.quiet:
+        print(f"✅ {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1382,6 +1382,36 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
     )
 
 
+def _warn_venv_integrity() -> None:
+    """Advisory-only primary-venv integrity probe (#6830 follow-up).
+
+    A mid-session venv rebuild can leave `.venv` empty (every import fails)
+    or with console-script launchers pointing at a deleted worktree venv
+    (`pytest`/`py.test`/`cbor2` live finding). This probe DETECTS and RECORDS
+    such corruption; it never blocks a dispatch and never repairs here —
+    reinstalling packages is a package mutation, gated to an explicit
+    operator command (see check_venv_integrity.py). Fails open on any probe
+    error, same contract as the sibling integrity watchdogs.
+    """
+    try:
+        try:
+            from scripts.audit.check_venv_integrity import check_venv_integrity
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_venv_integrity import check_venv_integrity
+
+        ok, message = check_venv_integrity(_REPO_ROOT, tasks_dir=_TASKS_DIR)
+    except Exception as exc:
+        print(
+            f"⚠️  venv-integrity probe errored ({type(exc).__name__}: {exc}); "
+            "proceeding — detection only, never blocks dispatch",
+            file=sys.stderr,
+        )
+        return
+
+    if not ok:
+        print(f"⚠️  {message}", file=sys.stderr)
+
+
 def _warn_node_modules_integrity() -> None:
     """Advisory-only node_modules symlink-corruption probe (#6818 follow-up).
 
@@ -4136,6 +4166,31 @@ def _run_worker(
             file=sys.stderr,
         )
 
+    # Post-worker venv-integrity sweep (#6830 follow-up): same shape as the
+    # node_modules-integrity sweep above, but for an empty/broken primary
+    # venv. ALERT-only — never blocks, never repairs; attributes this
+    # worker's task_id/agent/pid while they're still known.
+    try:
+        try:
+            from scripts.audit.check_venv_integrity import check_venv_integrity
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_venv_integrity import check_venv_integrity
+
+        vi_ok, vi_message = check_venv_integrity(_REPO_ROOT, tasks_dir=_TASKS_DIR)
+        if not vi_ok:
+            _append_dispatch_event(
+                "venv_integrity_post_worker",
+                task_id=task_id,
+                agent=agent,
+                ok=vi_ok,
+                detail=vi_message,
+            )
+    except Exception as vi_exc:
+        print(
+            f"[delegate] WARNING: venv-integrity post-worker sweep failed: {type(vi_exc).__name__}: {vi_exc}",
+            file=sys.stderr,
+        )
+
     if timed_out:
         _append_dispatch_event(
             "dispatch_silence_timeout",
@@ -4263,6 +4318,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         return 2
 
     _warn_node_modules_integrity()
+    _warn_venv_integrity()
 
     _warn_if_monitor_api_unreachable()
     if bool(getattr(args, "dry_run", False)):

--- a/tests/test_check_venv_integrity.py
+++ b/tests/test_check_venv_integrity.py
@@ -1,0 +1,308 @@
+"""Tests for the primary-venv integrity probe (#6830).
+
+scripts/audit/check_venv_integrity.py — detection ONLY of an empty/broken
+primary venv: (a) a curated set of lightweight core modules failing to
+import, (b) console-script launchers whose embedded interpreter doesn't
+match the venv's own. No repair path exists here; a detection is always an
+ALERT (mirrors check_node_modules_integrity.py's posture and test shape).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.check_venv_integrity import (
+    check_sentinel_imports,
+    check_venv_integrity,
+    find_broken_console_scripts,
+    main,
+)
+
+
+def _events(state_dir: Path) -> list[dict]:
+    path = state_dir / "events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_fake_venv(tmp_path: Path, name: str = "venv") -> tuple[Path, Path]:
+    """A minimal venv: bin/python + bin/python3 symlinked to THIS interpreter,
+    mirroring how `python -m venv` / `uv venv` actually lay out bin/ (the
+    venv's own python is normally a symlink OUT to the base interpreter, not
+    a copy — the whole reason find_broken_console_scripts cannot use a
+    "resolves inside venv_dir" test)."""
+    venv_dir = tmp_path / name
+    bin_dir = venv_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").symlink_to(Path(sys.executable))
+    (bin_dir / "python3").symlink_to(Path("python"))
+    return venv_dir, bin_dir
+
+
+def _write_direct_launcher(bin_dir: Path, name: str, interpreter: Path) -> Path:
+    script = bin_dir / name
+    script.write_text(f"#!{interpreter}\n# -*- coding: utf-8 -*-\nprint('ok')\n")
+    script.chmod(0o755)
+    return script
+
+
+def _write_exec_trick_launcher(bin_dir: Path, name: str, interpreter: Path) -> Path:
+    """Pip's long-path launcher form — matches the real broken pytest/py.test/
+    cbor2 scripts found on the primary venv verbatim (#6830 live finding)."""
+    script = bin_dir / name
+    script.write_text(f"#!/bin/sh\n'''exec' '{interpreter}' \"$0\" \"$@\"\n' '''\n# -*- coding: utf-8 -*-\nprint('ok')\n")
+    script.chmod(0o755)
+    return script
+
+
+# ---------------------------------------------------------------------------
+# console-script shebang detection
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_direct_shebang_is_not_flagged(tmp_path: Path) -> None:
+    venv_dir, bin_dir = _make_fake_venv(tmp_path)
+    _write_direct_launcher(bin_dir, "healthy", bin_dir / "python")
+
+    assert find_broken_console_scripts(venv_dir) == []
+
+
+def test_healthy_exec_trick_launcher_is_not_flagged(tmp_path: Path) -> None:
+    """The long-path launcher form itself is healthy when the embedded path
+    IS this venv's interpreter — only the pointed-at path matters, not which
+    of the two pip launcher forms is used."""
+    venv_dir, bin_dir = _make_fake_venv(tmp_path)
+    _write_exec_trick_launcher(bin_dir, "pytest", bin_dir / "python")
+
+    assert find_broken_console_scripts(venv_dir) == []
+
+
+def test_launcher_pointing_at_deleted_path_is_detected(tmp_path: Path) -> None:
+    """Reproduces the live #6830 finding verbatim: the exec-trick form
+    pointing at a python3 under a worktree venv that no longer exists."""
+    venv_dir, bin_dir = _make_fake_venv(tmp_path)
+    deleted = tmp_path / "some-worktree" / ".venv" / "bin" / "python3"
+    _write_exec_trick_launcher(bin_dir, "pytest", deleted)
+
+    found = find_broken_console_scripts(venv_dir)
+    assert len(found) == 1
+    assert found[0] == {"script": "pytest", "interpreter": str(deleted), "exists": False}
+
+
+def test_launcher_pointing_at_a_different_existing_interpreter_is_detected(tmp_path: Path) -> None:
+    """A launcher can point at a path that EXISTS but still isn't this venv's
+    interpreter (e.g. another venv survives but this one's identity drifted)
+    — existence alone must not clear it."""
+    venv_dir, bin_dir = _make_fake_venv(tmp_path)
+    other_interpreter = tmp_path / "other-venv" / "bin" / "python3"
+    other_interpreter.parent.mkdir(parents=True)
+    other_interpreter.write_text("#!/usr/bin/env python3\n")  # real file, distinct realpath
+    _write_direct_launcher(bin_dir, "stray", other_interpreter)
+
+    found = find_broken_console_scripts(venv_dir)
+    assert len(found) == 1
+    assert found[0]["script"] == "stray"
+    assert found[0]["exists"] is True
+
+
+def test_interpreter_symlinks_themselves_are_not_scanned(tmp_path: Path) -> None:
+    """bin/python and bin/python3 are the venv's own identity, not
+    console-script launchers — scanning them would be nonsensical (they'd
+    trivially "match themselves") and is explicitly skipped."""
+    venv_dir, _bin_dir = _make_fake_venv(tmp_path)
+
+    assert find_broken_console_scripts(venv_dir) == []
+
+
+def test_non_launcher_files_are_ignored(tmp_path: Path) -> None:
+    """A binary/non-text entry in bin/ (no `#!` first line) must not crash
+    the scan or be misread as a broken launcher."""
+    venv_dir, bin_dir = _make_fake_venv(tmp_path)
+    (bin_dir / "some-binary-tool").write_bytes(b"\x7fELF\x02\x01\x01\x00" + os.urandom(32))
+
+    assert find_broken_console_scripts(venv_dir) == []
+
+
+def test_missing_venv_bin_directory_does_not_crash(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "no-such-venv"
+    assert find_broken_console_scripts(venv_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# sentinel import detection
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_imports_all_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib", "os": "stdlib"})
+    missing, error = check_sentinel_imports(Path(sys.executable))
+    assert missing == []
+    assert error is None
+
+
+def test_sentinel_imports_detects_missing_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(
+        mod,
+        "CORE_SENTINEL_MODULES",
+        {"json": "stdlib", "definitely_not_a_real_module_xyz123": "fake-pkg"},
+    )
+    missing, error = check_sentinel_imports(Path(sys.executable))
+    assert error is None
+    assert len(missing) == 1
+    assert "definitely_not_a_real_module_xyz123" in missing[0]
+
+
+def test_sentinel_imports_missing_interpreter_reports_error(tmp_path: Path) -> None:
+    missing, error = check_sentinel_imports(tmp_path / "no-such-python")
+    assert missing == []
+    assert error is not None
+    assert "does not exist" in error
+
+
+# ---------------------------------------------------------------------------
+# combined probe
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_venv_is_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+    _write_exec_trick_launcher(bin_dir, "pytest", bin_dir / "python")
+
+    ok, message = check_venv_integrity(
+        repo, tasks_dir=tmp_path / "no-tasks", state_dir=tmp_path / "state", python_exe=bin_dir / "python"
+    )
+    assert ok is True
+    assert "ok" in message
+    assert _events(tmp_path / "state") == []
+
+
+def test_broken_launcher_is_alerted_and_recorded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+    deleted = tmp_path / "gone" / ".venv" / "bin" / "python3"
+    _write_exec_trick_launcher(bin_dir, "pytest", deleted)
+
+    ok, message = check_venv_integrity(
+        repo, tasks_dir=tmp_path / "no-tasks", state_dir=tmp_path / "state", python_exe=bin_dir / "python"
+    )
+    assert ok is False
+    assert "pytest" in message
+    assert "force-reinstall" in message
+    assert "pip install --force-reinstall" in message
+    # the printed repair command must name the OWNING PACKAGE, never invoke
+    # anything here — this probe must never mutate the venv itself.
+    assert f"{bin_dir / 'python'} -m pip install --force-reinstall pytest" in message
+
+    alerts = [e for e in _events(tmp_path / "state") if e["event"] == "venv_integrity_alert"]
+    assert alerts
+    assert alerts[0]["broken_console_scripts"][0]["script"] == "pytest"
+
+
+def test_py_test_and_pytest_dedupe_to_one_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """py.test and pytest are both launchers from the SAME `pytest`
+    distribution — the repair command must not suggest installing a
+    nonexistent `py.test` package."""
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+    deleted = tmp_path / "gone" / ".venv" / "bin" / "python3"
+    _write_exec_trick_launcher(bin_dir, "pytest", deleted)
+    _write_exec_trick_launcher(bin_dir, "py.test", deleted)
+
+    ok, message = check_venv_integrity(
+        repo, tasks_dir=tmp_path / "no-tasks", state_dir=tmp_path / "state", python_exe=bin_dir / "python"
+    )
+    assert ok is False
+    assert "py.test" not in message.split("force-reinstall", 1)[1]  # not suggested as an install target
+    assert message.count(" pytest") >= 1
+
+
+def test_missing_sentinel_module_is_alerted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"definitely_not_a_real_module_xyz123": "fake-pkg"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+
+    ok, message = check_venv_integrity(
+        repo, tasks_dir=tmp_path / "no-tasks", state_dir=tmp_path / "state", python_exe=bin_dir / "python"
+    )
+    assert ok is False
+    assert "sentinel module" in message
+
+
+# ---------------------------------------------------------------------------
+# attribution: running dispatches recorded on the alert event
+# ---------------------------------------------------------------------------
+
+
+def test_alert_event_names_running_dispatches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+    _write_exec_trick_launcher(bin_dir, "pytest", tmp_path / "gone" / "python3")
+
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "agy-suspect.json").write_text(
+        json.dumps({"task_id": "agy/suspect", "agent": "agy", "status": "running", "pid": os.getpid()})
+    )
+
+    check_venv_integrity(repo, tasks_dir=tasks_dir, state_dir=tmp_path / "state", python_exe=bin_dir / "python")
+    alerts = [e for e in _events(tmp_path / "state") if e["event"] == "venv_integrity_alert"]
+    assert alerts
+    running = alerts[0]["running_dispatches"]
+    assert any(d["task_id"] == "agy/suspect" for d in running)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exit_codes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.check_venv_integrity as mod
+
+    monkeypatch.setattr(mod, "CORE_SENTINEL_MODULES", {"json": "stdlib"})
+    repo = tmp_path / "repo"
+    _venv_dir, bin_dir = _make_fake_venv(repo, name=".venv")
+    _write_exec_trick_launcher(bin_dir, "pytest", bin_dir / "python")
+    state_dir = tmp_path / "cli-state"
+    tasks_dir = tmp_path / "no-tasks"
+    argv = [
+        "--repo",
+        str(repo),
+        "--python-exe",
+        str(bin_dir / "python"),
+        "--state-dir",
+        str(state_dir),
+        "--tasks-dir",
+        str(tasks_dir),
+    ]
+
+    assert main(argv) == 0
+
+    # Break it: overwrite the launcher to point somewhere else.
+    _write_exec_trick_launcher(bin_dir, "pytest", tmp_path / "gone" / "python3")
+    assert main(argv) == 1

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -86,6 +86,28 @@ def _stub_node_modules_integrity_sweep(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _stub_venv_integrity_sweep(monkeypatch):
+    """Keep _run_worker/cmd_dispatch tests hermetic from the ambient checkout.
+
+    Same rationale as the two stubs above (#6830 follow-up sweep, same
+    shape): the venv-integrity watchdog runs a real subprocess import probe
+    and scans real console-script launchers under delegate._REPO_ROOT's
+    venv. A checkout with the live #6830 finding (broken pytest/py.test/
+    cbor2 shebangs) or a differently-provisioned CI venv reads as ALERT, so
+    the sweep appends venv_integrity_post_worker to dispatch_events.jsonl —
+    breaking tests that assert on that file. The sweep itself is covered
+    against fixture repos in tests/test_check_venv_integrity.py.
+    """
+    import scripts.audit.check_venv_integrity as vi
+
+    monkeypatch.setattr(
+        vi,
+        "check_venv_integrity",
+        lambda *_args, **_kwargs: (True, "venv integrity ok (test stub)"),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _fixture_runtime_tmp_root(tmp_path, monkeypatch):
     """Keep dispatch-time orphan sweeps inside each test fixture only."""
     runtime_tmp = tmp_path / "runtime-tmp"


### PR DESCRIPTION
## Summary

Closes the standing debt items on #6830 (venv-side asks; background-kill attribution is scoped out — see the [design comment](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/6830#issuecomment-5309081686) on the issue).

1. **Manifest debt** — `requirements.txt` now declares `psutil`, `filelock`, `rapidfuzz` (the issue-reported gap) plus `lxml`, `pypdf`, `PyMuPDF`, `ruamel.yaml` (found via a fresh import-scan sweep: unconditionally imported by production `scripts/`, only ever pulled in transitively, so a from-scratch `requirements.txt`-only install left `pytest --collect-only` unable to collect 17 test modules — verified directly against the primary venv). All seven are already in `requirements-lock.txt`, so CI was never affected — only the dev-venv restore path was.
2. **Recovery runbook** — replaced the non-working `pip install -e .` step (fails outright: no `[build-system]` table, setuptools flat-layout discovery can't pick one top-level package out of `scripts/`/`wiki/`/`docs/`/…) with the verified working sequence, and documented the `.pth` story (why repo-root + `scripts/` need a site-packages `.pth`, and the two live import spellings it serves).
3. **Venv-integrity canary** (`scripts/audit/check_venv_integrity.py`) — detection-only, mirrors `check_primary_integrity.py` / `check_node_modules_integrity.py`. Catches two failure classes: an empty/broken venv (cheap sentinel-import probe, deliberately excludes torch/sentence-transformers so it's fit for a session-start hook) and broken console-script launchers — reproduces the live #6818-comment finding verbatim (`.venv/bin/pytest`, `py.test`, `cbor2` all pointed at a deleted worktree venv's `python3`). Wired into the same three call sites as its sibling. ALERT + RECORD only; repair is an operator-run command it prints, never executes.

## Live finding (not auto-repaired — primary venv is off-limits to dispatch writes)

```
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pip install --force-reinstall cbor2 pytest
```

## Testing

- `tests/test_check_venv_integrity.py` — 16 tests, mutation-checked (#M-16: reverting either detection path's core logic kills 2–6 tests).
- Ran against the real primary venv (read-only): correctly flags the 3 live broken launchers (`pytest`, `py.test`, `cbor2`) and zero false positives on the other ~30 healthy console scripts.
- `tests/test_delegate.py`, `tests/test_orient_api.py`, and the sibling integrity suites (`check_node_modules_integrity`, `check_primary_integrity`, `test_delegate_primary_integrity`) — 330 tests total, all green.
- `ruff check` clean on every touched file.
- Verified the requirements.txt fix in a scratch venv (`uv venv --system-site-packages` + installing just the 7 new packages) — never touched the primary venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
