### PR TITLE
fix(bridge): per-seat ask timeout profiles — kimi 1800s, others keep 300s (#6877)

### DIFF
--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -44,6 +44,26 @@ def require_compat_target(command_target: str) -> str:
         ) from exc
 
 
+# Per-seat default hard timeouts for compat asks (#6877). The generic 300s
+# ceiling is mis-sized for Kimi: K3 is a max-effort-only model whose long
+# deliberation before first output is designed behavior, and the fleet routes
+# hard reviews to this seat — a live CF review was killed at exactly 300.0s
+# and completed in ~10+ min only when retried with --no-timeout. Kimi gets a
+# 1800s profile aligned with that review workload; every other seat keeps the
+# generic default (none of the remaining compat seats is max-effort-only —
+# claude/grok/agy/glm/deepseek are pinned at "high"). ``--no-timeout``
+# (86400s) is unchanged and bypasses every profile.
+ASK_HARD_TIMEOUT_DEFAULT_S = 300
+ASK_HARD_TIMEOUT_PROFILES: dict[str, int] = {
+    "kimi": 1800,
+}
+
+
+def ask_hard_timeout(command_target: str) -> int:
+    """Default hard timeout in seconds for one compat ask to this seat (#6877)."""
+    return ASK_HARD_TIMEOUT_PROFILES.get(command_target, ASK_HARD_TIMEOUT_DEFAULT_S)
+
+
 def _result_receipt(
     result: object,
     *,
@@ -327,7 +347,7 @@ def run_compat_ask(
     review: bool = False,
     output_path: str | None = None,
     stdout_only: bool = False,
-    hard_timeout: int = 300,
+    hard_timeout: int | None = None,
 ) -> object:
     """Execute one normal ACP ask with fail-open body-free usage telemetry."""
     participant = require_compat_target(command_target)
@@ -376,7 +396,7 @@ def _run_compat_ask_impl(
     review: bool = False,
     output_path: str | None = None,
     stdout_only: bool = False,
-    hard_timeout: int = 300,
+    hard_timeout: int | None = None,
 ) -> object:
     """Execute the authority/ACP path after telemetry admission.
 
@@ -384,10 +404,15 @@ def _run_compat_ask_impl(
     cross-family round with the verdict posted on the PR by the requester
     (operator order 2026-08-06). The sealed ``review-pr`` path is opt-in for
     high-risk code only.
+
+    ``hard_timeout=None`` resolves the seat's profile default (#6877); an
+    explicit value always wins.
     """
     participant = require_compat_target(command_target)
     if not task_id or not task_id.strip():
         raise ValueError("ACP ask requires a non-empty task_id")
+    if hard_timeout is None:
+        hard_timeout = ask_hard_timeout(command_target)
 
     prompt = content
     if data:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from agent_runtime import usage as runtime_usage
+from agent_runtime.errors import AgentTimeoutError
 
 from ._ask_contract import EFFORT_CHOICES
 from ._ask_lifecycle import maybe_print_timeout_notice, print_asks, process_background_ask
@@ -1448,7 +1449,12 @@ def _handle_acp_compat(args, target: str) -> None:
     task_id = getattr(args, "task_id", None)
     if not task_id:
         raise SystemExit(f"ask-{target} requires --task-id")
-    from ._acp_compat import require_compat_target, run_compat_ask
+    from ._acp_compat import (
+        ASK_HARD_TIMEOUT_DEFAULT_S,
+        ask_hard_timeout,
+        require_compat_target,
+        run_compat_ask,
+    )
 
     try:
         require_compat_target(target)
@@ -1468,7 +1474,9 @@ def _handle_acp_compat(args, target: str) -> None:
             ),
             output_path=getattr(args, "output_path", None),
             stdout_only=bool(getattr(args, "stdout_only", False)),
-            hard_timeout=86400 if bool(getattr(args, "no_timeout", False)) else 300,
+            # None resolves the seat's per-seat timeout profile (#6877);
+            # --no-timeout bypasses every profile as before.
+            hard_timeout=86400 if bool(getattr(args, "no_timeout", False)) else None,
         )
         if not bool(getattr(result, "ok", False)):
             raise SystemExit(
@@ -1476,6 +1484,13 @@ def _handle_acp_compat(args, target: str) -> None:
             )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
