### PR TITLE
fix(runtime): silence watchdog ignores idle-CPU noise from wedged agent CLIs (#6888)

### DIFF
--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -53,7 +53,18 @@ _MTIME_POLL_INTERVAL_S = 5.0
 # demonstrably doing work. Poll slowly; stdout/stderr/liveness file events remain
 # the primary cheap signals.
 _PROCESS_ACTIVITY_POLL_INTERVAL_S = 5.0
-_PROCESS_ACTIVITY_MIN_CPU_SECONDS = 0.05
+# Work-grade CPU bar for one poll window. The previous 0.05s value was below
+# idle-runtime noise: a completely idle `agy` CLI burns ~0.03s CPU per 5s and
+# spikes past 0.05s (measured 0.066s in a 30s sample of a wedged/idle process,
+# #6888). Every such blip refreshed ``last_activity``, so an agy session that
+# stalled with zero stdout/stderr for the full run still never tripped
+# ``stdout_silence_timeout``/``initial_response_timeout`` and burned the entire
+# 7200s hard-timeout — twice on 2026-08-16 (work-6862-historical-reviews,
+# infra-6869-fix2). 0.5s per 5s (~10% of one core) sits ~8x above the observed
+# idle-noise ceiling and far below genuine build/test/tool work, so quiet-but-
+# productive phases keep their protection while wedged idle trees now starve
+# the clock as intended.
+_PROCESS_ACTIVITY_MIN_CPU_SECONDS = 0.5
 
 # Maximum number of liveness paths to poll. Adapters returning more than
 # this many paths will only have the first _MAX_LIVENESS_PATHS polled.

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -2771,7 +2771,7 @@ def test_process_tree_has_activity_tracks_descendant_cpu(monkeypatch):
 
     import agent_runtime.watchdog as watchdog_module
 
-    samples = iter([(0.0, 0.0), (0.0, 0.10)])
+    samples = iter([(0.0, 0.0), (0.0, 1.5)])
 
     def fake_process(_pid):
         root_cpu, child_cpu = next(samples)
@@ -2786,6 +2786,56 @@ def test_process_tree_has_activity_tracks_descendant_cpu(monkeypatch):
     proc = SimpleNamespace(pid=123)
 
     assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is False
+    assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is True
+
+
+def test_process_tree_has_activity_ignores_idle_cpu_noise(monkeypatch):
+    """Idle-runtime CPU blips must not read as work (#6888).
+
+    A wedged/idle ``agy`` CLI measurably burns ~0.03s CPU per 5s poll with
+    spikes past the old 0.05s bar; each blip refreshed ``last_activity`` and
+    kept ``stdout_silence_timeout`` dead for the full 7200s hard-timeout.
+    Sub-threshold noise must NOT count as activity, while work-grade CPU
+    (compiles, test runs, tool subprocesses) still does.
+    """
+
+    class FakeProcess:
+        def __init__(self, pid, cpu_seconds):
+            self.pid = pid
+            self._cpu_seconds = cpu_seconds
+
+        def cpu_times(self):
+            return SimpleNamespace(user=self._cpu_seconds, system=0.0)
+
+        def io_counters(self):
+            raise AttributeError("not available on this platform")
+
+        def children(self, recursive=False):
+            assert recursive is True
+            return []
+
+    import agent_runtime.watchdog as watchdog_module
+
+    samples = iter([0.0, 0.06, 0.12, 2.12])
+    monkeypatch.setattr(
+        watchdog_module.psutil,
+        "Process",
+        lambda _pid: FakeProcess(pid=123, cpu_seconds=next(samples)),
+    )
+
+    primed_pids: set[int] = set()
+    cpu_baselines: dict[int, float] = {}
+    io_baselines: dict[int, tuple[int, int, int, int]] = {}
+    proc = SimpleNamespace(pid=123)
+
+    # First poll only primes the baseline.
+    assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is False
+    # +0.06s: idle-noise blip — above the pre-#6888 0.05s bar, below the
+    # work-grade bar. Must NOT count as activity.
+    assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is False
+    # +0.06s again: repeated idle noise still does not count.
+    assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is False
+    # +2.0s: real work crosses the bar and counts.
     assert _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines) is True
 
 


### PR DESCRIPTION
## Root cause

Both 2026-08-16 agy burns had `silence_timeout: 3600` and `initial_response_timeout: 600` configured, yet only `hard_timeout` fired:

