### PR TITLE
fix(routing): close grok-4.6 rotation residuals (#6870)

### DIFF
--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -315,7 +315,9 @@ _ROUTABLE_MODELS: dict[str, ModelRoute] = {
     "claude-opus-4-8": ModelRoute(family="anthropic", backend=_claude_backend),
     "claude-opus-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
     "claude-sonnet-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
-    "grok-4.5": ModelRoute(family="xai", backend=_hermes_backend),
+    # grok-4.5 → Hermes removed (#6870 / #6865): Hermes is banned for grok;
+    # requests for grok-4.5 (or any grok id) 404 via the normal unknown-model path.
+    # Native grok-4.6 is not an openai_proxy route — use the grok CLI / GrokBuildAdapter.
 }
 
 

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -39,6 +39,14 @@ policy:
       Operator order 2026-08-16 (#6865) retires the 2026-07-27 ruling that sanctioned opencode
       first-party xai/grok-4.5 for orchestrator seats — opencode is no longer a sanctioned grok
       route for any seat. Hermes and OpenRouter grok routes remain banned.
+    - >-
+      EXEMPT (not a fleet seat) — scripts/projects/open_model_data Phase 3 v2.1 ROLE_EXECUTION
+      still pins harness opencode + exact_model grok-4.5 for ukrainian_source_reviewer /
+      cross_family_code_infra_reviewer / textbook_nonhit_auditor (and OPENCODE_REVIEW_MODEL
+      xai/grok-4.5). Those pins live in hash-bound v2.1 evidence/validator artifacts
+      (phase3_functional_roles.py validator_sha256 + phase3_source_production_transport.py
+      inventory sha); rotating or rewriting them is outside the fleet seat list and requires
+      a separate open-model-data rebind (#6870 item 3). Fleet routing must not read them.
     - Composer 2.5 conservatively shares Moonshot independence lineage with Kimi.
 
 # Canonical sealed formal-review transports. Resolver policy consumes these

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -356,6 +356,20 @@ launcher_validate_mode() {
 }
 
 launcher_validate_driver_certification() {
+  # Interactive Grok: empty --model keeps the last TUI selection; an explicit
+  # pin must be the certified native model (refuse retired grok-4.5, #6870).
+  if [ "$LC_MODE" = "interactive" ] && [ "$LC_PROVIDER" = "grok" ]; then
+    if [ -z "${LC_MODEL:-}" ]; then
+      return 0
+    fi
+    case "$LC_MODEL" in
+      grok-4.6) return 0 ;;
+      *)
+        launcher_error "model '$LC_MODEL' is not certified for the grok launcher (use grok-4.6, or omit --model)."
+        exit 4
+        ;;
+    esac
+  fi
   [ "$LC_MODE" = "driver" ] || return 0
   [ "$LC_GOVERNOR" = "0" ] || return 0
   # Claude/Grok may omit --model so the TUI keeps the last session selection.

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -53,22 +53,18 @@ def test_chat_completions_codex_round_trip(monkeypatch):
     assert body["choices"][0]["finish_reason"] == "stop"
 
 
-def test_chat_completions_grok_via_hermes(monkeypatch):
-    def backend(model, messages, **kwargs):
-        return proxy.CompletionResponse(content="hello from grok")
-
-    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "grok-4.5", _route_with_backend("grok-4.5", backend))
-
+def test_chat_completions_retired_grok_45_returns_404():
+    """#6870: grok-4.5 → Hermes mapping is gone; retired pin must 404."""
+    assert "grok-4.5" not in proxy._ROUTABLE_MODELS
     response = _client().post(
         "/v1/chat/completions",
         json={"model": "grok-4.5", "messages": [{"role": "user", "content": "hello"}]},
     )
 
+    assert response.status_code == 404
     body = response.json()
-    assert response.status_code == 200
-    assert body["model"] == "grok-4.5"
-    assert body["choices"][0]["message"]["content"] == "hello from grok"
-    assert body["choices"][0]["finish_reason"] == "stop"
+    assert body["error"]["code"] == "model_not_found"
+    assert "grok-4.5" in body["error"]["message"]
 
 
 def test_chat_completions_gemini_round_trip(monkeypatch):

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -282,8 +282,9 @@ def test_grok_build_lane_defaults_to_grok_46():
 
 
 def test_grok_build_rejects_retired_model_pin(tmp_path):
-    with pytest.raises(ValueError, match="unsupported Grok model"):
-        _build("x", tmp_path, model="grok-build", effort="high")
+    """#6870: pin the literal retired model id, not the grok-build agent alias."""
+    with pytest.raises(ValueError, match=r"unsupported Grok model 'grok-4\.5'"):
+        _build("x", tmp_path, model="grok-4.5", effort="high")
 
 
 def test_grok_build_default_model_is_listed_by_cli():

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -1473,8 +1473,9 @@ def test_grok_print_config_golden(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_grok_print_config_rejects_retired_model_pin(capsys: pytest.CaptureFixture[str]) -> None:
+    """#6870: pin the literal retired model id, not the grok-build agent alias."""
     assert layerb_judge_bridge.main(
-        ["--judge-family", "grok", "--judge-model", "grok-build", "--print-config"]
+        ["--judge-family", "grok", "--judge-model", "grok-4.5", "--print-config"]
     ) == 2
     assert "Grok Layer-B judges must use grok-4.6" in capsys.readouterr().err
 

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -20,10 +20,19 @@ def test_grok_interactive_defaults_to_native_harness_and_rejects_epic() -> None:
     assert "interactive launchers reject --epic" in epic.stderr
 
 
-def test_grok_explicit_model_still_pins() -> None:
+def test_grok_explicit_retired_model_is_refused() -> None:
+    """#6870: interactive start-grok.sh must refuse retired grok-4.5."""
     result = run_launcher("start-grok.sh", "--model", "grok-4.5")
+    assert result.returncode == 4, result.stderr
+    assert "not certified" in result.stderr
+    assert "grok-4.5" in result.stderr
+    assert "--model grok-4.5" not in result.stdout
+
+
+def test_grok_explicit_certified_model_still_pins() -> None:
+    result = run_launcher("start-grok.sh", "--model", "grok-4.6")
     assert result.returncode == 0, result.stderr
-    assert "--model grok-4.5" in result.stdout
+    assert "--model grok-4.6" in result.stdout
 
 
 def test_grok_effort_injects_reasoning_effort_only_when_set() -> None:


### PR DESCRIPTION
## Summary

Closes the non-blocking residuals banked from the PR #6868 CF review (grok-4.6 APPROVE) as issue #6870 items 1, 2, and 4, plus an explicit item-3 exemption.

- **Item 1:** remove the `openai_proxy` `grok-4.5` → Hermes route; retired pin now 404s (`model_not_found`). Native grok-4.6 remains CLI / `GrokBuildAdapter`, not an openai_proxy backend.
- **Item 2:** interactive `start-grok.sh --model grok-4.5` now refuses (exit 4); omit `--model` still keeps the TUI session selection; `--model grok-4.6` still pins.
- **Item 3:** **exempt-with-comment** (not align). Fleet seat list consumers read `model_catalog.yaml`; they do not read `open_model_data` ROLE_EXECUTION. The Phase 3 v2.1 opencode + `grok-4.5` pins are hash-bound (`phase3_functional_roles.py` validator_sha256 + `phase3_source_production_transport.py` inventory sha) — #6868 already tried rotating them and had to revert for CI hash drift. Aligning harness/model here would unilaterally rewrite frozen project evidence. Exemption note added under `policy.notes` in `model_catalog.yaml`.
- **Item 4:** `*_rejects_retired_model_pin` tests now feed literal `grok-4.5` (not the `grok-build` agent alias).
- **Out of scope:** 4.6/4.7 two-tier split (operator-gated).

## Evidence (#M-4)

Launcher refuse (quoted):
```text
Error: model 'grok-4.5' is not certified for the grok launcher (use grok-4.6, or omit --model).
exit=4
```

openai_proxy refuse (quoted):
```text
status 404
body {'error': {'message': "model 'grok-4.5' not found", 'type': 'invalid_request_error', 'code': 'model_not_found'}}
routable ['claude-opus-4-7', 'claude-opus-4-8', 'claude-sonnet-4-7', 'codex', 'gemini-3.0-flash-preview', 'gemini-3.1-pro-preview']
```

## Test plan

- [x] `ruff check` on touched Python files — clean
- [x] `pytest` affected suite — 94 passed (`test_openai_proxy*`, `test_start_grok_launcher`, retired-model pin tests, `test_model_catalog`)
- [x] `lint_fleet_roster.py` — OK
- [ ] CI green on this PR
- [ ] Independent cross-family review (driver-owned; do not auto-merge)

Refs: #6870, #6868, #6865


Made with [Cursor](https://cursor.com)