### PR TITLE
fix(telemetry): record gemma and ACP shadow-adapter bridge usage

### DIFF
--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -62,6 +62,30 @@ def _warn_unknown(field: str, agent_name: str, detail: str) -> None:
     )
 
 
+def _metadata_text(plan: InvocationPlan | None, *keys: str) -> str | None:
+    if plan is None:
+        return None
+    for key in keys:
+        raw = plan.metadata.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+def _is_acp_shadow_identity(
+    agent_name: str, plan: InvocationPlan | None = None
+) -> bool:
+    name = str(agent_name).strip().lower()
+    if name.startswith("acpx-") and name.endswith("-shadow"):
+        return True
+    if plan is None:
+        return False
+    return any(
+        plan.metadata.get(flag) is True
+        for flag in ("acpx_discussion", "acpx_transport", "acpx_shadow")
+    ) or isinstance(plan.metadata.get("acpx_cli_version"), str)
+
+
 def _arg_after(cmd: list[str], *flags: str) -> str | None:
     for index, token in enumerate(cmd):
         if token in flags and index + 1 < len(cmd):
@@ -173,6 +197,12 @@ def _hermes_configured_effort() -> str | None:
 
 
 def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
+    if _is_acp_shadow_identity(agent_name, plan):
+        return (
+            _metadata_text(plan, "model")
+            or _arg_after(plan.cmd, "-m", "--model")
+            or _NOT_EXPOSED
+        )
     if agent_name == "kimi" and plan.metadata.get("harness") == "kimicc":
         alias = plan.metadata.get("kimicc_alias")
         return str(alias).strip() if isinstance(alias, str) and alias.strip() else None
@@ -180,6 +210,11 @@ def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | Non
 
 
 def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
+    if _is_acp_shadow_identity(agent_name, plan):
+        # ACP adapters stamp fixed effort when the seat has one. Seats with
+        # no per-invocation knob (gemma, kimi, cursor, pool, unpinned
+        # codex) must record the honest marker, not warn as unknown (#6852).
+        return _metadata_text(plan, "effort") or _NOT_EXPOSED
     if agent_name == "codex":
         return _config_override(plan.cmd, "model_reasoning_effort")
     from .agent_identity import is_hermes_grok_seat, is_native_grok_seat
