### PR TITLE
feat(work): stream-scoped next-queue API — GET /api/work/v1/next (#6880)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -15,6 +15,7 @@ Read-only public Work attention projection (`FOUNDATION_COMPLETE` foundation onl
 | Method | Path | Notes |
 | --- | --- | --- |
 | GET | `/api/work/v1/projection` | Normalized items + attention + source envelopes + `cache_age_s` |
+| GET | `/api/work/v1/next` | Stream-scoped actionable pick list (`stream=` required, `limit=` ≤25); warm cache only, 503 `building` when cold |
 | GET | `/api/work/v1/capabilities` | Schema digest, budgets, private-source seam (`not_configured`) |
 | GET | `/api/work/v1/health` | Work surface liveness |
 

--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -19,8 +19,36 @@ Base URL (public Monitor): `http://127.0.0.1:8765` (prefer loopback IP).
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/work/v1/projection` | Normalized attention list, work items, source envelopes, denominator, cache age |
+| `GET` | `/api/work/v1/next` | Stream-scoped actionable pick list for orchestrators (#6880) |
 | `GET` | `/api/work/v1/capabilities` | Schema digest, budgets, class-4 endpoint freeze, private-source seam |
 | `GET` | `/api/work/v1/health` | Cheap Work surface liveness |
+
+### `GET /api/work/v1/next` (next-queue, #6880)
+
+Machine contract for "what should this lane do next" — a driver never needs the
+586-row projection dump. Params: `stream=<stream key>` (required; keys from
+`scripts/config/issue_streams.yaml`, unknown keys 400 with `valid_streams`) and
+`limit` (default 7, max 25).
+
+- **Pick list is stream-scoped** (operator addendum on #6880): only actionable
+  rows whose `projections.stream.streams` membership includes the requested
+  stream. Items with no stream membership (orphans, pending-native, PRs, tasks)
+  are NEVER pick items — they appear only as `digest.unscoped_actionable_count`.
+- **Actionable** is the server-side SSOT `scripts/work/attention.py::is_actionable`
+  (OFF_TRACK/AT_RISK always; otherwise `safe_next_action.code` outside the
+  `INSPECT_UNKNOWN`/`OPEN_GITHUB`/`NONE` deny list). `dashboards/work.html`
+  mirrors it in JS under a parity contract test.
+- **Digest, never a queue**: `other_streams.actionable_counts_by_stream`
+  (counts only), `other_streams.top_blockers` (≤3 repo-wide OFF_TRACK
+  pointers), `unscoped_actionable_count`.
+- **Warm cache only**: serves strictly from the unfiltered projection cache
+  (single-flight, #6861). Cold → `503 {"error": "building", "retry_after_s"}`
+  and never triggers a build; expired-but-present entries are served with an
+  honest `cache_age_s` while the shared background refresh runs. Warm calls
+  measure ~1ms locally.
+- **Deterministic**: rank is the projection's `attention_rank` with a
+  `work_id` tie-break; two calls over an unchanged projection return identical
+  order.
 
 UI: [`/work.html`](../../dashboards/work.html) — Evidence rail attention list
 (Monitor paper language).

--- a/scripts/api/work_router.py
+++ b/scripts/api/work_router.py
@@ -11,7 +11,9 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from scripts.api.state_helpers import cache_get_with_age, cache_invalidate, cache_set
+from scripts.api.state_helpers import cache_get, cache_get_with_age, cache_invalidate, cache_set
+from scripts.orchestration.issue_stream_audit import load_registry
+from scripts.work.attention import is_actionable
 from scripts.work.normalize import build_public_projection
 from scripts.work.schema import (
     SchemaValidationError,
@@ -28,6 +30,13 @@ CACHE_KEY = "work:v1:projection"
 CACHE_TTL_S = 30.0
 WARM_TARGET_S = 2.0
 TIMEOUT_S = 5.0
+
+NEXT_DEFAULT_LIMIT = 7
+NEXT_MAX_LIMIT = 25
+NEXT_RETRY_AFTER_S = 3.0
+NEXT_TOP_BLOCKERS = 3
+STREAM_REGISTRY_CACHE_KEY = "work:v1:stream-registry"
+STREAM_REGISTRY_TTL_S = 60.0
 
 
 def _filters_from_request(request: Request) -> dict[str, Any]:
@@ -181,6 +190,138 @@ async def work_projection(
     return out
 
 
+def _known_streams() -> list[str] | None:
+    """Registry stream keys with a small TTL cache; None when unreadable (fail open)."""
+    cached = cache_get(STREAM_REGISTRY_CACHE_KEY, STREAM_REGISTRY_TTL_S)
+    if isinstance(cached, list):
+        return cached
+    try:
+        names = sorted(load_registry().keys())
+    except Exception:
+        return None
+    cache_set(STREAM_REGISTRY_CACHE_KEY, names)
+    return names
+
+
+def _item_streams(item: dict[str, Any]) -> list[str]:
+    streams = ((item.get("projections") or {}).get("stream") or {}).get("streams")
+    if not isinstance(streams, list):
+        return []
+    return [s for s in streams if isinstance(s, str) and s]
+
+
+def _next_rank_key(item: dict[str, Any]) -> tuple[int, str]:
+    return (int(item.get("attention_rank") or 0), str(item.get("work_id") or ""))
+
+
+@router.get("/v1/next")
+async def work_next(
+    stream: str = Query(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Stream key from scripts/config/issue_streams.yaml (the caller's lane epic).",
+    ),
+    limit: int = Query(NEXT_DEFAULT_LIMIT, ge=1, le=NEXT_MAX_LIMIT),
+) -> dict[str, Any]:
+    """Stream-scoped actionable pick list served strictly from the warm cache (#6880).
+
+    Never builds a cold projection: absent cache → 503 ``building`` with
+    ``retry_after_s``. A present-but-expired cache is served as-is (honest
+    ``cache_age_s``) while the shared single-flight refresh runs in the
+    background so /next-only pollers converge without ever blocking.
+    """
+    known = _known_streams()
+    if known is not None and stream not in known:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unknown_stream",
+                "message": f"unknown stream {stream!r}",
+                "valid_streams": known,
+            },
+        )
+
+    key = projection_cache_key({})
+    cached = cache_get_with_age(key, float("inf"))
+    if cached is None or not isinstance(cached[0], dict):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "building",
+                "message": "work projection cache is cold; retry shortly",
+                "retry_after_s": NEXT_RETRY_AFTER_S,
+            },
+            headers={"Retry-After": str(int(NEXT_RETRY_AFTER_S))},
+        )
+    payload, age = cached
+    if age >= CACHE_TTL_S:
+        _get_or_create_build_task(key, {})
+
+    items = [i for i in payload.get("items") or [] if isinstance(i, dict)]
+    actionable = [i for i in items if is_actionable(i)]
+
+    scoped = sorted(
+        (i for i in actionable if stream in _item_streams(i)), key=_next_rank_key
+    )
+    queue = [
+        {
+            "work_id": i.get("work_id"),
+            "resource_kind": i.get("resource_kind"),
+            "remote_id": i.get("remote_id"),
+            "title": i.get("title") or "",
+            "health": i.get("health"),
+            "safe_next_action": i.get("safe_next_action") or {},
+            "attention_rank": i.get("attention_rank"),
+            "url": (i.get("urls") or {}).get("html"),
+        }
+        for i in scoped[:limit]
+    ]
+
+    counts: dict[str, int] = {name: 0 for name in known or [] if name != stream}
+    unscoped = 0
+    for i in actionable:
+        streams_of = _item_streams(i)
+        if not streams_of:
+            unscoped += 1
+            continue
+        for name in streams_of:
+            if name != stream:
+                counts[name] = counts.get(name, 0) + 1
+
+    top_blockers = [
+        {
+            "work_id": i.get("work_id"),
+            "resource_kind": i.get("resource_kind"),
+            "title": i.get("title") or "",
+            "health": i.get("health"),
+            "action_code": str(((i.get("safe_next_action") or {}).get("code")) or ""),
+            "streams": _item_streams(i),
+        }
+        for i in sorted(
+            (i for i in actionable if i.get("health") == "OFF_TRACK"),
+            key=_next_rank_key,
+        )[:NEXT_TOP_BLOCKERS]
+    ]
+
+    return {
+        "schema_version": "work-next.v1",
+        "stream": stream,
+        "generated_at": payload.get("generated_at"),
+        "cache_age_s": float(age),
+        "limit": limit,
+        "queue": queue,
+        "digest": {
+            "other_streams": {
+                "actionable_counts_by_stream": {k: counts[k] for k in sorted(counts)},
+                "top_blockers": top_blockers,
+            },
+            "unscoped_actionable_count": unscoped,
+        },
+        "capabilities": {"mutation": False},
+    }
+
+
 @router.get("/v1/capabilities")
 async def work_capabilities() -> dict[str, Any]:
     """Public-safe capability + optional private-source seam metadata."""
@@ -201,6 +342,17 @@ async def work_capabilities() -> dict[str, Any]:
         "saved_view_keys": sorted(
             {"health", "kind", "lifecycle", "orphan", "repository_id", "source_id"}
         ),
+        "next_queue": {
+            "route": "GET /api/work/v1/next",
+            "params": {
+                "stream": (
+                    "required — stream key from scripts/config/issue_streams.yaml; "
+                    "the pick list is scoped to it"
+                ),
+                "limit": f"optional int, default {NEXT_DEFAULT_LIMIT}, max {NEXT_MAX_LIMIT}",
+            },
+            "served_from": "warm projection cache only; 503 building + retry_after_s when cold",
+        },
     }
 
 

--- a/scripts/work/attention.py
+++ b/scripts/work/attention.py
@@ -15,6 +15,26 @@ HEALTH_RANK = {
     "ON_TRACK": 3,
 }
 
+# Actionable-view deny list (#6850): rows whose only next step is browsing
+# GitHub, inspecting an unknown, or nothing are not pick-list work. This is
+# the SSOT for the server-side predicate; dashboards/work.html mirrors it in
+# JS (parity contract test in tests/test_work_dashboard.py).
+NON_ACTIONABLE_ACTION_CODES = frozenset({"INSPECT_UNKNOWN", "OPEN_GITHUB", "NONE"})
+
+
+def is_actionable(item: dict[str, Any] | None) -> bool:
+    """True when a projection row is real pick-list work (#6850 semantics).
+
+    OFF_TRACK / AT_RISK always demand attention; otherwise the safe next
+    action must be a doing verb outside the deny list.
+    """
+    if not item:
+        return False
+    if item.get("health") in {"OFF_TRACK", "AT_RISK"}:
+        return True
+    code = str(((item.get("safe_next_action") or {}).get("code")) or "")
+    return bool(code) and code not in NON_ACTIONABLE_ACTION_CODES
+
 
 def _pr_check_state(pr: dict[str, Any] | None) -> str:
     """Return failing | pending | passing | unknown from GH list rollup only."""

--- a/scripts/work/normalize.py
+++ b/scripts/work/normalize.py
@@ -67,6 +67,8 @@ def _stream_index(streams: dict[str, Any] | None) -> dict[str, Any]:
             "multi": {},
             "pending": set(),
             "titles": {},
+            "membership": {},
+            "epic_of": {},
             "fresh": False,
             "missing": True,
             "generated_at": None,
@@ -84,12 +86,35 @@ def _stream_index(streams: dict[str, Any] | None) -> dict[str, Any]:
             pending.add(int(entry["number"]))
         elif isinstance(entry, int):
             pending.add(entry)
+    # Public-safe open-issue→stream-names map (#6880) and the registry's
+    # epic→stream map; both power stream-scoped pick lists in /next.
+    membership: dict[int, list[str]] = {}
+    for key, names in (streams.get("open_stream_membership") or {}).items():
+        try:
+            number = int(key)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(names, list):
+            clean = [str(s) for s in names if isinstance(s, str) and s]
+            if clean:
+                membership[number] = clean
+    epic_of: dict[int, str] = {}
+    registry = streams.get("streams")
+    if isinstance(registry, dict):
+        for name, epics in registry.items():
+            for epic in epics or []:
+                try:
+                    epic_of[int(epic)] = str(name)
+                except (TypeError, ValueError):
+                    continue
     missing = bool(streams.get("error") or streams.get("status") == "no-cache")
     stale = bool(streams.get("stale"))
     return {
         "orphans": orphans,
         "multi": multi,
         "pending": pending,
+        "membership": membership,
+        "epic_of": epic_of,
         "fresh": not missing and not stale,
         "missing": missing,
         "stale": stale,
@@ -211,12 +236,15 @@ def _build_issue_item(
     elif number in stream_idx["pending"]:
         stream_status = "pending_native"
         epic_streams = []
+    elif number in stream_idx.get("epic_of", {}):
+        stream_status = "epic"
+        epic_streams = [stream_idx["epic_of"][number]]
     elif stream_idx["missing"]:
         stream_status = "unknown"
         epic_streams = []
     else:
         stream_status = "homed"
-        epic_streams = []
+        epic_streams = stream_idx.get("membership", {}).get(number, [])
 
     dispatch = _match_dispatch(tasks, issue_number=number, pr_number=None)
     streams_section = section_times.get("streams")

--- a/scripts/work/sources_public.py
+++ b/scripts/work/sources_public.py
@@ -348,6 +348,38 @@ def fetch_open_prs(
     )
 
 
+def public_open_stream_membership(report: dict[str, Any]) -> dict[str, list[str]]:
+    """Public-safe issue→stream-names map for OPEN issues only (#6880).
+
+    Derived from the ADR-011 P4 private index BEFORE it is stripped. Keeps only
+    stream NAMES — already public via the registry ``streams`` key and the
+    ``multi_homed`` rows — for issues in the open set. Epic ownership, closed
+    issues, and the via/uniqueness proofs never leave the private cache.
+    """
+    membership = report.get("effective_membership")
+    open_numbers = report.get("open_issue_numbers")
+    if not isinstance(membership, dict) or not isinstance(open_numbers, list):
+        return {}
+    open_set: set[int] = set()
+    for n in open_numbers:
+        try:
+            open_set.add(int(n))
+        except (TypeError, ValueError):
+            continue
+    out: dict[str, list[str]] = {}
+    for key, entry in membership.items():
+        try:
+            number = int(key)
+        except (TypeError, ValueError):
+            continue
+        if number not in open_set or not isinstance(entry, dict):
+            continue
+        streams = sorted({str(s) for s in entry.get("streams") or [] if isinstance(s, str) and s})
+        if streams:
+            out[str(number)] = streams
+    return out
+
+
 def fetch_streams_projection(
     loader: Callable[[], dict[str, Any]] | None = None,
 ) -> SectionResult:
@@ -366,13 +398,18 @@ def fetch_streams_projection(
         )
         if report is not None:
             payload = _strip_private_index(report)
+            membership = public_open_stream_membership(report)
             status = "ok"
         elif stale is not None:
             payload = {**_strip_private_index(stale), "stale": True}
+            membership = public_open_stream_membership(stale)
             status = "stale"
         else:
             payload = {"status": "no-cache", "ok": None}
+            membership = {}
             status = "unavailable"
+        if membership:
+            payload["open_stream_membership"] = membership
         return {"_status": status, **_with_refresh(payload, state)}
 
     try:
@@ -381,11 +418,16 @@ def fetch_streams_projection(
         return SectionResult("streams", "unavailable", reason=f"streams_error:{type(exc).__name__}")
 
     status = str(payload.pop("_status", "ok"))
+    # Injected loaders may hand up a raw audit report; derive the public-safe
+    # membership map before the hard gate drops the private index below.
+    membership = public_open_stream_membership(payload)
     # Privacy hard gate: never forward private index keys even if a loader errs.
     from scripts.orchestration.issue_stream_audit import PRIVATE_CACHE_KEYS
 
     for key in PRIVATE_CACHE_KEYS:
         payload.pop(key, None)
+    if membership and "open_stream_membership" not in payload:
+        payload["open_stream_membership"] = membership
     if payload.get("stale"):
         status = "stale"
     if payload.get("error") or payload.get("status") == "no-cache":

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -289,3 +289,361 @@ def test_independent_degradation_when_one_section_fails(monkeypatch):
     assert public_source["sections"]["streams"]["status"] == "stale"
     assert public_source["sections"]["issues"]["status"] == "ok"
     assert public_source["sections"]["prs"]["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/work/v1/next — stream-scoped pick list (#6880)
+# ---------------------------------------------------------------------------
+
+NEXT_STREAMS = ["atlas-practice", "devops", "infra-harness"]
+
+
+def _wid(number: int) -> str:
+    from scripts.work.relations import issue_work_id
+
+    return issue_work_id(REPO, number)
+
+
+
+def _next_sections() -> dict[str, SectionResult]:
+    """Fixture with in-stream, other-stream, unscoped, epic, and non-actionable rows."""
+
+    def issue(number: int, title: str, *, body: str = "") -> dict:
+        return {
+            "number": number,
+            "title": title,
+            "labels": [],
+            "assignees": [],
+            "body": body,
+            "createdAt": "2026-08-01T00:00:00Z",
+            "updatedAt": "2026-08-02T00:00:00Z",
+            "url": f"https://github.com/{REPO}/issues/{number}",
+            "state": "OPEN",
+        }
+
+    return {
+        "issues": SectionResult(
+            "issues",
+            "ok",
+            payload=[
+                issue(6001, "Blocked infra work", body="blocked by #1"),
+                issue(6002, "Blocked atlas work", body="blocked by #2"),
+                issue(6003, "Orphan issue"),
+                issue(6004, "Multi-homed issue"),
+                issue(6005, "Healthy homed infra issue"),
+                issue(6900, "Infra epic"),
+            ],
+            count=6,
+        ),
+        "prs": SectionResult(
+            "prs",
+            "ok",
+            payload=[
+                {
+                    "number": 100,
+                    "title": "Reviewable PR",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "statusCheckRollup": [{"state": "SUCCESS"}],
+                    "mergeStateStatus": "BLOCKED",
+                    "labels": [],
+                    "assignees": [],
+                    "url": f"https://github.com/{REPO}/pull/100",
+                    "createdAt": "2026-08-01T00:00:00Z",
+                    "updatedAt": "2026-08-02T00:00:00Z",
+                    "headRefOid": "deadbeef",
+                    "headRefName": "feat/next",
+                }
+            ],
+            count=1,
+        ),
+        "streams": SectionResult(
+            "streams",
+            "ok",
+            payload={
+                "generated_at": 1,
+                "open_total": 6,
+                "streams": {
+                    "infra-harness": [6900],
+                    "atlas-practice": [6901],
+                    "devops": [6902],
+                },
+                "orphans": [{"number": 6003, "title": "Orphan issue"}],
+                "multi_homed": [
+                    {
+                        "number": 6004,
+                        "title": "Multi-homed issue",
+                        "streams": ["atlas-practice", "infra-harness"],
+                    }
+                ],
+                "pending_native_link": [],
+                "open_stream_membership": {
+                    "6001": ["infra-harness"],
+                    "6002": ["atlas-practice"],
+                    "6005": ["infra-harness"],
+                },
+                "ok": False,
+            },
+            count=6,
+        ),
+        "delegate_active": SectionResult(
+            "delegate_active", "ok", payload={"total": 0, "tasks": []}, count=0
+        ),
+        "delegate_tasks": SectionResult(
+            "delegate_tasks", "ok", payload={"total": 0, "tasks": []}, count=0
+        ),
+        "fleet_reviews": SectionResult(
+            "fleet_reviews", "ok", payload={"total": 0, "reviews": []}, count=0
+        ),
+    }
+
+
+def _warm_next_cache() -> dict:
+    """Build the fixture projection and install it as the unfiltered warm cache."""
+    from scripts.api.state_helpers import cache_set
+    from scripts.api.work_router import projection_cache_key
+
+    cache_invalidate("work:v1:projection")
+    payload = build_projection(_next_sections(), repository_id=REPO)
+    cache_set(projection_cache_key({}), payload)
+    return payload
+
+
+def _patch_known_streams(monkeypatch):
+    monkeypatch.setattr(work_router, "_known_streams", lambda: list(NEXT_STREAMS))
+
+
+def test_next_stream_scoped_queue_and_digest(monkeypatch):
+    """Pick list is in-stream only; everything else is digest counts (#6880 point 1/2/6)."""
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["stream"] == "infra-harness"
+    assert data["capabilities"]["mutation"] is False
+
+    queue_ids = [row["work_id"] for row in data["queue"]]
+    # In-stream actionable only: the multi-homed OFF_TRACK row ranks first,
+    # then the blocked homed infra issue.
+    assert queue_ids == [_wid(6004), _wid(6001)]
+    for row in data["queue"]:
+        assert row["url"], row
+        assert row["safe_next_action"]["code"] not in {"NONE", "OPEN_GITHUB", "INSPECT_UNKNOWN"}
+    # Never other-stream, unscoped, non-actionable, or epic rows.
+    remote_ids = {row["remote_id"] for row in data["queue"]}
+    assert remote_ids.isdisjoint({"6002", "6003", "6005", "6900", "100"})
+
+    digest = data["digest"]
+    # atlas-practice: blocked atlas issue + the multi-homed row; devops: zero.
+    assert digest["other_streams"]["actionable_counts_by_stream"] == {
+        "atlas-practice": 2,
+        "devops": 0,
+    }
+    # Orphan issue + PR have no stream membership: counted, never picked.
+    assert digest["unscoped_actionable_count"] == 2
+    blockers = digest["other_streams"]["top_blockers"]
+    assert len(blockers) == 1
+    assert blockers[0]["work_id"] == _wid(6004)
+    assert blockers[0]["health"] == "OFF_TRACK"
+    assert blockers[0]["action_code"] == "RESOLVE_MULTI_HOME"
+
+
+def test_next_other_stream_perspective(monkeypatch):
+    """Same projection, atlas caller: its own rows in the queue, infra in the digest."""
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    response = client.get("/api/work/v1/next?stream=atlas-practice")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    queue_ids = [row["work_id"] for row in data["queue"]]
+    assert queue_ids == [_wid(6004), _wid(6002)]
+    assert data["digest"]["other_streams"]["actionable_counts_by_stream"] == {
+        "devops": 0,
+        "infra-harness": 2,
+    }
+    assert data["digest"]["unscoped_actionable_count"] == 2
+
+
+def test_next_determinism_two_calls_identical(monkeypatch):
+    """Two calls over an unchanged projection return identical order (#6880 point 5)."""
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    first = client.get("/api/work/v1/next?stream=infra-harness")
+    second = client.get("/api/work/v1/next?stream=infra-harness")
+    assert first.status_code == 200 and second.status_code == 200
+    a, b = first.json(), second.json()
+    assert [r["work_id"] for r in a["queue"]] == [r["work_id"] for r in b["queue"]]
+    a.pop("cache_age_s")
+    b.pop("cache_age_s")
+    assert a == b
+
+
+def test_next_limit_bounds(monkeypatch):
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    top1 = client.get("/api/work/v1/next?stream=infra-harness&limit=1")
+    assert top1.status_code == 200
+    assert [r["work_id"] for r in top1.json()["queue"]] == [_wid(6004)]
+    assert top1.json()["limit"] == 1
+
+    assert client.get("/api/work/v1/next?stream=infra-harness&limit=0").status_code == 422
+    assert client.get("/api/work/v1/next?stream=infra-harness&limit=26").status_code == 422
+    default = client.get("/api/work/v1/next?stream=infra-harness")
+    assert default.status_code == 200
+    assert default.json()["limit"] == 7
+
+
+def test_next_cold_cache_503_never_builds(monkeypatch):
+    """Cold cache → 503 building + retry_after_s; /next never triggers a build."""
+    _patch_known_streams(monkeypatch)
+    cache_invalidate("work:v1:projection")
+
+    def forbidden_build(**_kwargs):
+        raise AssertionError("/next must never build the projection")
+
+    monkeypatch.setattr(work_router, "build_public_projection", forbidden_build)
+    scheduled: list[str] = []
+    monkeypatch.setattr(
+        work_router,
+        "_get_or_create_build_task",
+        lambda key, filters: scheduled.append(key),
+    )
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 503, response.text
+    detail = response.json()["detail"]
+    assert detail["error"] == "building"
+    assert detail["retry_after_s"] > 0
+    assert response.headers.get("retry-after") == "3"
+    assert scheduled == []
+    assert work_router._IN_FLIGHT_BUILDS == {}
+
+
+def test_next_stale_cache_served_with_background_refresh(monkeypatch):
+    """Expired-but-present cache is served honestly and kicks the single-flight refresh."""
+    import time
+
+    from scripts.api.state_helpers import _ttl_cache
+    from scripts.api.work_router import projection_cache_key
+
+    _patch_known_streams(monkeypatch)
+    payload = _warm_next_cache()
+    key = projection_cache_key({})
+    _ttl_cache[key] = (time.monotonic() - 45.0, payload)
+
+    called = []
+
+    def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
+        called.append(True)
+        return build_projection(
+            _next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s
+        )
+
+    monkeypatch.setattr(work_router, "build_public_projection", fake_build)
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["cache_age_s"] >= 30.0
+    assert [r["work_id"] for r in data["queue"]] == [_wid(6004), _wid(6001)]
+    # The shared single-flight refresh was scheduled (it may or may not have
+    # completed and popped itself by the time the response returns).
+    assert called or key in work_router._IN_FLIGHT_BUILDS
+
+
+def test_next_rejects_unknown_and_missing_stream(monkeypatch):
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    bad = client.get("/api/work/v1/next?stream=not-a-stream")
+    assert bad.status_code == 400
+    detail = bad.json()["detail"]
+    assert detail["error"] == "unknown_stream"
+    assert detail["valid_streams"] == NEXT_STREAMS
+
+    assert client.get("/api/work/v1/next").status_code == 422
+
+
+def test_next_known_streams_come_from_registry():
+    """_known_streams reflects scripts/config/issue_streams.yaml (fail-open on error)."""
+    from scripts.orchestration.issue_stream_audit import load_registry
+
+    cache_invalidate(work_router.STREAM_REGISTRY_CACHE_KEY)
+    names = work_router._known_streams()
+    assert names == sorted(load_registry().keys())
+    assert "infra-harness" in names
+
+
+def test_capabilities_advertise_next_queue():
+    caps = client.get("/api/work/v1/capabilities")
+    assert caps.status_code == 200
+    nq = caps.json()["next_queue"]
+    assert nq["route"] == "GET /api/work/v1/next"
+    assert "stream" in nq["params"] and "limit" in nq["params"]
+    assert "default 7, max 25" in nq["params"]["limit"]
+    assert "503" in nq["served_from"]
+
+
+def test_projection_membership_and_epic_status():
+    """Homed issues carry public-safe stream membership; epics get status=epic."""
+    projection = build_projection(_next_sections(), repository_id=REPO)
+    by_id = {i["work_id"]: i for i in projection["items"]}
+
+    homed = by_id[_wid(6001)]["projections"]["stream"]
+    assert homed["status"] == "homed"
+    assert homed["streams"] == ["infra-harness"]
+
+    epic = by_id[_wid(6900)]["projections"]["stream"]
+    assert epic["status"] == "epic"
+    assert epic["streams"] == ["infra-harness"]
+
+    orphan = by_id[_wid(6003)]["projections"]["stream"]
+    assert orphan["status"] == "orphan"
+    assert orphan["streams"] == []
+
+
+def test_streams_loader_derives_public_membership_and_strips_private_index():
+    """fetch_streams_projection derives open-issue→stream names, drops the raw index."""
+    from scripts.work.sources_public import fetch_streams_projection
+
+    def loader():
+        return {
+            "_status": "ok",
+            "generated_at": 1,
+            "open_total": 1,
+            "streams": {"infra-harness": [6900]},
+            "orphans": [],
+            "multi_homed": [],
+            "pending_native_link": [],
+            "ok": True,
+            "effective_membership": {
+                "6001": {
+                    "epics": [6900],
+                    "streams": ["infra-harness"],
+                    "via": "native",
+                    "unique_stream": True,
+                },
+                "5000": {
+                    "epics": [6900],
+                    "streams": ["infra-harness"],
+                    "via": "body",
+                    "unique_stream": True,
+                },
+            },
+            "open_issue_numbers": [6001],
+        }
+
+    section = fetch_streams_projection(loader=loader)
+    assert section.status == "ok"
+    assert section.payload["open_stream_membership"] == {"6001": ["infra-harness"]}
+    # Closed issue 5000 never surfaces; the private index keys are stripped.
+    assert "effective_membership" not in section.payload
+    assert "open_issue_numbers" not in section.payload
+    blob = json.dumps(section.payload)
+    assert "5000" not in blob
+    assert "unique_stream" not in blob
+    assert "via" not in blob

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -162,3 +162,40 @@ def test_work_page_actionable_default_view_contracts():
     assert "NONE" in html
     assert "OFF_TRACK" in html
     assert "AT_RISK" in html
+
+
+def test_work_page_actionable_predicate_parity_with_server_ssot():
+    """The JS isActionable predicate must match scripts/work/attention.py (#6880).
+
+    The server-side predicate is the SSOT for /api/work/v1/next; the dashboard
+    keeps a JS mirror. Deny-list drift or a dropped OFF_TRACK/AT_RISK inclusion
+    would silently fork the Actionable view from the machine pick list.
+    """
+    from scripts.work.attention import NON_ACTIONABLE_ACTION_CODES, is_actionable
+
+    html = WORK.read_text(encoding="utf-8")
+    match = re.search(r"NON_ACTIONABLE_ACTION_CODES = new Set\(\[(.*?)\]\)", html)
+    assert match, "JS deny-list constant missing from work.html"
+    js_codes = set(re.findall(r"'([A-Z_]+)'", match.group(1)))
+    assert js_codes == set(NON_ACTIONABLE_ACTION_CODES)
+
+    start = html.index("function isActionable(")
+    end = html.index("function ", start + 1)
+    body = html[start:end]
+    # Health inclusion mirrors the Python short-circuit exactly.
+    assert "item.health === 'OFF_TRACK' || item.health === 'AT_RISK'" in body
+    assert "return true" in body
+    # Fallback path consults the same deny list on safe_next_action.code.
+    assert "safe_next_action" in body
+    assert "NON_ACTIONABLE_ACTION_CODES.has(code)" in body
+    assert "!!code" in body
+
+    # Truth table over the Python SSOT — the semantics both sides must share.
+    assert is_actionable({"health": "OFF_TRACK", "safe_next_action": {"code": "NONE"}})
+    assert is_actionable({"health": "AT_RISK", "safe_next_action": {"code": "OPEN_GITHUB"}})
+    assert is_actionable({"health": "ON_TRACK", "safe_next_action": {"code": "MERGE_WHEN_READY"}})
+    for denied in sorted(NON_ACTIONABLE_ACTION_CODES):
+        assert not is_actionable({"health": "ON_TRACK", "safe_next_action": {"code": denied}})
+        assert not is_actionable({"health": "UNKNOWN", "safe_next_action": {"code": denied}})
+    assert not is_actionable({"health": "ON_TRACK", "safe_next_action": {}})
+    assert not is_actionable(None)


### PR DESCRIPTION
Implements the 8-point design decision on #6880 (grok-bot QA report + operator addendum).

## What

- **`GET /api/work/v1/next?stream=<key>&limit=7`** — stream-scoped actionable pick list for orchestrators. Unknown stream → 400 with `valid_streams`; `limit` 1–25 (default 7).
- **Actionable predicate SSOT** moved server-side: `scripts/work/attention.py::is_actionable` + `NON_ACTIONABLE_ACTION_CODES`, with a parity contract test against the JS predicate in `dashboards/work.html` (deny-list set equality + health-inclusion string contract + truth table).
- **Stream membership** now flows into `projections.stream.streams` for homed issues, and registry epics get stream status `epic`. Mechanic (design point 6 refinement): `fetch_streams_projection` derives a public-safe `open_stream_membership` map (open issue → stream NAMES only) from the audit cache **before** the ADR-011 P4 private index is stripped. Stream names and open-issue numbers are already public via the registry `streams` key, `orphans`, and `multi_homed` rows; epic ownership, closed issues, and via/uniqueness proofs never leave the private cache (test-asserted).
- **Warm-cache-only serving**: `/next` reads strictly from the unfiltered single-flight projection cache (#6861). Cold → `503 {"error":"building","retry_after_s":3}` + `Retry-After`, and never schedules a build (test-asserted). Refinement with justification: an **expired-but-present** entry is served with honest `cache_age_s` while the shared single-flight background refresh is kicked — without this, a driver polling only `/next` would loop on frozen data forever; it never blocks and it is not a cold build.
- **Digest, never a queue** (operator addendum): `other_streams.actionable_counts_by_stream` (counts only), `other_streams.top_blockers` (≤3 repo-wide OFF_TRACK pointers), `unscoped_actionable_count` (orphans/pending-native/PRs/tasks — no stream membership, never pick items).
- **Determinism**: rank = projection `attention_rank` + `work_id` tie-break; identical order across calls on an unchanged projection (test).
- **Capabilities** advertises the route + params; `/api/work` route contract is prefix-scoped so no registry change needed. Docs: `MONITOR-API.md` + `docs/monitor-api/work.md`.

## Evidence (#M-4)

- Live projection probe pre-impl: 587 items (83 issues / 5 PRs / 1 task / 498 retired reviews), 32 actionable, only 1 item carried stream membership — confirming the gap.
- Live verify (worktree API instance, real audit cache): warm `/next` for `infra-harness` in **0.9–1.2ms** (target <100ms). Queue currently empty for infra-harness (all 14 homed members ON_TRACK — the operator's split working as intended); actionable counts `atlas-intake: 1, atlas-practice: 2`; top blocker = multi-homed issue #5230 (`RESOLVE_MULTI_HOME`); `unscoped_actionable_count: 25` (orphans/pending/PRs stay a triage number, not someone's false queue). Cold cache → 503 `building`; unknown stream → 400.
- **Mutation checks (#M-16), all killed**: M1 scoping removed → 3 tests fail; M2 deny-list code dropped → 4 fail; M3 health short-circuit removed → parity fails; M4 unscoped count dropped → 2 fail; M5 deterministic sort removed → 4 fail; M6 cold path schedules build → cold test fails; M7 homed membership never populated → 4 fail; M8 stale refresh removed → stale test fails.
- Tests: 29 new/updated in `test_work_api.py` + `test_work_dashboard.py`; full affected set (`test_work_api`, `test_work_contract`, `test_work_privacy`, `test_work_dashboard`, `test_work_dashboard_private_integration`, `test_driver_work_api_onboarding`, `test_issue_stream_audit`, `test_entire_context_recall`) green — 270 passed. One pre-existing environmental failure (`test_research_registry_p4::test_strict_adoption_gate_runs_as_bare_script` invokes `.venv/bin/python` relative to the worktree root; dispatch worktrees have no `.venv` by policy — same class as #6874, unrelated to this diff).

## Non-goals (per design point 7)

No claim/lease, no mutation, no projection payload diet, no facade/board or `/api/orient` latency fixes. Drive-epic skill onboarding pointer = separate small PR (point 8).

Closes #6880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)