### PR TITLE
fix(comms): accept non_evidentiary in authority failure-code allowlist (#6886)

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -720,6 +720,11 @@ The DeepSeek seat's **standing route** is first-party via opencode:
 - Bridge asks use `ask-deepseek` (or the `ask-hermes` alias) — both ride the
   `acpx-deepseek-shadow` ACP participant on native `opencode acp --pure`
   pinned to `deepseek-direct/deepseek-v4-flash` at high effort (#6805).
+  DeepSeek ASKs are toolless and self-contained: the seat has no repo or
+  tool access, so paste everything the answer needs into the prompt —
+  reviews that require repo access go to `delegate.py dispatch --agent
+  deepseek` instead (#6886: the seat otherwise tries to emit tool calls and
+  the reply terminalizes `failed:non_evidentiary`).
 - Direct one-shot review/research outside the bridge runs
   `opencode run --model deepseek-direct/deepseek-v4-flash --variant high`
   (native Entire capture).

--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -51,6 +51,7 @@ _FAILURE_CODES = frozenset(
     {
         "adapter_refused",
         "conversation_state_missing",
+        "non_evidentiary",
         "primary_cwd_rejected",
         "protocol_output_limit",
         "provider_unavailable",

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -283,11 +283,23 @@ def test_cli_returns_nonzero_for_replayed_or_live_failure(
         _cli._handle_ask_agy(args)
 
 
+# Raw DSML tool-call markup leaked by the toolless deepseek seat on the first
+# live firing of the #6878 gate (#6886): the model attempted tool calls it
+# does not have instead of delivering a verdict. Kept as a gate fixture.
+DSML_TOOLCALL_GARBLE = (
+    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>read_file\n"
+    '```json\n{"path": "scripts/fleet_comms/authority.py"}\n```'
+    "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+)
+
+
 @pytest.mark.parametrize(
     "response",
     [
         # Documented on #6805: literal garbage with transport outcome=ok.
         "DXVECTOR",
+        # The #6886 live firing: raw DSML tool-call markup, no verdict.
+        DSML_TOOLCALL_GARBLE,
         # Model preamble / harness confusion, no verdict ever delivered.
         "Deep breath — emit the tool call now… Wait, formatting requires blocks.",
         "I'll verify key claims against the diff before writing anything.",
@@ -410,6 +422,66 @@ def test_non_review_ask_is_not_outcome_validated(monkeypatch: pytest.MonkeyPatch
 
     assert result.ok is True
     assert authority.finished[0]["state"] == "complete"
+
+
+def test_non_evidentiary_review_ask_terminalizes_through_real_authority_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#6886: end-to-end seam the #6878 tests missed — the gate and the
+    failure metadata were each validated against a recording stub, so the real
+    authority failure-code allowlist rejecting ``non_evidentiary`` crashed
+    finish_job AFTER the provider replied and stranded the claimed lease.
+    Run the gate through the real store: the job must terminalize
+    failed:non_evidentiary with the lease released and no exception."""
+    from scripts.fleet_comms.authority import AuthorityService
+
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "fleet-comms"))
+    invoke = Mock(return_value=_make_ok_result(DSML_TOOLCALL_GARBLE))
+    monkeypatch.setattr("agent_runtime.runner.invoke_inter_agent", invoke)
+    monkeypatch.setattr(
+        "scripts.agent_runtime.adapters.acpx.probe_participant_reachability",
+        Mock(return_value=None),
+    )
+
+    @contextmanager
+    def execution_cwd(*_args, **_kwargs):
+        yield tmp_path
+
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._acp_execution.acp_execution_cwd", execution_cwd
+    )
+
+    result = _acp_compat._run_compat_ask_impl(
+        "deepseek", "review this diff", task_id="review-6886-seam", review=True
+    )
+
+    assert result.ok is False
+    assert result.transport_outcome == "non_evidentiary"
+
+    with AuthorityService() as service:
+        rows = service.store.connection.execute(
+            "SELECT job_id FROM authority_jobs"
+        ).fetchall()
+        assert len(rows) == 1
+        job = service.get_job(str(rows[0]["job_id"]))
+        events = service.store.connection.execute(
+            """SELECT event_type, metadata_json FROM authority_job_events
+               WHERE job_id = ? ORDER BY created_at""",
+            (job.job_id,),
+        ).fetchall()
+
+    # Clean terminalization — the #6886 crash left the job mid-lease instead.
+    assert job.state == "failed"
+    assert job.lease_owner is None
+    assert job.lease_expires_at is None
+    finished = [event for event in events if event["event_type"] == "finished"]
+    assert len(finished) == 1
+    metadata = json.loads(str(finished[0]["metadata_json"]))
+    assert metadata["failure"] == {
+        "phase": "postprocess",
+        "code": "non_evidentiary",
+        "retryable": False,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

First live firing of the #6878 review-ask gate correctly flagged a garbage DSML reply from the toolless deepseek seat (`outcome=non_evidentiary`), but `authority.py`'s failure-code allowlist was never extended — `finish_job` raised `failure_code_invalid` after the provider response and the ask crashed, stranding the claimed lease.

Fixes #6886.

## Changes

- **`scripts/fleet_comms/authority.py`** — add `non_evidentiary` to `_FAILURE_CODES` (one line; the #6878 metadata builder already emitted it).
- **`tests/ai_agent_bridge/test_ask_contract.py`** — the end-to-end seam regression the #6878 tests missed (they validated the gate and the metadata separately against a recording stub): a non-evidentiary review reply runs the gate through the **real** authority store and terminalizes `failed:non_evidentiary` cleanly — lease released, exactly one `finished` event carrying `{phase: postprocess, code: non_evidentiary, retryable: false}`.
- **DSML fixture (issue note b)** — the leaked raw DSML tool-call markup is kept as `DSML_TOOLCALL_GARBLE` and added to the gate's rejection parametrization.
- **Runbook (issue note a)** — `docs/runbooks/agent-seat-onboarding.md`: deepseek ASKs are toolless/self-contained; reviews needing repo access go to `delegate.py dispatch --agent deepseek`.

## Mutation check (#M-16)

Reverting the allowlist entry makes the new seam test fail with the **exact production traceback** from the issue:

```
RuntimeError: ACP terminal bookkeeping failed after provider response: failure_code_invalid
```

## Stranded-job recovery (scope item 3)

The crashed ask's job **was stranded** mid-lease in the authority store:

- `authority-job_4fdd63420a564164b5e244ece002725a` — task `review-6884-r2`, agent deepseek, state `running`, lease owner `acp-compat:5601` (process verified dead).
- Terminalized via the public `finish_job` API as `failed:non_evidentiary` with a recovery receipt (the original DSML body was lost with the crashed worker); lease released, `completed_at=2026-08-16T20:00:38Z`.

Adjacent observation (out of scope, not touched): `authority-job_f390bf24ba694266b9d0d5e65727b35e` (`reverdict-6883-r2`, grok seat) is also `running` with an **expired** lease (19:29:23Z) — `reclaim_expired_jobs` can recover it; worth a look by the grok lane.

## Verification (quoted, #M-4)

```
$ python -m pytest tests/ai_agent_bridge/test_ask_contract.py tests/test_fleet_comms_authority_cutover.py -q
============================== 90 passed in 1.00s ==============================

$ python -m pytest tests/ai_agent_bridge tests/fleet_comms -q
======================== 3 failed, 384 passed in 25.73s ========================
```

The 3 failures (`test_review_worktree.py::test_sealed_acp_config_is_parent_owned_and_snapshot_pinned`, `test_cold_start_board.py::test_size_cap`, `test_markdown_path`) are **pre-existing at the base commit** — verified by stashing this change and re-running: same 3 fail on unmodified HEAD (host-environment dependent, unrelated to this diff).

```
$ python -m ruff check scripts/fleet_comms/authority.py tests/ai_agent_bridge/test_ask_contract.py
All checks passed!
```

(`ruff format` is not gated in CI — `ci.yml` runs `ruff check scripts/` only; the file predates the configured 120-col style.)

NO auto-merge — per cross-family review gate.

X-Agent: kimi/infra-6886-failure-code