@@ -239,6 +274,8 @@ def _resolve_model_from_defaults(
         return requested_model or KimiccHarness.default_model
     if requested_model:
         return requested_model
+    if _is_acp_shadow_identity(agent_name):
+        return _default_model_for(agent_name) or _NOT_EXPOSED
     if agent_name == "codex":
         # The codex adapter ALWAYS passes an explicit ``-m {registry default}``
         # when no override is given (adapters/codex.py::build_invocation), so
@@ -276,6 +313,8 @@ def _resolve_effort_from_defaults(
     # routine task state look broken (#4837).
     from .agent_identity import is_hermes_grok_seat
 
+    if _is_acp_shadow_identity(agent_name):
+        return requested_effort or _NOT_EXPOSED
     if agent_name in {"agy", "cursor", "gemini"}:
         return _NOT_EXPOSED
     if agent_name in {"deepseek", "hermes-deepseek", "qwen"} or is_hermes_grok_seat(agent_name):
@@ -430,6 +469,17 @@ def kimi_cli_version(prefix: tuple[str, ...] = ("kimi",), cwd: str | None = None
 
 def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) -> str | None:
     probe_cwd = str(plan.cwd) if plan is not None else None
+    if _is_acp_shadow_identity(agent_name, plan):
+        stamped = _metadata_text(
+            plan,
+            "provider_cli_version",
+            "grok_cli_version",
+            "acpx_cli_version",
+        )
+        if stamped:
+            return stamped
+        prefix = (plan.cmd[0],) if plan is not None and plan.cmd else ("acpx",)
+        return _probe_version_at(prefix, probe_cwd)
     if agent_name == "codex":
         prefix = _codex_version_prefix(plan.cmd) if plan is not None else ("codex",)
         return codex_cli_version(prefix, probe_cwd)

--- a/scripts/telemetry/legacy_bridge.py
+++ b/scripts/telemetry/legacy_bridge.py
@@ -49,11 +49,23 @@ _TARGETS = (
     "codex",
     "cursor",
     "deepseek",
+    "gemma",
     "glm",
     "grok",
     "kimi",
     "pool",
 )
+# Command aliases and ACP transport ids collapse to one allowlisted seat.
+# ``acpx-<seat>-shadow`` is handled in ``_canonical_bridge_target``.
+_TARGET_ALIASES = {
+    "gemini": "agy",
+    "hermes": "deepseek",
+    "grok-build": "grok",
+    "kimicc": "kimi",
+}
+_ACPX_SHADOW_PREFIX = "acpx-"
+_ACPX_SHADOW_SUFFIX = "-shadow"
+_BRIDGE_SCHEMA_VERSION = 2
 _init_lock = threading.Lock()
 _initialized_paths: set[Path] = set()
 
@@ -87,8 +99,20 @@ def _hour_z(value: datetime) -> str:
     return _iso_z(_normalized_utc(value).replace(minute=0, second=0, microsecond=0))
 
 
-def normalize_target(value: str) -> str:
+def _canonical_bridge_target(value: str) -> str:
+    """Map adapter / alias identities onto the durable telemetry seat."""
     normalized = str(value).strip().lower()
+    if normalized.startswith(_ACPX_SHADOW_PREFIX) and normalized.endswith(
+        _ACPX_SHADOW_SUFFIX
+    ):
+        normalized = normalized[
+            len(_ACPX_SHADOW_PREFIX) : -len(_ACPX_SHADOW_SUFFIX)
+        ]
+    return _TARGET_ALIASES.get(normalized, normalized)
+
+
+def normalize_target(value: str) -> str:
+    normalized = _canonical_bridge_target(value)
     if normalized not in _TARGETS:
         raise ValueError("bridge telemetry target is not allowlisted")
     return normalized
@@ -102,7 +126,7 @@ def classify_caller_family(source: str | None) -> str:
     prefixes = (
         (("claude",), "anthropic"),
         (("codex",), "openai"),
-        (("agy", "gemini"), "google"),
+        (("agy", "gemini", "gemma"), "google"),
         (("grok",), "xai"),
         (("kimi",), "moonshot"),
         (("glm",), "zhipu"),
@@ -137,25 +161,16 @@ def _prepare_private_db_file(path: Path) -> None:
         os.close(descriptor)
 
 
-def _initialize_db(path: Path, *, now: datetime | None = None) -> None:
-    _prepare_private_db_file(path)
-    observed_at = _iso_z(now or _now_utc())
-    with closing(_connect(path)) as connection:
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS telemetry_meta (
-                key   TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            );
+def _sql_literal_list(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
 
-            CREATE TABLE IF NOT EXISTS legacy_bridge_ask_usage (
+
+def _usage_table_sql() -> str:
+    return f"""
+            CREATE TABLE legacy_bridge_ask_usage (
                 hour_utc       TEXT NOT NULL,
                 target         TEXT NOT NULL CHECK (
-                    target IN (
-                        'agy', 'claude', 'codex', 'cursor', 'deepseek',
-                        'glm', 'grok', 'kimi', 'pool'
-                    )
+                    target IN ({_sql_literal_list(_TARGETS)})
                 ),
                 caller_family  TEXT NOT NULL CHECK (
                     caller_family IN (
@@ -172,13 +187,93 @@ def _initialize_db(path: Path, *, now: datetime | None = None) -> None:
                 CHECK (succeeded_count + failed_count <= started_count),
                 PRIMARY KEY (hour_utc, target, caller_family)
             );
-            CREATE INDEX IF NOT EXISTS idx_legacy_bridge_usage_last_seen
-                ON legacy_bridge_ask_usage(last_seen);
+            """
+
+
+def _table_exists(connection: sqlite3.Connection, name: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _bridge_schema_version(connection: sqlite3.Connection) -> int:
+    if not _table_exists(connection, "telemetry_meta"):
+        return 0
+    row = connection.execute(
+        "SELECT value FROM telemetry_meta WHERE key = 'bridge_schema_version'"
+    ).fetchone()
+    if row is None:
+        return 0
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return 0
+
+
+def _set_bridge_schema_version(connection: sqlite3.Connection, version: int) -> None:
+    connection.execute(
+        "INSERT INTO telemetry_meta(key, value) VALUES ('bridge_schema_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (str(version),),
+    )
+
+
+def _rebuild_usage_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        "ALTER TABLE legacy_bridge_ask_usage RENAME TO legacy_bridge_ask_usage_old"
+    )
+    connection.execute(_usage_table_sql())
+    connection.execute(
+        """
+        INSERT INTO legacy_bridge_ask_usage(
+            hour_utc, target, caller_family, started_count,
+            succeeded_count, failed_count, first_seen, last_seen
+        )
+        SELECT hour_utc, target, caller_family, started_count,
+               succeeded_count, failed_count, first_seen, last_seen
+        FROM legacy_bridge_ask_usage_old
+        """
+    )
+    connection.execute("DROP TABLE legacy_bridge_ask_usage_old")
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_legacy_bridge_usage_last_seen "
+        "ON legacy_bridge_ask_usage(last_seen)"
+    )
+
+
+def _migrate_bridge_schema(connection: sqlite3.Connection) -> None:
+    version = _bridge_schema_version(connection)
+    if version >= _BRIDGE_SCHEMA_VERSION:
+        return
+    if version < 2 and _table_exists(connection, "legacy_bridge_ask_usage"):
+        _rebuild_usage_table(connection)
+    _set_bridge_schema_version(connection, _BRIDGE_SCHEMA_VERSION)
+
+
+def _initialize_db(path: Path, *, now: datetime | None = None) -> None:
+    _prepare_private_db_file(path)
+    observed_at = _iso_z(now or _now_utc())
+    with closing(_connect(path)) as connection:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS telemetry_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
             """
         )
-        connection.execute(
-            "INSERT OR IGNORE INTO telemetry_meta(key, value) VALUES ('bridge_schema_version', '1')"
-        )
+        if _table_exists(connection, "legacy_bridge_ask_usage"):
+            _migrate_bridge_schema(connection)
+        else:
+            connection.execute(_usage_table_sql())
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_legacy_bridge_usage_last_seen "
+                "ON legacy_bridge_ask_usage(last_seen)"
+            )
+            _set_bridge_schema_version(connection, _BRIDGE_SCHEMA_VERSION)
         connection.execute(
             "INSERT OR IGNORE INTO telemetry_meta(key, value) "
             "VALUES ('bridge_coverage_started_at', ?)",
@@ -294,9 +389,10 @@ def start_bridge_invocation_safely(target: str, source: str | None) -> BridgeInv
     try:
         return record_bridge_invocation_start(target, source)
     except (OSError, RuntimeError, sqlite3.Error, ValueError):
+        mapped = _canonical_bridge_target(target)
         logger.exception(
             "legacy bridge telemetry start failed target=%s caller_family=%s",
-            target if target in _TARGETS else "unknown",
+            mapped if mapped in _TARGETS else "unknown",
             classify_caller_family(source),
         )
         return None

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -338,6 +338,97 @@ def test_resolve_dispatch_start_telemetry_kimi_resolves_binary(tmp_path, monkeyp
     assert telemetry_with_plan.cli_version == "0.42.1"
 
 
+def test_acp_gemma_shadow_reads_stamped_plan_metadata(tmp_path, caplog):
+    """#6852: gemma ACP plans already carry model/version; do not warn unknown."""
+    plan = InvocationPlan(
+        cmd=["acpx", "--model", "google-ais/gemma-4-31b-it", "gemma", "exec", "-f", "-"],
+        cwd=tmp_path,
+        metadata={
+            "acpx_transport": True,
+            "target_agent": "gemma",
+            "model": "google-ais/gemma-4-31b-it",
+            "acpx_cli_version": "0.14.7",
+            "provider_cli": "opencode",
+            "provider_cli_version": "1.2.3",
+        },
+    )
+    caplog.set_level(logging.WARNING, logger="agent_runtime.telemetry")
+    telemetry = resolve_invocation_telemetry(
+        agent_name="acpx-gemma-shadow",
+        plan=plan,
+        requested_model=None,
+        requested_effort=None,
+    )
+    assert telemetry.model == "google-ais/gemma-4-31b-it"
+    assert telemetry.effort == "not-exposed"
+    assert telemetry.cli_version == "1.2.3"
+    assert "dispatch telemetry for" not in caplog.text
+
+
+def test_acp_kimi_shadow_does_not_warn_unknown_effort_or_version(tmp_path, caplog):
+    """#6852 sibling: kimi ACP shadow has the same identity-mapping gap."""
+    plan = InvocationPlan(
+        cmd=["acpx", "kimi", "exec", "-f", "-"],
+        cwd=tmp_path,
+        metadata={
+            "acpx_transport": True,
+            "target_agent": "kimi",
+            "acpx_cli_version": "0.14.7",
+        },
+    )
+    caplog.set_level(logging.WARNING, logger="agent_runtime.telemetry")
+    telemetry = resolve_invocation_telemetry(
+        agent_name="acpx-kimi-shadow",
+        plan=plan,
+        requested_model=None,
+        requested_effort=None,
+    )
+    assert telemetry.effort == "not-exposed"
+    assert telemetry.cli_version == "0.14.7"
+    assert "could not resolve effort" not in caplog.text
+    assert "could not resolve cli_version" not in caplog.text
+
+
+def test_acp_shadow_adapters_resolve_effort_and_cli_version_from_identity(tmp_path, caplog):
+    """Sibling sweep: every ACP shadow seat maps identity, never warns unknown."""
+    from scripts.agent_runtime.adapters.acpx import (
+        ACPX_PARTICIPANT_EFFORTS,
+        ACPX_SUPPORTED_PARTICIPANTS,
+    )
+
+    caplog.set_level(logging.WARNING, logger="agent_runtime.telemetry")
+    for seat, spec in ACPX_SUPPORTED_PARTICIPANTS.items():
+        adapter = str(spec["seat"])
+        stamped_effort = ACPX_PARTICIPANT_EFFORTS.get(seat)
+        metadata = {
+            "acpx_transport": True,
+            "target_agent": spec["agent"],
+            "acpx_cli_version": "0.14.7",
+        }
+        if spec["model"]:
+            metadata["model"] = spec["model"]
+        if stamped_effort:
+            metadata["effort"] = stamped_effort
+        plan = InvocationPlan(
+            cmd=["acpx", seat, "exec", "-f", "-"],
+            cwd=tmp_path,
+            metadata=metadata,
+        )
+        telemetry = resolve_invocation_telemetry(
+            agent_name=adapter,
+            plan=plan,
+            requested_model=None,
+            requested_effort=None,
+        )
+        assert telemetry.effort == (stamped_effort or "not-exposed"), adapter
+        assert telemetry.cli_version == "0.14.7", adapter
+        if spec["model"]:
+            assert telemetry.model == spec["model"], adapter
+        else:
+            assert telemetry.model == "not-exposed", adapter
+    assert "dispatch telemetry for" not in caplog.text
+
+
 def test_kimicc_telemetry_records_the_headless_k3_route(tmp_path):
     plan = InvocationPlan(
         cmd=["kimicc_headless.sh", "--model", "k3", "--effort", "high"],

--- a/tests/test_legacy_bridge_telemetry.py
+++ b/tests/test_legacy_bridge_telemetry.py
@@ -85,6 +85,7 @@ def test_release_snapshot_store_uses_its_primary_data_symlink(tmp_path: Path) ->
         ("codex-infra", "openai"),
         ("claude-desktop", "anthropic"),
         ("agy", "google"),
+        ("gemma-seat", "google"),
         ("grok-build", "xai"),
         ("kimi-devops", "moonshot"),
         ("glm", "zhipu"),
@@ -318,7 +319,9 @@ def test_read_only_api_returns_all_targets_and_rejects_invalid_window(
         payload = response.json()
         assert payload["started"] == 0
         assert payload["window_fully_observed"] is False
-        assert len(payload["targets"]) == 9
+        assert [item["target"] for item in payload["targets"]] == list(
+            legacy_bridge._TARGETS
+        )
         assert client.get(
             "/api/telemetry/legacy-bridge-asks?window=forever"
         ).status_code == 422
@@ -343,3 +346,125 @@ def test_summary_json_never_contains_raw_caller_value(telemetry_db: Path) -> Non
     payload = legacy_bridge.bridge_usage_summary("1h", db_path=telemetry_db)
     assert "private-caller-family-6106" not in json.dumps(payload)
     assert payload["by_caller_family"] == {"unknown": 1}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("gemma", "gemma"),
+        ("acpx-gemma-shadow", "gemma"),
+        ("gemini", "agy"),
+        ("hermes", "deepseek"),
+        ("grok-build", "grok"),
+        ("acpx-kimicc-shadow", "kimi"),
+        ("acpx-kimi-shadow", "kimi"),
+    ],
+)
+def test_normalize_target_maps_adapter_identities(raw: str, expected: str) -> None:
+    assert legacy_bridge.normalize_target(raw) == expected
+
+
+def test_compat_and_acpx_shadow_identities_are_allowlisted() -> None:
+    """Sibling sweep: every live ACP route must map onto a telemetry seat (#6852)."""
+    from scripts.agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    for command, participant in _acp_compat._TARGETS.items():
+        assert legacy_bridge.normalize_target(command) == (
+            legacy_bridge.normalize_target(participant)
+        )
+        assert legacy_bridge.normalize_target(participant) in legacy_bridge._TARGETS
+    for seat, spec in ACPX_SUPPORTED_PARTICIPANTS.items():
+        adapter = str(spec["seat"])
+        assert legacy_bridge.normalize_target(adapter) == legacy_bridge.normalize_target(
+            seat
+        )
+        assert legacy_bridge.normalize_target(adapter) in legacy_bridge._TARGETS
+
+
+def test_unknown_adapter_identity_is_still_rejected() -> None:
+    with pytest.raises(ValueError, match="not allowlisted"):
+        legacy_bridge.normalize_target("acpx-no-such-shadow")
+    with pytest.raises(ValueError, match="not allowlisted"):
+        legacy_bridge.normalize_target("retired")
+
+
+def test_gemma_compat_ask_records_allowlisted_target(
+    telemetry_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _acp_compat,
+        "_run_compat_ask_impl",
+        lambda *_args, **_kwargs: SimpleNamespace(ok=True),
+    )
+    result = _acp_compat.run_compat_ask(
+        "gemma", "prompt", task_id="gemma-6852", source="claude-infra"
+    )
+    assert result.ok is True
+    assert _rows(telemetry_db)[0][1:6] == ("gemma", "anthropic", 1, 1, 0)
+
+
+def test_schema_v1_store_migrates_and_accepts_gemma(telemetry_db: Path) -> None:
+    """Existing CHECK-constrained stores must admit the new gemma seat."""
+    telemetry_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(telemetry_db)) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE telemetry_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE legacy_bridge_ask_usage (
+                hour_utc       TEXT NOT NULL,
+                target         TEXT NOT NULL CHECK (
+                    target IN (
+                        'agy', 'claude', 'codex', 'cursor', 'deepseek',
+                        'glm', 'grok', 'kimi', 'pool'
+                    )
+                ),
+                caller_family  TEXT NOT NULL CHECK (
+                    caller_family IN (
+                        'anthropic', 'cursor', 'deepseek', 'google',
+                        'moonshot', 'openai', 'operator', 'xai', 'zhipu',
+                        'unknown'
+                    )
+                ),
+                started_count   INTEGER NOT NULL DEFAULT 0,
+                succeeded_count INTEGER NOT NULL DEFAULT 0,
+                failed_count    INTEGER NOT NULL DEFAULT 0,
+                first_seen      TEXT NOT NULL,
+                last_seen       TEXT NOT NULL,
+                PRIMARY KEY (hour_utc, target, caller_family)
+            );
+            INSERT INTO telemetry_meta(key, value)
+            VALUES ('bridge_schema_version', '1');
+            INSERT INTO legacy_bridge_ask_usage(
+                hour_utc, target, caller_family, started_count,
+                succeeded_count, failed_count, first_seen, last_seen
+            ) VALUES (
+                '2026-08-02T00:00:00Z', 'glm', 'operator', 1, 1, 0,
+                '2026-08-02T00:30:00Z', '2026-08-02T00:30:00Z'
+            );
+            """
+        )
+        connection.commit()
+
+    now = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+    token = legacy_bridge.record_bridge_invocation_start(
+        "acpx-gemma-shadow", "claude-infra", db_path=telemetry_db, now=now
+    )
+    legacy_bridge.record_bridge_invocation_finish(token, succeeded=True, now=now)
+
+    assert token.target == "gemma"
+    with sqlite3.connect(str(telemetry_db)) as connection:
+        version = connection.execute(
+            "SELECT value FROM telemetry_meta WHERE key = 'bridge_schema_version'"
+        ).fetchone()[0]
+        targets = {
+            row[0]
+            for row in connection.execute(
+                "SELECT DISTINCT target FROM legacy_bridge_ask_usage"
+            )
+        }
+    assert version == str(legacy_bridge._BRIDGE_SCHEMA_VERSION)
+    assert targets == {"gemma", "glm"}


### PR DESCRIPTION
## Summary

Legacy `ask-gemma` invocations were fail-open dropped from bridge telemetry because `normalize_target("gemma")` was not allowlisted. The same identity-mapping gap left every `acpx-*-shadow` adapter name rejected if it reached the allowlist, and left ACP shadow seats recording `effort`/`cli_version` as `unknown`.

This PR fixes the mapping layer (not the exception handler): add `gemma` as a first-class telemetry seat, map ACP shadow / alias identities onto the durable seats, migrate the SQLite CHECK, and read ACP plan metadata for effort/version.

## Changes

- Allowlist `gemma` in `scripts/telemetry/legacy_bridge.py` and rebuild the usage-table CHECK via schema v2 so existing stores accept the new seat.
- Map adapter identities (`acpx-<seat>-shadow`, `kimicc`, `gemini`/`hermes`/`grok-build`) onto allowlisted seats.
- Classify `gemma*` callers as `google`.
- Resolve ACP shadow `effort`/`cli_version`/`model` from stamped plan metadata (`provider_cli_version` / `acpx_cli_version` / fixed effort). Seats with no knob record `not-exposed` instead of warning `unknown`.
- Regression tests: gemma compat ask, schema v1 migration, sibling sweep of every compat + ACPX shadow identity.

## Evidence (#M-4)

**Before** (cwd: this worktree, current `main` head before the fix):

```
compat 'gemma' -> participant 'gemma': REJECTED: bridge telemetry target is not allowlisted
acpx-gemma-shadow: REJECTED
acpx-kimi-shadow: REJECTED
start_bridge_invocation_safely('gemma') -> token = None
  ValueError: bridge telemetry target is not allowlisted
acpx-gemma-shadow: model='google-ais/gemma-4-31b-it' effort='unknown' cli_version='unknown'
acpx-kimi-shadow: model='unknown' effort='unknown' cli_version='unknown'
WARNING ... could not resolve effort: invocation plan had no effort flag; recording 'unknown'
WARNING ... could not resolve cli_version: version probe failed; recording 'unknown'
```

**After** (same probes):

```
compat 'gemma' -> participant 'gemma': ok -> gemma
acpx-gemma-shadow: ok -> gemma
acpx-kimi-shadow: ok -> kimi
token.target = gemma
acpx-gemma-shadow: model='google-ais/gemma-4-31b-it' effort='not-exposed' cli_version='1.2.3'
acpx-kimi-shadow: model='not-exposed' effort='not-exposed' cli_version='0.14.7'
```

Sibling sweep: every `_acp_compat._TARGETS` participant and every `ACPX_SUPPORTED_PARTICIPANTS` seat now normalizes onto `_TARGETS`. The allowlist `ValueError` reproduced only on gemma among compat participants; the effort/cli_version gap covered the whole ACP shadow class (gemma + kimi confirmed live, all seats covered in tests).

## Testing

- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check` on edited files — clean
- [x] `.venv/bin/python -m pytest tests/test_legacy_bridge_telemetry.py tests/test_dispatch_telemetry.py` — **51 passed**
- [x] `.venv/bin/python -m pytest tests/ai_agent_bridge/test_ask_contract.py tests/test_fleet_comms_legacy_broker_report.py` — **73 passed**
- [ ] Modules pass audit (`scripts/audit_module.py`) — N/A (infra/telemetry)
- [ ] Website builds without errors (`cd site && npm run build`) — N/A
- [ ] Ukrainian text reviewed for naturalness — N/A

## Related Issues

Closes #6852