- `batch_state/tasks/work-6862-historical-reviews.json`: `"duration_s": 7202.49`, `"response_chars": 0`, `"silence_timeout": 3600`, `"initial_response_timeout": 600`, `"last_error": "hard_timeout fired after 7200s..."`, `"commits_ahead": 0`
- `batch_state/tasks/infra-6869-fix2.json`: `"duration_s": 7203.935`, `"response_chars": 0`, `"commits_ahead": 2` (work was complete; session wedged before PR comment)

Tool-backed evidence chain:

1. Usage records for both tasks report `agy subprocess exited rc=-9 in 7200.50s with no captured stdout/stderr (stdin_bytes=0)` — **zero** stdout/stderr lines in 2h, so the streamers never refreshed `last_activity`.
2. agy transcripts (`~/.gemini/antigravity-cli/brain/<conv>/`) stopped advancing **19s** after spawn for burn 1 (all files ≤ 15:03:10, spawn 15:02:51) and **~3.5min** in for burn 2 (last write 17:41:02, spawn 17:37:31) — yet the processes ran to 17:02:53 / 19:37:35.
3. The defeat mechanism: `_process_activity_poller` counts any 5s window with ≥ `_PROCESS_ACTIVITY_MIN_CPU_SECONDS = 0.05` CPU as "work" (`watchdog.py`). Sampling the live **idle** agy process tree (pid 52087, sitting at a prompt): steady ~0.03s CPU per 5s, with a **0.0657s spike inside 30s** — above the 0.05s bar. One such blip per hour refreshes `last_activity` forever; silence detection was structurally dead regardless of the configured window. Same blips set `observed_io`, neutering `initial_response_timeout`.
4. Supporting negative: 20s file-watch over `~/.gemini/antigravity-cli/` while agy sat idle showed 0 file modifications — no log-heartbeat channel needed to explain the stalls; idle CPU noise alone suffices.

### Sibling check

`track_process_activity` is enabled runner-wide for every adapter whenever a silence/initial-response timeout is set (`runner.py:1431-1437`); no adapter overrides it. Every lane's silence detection was suppressible by idle-CPU noise — agy is simply the lane whose CLI wedges open-endedly instead of exiting. The fix is at the watchdog layer, so all lanes are covered.

## Fix

`scripts/agent_runtime/watchdog.py`: raise `_PROCESS_ACTIVITY_MIN_CPU_SECONDS` from `0.05` to `0.5` per 5s poll (~10% of one core) — ~8x above the observed idle-noise ceiling, far below genuine build/test/tool work, so the #3875 false-kill protection for quiet-but-productive phases is preserved while wedged idle trees now starve the silence clock.

### Why not the issue's other hypotheses

- **Tighter agy silence default alone**: useless while a single hourly CPU blip resets the clock — any window is defeated. With the mechanism fixed, the existing 3600s default now actually fires; tightening it further risks false-killing legit quiet tool phases (long in-tool pytest runs produce no transcript/stdout), so it was left unchanged.
- **End-of-work exit contract in the agy adapter**: the adapter only builds argv; the wedge is inside the third-party CLI (burn 2 sat *after* all work completed). A live probe (`agy -p ... --print-timeout 3m`, rc=0 in <10s) confirms healthy agy exits fine — detection, not invocation shape, was the broken layer.

## Verification

- Guard test added: `test_process_tree_has_activity_ignores_idle_cpu_noise` (+0.06s/poll idle noise must NOT count; +2.0s work must). Existing `test_process_tree_has_activity_tracks_descendant_cpu` updated to a work-grade delta (1.5s).
- **Mutation check**: reverting the threshold to `0.05` fails the guard test:
  `FAILED tests/test_agent_runtime.py::test_process_tree_has_activity_ignores_idle_cpu_noise - assert True is False`
  Restored to `0.5` → passes.
- `pytest tests/test_agent_runtime.py tests/test_delegate.py`: **459 passed**.
- `pytest tests/agent_runtime`: 380 passed, 2 failed — both failures (`test_render_writer_prompt_*` in `test_agy_adapter.py`) **pre-exist on the clean base** (verified via `git stash`); unrelated to this change.
- `ruff check scripts/agent_runtime/watchdog.py tests/test_agent_runtime.py`: clean.

Closes #6888