+    except AgentTimeoutError as exc:
+        raise SystemExit(
+            f"ask-{target} exceeded hard_timeout={exc.hard_timeout}s "
+            f"(seat profile: ask-{target} defaults to {ask_hard_timeout(target)}s, "
+            f"generic default {ASK_HARD_TIMEOUT_DEFAULT_S}s). "
+            "Retry with --no-timeout to lift the wall-clock cap for this ask."
+        ) from exc
 
 
 def _handle_ask_claude(args):

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -705,3 +705,112 @@ def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> 
     # ABSENT in full driver prompt
     full_driver_prompt = _build_full_execution_prompt(dummy_msg, delimiters=None)
     assert NATIVE_ASK_TOOL_CONTRACT not in full_driver_prompt
+
+
+# --- #6877: per-seat ask timeout profiles -------------------------------
+
+
+def test_ask_hard_timeout_profile_table_is_exact() -> None:
+    """Mutation-check (#M-16): every compat seat resolves its exact profile.
+
+    Kimi is the only max-effort-only seat on the compat routes (K3; long
+    deliberation before first output is designed behavior), so it gets 1800s.
+    Every other seat — claude/grok/agy/glm/deepseek are pinned at "high", not
+    max-only — keeps the generic 300s default. Exact equality here means a
+    silent profile-table edit fails this test.
+    """
+    assert _acp_compat.ASK_HARD_TIMEOUT_DEFAULT_S == 300
+    assert _acp_compat.ASK_HARD_TIMEOUT_PROFILES == {"kimi": 1800}
+    for target in _acp_compat._TARGETS:
+        expected = 1800 if target == "kimi" else 300
+        assert _acp_compat.ask_hard_timeout(target) == expected, target
+    assert _acp_compat.ask_hard_timeout("no-such-seat") == 300
+
+
+def test_compat_ask_resolves_seat_timeout_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """hard_timeout=None resolves the seat profile before the provider call."""
+    authority = _RecordingAuthority()
+    invoke = _stub_live_invocation(monkeypatch, authority, _make_ok_result("OK"))
+
+    _acp_compat._run_compat_ask_impl("kimi", "review this diff", task_id="kimi-profile")
+    assert invoke.call_args.kwargs["hard_timeout"] == 1800
+
+    _acp_compat._run_compat_ask_impl("glm", "ping", task_id="glm-profile")
+    assert invoke.call_args.kwargs["hard_timeout"] == 300
+
+
+def test_compat_ask_explicit_timeout_beats_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit hard_timeout (--no-timeout's 86400) bypasses the profile."""
+    authority = _RecordingAuthority()
+    invoke = _stub_live_invocation(monkeypatch, authority, _make_ok_result("OK"))
+
+    _acp_compat._run_compat_ask_impl(
+        "kimi", "review this diff", task_id="kimi-no-timeout", hard_timeout=86400
+    )
+    assert invoke.call_args.kwargs["hard_timeout"] == 86400
+
+
+@pytest.mark.parametrize(
+    ("command", "handler_name", "expected"),
+    [
+        ("ask-kimi", "_handle_ask_kimi", None),  # None → compat resolves 1800s
+        ("ask-claude", "_handle_ask_claude", None),  # None → compat resolves 300s
+    ],
+)
+def test_cli_defers_timeout_to_seat_profile(
+    command: str, handler_name: str, expected: int | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        _acp_compat,
+        "run_compat_ask",
+        lambda *args, **kwargs: captured.update(kwargs) or SimpleNamespace(ok=True),
+    )
+    args = _cli._build_parser().parse_args(
+        [command, "question", "--task-id", "profile-forward", "--from", "codex"]
+    )
+
+    getattr(_cli, handler_name)(args)
+
+    assert captured["hard_timeout"] is expected
+
+
+def test_cli_no_timeout_still_bypasses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        _acp_compat,
+        "run_compat_ask",
+        lambda *args, **kwargs: captured.update(kwargs) or SimpleNamespace(ok=True),
+    )
+    args = _cli._build_parser().parse_args(
+        ["ask-kimi", "question", "--task-id", "no-timeout", "--from", "codex", "--no-timeout"]
+    )
+
+    _cli._handle_ask_kimi(args)
+
+    assert captured["hard_timeout"] == 86400
+
+
+def test_timeout_error_names_seat_profile_and_no_timeout_escape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#6877: the timeout exit text names the seat's profile and the escape."""
+    from agent_runtime.errors import AgentTimeoutError
+
+    def raise_timeout(*args: object, **kwargs: object) -> object:
+        raise AgentTimeoutError("acpx-kimi-shadow", 1800)
+
+    monkeypatch.setattr(_acp_compat, "run_compat_ask", raise_timeout)
+    args = _cli._build_parser().parse_args(
+        ["ask-kimi", "question", "--task-id", "slow-review", "--from", "codex"]
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cli._handle_ask_kimi(args)
+
+    message = str(exc_info.value)
+    assert "ask-kimi" in message
+    assert "hard_timeout=1800s" in message
+    assert "defaults to 1800s" in message
+    assert "generic default 300s" in message
+    assert "--no-timeout" in message


### PR DESCRIPTION
## What

Per-seat hard-timeout profiles for `_acp_compat` compat asks (#6877). The compat ask path pinned `hard_timeout=300s` for every seat; Kimi K3 is a max-effort-only model (long deliberation before first output is designed behavior) and is the seat the fleet routes hard reviews to. Measured on the issue: live CF review `review-6857` killed at exactly 300.0s; retried with `--no-timeout` it completed in ~10+ min.

## Profile table (before → after)

| seat | before | after | justification |
|---|---|---|---|
| kimi | 300s | **1800s** | max-effort-only K3; review workload (issue evidence) |
| claude | 300s | 300s | pinned `high` effort, not max-only |
| codex | 300s | 300s | adapter-owned defaults, not max-only |
| agy / gemini→agy | 300s | 300s | pinned `high`, not max-only |
| grok / grok-build→grok | 300s | 300s | pinned `high` (`GROK_SHADOW_EFFORT`), not max-only |
| hermes→deepseek, deepseek | 300s | 300s | pinned `high` via opencode transport, not max-only |
| glm, gemma | 300s | 300s | pinned `high` via opencode, not max-only |
| cursor, pool | 300s | 300s | unpinned built-ins, no max-effort behavior |

Sibling sweep (scope item 3): kimi is the **only** max-effort-only seat on the compat routes (`ACPX_PARTICIPANT_EFFORTS` pins claude/grok/agy/glm/deepseek at `"high"`; the native Kimi adapter refuses non-max effort for K3 — `scripts/agent_runtime/adapters/kimi.py`). No other seat profile changed. `kimicc` (the other kimi participant in the ACPX registry) has no compat `ask-*` route in `_TARGETS`, so nothing to size there.

## Changes

- `scripts/ai_agent_bridge/_acp_compat.py`: `ASK_HARD_TIMEOUT_DEFAULT_S = 300`, `ASK_HARD_TIMEOUT_PROFILES = {"kimi": 1800}`, `ask_hard_timeout()` resolver. `run_compat_ask` / `_run_compat_ask_impl` now take `hard_timeout: int | None = None`; `None` resolves the seat profile at the compat layer, explicit values always win — so `--no-timeout` (86400s) is unchanged.
- `scripts/ai_agent_bridge/_cli.py`: `_handle_acp_compat` passes `None` (profile) unless `--no-timeout`; an `AgentTimeoutError` now exits with text naming the seat's profile and the escape:
  > `ask-kimi exceeded hard_timeout=1800s (seat profile: ask-kimi defaults to 1800s, generic default 300s). Retry with --no-timeout to lift the wall-clock cap for this ask.`
- `tests/ai_agent_bridge/test_ask_contract.py`: mutation-checked (#M-16) coverage — exact table equality for every `_TARGETS` seat (a silent table edit fails), profile resolution at the impl boundary (kimi→1800, glm→300), explicit-timeout precedence, CLI forwarding, `--no-timeout` bypass, and the error-text contract.

## Evidence (#M-4)

- `pytest tests/ai_agent_bridge/ tests/test_grok_build_bridge.py tests/test_kimi_integration.py tests/test_legacy_bridge_telemetry.py` — 415 passed, 1 pre-existing environmental failure (`test_review_worktree.py::test_sealed_acp_config_is_parent_owned_and_snapshot_pinned` requires a worktree `.venv`, which the dispatch contract forbids; fails identically on the base commit).
- `pytest tests/test_gemini_bridge.py tests/test_codex_bridge.py tests/test_bridge_inbox_cli.py` — 73 passed.
- `ruff check` on the three touched files — clean. (`ruff format --check` reports these files equally on the base commit; repo config ignores E501 and does not enforce format here, so no reformat churn was introduced.)

## Out of scope

- The legacy native background lane `scripts/ai_agent_bridge/_kimi.py` has its own 900s default with `KIMI_BRIDGE_TIMEOUT` override — not a compat ask, untouched.
- The `needs_finalize` / `no_deliverable` finalize-path friction noted on the issue is explicitly a separate audit.

No auto-merge; cross-family review required per the review gate.

Refs #6877
