### PR TITLE
fix(atlas): close #6876 residual job + workdir symlink resolve

### DIFF
--- a/batch_state/atlas-jobs/receipts/6876-missing-anchor-2295.json
+++ b/batch_state/atlas-jobs/receipts/6876-missing-anchor-2295.json
@@ -1,0 +1,52 @@
+{
+  "issue": 6876,
+  "summary": {
+    "target": "missing-anchor",
+    "targets": 2295,
+    "target_snapshot": {
+      "count": 2295,
+      "sha256": "14e89c1c128f303aaa7ad24c27b5c5650622833fcf30bcab41306c02b5e27e6c"
+    },
+    "changed": 984,
+    "filled_translation": 984,
+    "gained_english_anchor": 984,
+    "remaining_old_gate_no_english_anchor": 1311,
+    "categorical_binning": {
+      "ENRICHED": 984,
+      "DETERMINISTIC_EXCLUSION": 0,
+      "UNRESOLVED_RESIDUAL": 1311
+    },
+    "layer_counters": {
+      "proverbs": 4,
+      "usage_notes": 1,
+      "grinchenko": 14,
+      "forms": 2088
+    },
+    "circuit_breaker_tripped": false,
+    "consecutive_misses": 2
+  },
+  "exit_status": {
+    "service_result": "success",
+    "exit_code": "exited",
+    "exit_status": "0"
+  },
+  "delivery": "ok",
+  "backup": {
+    "attempted": false,
+    "ok": false,
+    "snapshot_id": null,
+    "error": "skipped"
+  },
+  "closed_at": "2026-08-17T00:03:03+00:00",
+  "schema": "atlas-job-result.v1",
+  "unit": "atlas-job-6876-missing-anchor-2295.service",
+  "host": "atlas-runner",
+  "denominator": 2295,
+  "pulled": true,
+  "workdir": "run-atlas-job-6876-missing-anchor-2295",
+  "plan_sha256": "9af14c8b6e958acecd5a0409658f192f683b6126a6734c19129507cd622198bf",
+  "git_pr": null,
+  "id": "6876-missing-anchor-2295",
+  "kind": "reenrich",
+  "state": "succeeded"
+}

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -333,13 +333,15 @@ def require_safe_workdir(workdir: object) -> str:
     raw = Path(workdir)
     if ".." in raw.parts:
         raise ValueError("workdir must not contain ..")
-    run_root = _run_root().resolve()
+    run_root = _run_root()
     if raw.is_absolute():
-        resolved = raw.resolve()
         try:
-            rel = resolved.relative_to(run_root)
+            rel = raw.relative_to(run_root)
         except ValueError as exc:
-            raise ValueError("workdir must be under ATLAS_RUN_ROOT") from exc
+            try:
+                rel = raw.resolve().relative_to(run_root.resolve())
+            except ValueError:
+                raise ValueError("workdir must be under ATLAS_RUN_ROOT") from exc
         if not rel.parts:
             raise ValueError("workdir must be a subdirectory of ATLAS_RUN_ROOT")
         safe_rel = [_safe_id_token(part) for part in rel.parts]

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -469,7 +469,7 @@ def test_workdir_honored_only_when_safe(tmp_path: Path, monkeypatch: pytest.Monk
     monkeypatch.setenv("ATLAS_RUN_ROOT", str(tmp_path / "runs"))
     job = "safe-job"
     nested = tmp_path / "runs" / "run-atlas-job-safe-job"
-    assert atlas_job.work_dir_for(job, {"workdir": str(nested)}) == str(nested.resolve())
+    assert atlas_job.work_dir_for(job, {"workdir": str(nested)}) in {str(nested), str(nested.resolve())}
     assert atlas_job.work_dir_for(job, {"workdir": "run-atlas-job-safe-job"}) == (
         "run-atlas-job-safe-job"
     )
@@ -478,6 +478,12 @@ def test_workdir_honored_only_when_safe(tmp_path: Path, monkeypatch: pytest.Monk
             atlas_job.work_dir_for(job, {"workdir": bad})
         errors = atlas_job.validate_plan(_plan(workdir=bad))
         assert errors, bad
+
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    assert (
+        atlas_job.require_safe_workdir("/home/ops/atlas-runner/run-atlas-job-test")
+        == "/home/ops/atlas-runner/run-atlas-job-test"
+    )
 
 
 def test_close_and_cli_reject_unsafe_job_id(


### PR DESCRIPTION
## Summary
Protocol-close of `6876-missing-anchor-2295` (2295 → 984 filled, **1311 remaining**). Also fixes `require_safe_workdir` so macOS `/home` symlink resolve does not rewrite Linux `ATLAS_RUN_ROOT` paths.

Receipt: `batch_state/atlas-jobs/receipts/6876-missing-anchor-2295.json`

#6876 stays open (1311 residual).

X-Agent: agy/6876-close