### PR TITLE
fix(work): harden /next residuals from #6889 CF review (#6890)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -15,7 +15,7 @@ Read-only public Work attention projection (`FOUNDATION_COMPLETE` foundation onl
 | Method | Path | Notes |
 | --- | --- | --- |
 | GET | `/api/work/v1/projection` | Normalized items + attention + source envelopes + `cache_age_s` |
-| GET | `/api/work/v1/next` | Stream-scoped actionable pick list (`stream=` required, `limit=` ≤25); warm cache only, 503 `building` when cold |
+| GET | `/api/work/v1/next` | Stream-scoped actionable pick list (`stream=` required, `limit=` ≤25); warm cache only; 503 `building` / `stale` / `registry_unavailable` (unwrapped body) |
 | GET | `/api/work/v1/capabilities` | Schema digest, budgets, private-source seam (`not_configured`) |
 | GET | `/api/work/v1/health` | Work surface liveness |
 

--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -42,10 +42,19 @@ Machine contract for "what should this lane do next" — a driver never needs th
   (counts only), `other_streams.top_blockers` (≤3 repo-wide OFF_TRACK
   pointers), `unscoped_actionable_count`.
 - **Warm cache only**: serves strictly from the unfiltered projection cache
-  (single-flight, #6861). Cold → `503 {"error": "building", "retry_after_s"}`
-  and never triggers a build; expired-but-present entries are served with an
-  honest `cache_age_s` while the shared background refresh runs. Warm calls
-  measure ~1ms locally.
+  (single-flight, #6861). Cold → wire body
+  `503 {"error": "building", "retry_after_s": 3}` (no FastAPI `detail`
+  wrapper — machine-consumable as documented) and never triggers a build;
+  expired-but-present entries are served with an honest `cache_age_s` while
+  the shared background refresh runs, until age exceeds `max_stale_s` (300s)
+  → `503 {"error": "stale", "cache_age_s", "max_stale_s", "retry_after_s"}`.
+  An unreadable `issue_streams.yaml` registry →
+  `503 {"error": "registry_unavailable", "retry_after_s"}` (fail closed —
+  never 200 + empty queue for a stream typo). Warm calls measure ~1ms
+  locally.
+- **Stream-name allowlist**: derive-time membership and any pre-set
+  `open_stream_membership` are re-validated against registry keys before they
+  enter the public projection (#6890).
 - **Deterministic**: rank is the projection's `attention_rank` with a
   `work_id` tie-break; two calls over an unchanged projection return identical
   order.

--- a/scripts/api/work_router.py
+++ b/scripts/api/work_router.py
@@ -10,6 +10,7 @@ import asyncio
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from scripts.api.state_helpers import cache_get, cache_get_with_age, cache_invalidate, cache_set
 from scripts.orchestration.issue_stream_audit import load_registry
@@ -35,8 +36,24 @@ NEXT_DEFAULT_LIMIT = 7
 NEXT_MAX_LIMIT = 25
 NEXT_RETRY_AFTER_S = 3.0
 NEXT_TOP_BLOCKERS = 3
+# Bound stale-serve for /next: expired cache may be returned while a
+# single-flight refresh runs, but never past this age (residual #3 / #6890).
+NEXT_MAX_STALE_S = 300.0
 STREAM_REGISTRY_CACHE_KEY = "work:v1:stream-registry"
 STREAM_REGISTRY_TTL_S = 60.0
+
+
+def _next_error(
+    status_code: int,
+    body: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    """Return a /next error body without FastAPI ``{"detail": ...}`` wrapping.
+
+    Machine consumers parse the documented inner object on the wire (#6890 #6).
+    """
+    return JSONResponse(status_code=status_code, content=body, headers=headers)
 
 
 def _filters_from_request(request: Request) -> dict[str, Any]:
@@ -109,9 +126,7 @@ async def _run_build_job(key: str, filters: dict[str, Any]) -> dict[str, Any]:
         _IN_FLIGHT_BUILDS.pop(key, None)
 
 
-def _get_or_create_build_task(
-    key: str, filters: dict[str, Any]
-) -> asyncio.Task[dict[str, Any]]:
+def _get_or_create_build_task(key: str, filters: dict[str, Any]) -> asyncio.Task[dict[str, Any]]:
     task = _IN_FLIGHT_BUILDS.get(key)
     if task is None or task.done():
         task = asyncio.create_task(_run_build_job(key, filters))
@@ -191,7 +206,7 @@ async def work_projection(
 
 
 def _known_streams() -> list[str] | None:
-    """Registry stream keys with a small TTL cache; None when unreadable (fail open)."""
+    """Registry stream keys with a small TTL cache; None when unreadable (fail closed)."""
     cached = cache_get(STREAM_REGISTRY_CACHE_KEY, STREAM_REGISTRY_TTL_S)
     if isinstance(cached, list):
         return cached
@@ -214,7 +229,7 @@ def _next_rank_key(item: dict[str, Any]) -> tuple[int, str]:
     return (int(item.get("attention_rank") or 0), str(item.get("work_id") or ""))
 
 
-@router.get("/v1/next")
+@router.get("/v1/next", response_model=None)
 async def work_next(
     stream: str = Query(
         ...,
@@ -223,19 +238,32 @@ async def work_next(
         description="Stream key from scripts/config/issue_streams.yaml (the caller's lane epic).",
     ),
     limit: int = Query(NEXT_DEFAULT_LIMIT, ge=1, le=NEXT_MAX_LIMIT),
-) -> dict[str, Any]:
+) -> dict[str, Any] | JSONResponse:
     """Stream-scoped actionable pick list served strictly from the warm cache (#6880).
 
     Never builds a cold projection: absent cache → 503 ``building`` with
     ``retry_after_s``. A present-but-expired cache is served as-is (honest
     ``cache_age_s``) while the shared single-flight refresh runs in the
-    background so /next-only pollers converge without ever blocking.
+    background so /next-only pollers converge without ever blocking — until
+    age exceeds ``NEXT_MAX_STALE_S``, which fails closed with 503 ``stale``.
+    An unreadable stream registry fails closed with 503 ``registry_unavailable``
+    rather than treating typos as an empty queue (#6890).
     """
     known = _known_streams()
-    if known is not None and stream not in known:
-        raise HTTPException(
-            status_code=400,
-            detail={
+    if known is None:
+        return _next_error(
+            503,
+            {
+                "error": "registry_unavailable",
+                "message": "issue stream registry is unreadable; refusing to serve /next",
+                "retry_after_s": NEXT_RETRY_AFTER_S,
+            },
+            headers={"Retry-After": str(int(NEXT_RETRY_AFTER_S))},
+        )
+    if stream not in known:
+        return _next_error(
+            400,
+            {
                 "error": "unknown_stream",
                 "message": f"unknown stream {stream!r}",
                 "valid_streams": known,
@@ -245,9 +273,9 @@ async def work_next(
     key = projection_cache_key({})
     cached = cache_get_with_age(key, float("inf"))
     if cached is None or not isinstance(cached[0], dict):
-        raise HTTPException(
-            status_code=503,
-            detail={
+        return _next_error(
+            503,
+            {
                 "error": "building",
                 "message": "work projection cache is cold; retry shortly",
                 "retry_after_s": NEXT_RETRY_AFTER_S,
@@ -255,15 +283,26 @@ async def work_next(
             headers={"Retry-After": str(int(NEXT_RETRY_AFTER_S))},
         )
     payload, age = cached
+    if age >= NEXT_MAX_STALE_S:
+        _get_or_create_build_task(key, {})
+        return _next_error(
+            503,
+            {
+                "error": "stale",
+                "message": (f"work projection cache age {age:.0f}s exceeds max stale {NEXT_MAX_STALE_S:.0f}s"),
+                "cache_age_s": float(age),
+                "max_stale_s": NEXT_MAX_STALE_S,
+                "retry_after_s": NEXT_RETRY_AFTER_S,
+            },
+            headers={"Retry-After": str(int(NEXT_RETRY_AFTER_S))},
+        )
     if age >= CACHE_TTL_S:
         _get_or_create_build_task(key, {})
 
     items = [i for i in payload.get("items") or [] if isinstance(i, dict)]
     actionable = [i for i in items if is_actionable(i)]
 
-    scoped = sorted(
-        (i for i in actionable if stream in _item_streams(i)), key=_next_rank_key
-    )
+    scoped = sorted((i for i in actionable if stream in _item_streams(i)), key=_next_rank_key)
     queue = [
         {
             "work_id": i.get("work_id"),
@@ -278,7 +317,7 @@ async def work_next(
         for i in scoped[:limit]
     ]
 
-    counts: dict[str, int] = {name: 0 for name in known or [] if name != stream}
+    counts: dict[str, int] = {name: 0 for name in known if name != stream}
     unscoped = 0
     for i in actionable:
         streams_of = _item_streams(i)
@@ -339,19 +378,20 @@ async def work_capabilities() -> dict[str, Any]:
         ],
         "github_enumerations_per_refresh": 2,
         "private_source": private_capability_seam(),
-        "saved_view_keys": sorted(
-            {"health", "kind", "lifecycle", "orphan", "repository_id", "source_id"}
-        ),
+        "saved_view_keys": sorted({"health", "kind", "lifecycle", "orphan", "repository_id", "source_id"}),
         "next_queue": {
             "route": "GET /api/work/v1/next",
             "params": {
                 "stream": (
-                    "required — stream key from scripts/config/issue_streams.yaml; "
-                    "the pick list is scoped to it"
+                    "required — stream key from scripts/config/issue_streams.yaml; the pick list is scoped to it"
                 ),
                 "limit": f"optional int, default {NEXT_DEFAULT_LIMIT}, max {NEXT_MAX_LIMIT}",
             },
-            "served_from": "warm projection cache only; 503 building + retry_after_s when cold",
+            "served_from": (
+                "warm projection cache only; 503 building + retry_after_s when cold; "
+                f"503 stale when cache_age_s ≥ {int(NEXT_MAX_STALE_S)}s; "
+                "503 registry_unavailable when the stream registry is unreadable"
+            ),
         },
     }
 

--- a/scripts/work/normalize.py
+++ b/scripts/work/normalize.py
@@ -24,11 +24,13 @@ from scripts.work.sources_public import (
     GH_ENUM_LIMIT,
     SectionResult,
     admit_public_repository_id,
+    allowlist_stream_names,
     collect_public_sections,
     filter_public_delegate_tasks,
     private_capability_seam,
     private_source_envelope,
     public_source_envelope,
+    registry_stream_names,
 )
 
 
@@ -73,12 +75,15 @@ def _stream_index(streams: dict[str, Any] | None) -> dict[str, Any]:
             "missing": True,
             "generated_at": None,
         }
+    known = registry_stream_names(streams)
     orphans = {int(o["number"]) for o in streams.get("orphans") or [] if isinstance(o, dict) and "number" in o}
-    multi = {
-        int(m["number"]): list(m.get("streams") or [])
-        for m in streams.get("multi_homed") or []
-        if isinstance(m, dict) and "number" in m
-    }
+    multi: dict[int, list[str]] = {}
+    for m in streams.get("multi_homed") or []:
+        if not isinstance(m, dict) or "number" not in m:
+            continue
+        # Keep the multi_homed classification even when every name is unknown —
+        # drop the bogus lanes, do not silently reclassify the issue as homed.
+        multi[int(m["number"])] = allowlist_stream_names(m.get("streams"), known)
     pending_raw = streams.get("pending_native_link") or []
     pending: set[int] = set()
     for entry in pending_raw:
@@ -86,25 +91,27 @@ def _stream_index(streams: dict[str, Any] | None) -> dict[str, Any]:
             pending.add(int(entry["number"]))
         elif isinstance(entry, int):
             pending.add(entry)
-    # Public-safe open-issue→stream-names map (#6880) and the registry's
-    # epic→stream map; both power stream-scoped pick lists in /next.
+    # Public-safe open-issue→stream-names map (#6880/#6890) and the registry's
+    # epic→stream map; both power stream-scoped pick lists in /next. Stream
+    # names are re-allowlisted against the registry keys on every build.
     membership: dict[int, list[str]] = {}
     for key, names in (streams.get("open_stream_membership") or {}).items():
         try:
             number = int(key)
         except (TypeError, ValueError):
             continue
-        if isinstance(names, list):
-            clean = [str(s) for s in names if isinstance(s, str) and s]
-            if clean:
-                membership[number] = clean
+        clean = allowlist_stream_names(names, known)
+        if clean:
+            membership[number] = clean
     epic_of: dict[int, str] = {}
     registry = streams.get("streams")
     if isinstance(registry, dict):
         for name, epics in registry.items():
+            if not isinstance(name, str) or not name:
+                continue
             for epic in epics or []:
                 try:
-                    epic_of[int(epic)] = str(name)
+                    epic_of[int(epic)] = name
                 except (TypeError, ValueError):
                     continue
     missing = bool(streams.get("error") or streams.get("status") == "no-cache")
@@ -148,10 +155,7 @@ def _has_bounded_pr_id(hay: str, number: int) -> bool:
     ``pr-10`` from matching ``pr-100``.
     """
     n = str(int(number))
-    return bool(
-        re.search(rf"pr[-_/]{n}(?!\d)", hay)
-        or hay.endswith(f"-pr{n}")
-    )
+    return bool(re.search(rf"pr[-_/]{n}(?!\d)", hay) or hay.endswith(f"-pr{n}"))
 
 
 def _match_dispatch(tasks: list[dict[str, Any]], *, issue_number: int | None, pr_number: int | None) -> dict[str, Any]:
@@ -185,18 +189,13 @@ def _match_reviews(reviews: list[dict[str, Any]], *, pr_number: int | None, repo
     matched = [
         r
         for r in reviews
-        if int(r.get("pr_number") or 0) == pr_number
-        and str(r.get("repository") or "") == repository_id
+        if int(r.get("pr_number") or 0) == pr_number and str(r.get("repository") or "") == repository_id
     ]
     return {
         "review_ids": [str(r.get("review_id")) for r in matched if r.get("review_id")],
         "states": [str(r.get("state")) for r in matched if r.get("state")],
         "sealed_verdict_available": any(bool(r.get("sealed_verdict_available")) for r in matched),
-        "latest_attempt_states": [
-            str(r.get("latest_attempt_state"))
-            for r in matched
-            if r.get("latest_attempt_state")
-        ],
+        "latest_attempt_states": [str(r.get("latest_attempt_state")) for r in matched if r.get("latest_attempt_state")],
     }
 
 
@@ -563,10 +562,7 @@ def apply_filters(items: list[dict[str, Any]], filters: dict[str, Any] | None) -
     if "orphan" in filters:
         want = bool(filters["orphan"])
         out = [
-            i
-            for i in out
-            if bool(((i.get("projections") or {}).get("stream") or {}).get("status") == "orphan")
-            is want
+            i for i in out if bool(((i.get("projections") or {}).get("stream") or {}).get("status") == "orphan") is want
         ]
     return out
 
@@ -604,9 +600,7 @@ def build_projection(
         if tid and tid not in seen_task_ids:
             raw_task_rows.append(row)
             seen_task_ids.add(tid)
-    task_rows, _task_total, _task_truncated = filter_public_delegate_tasks(
-        raw_task_rows, repository_id=repo
-    )
+    task_rows, _task_total, _task_truncated = filter_public_delegate_tasks(raw_task_rows, repository_id=repo)
     review_rows = list((reviews_section.payload or {}).get("reviews") or [])
 
     items: list[dict[str, Any]] = []
@@ -686,13 +680,9 @@ def build_projection(
 
     omissions: list[dict[str, Any]] = []
     if issues_section.truncated:
-        omissions.append(
-            {"class": "issues", "reason": "enumeration_cap", "count": GH_ENUM_LIMIT}
-        )
+        omissions.append({"class": "issues", "reason": "enumeration_cap", "count": GH_ENUM_LIMIT})
     if prs_section.truncated:
-        omissions.append(
-            {"class": "prs", "reason": "enumeration_cap", "count": GH_ENUM_LIMIT}
-        )
+        omissions.append({"class": "prs", "reason": "enumeration_cap", "count": GH_ENUM_LIMIT})
     if issues_section.status in {"unavailable", "timeout", "degraded"}:
         omissions.append(
             {

--- a/scripts/work/sources_public.py
+++ b/scripts/work/sources_public.py
@@ -65,9 +65,7 @@ def admit_public_repository_id(repository_id: str | None = None) -> str:
     if repository_id is None or repository_id == "":
         return allowed
     if repository_id != allowed:
-        raise ValueError(
-            f"public repository_id must be exactly {allowed!r}; got {repository_id!r}"
-        )
+        raise ValueError(f"public repository_id must be exactly {allowed!r}; got {repository_id!r}")
     return allowed
 
 
@@ -178,9 +176,7 @@ def filter_public_delegate_tasks(
     allowed = admit_public_repository_id(repository_id)
     admitted: list[dict[str, Any]] = []
     for row in rows or []:
-        summary = admit_delegate_task_row(
-            row, repository_id=allowed, trusted_scoped=trusted_scoped
-        )
+        summary = admit_delegate_task_row(row, repository_id=allowed, trusted_scoped=trusted_scoped)
         if summary is not None:
             admitted.append(summary)
 
@@ -348,17 +344,52 @@ def fetch_open_prs(
     )
 
 
+def registry_stream_names(report: dict[str, Any] | None) -> frozenset[str]:
+    """Stream keys admitted by the public registry map in a streams payload."""
+    if not isinstance(report, dict):
+        return frozenset()
+    registry = report.get("streams")
+    if not isinstance(registry, dict):
+        return frozenset()
+    return frozenset(str(k) for k in registry if isinstance(k, str) and k)
+
+
+def allowlist_stream_names(names: Any, known: frozenset[str]) -> list[str]:
+    """Return sorted registry-known stream names; empty known → fail closed."""
+    if not known or not isinstance(names, list):
+        return []
+    return sorted({str(s) for s in names if isinstance(s, str) and s and s in known})
+
+
+def allowlist_open_stream_membership(membership: Any, known: frozenset[str]) -> dict[str, list[str]]:
+    """Re-validate a pre-set / derived issue→streams map against the registry."""
+    if not isinstance(membership, dict) or not known:
+        return {}
+    out: dict[str, list[str]] = {}
+    for key, names in membership.items():
+        try:
+            number = int(key)
+        except (TypeError, ValueError):
+            continue
+        clean = allowlist_stream_names(names, known)
+        if clean:
+            out[str(number)] = clean
+    return out
+
+
 def public_open_stream_membership(report: dict[str, Any]) -> dict[str, list[str]]:
-    """Public-safe issue→stream-names map for OPEN issues only (#6880).
+    """Public-safe issue→stream-names map for OPEN issues only (#6880 / #6890).
 
     Derived from the ADR-011 P4 private index BEFORE it is stripped. Keeps only
-    stream NAMES — already public via the registry ``streams`` key and the
-    ``multi_homed`` rows — for issues in the open set. Epic ownership, closed
-    issues, and the via/uniqueness proofs never leave the private cache.
+    stream NAMES that also appear in the public registry ``streams`` key — derive
+    time re-allowlists so a typo or private-index drift cannot mint unknown
+    lanes into the projection. Epic ownership, closed issues, and the
+    via/uniqueness proofs never leave the private cache.
     """
+    known = registry_stream_names(report)
     membership = report.get("effective_membership")
     open_numbers = report.get("open_issue_numbers")
-    if not isinstance(membership, dict) or not isinstance(open_numbers, list):
+    if not known or not isinstance(membership, dict) or not isinstance(open_numbers, list):
         return {}
     open_set: set[int] = set()
     for n in open_numbers:
@@ -374,10 +405,19 @@ def public_open_stream_membership(report: dict[str, Any]) -> dict[str, list[str]
             continue
         if number not in open_set or not isinstance(entry, dict):
             continue
-        streams = sorted({str(s) for s in entry.get("streams") or [] if isinstance(s, str) and s})
+        streams = allowlist_stream_names(entry.get("streams"), known)
         if streams:
             out[str(number)] = streams
     return out
+
+
+def _admit_open_stream_membership(payload: dict[str, Any]) -> dict[str, list[str]]:
+    """Derive-or-revalidate membership; always overwrite untrusted pre-sets (#6890)."""
+    known = registry_stream_names(payload)
+    derived = public_open_stream_membership(payload)
+    if derived:
+        return derived
+    return allowlist_open_stream_membership(payload.get("open_stream_membership"), known)
 
 
 def fetch_streams_projection(
@@ -391,11 +431,7 @@ def fetch_streams_projection(
 
         report = audit.read_cache(max_age_s=3600)
         stale = None if report is not None else audit.read_cache(max_age_s=7 * 24 * 3600)
-        state = (
-            audit.schedule_refresh(force=False)
-            if report is None
-            else audit.read_refresh_state()
-        )
+        state = audit.schedule_refresh(force=False) if report is None else audit.read_refresh_state()
         if report is not None:
             payload = _strip_private_index(report)
             membership = public_open_stream_membership(report)
@@ -410,6 +446,8 @@ def fetch_streams_projection(
             status = "unavailable"
         if membership:
             payload["open_stream_membership"] = membership
+        else:
+            payload.pop("open_stream_membership", None)
         return {"_status": status, **_with_refresh(payload, state)}
 
     try:
@@ -420,14 +458,18 @@ def fetch_streams_projection(
     status = str(payload.pop("_status", "ok"))
     # Injected loaders may hand up a raw audit report; derive the public-safe
     # membership map before the hard gate drops the private index below.
-    membership = public_open_stream_membership(payload)
+    # Always re-validate pre-set open_stream_membership against the registry
+    # (residual #2) — never leave an unallowlisted map in the public payload.
+    membership = _admit_open_stream_membership(payload)
     # Privacy hard gate: never forward private index keys even if a loader errs.
     from scripts.orchestration.issue_stream_audit import PRIVATE_CACHE_KEYS
 
     for key in PRIVATE_CACHE_KEYS:
         payload.pop(key, None)
-    if membership and "open_stream_membership" not in payload:
+    if membership:
         payload["open_stream_membership"] = membership
+    else:
+        payload.pop("open_stream_membership", None)
     if payload.get("stale"):
         status = "stale"
     if payload.get("error") or payload.get("status") == "no-cache":
@@ -547,9 +589,7 @@ def fetch_delegate_tasks(
     def _default_tasks(repository: str) -> dict[str, Any]:
         from scripts.api.delegate_router import list_delegate_tasks
 
-        return list_delegate_tasks(
-            status="all", limit=DELEGATE_TASK_LIMIT, repository=repository
-        )
+        return list_delegate_tasks(status="all", limit=DELEGATE_TASK_LIMIT, repository=repository)
 
     try:
         page_fn = loader if loader is not None else _default_tasks
@@ -700,15 +740,9 @@ def collect_public_sections(
         "issues": lambda: fetch_open_issues(repo, runner=gh_runner),
         "prs": lambda: fetch_open_prs(repo, runner=gh_runner),
         "streams": lambda: fetch_streams_projection(loader=streams_loader),
-        "delegate_active": lambda: fetch_delegate_active(
-            loader=delegate_active_loader, repository_id=repo
-        ),
-        "delegate_tasks": lambda: fetch_delegate_tasks(
-            loader=delegate_tasks_loader, repository_id=repo
-        ),
-        "fleet_reviews": lambda: fetch_fleet_reviews(
-            loader=fleet_reviews_loader, repository_id=repo
-        ),
+        "delegate_active": lambda: fetch_delegate_active(loader=delegate_active_loader, repository_id=repo),
+        "delegate_tasks": lambda: fetch_delegate_tasks(loader=delegate_tasks_loader, repository_id=repo),
+        "fleet_reviews": lambda: fetch_fleet_reviews(loader=fleet_reviews_loader, repository_id=repo),
     }
     results: dict[str, SectionResult] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -764,9 +798,7 @@ def public_source_envelope(sections: dict[str, SectionResult]) -> dict[str, Any]
         and prs is not None
         and prs.status in {"ok", "truncated"}
     )
-    source_status = (
-        "degraded" if core_ok and rank.get(worst, 0) > rank.get("degraded", 0) else worst
-    )
+    source_status = "degraded" if core_ok and rank.get(worst, 0) > rank.get("degraded", 0) else worst
     return {
         "source_id": SOURCE_PUBLIC,
         "status": source_status,

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -200,9 +200,7 @@ def test_projection_rejects_oversized_repeated_filters(monkeypatch):
     assert "exceeds max" in detail["message"]
 
     # Singleton repository_id also 400s on raw repetition.
-    dup_repo = client.get(
-        f"/api/work/v1/projection?repository_id={REPO}&repository_id={REPO}"
-    )
+    dup_repo = client.get(f"/api/work/v1/projection?repository_id={REPO}&repository_id={REPO}")
     assert dup_repo.status_code == 400
     assert dup_repo.json()["detail"]["error"] == "invalid_saved_view"
 
@@ -215,9 +213,7 @@ def test_source_id_filter_echoed_and_schema_valid(monkeypatch):
 
     def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
         builds.append(dict(filters or {}))
-        return build_projection(
-            sections, repository_id=REPO, filters=filters, cache_age_s=cache_age_s
-        )
+        return build_projection(sections, repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
 
     monkeypatch.setattr(work_router, "build_public_projection", fake_build)
     response = client.get("/api/work/v1/projection?source_id=public-monitor")
@@ -236,19 +232,12 @@ def test_duplicate_multivalue_filters_share_cache_entry(monkeypatch):
 
     def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
         build_count["n"] += 1
-        return build_projection(
-            sections, repository_id=REPO, filters=filters, cache_age_s=cache_age_s
-        )
+        return build_projection(sections, repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
 
     monkeypatch.setattr(work_router, "build_public_projection", fake_build)
 
-    first = client.get(
-        "/api/work/v1/projection?health=ON_TRACK&health=AT_RISK&kind=pr&kind=issue"
-    )
-    second = client.get(
-        "/api/work/v1/projection?health=AT_RISK&health=ON_TRACK&health=AT_RISK"
-        "&kind=issue&kind=pr"
-    )
+    first = client.get("/api/work/v1/projection?health=ON_TRACK&health=AT_RISK&kind=pr&kind=issue")
+    second = client.get("/api/work/v1/projection?health=AT_RISK&health=ON_TRACK&health=AT_RISK&kind=issue&kind=pr")
     assert first.status_code == 200, first.text
     assert second.status_code == 200, second.text
     assert build_count["n"] == 1
@@ -265,10 +254,13 @@ def test_duplicate_multivalue_filters_share_cache_entry(monkeypatch):
 def test_independent_degradation_when_one_section_fails(monkeypatch):
     cache_invalidate("work:v1:projection")
     sections = _sections_with_canary()
-    sections["fleet_reviews"] = SectionResult(
-        "fleet_reviews", "timeout", reason="fleet_reviews_timeout"
+    sections["fleet_reviews"] = SectionResult("fleet_reviews", "timeout", reason="fleet_reviews_timeout")
+    sections["streams"] = SectionResult(
+        "streams",
+        "stale",
+        payload={"stale": True, "orphans": [], "multi_homed": [], "pending_native_link": [], "open_total": 0},
+        reason="stale",
     )
-    sections["streams"] = SectionResult("streams", "stale", payload={"stale": True, "orphans": [], "multi_homed": [], "pending_native_link": [], "open_total": 0}, reason="stale")
 
     def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
         return build_projection(sections, repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
@@ -302,7 +294,6 @@ def _wid(number: int) -> str:
     from scripts.work.relations import issue_work_id
 
     return issue_work_id(REPO, number)
-
 
 
 def _next_sections() -> dict[str, SectionResult]:
@@ -387,15 +378,9 @@ def _next_sections() -> dict[str, SectionResult]:
             },
             count=6,
         ),
-        "delegate_active": SectionResult(
-            "delegate_active", "ok", payload={"total": 0, "tasks": []}, count=0
-        ),
-        "delegate_tasks": SectionResult(
-            "delegate_tasks", "ok", payload={"total": 0, "tasks": []}, count=0
-        ),
-        "fleet_reviews": SectionResult(
-            "fleet_reviews", "ok", payload={"total": 0, "reviews": []}, count=0
-        ),
+        "delegate_active": SectionResult("delegate_active", "ok", payload={"total": 0, "tasks": []}, count=0),
+        "delegate_tasks": SectionResult("delegate_tasks", "ok", payload={"total": 0, "tasks": []}, count=0),
+        "fleet_reviews": SectionResult("fleet_reviews", "ok", payload={"total": 0, "reviews": []}, count=0),
     }
 
 
@@ -516,9 +501,11 @@ def test_next_cold_cache_503_never_builds(monkeypatch):
     )
     response = client.get("/api/work/v1/next?stream=infra-harness")
     assert response.status_code == 503, response.text
-    detail = response.json()["detail"]
-    assert detail["error"] == "building"
-    assert detail["retry_after_s"] > 0
+    # Wire body is the documented inner object (no FastAPI detail wrapper).
+    body = response.json()
+    assert body["error"] == "building"
+    assert body["retry_after_s"] > 0
+    assert "detail" not in body
     assert response.headers.get("retry-after") == "3"
     assert scheduled == []
     assert work_router._IN_FLIGHT_BUILDS == {}
@@ -540,9 +527,7 @@ def test_next_stale_cache_served_with_background_refresh(monkeypatch):
 
     def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
         called.append(True)
-        return build_projection(
-            _next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s
-        )
+        return build_projection(_next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
 
     monkeypatch.setattr(work_router, "build_public_projection", fake_build)
     response = client.get("/api/work/v1/next?stream=infra-harness")
@@ -555,21 +540,67 @@ def test_next_stale_cache_served_with_background_refresh(monkeypatch):
     assert called or key in work_router._IN_FLIGHT_BUILDS
 
 
+def test_next_max_stale_503_when_refresh_never_finishes(monkeypatch):
+    """Cache older than NEXT_MAX_STALE_S fails closed with 503 stale (#6890 #3)."""
+    import time
+
+    from scripts.api.state_helpers import _ttl_cache
+    from scripts.api.work_router import projection_cache_key
+
+    _patch_known_streams(monkeypatch)
+    payload = _warm_next_cache()
+    key = projection_cache_key({})
+    age = work_router.NEXT_MAX_STALE_S + 15.0
+    _ttl_cache[key] = (time.monotonic() - age, payload)
+
+    scheduled: list[str] = []
+    monkeypatch.setattr(
+        work_router,
+        "_get_or_create_build_task",
+        lambda k, filters: scheduled.append(k),
+    )
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"] == "stale"
+    assert body["max_stale_s"] == work_router.NEXT_MAX_STALE_S
+    assert body["cache_age_s"] >= work_router.NEXT_MAX_STALE_S
+    assert body["retry_after_s"] > 0
+    assert "detail" not in body
+    assert response.headers.get("retry-after") == "3"
+    assert scheduled == [key]
+
+
 def test_next_rejects_unknown_and_missing_stream(monkeypatch):
     _patch_known_streams(monkeypatch)
     _warm_next_cache()
 
     bad = client.get("/api/work/v1/next?stream=not-a-stream")
     assert bad.status_code == 400
-    detail = bad.json()["detail"]
-    assert detail["error"] == "unknown_stream"
-    assert detail["valid_streams"] == NEXT_STREAMS
+    body = bad.json()
+    assert body["error"] == "unknown_stream"
+    assert body["valid_streams"] == NEXT_STREAMS
+    assert "detail" not in body
 
     assert client.get("/api/work/v1/next").status_code == 422
 
 
+def test_next_registry_unavailable_503(monkeypatch):
+    """Unreadable registry → 503 registry_unavailable, never 200 empty (#6890 #5)."""
+    _warm_next_cache()
+    monkeypatch.setattr(work_router, "_known_streams", lambda: None)
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"] == "registry_unavailable"
+    assert body["retry_after_s"] > 0
+    assert "detail" not in body
+    assert "queue" not in body
+    assert response.headers.get("retry-after") == "3"
+
+
 def test_next_known_streams_come_from_registry():
-    """_known_streams reflects scripts/config/issue_streams.yaml (fail-open on error)."""
+    """_known_streams reflects scripts/config/issue_streams.yaml."""
     from scripts.orchestration.issue_stream_audit import load_registry
 
     cache_invalidate(work_router.STREAM_REGISTRY_CACHE_KEY)
@@ -586,6 +617,8 @@ def test_capabilities_advertise_next_queue():
     assert "stream" in nq["params"] and "limit" in nq["params"]
     assert "default 7, max 25" in nq["params"]["limit"]
     assert "503" in nq["served_from"]
+    assert "registry_unavailable" in nq["served_from"]
+    assert "stale" in nq["served_from"]
 
 
 def test_projection_membership_and_epic_status():
@@ -647,3 +680,99 @@ def test_streams_loader_derives_public_membership_and_strips_private_index():
     assert "5000" not in blob
     assert "unique_stream" not in blob
     assert "via" not in blob
+
+
+def test_streams_loader_allowlists_derived_and_preset_membership():
+    """Unknown stream names are dropped at derive time and on pre-set maps (#6890)."""
+    from scripts.work.sources_public import fetch_streams_projection
+
+    def loader_with_typo():
+        return {
+            "_status": "ok",
+            "generated_at": 1,
+            "open_total": 2,
+            "streams": {"infra-harness": [6900]},
+            "orphans": [],
+            "multi_homed": [
+                {
+                    "number": 6004,
+                    "title": "Multi",
+                    "streams": ["infra-harness", "not-a-real-stream"],
+                }
+            ],
+            "pending_native_link": [],
+            "ok": True,
+            "effective_membership": {
+                "6001": {
+                    "epics": [6900],
+                    "streams": ["infra-harness", "ghost-lane"],
+                    "via": "native",
+                    "unique_stream": False,
+                },
+            },
+            "open_issue_numbers": [6001, 6004],
+            # Pre-set map with a typo — must be re-validated, not trusted.
+            "open_stream_membership": {
+                "6009": ["infra-harness", "typo-stream"],
+                "6010": ["only-typo"],
+            },
+        }
+
+    section = fetch_streams_projection(loader=loader_with_typo)
+    assert section.status == "ok"
+    # Derived from effective_membership wins and is allowlisted.
+    assert section.payload["open_stream_membership"] == {"6001": ["infra-harness"]}
+    assert "ghost-lane" not in json.dumps(section.payload["open_stream_membership"])
+
+    def loader_preset_only():
+        return {
+            "_status": "ok",
+            "generated_at": 1,
+            "open_total": 1,
+            "streams": {"infra-harness": [6900], "devops": [6902]},
+            "orphans": [],
+            "multi_homed": [],
+            "pending_native_link": [],
+            "ok": True,
+            "open_stream_membership": {
+                "6001": ["infra-harness", "not-registered"],
+                "6002": ["not-registered"],
+            },
+        }
+
+    preset = fetch_streams_projection(loader=loader_preset_only)
+    assert preset.payload["open_stream_membership"] == {"6001": ["infra-harness"]}
+
+    projection = build_projection(
+        {
+            **_next_sections(),
+            "streams": SectionResult(
+                "streams",
+                "ok",
+                payload={
+                    "generated_at": 1,
+                    "open_total": 1,
+                    "streams": {"infra-harness": [6900]},
+                    "orphans": [],
+                    "multi_homed": [
+                        {
+                            "number": 6004,
+                            "title": "Multi",
+                            "streams": ["infra-harness", "bogus-stream"],
+                        }
+                    ],
+                    "pending_native_link": [],
+                    "open_stream_membership": {
+                        "6001": ["infra-harness", "bogus-stream"],
+                    },
+                    "ok": False,
+                },
+                count=1,
+            ),
+        },
+        repository_id=REPO,
+    )
+    by_id = {i["work_id"]: i for i in projection["items"]}
+    assert by_id[_wid(6001)]["projections"]["stream"]["streams"] == ["infra-harness"]
+    assert by_id[_wid(6004)]["projections"]["stream"]["streams"] == ["infra-harness"]
+    assert "bogus-stream" not in json.dumps(projection)

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORK = ROOT / "dashboards" / "work.html"
@@ -199,3 +204,61 @@ def test_work_page_actionable_predicate_parity_with_server_ssot():
         assert not is_actionable({"health": "UNKNOWN", "safe_next_action": {"code": denied}})
     assert not is_actionable({"health": "ON_TRACK", "safe_next_action": {}})
     assert not is_actionable(None)
+
+
+def test_work_page_actionable_predicate_behavioral_js_parity():
+    """Run the live JS predicate in Node against shared fixtures (#6890 #4).
+
+    Substring scans cannot catch a boolean inversion that keeps the scanned
+    tokens; evaluating the extracted JS against the Python SSOT closes that gap.
+    """
+    if shutil.which("node") is None:
+        pytest.skip("node required for JS actionable parity")
+
+    from scripts.work.attention import NON_ACTIONABLE_ACTION_CODES, is_actionable
+
+    fixtures = [
+        None,
+        {},
+        {"health": "OFF_TRACK", "safe_next_action": {"code": "NONE"}},
+        {"health": "AT_RISK", "safe_next_action": {"code": "OPEN_GITHUB"}},
+        {"health": "ON_TRACK", "safe_next_action": {"code": "MERGE_WHEN_READY"}},
+        {"health": "ON_TRACK", "safe_next_action": {"code": "FIX_CI"}},
+        {"health": "UNKNOWN", "safe_next_action": {"code": "WAIT_CI"}},
+        {"health": "ON_TRACK", "safe_next_action": {}},
+        {"health": "ON_TRACK"},
+        {"health": "UNKNOWN", "safe_next_action": {"code": ""}},
+    ]
+    for denied in sorted(NON_ACTIONABLE_ACTION_CODES):
+        fixtures.append({"health": "ON_TRACK", "safe_next_action": {"code": denied}})
+        fixtures.append({"health": "UNKNOWN", "safe_next_action": {"code": denied}})
+
+    expected = [bool(is_actionable(item)) for item in fixtures]
+    html_path = json.dumps(str(WORK))
+    fixtures_json = json.dumps(fixtures)
+    script = f"""
+    const fs = require('fs');
+    const html = fs.readFileSync({html_path}, 'utf8');
+    const start = html.indexOf('const NON_ACTIONABLE_ACTION_CODES');
+    const fnStart = html.indexOf('function isActionable(');
+    const fnEnd = html.indexOf('function ', fnStart + 1);
+    if (start < 0 || fnStart < 0 || fnEnd <= fnStart) {{
+      throw new Error('isActionable block not found');
+    }}
+    eval(html.slice(start, fnEnd));
+    const fixtures = {fixtures_json};
+    console.log(JSON.stringify(fixtures.map((item) => isActionable(item))));
+    """
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    js_results = json.loads(result.stdout)
+    assert js_results == expected
+    # Explicit kill for the boolean-inversion residual the substring scan misses.
+    assert expected[fixtures.index({"health": "ON_TRACK", "safe_next_action": {"code": "NONE"}})] is False
+    assert expected[fixtures.index({"health": "ON_TRACK", "safe_next_action": {"code": "MERGE_WHEN_READY"}})] is True


### PR DESCRIPTION
## Summary

Closes the six non-blocking residuals from the #6889 CF review (grok-4.6 APPROVE). Refs #6880 #6889. Fixes #6890.

**Design choices (fail-closed / honest signal):**
- Unreadable stream registry → `503 registry_unavailable` (not 200 + empty queue).
- Stale-serve is bounded at `NEXT_MAX_STALE_S=300` → `503 stale` (not unbounded).
- `/next` error bodies are unwrapped `JSONResponse` content matching the documented machine contract (not FastAPI `{"detail": ...}`).

## Residuals → fix → evidence

### 1. Derive-time stream names re-allowlisted
- **Fix:** `public_open_stream_membership` keeps only names present in the payload registry `streams` keys via `allowlist_stream_names` / `registry_stream_names`.
- **Evidence:** `test_streams_loader_allowlists_derived_and_preset_membership` — derived `ghost-lane` dropped; membership is `{"6001": ["infra-harness"]}`.

### 2. Pre-set `open_stream_membership` re-validated
- **Fix:** `_admit_open_stream_membership` always overwrites the public map: prefer derived, else allowlist any pre-set; never leave an unvalidated preset in place. Normalize also re-allowlists membership + `multi_homed` lists.
- **Evidence:** same test — preset-only loader with `not-registered` collapses to `{"6001": ["infra-harness"]}`; projection build strips `bogus-stream`.

### 3. Max-stale 503
- **Fix:** when `cache_age_s >= NEXT_MAX_STALE_S` (300s), `/next` returns `503 {"error":"stale",...}` and still schedules the single-flight refresh.
- **Evidence:** `test_next_max_stale_503_when_refresh_never_finishes` — status 503, `error=stale`, `max_stale_s=300.0`, refresh scheduled.

### 4. Behavioral JS/Python actionable parity
- **Fix:** `test_work_page_actionable_predicate_behavioral_js_parity` extracts the live `isActionable` + deny-list from `dashboards/work.html`, evaluates it in Node against shared fixtures, and asserts equality with `scripts.work.attention.is_actionable` (catches deny-list boolean inversion the substring scan misses).
- **Evidence:** that test passes under the suite below.

### 5. `_known_streams` fail-closed
- **Fix:** `known is None` → `503 {"error":"registry_unavailable","retry_after_s":3}` with `Retry-After`.
- **Evidence:** `test_next_registry_unavailable_503` — 503, no `queue`, no FastAPI `detail` wrapper.

### 6. Wire 503 body alignment
- **Fix:** `/next` structured errors use `_next_error` → unwrapped JSON body; docs updated in `docs/monitor-api/work.md` and `docs/MONITOR-API.md`.
- **Evidence:** cold/unknown/stale/registry tests assert `"detail" not in body` and top-level `error`.

## Test plan

- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_work_api.py tests/test_work_dashboard.py -q`
  - raw: `33 passed in 0.95s` (HEAD `839c1e74ed`)
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check` on every edited file
  - raw: `All checks passed!`
- [ ] CI green on this PR
- [ ] Independent cross-family exact-head review (driver owns; do not auto-merge)


Made with [Cursor](https://cursor.com)