### PR TITLE
feat(lexicon): deadjectival adverb EN fallback (#6876)

### DIFF
--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -41,6 +42,7 @@ from scripts.lexicon.publish_manifest import (
     gzip_manifest,
     write_pointer,
 )
+from scripts.verification.vesum import verify_word
 
 
 def _is_proper_noun_entry(entry: dict[str, Any]) -> bool:
@@ -145,7 +147,6 @@ def write_target_snapshot(targets: list[dict[str, Any]], snapshot_file: Path) ->
     return snapshot
 
 
-
 def _load_kaikki_lookup(path: Path) -> dict[str, dict[str, Any]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -240,12 +241,186 @@ def _add_source(enrichment: dict[str, Any], source: object) -> None:
     enrichment["sources"] = sorted(sources)
 
 
+def _derive_adverb_en_gloss(adj_gloss: str) -> str:
+    """Derive an adverbial English gloss from an adjective gloss.
+
+    Examples:
+    - 'abstract' -> 'abstractly'
+    - 'abstract (apart from practice or reality; not concrete)' -> 'abstractly (apart from practice or reality; not concrete)'
+    - 'heroic' -> 'heroically'
+    - 'flexible (easily bent without breaking)' -> 'flexibly (easily bent without breaking)'
+    - 'cloudless (without any clouds)' -> 'cloudlessly (without any clouds)'
+    - '(literally) cloudless, unclouded' -> '(literally) cloudlessly, uncloudedly'
+    - 'colourful (UK), colorful (US)' -> 'colourfully (UK), colorfully (US)'
+    """
+    if not adj_gloss or not isinstance(adj_gloss, str):
+        return ""
+
+    def split_commas_outside_parens(s: str) -> list[str]:
+        parts = []
+        cur: list[str] = []
+        depth = 0
+        for ch in s:
+            if ch in "([":
+                depth += 1
+                cur.append(ch)
+            elif ch in ")]":
+                depth = max(0, depth - 1)
+                cur.append(ch)
+            elif ch == "," and depth == 0:
+                parts.append("".join(cur).strip())
+                cur = []
+            else:
+                cur.append(ch)
+        if cur:
+            parts.append("".join(cur).strip())
+        return [p for p in parts if p]
+
+    def word_to_adverb(w: str) -> str:
+        w_lower = w.lower()
+        if w_lower.endswith("ly"):
+            return w
+        if w_lower == "public":
+            res = "publicly"
+        elif w_lower.endswith("ic"):
+            res = w_lower + "ally"
+        elif (
+            w_lower.endswith("ble")
+            or w_lower.endswith("ple")
+            or w_lower.endswith("tle")
+            or w_lower.endswith("dle")
+            or w_lower.endswith("gle")
+        ):
+            res = w_lower[:-1] + "y"
+        elif len(w_lower) > 2 and w_lower.endswith("y") and w_lower[-2] not in "aeiou":
+            res = w_lower[:-1] + "ily"
+        elif w_lower.endswith("ll"):
+            res = w_lower + "y"
+        elif w_lower.endswith("ue"):
+            res = w_lower[:-1] + "ly"
+        elif w_lower == "whole":
+            res = "wholly"
+        elif w_lower == "good":
+            res = "well"
+        else:
+            res = w_lower + "ly"
+        if w.istitle():
+            return res.capitalize()
+        return res
+
+    def transform_single_phrase(phrase: str) -> str:
+        phrase = phrase.strip()
+        if not phrase:
+            return ""
+        leading_paren_match = re.match(r"^(\([^)]+\)\s*)(.*)$", phrase)
+        leading_paren = ""
+        core_and_trailing = phrase
+        if leading_paren_match:
+            leading_paren = leading_paren_match.group(1)
+            core_and_trailing = leading_paren_match.group(2).strip()
+
+        trailing_paren_match = re.search(r"(\s*\([^)]+\))$", core_and_trailing)
+        trailing_paren = ""
+        core = core_and_trailing
+        if trailing_paren_match:
+            trailing_paren = trailing_paren_match.group(1)
+            core = core_and_trailing[: trailing_paren_match.start()].strip()
+
+        if not core:
+            return phrase
+
+        words = core.split()
+        if not words:
+            return phrase
+
+        transformed_words = list(words)
+        transformed_words[-1] = word_to_adverb(words[-1])
+        transformed_core = " ".join(transformed_words)
+
+        return f"{leading_paren}{transformed_core}{trailing_paren}"
+
+    sub_parts = split_commas_outside_parens(adj_gloss)
+    transformed_parts = [transform_single_phrase(p) for p in sub_parts]
+    return ", ".join(transformed_parts)
+
+
+def _deadjectival_adverb_translation(
+    entry: dict[str, Any],
+    manifest_index: dict[str, dict[str, Any]],
+) -> dict[str, object] | None:
+    """Derive English translation for a deadjectival adverb in -о/-е from its base adjective."""
+    pos = str(entry.get("pos") or "").casefold().strip()
+    if not (pos in ("adverb", "adv", "advp", "adverbial") or "adverb" in pos):
+        return None
+    lemma = str(entry.get("lemma") or "").strip()
+    if not (lemma.endswith("о") or lemma.endswith("е")):
+        return None
+    try:
+        if not verify_word(lemma, pos_filter="adv"):
+            return None
+    except Exception:
+        return None
+
+    candidates: list[str] = []
+    if lemma.endswith("о"):
+        stem = lemma[:-1]
+        candidates.extend([stem + "ий", stem + "ій"])
+        if stem.endswith("ь"):
+            candidates.extend([stem[:-1] + "ій", stem[:-1] + "ий"])
+        if stem.endswith("н"):
+            candidates.append(stem + "ій")
+    elif lemma.endswith("е"):
+        stem = lemma[:-1]
+        candidates.extend([stem + "ий", stem + "ій", stem + "їй"])
+        if stem.endswith("ь"):
+            candidates.append(stem[:-1] + "ій")
+
+    for cand in dict.fromkeys(candidates):
+        if cand == lemma:
+            continue
+        try:
+            if not verify_word(cand, pos_filter="adj"):
+                continue
+        except Exception:
+            continue
+        cand_entry = manifest_index.get(cand)
+        if not cand_entry:
+            continue
+        cand_pos = str(cand_entry.get("pos") or "").casefold()
+        if not ("adj" in cand_pos or "adjective" in cand_pos):
+            continue
+        adj_enr = cand_entry.get("enrichment")
+        if not isinstance(adj_enr, dict):
+            continue
+        adj_trans = adj_enr.get("translation")
+        if not isinstance(adj_trans, dict):
+            continue
+        adj_en = adj_trans.get("en")
+        if not (isinstance(adj_en, list) and any(isinstance(x, str) and x.strip() for x in adj_en)):
+            continue
+
+        derived_en = [_derive_adverb_en_gloss(term) for term in adj_en if isinstance(term, str) and term.strip()]
+        derived_en = [t for t in derived_en if t]
+        if not derived_en:
+            continue
+
+        block: dict[str, object] = {
+            "en": derived_en,
+            "source": adj_trans.get("source"),
+        }
+        if "pos" in adj_trans:
+            block["pos"] = "adverb"
+        return enrich_manifest._with_base_source_label(block, cand)
+    return None
+
+
 def _translation_for_entry(
     conn: sqlite3.Connection,
     entry: dict[str, Any],
     kaikki_lookup: dict[str, dict[str, Any]],
     *,
     cached_slovnyk_only: bool = False,
+    manifest_index: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, object] | None:
     lemma = str(entry.get("lemma") or "")
     entry_pos = entry.get("pos")
@@ -267,25 +442,26 @@ def _translation_for_entry(
     if translation:
         return translation
     fallback_base = enrich_manifest._base_lookup_for_entry(lemma, entry_pos)
-    if not fallback_base:
-        return None
-    fallback_cache = enrich_manifest._slovnyk_cache(fallback_base)
-    if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
-        fallback_cache,
-        enrich_manifest._SLOVNYK_UKRENG_SLUG,
-    ):
-        fallback_cache = None
-    translation = enrich_manifest._translation(
-        conn,
-        fallback_base,
-        kaikki_lookup,
-        entry_pos=entry_pos,
-        gloss_hints=gloss_hints,
-        slovnyk_cache=fallback_cache,
-    )
-    if not translation:
-        return None
-    return enrich_manifest._with_base_source_label(translation, fallback_base)
+    if fallback_base:
+        fallback_cache = enrich_manifest._slovnyk_cache(fallback_base)
+        if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
+            fallback_cache,
+            enrich_manifest._SLOVNYK_UKRENG_SLUG,
+        ):
+            fallback_cache = None
+        translation = enrich_manifest._translation(
+            conn,
+            fallback_base,
+            kaikki_lookup,
+            entry_pos=entry_pos,
+            gloss_hints=gloss_hints,
+            slovnyk_cache=fallback_cache,
+        )
+        if translation:
+            return enrich_manifest._with_base_source_label(translation, fallback_base)
+    if manifest_index is not None:
+        return _deadjectival_adverb_translation(entry, manifest_index)
+    return None
 
 
 def _reenrich_translation_only(
@@ -294,12 +470,14 @@ def _reenrich_translation_only(
     kaikki_lookup: dict[str, dict[str, Any]],
     *,
     cached_slovnyk_only: bool = False,
+    manifest_index: dict[str, dict[str, Any]] | None = None,
 ) -> None:
     translation = _translation_for_entry(
         conn,
         entry,
         kaikki_lookup,
         cached_slovnyk_only=cached_slovnyk_only,
+        manifest_index=manifest_index,
     )
     if not translation:
         return
@@ -387,6 +565,8 @@ def reenrich_thin_entries(
     if not refresh_wiki:
         enrich_manifest._wiki_reference = lambda *args, **kwargs: None
 
+    manifest_index = {str(e["lemma"]): e for e in manifest.get("entries", []) if isinstance(e, dict) and e.get("lemma")}
+
     changed = 0
     gained_anchor = 0
     filled_translation = 0
@@ -414,6 +594,7 @@ def reenrich_thin_entries(
                     entry,
                     kaikki_lookup,
                     cached_slovnyk_only=cached_slovnyk_only,
+                    manifest_index=manifest_index,
                 )
             _preserve_existing_metadata(
                 entry,
@@ -427,7 +608,9 @@ def reenrich_thin_entries(
             if after != before:
                 changed += 1
 
-            is_now_enriched = has_learner_english_anchor(entry) or _has_translation(entry) or (_categorize_entry(entry) == "ENRICHED")
+            is_now_enriched = (
+                has_learner_english_anchor(entry) or _has_translation(entry) or (_categorize_entry(entry) == "ENRICHED")
+            )
             if was_enriched or is_now_enriched or after != before:
                 consecutive_misses = 0
             else:
@@ -592,7 +775,9 @@ def main() -> int:
                 )
                 return CANARY_FAILURE_EXIT_CODE
             if args.canary:
-                print(json.dumps({"canary_passed": True, "details": canary_res["details"]}, ensure_ascii=False, indent=2))
+                print(
+                    json.dumps({"canary_passed": True, "details": canary_res["details"]}, ensure_ascii=False, indent=2)
+                )
                 return 0
 
         summary = reenrich_thin_entries(
@@ -635,10 +820,7 @@ def main() -> int:
             allow_richness_regression_reason=args.allow_richness_regression,
         )
         if pointer:
-            print(
-                "Updated local atlas-manifest pointer "
-                f"{pointer['manifest_fingerprint']} {pointer['json_sha256']}"
-            )
+            print(f"Updated local atlas-manifest pointer {pointer['manifest_fingerprint']} {pointer['json_sha256']}")
     else:
         print("Dry run only; pass --write to update the manifest.")
     return 0
@@ -646,4 +828,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -219,7 +219,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "0ef7b15966f624423f7b6a799906e3fd55f7e78f3a1c9d53c304daf59760516a"
+        "sha256": "35b632889cea598aef2334b292972f4ad19f10c33e8396d86bfdad445dc152de"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -478,6 +478,16 @@ def test_deadjectival_adverb_fallback_fills_abstractly(monkeypatch) -> None:
     monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+    monkeypatch.setattr(
+        reenrich,
+        "verify_word",
+        lambda word, pos_filter=None, **kwargs: (
+            [{"lemma": word, "pos": pos_filter or "adv"}]
+            if (word == "абстрактно" and pos_filter in ("adv", None))
+            or (word == "абстрактний" and pos_filter in ("adj", None))
+            else []
+        ),
+    )
 
     with sqlite3.connect(":memory:") as conn:
         summary = reenrich.reenrich_thin_entries(
@@ -520,6 +530,16 @@ def test_deadjectival_adverb_fallback_no_fill_when_adjective_missing_en(monkeypa
     monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+    monkeypatch.setattr(
+        reenrich,
+        "verify_word",
+        lambda word, pos_filter=None, **kwargs: (
+            [{"lemma": word, "pos": pos_filter or "adv"}]
+            if (word == "гамірно" and pos_filter in ("adv", None))
+            or (word == "гамірний" and pos_filter in ("adj", None))
+            else []
+        ),
+    )
 
     with sqlite3.connect(":memory:") as conn:
         summary = reenrich.reenrich_thin_entries(
@@ -535,6 +555,16 @@ def test_deadjectival_adverb_fallback_no_fill_when_adjective_missing_en(monkeypa
 
 
 def test_deadjectival_adverb_fallback_no_uk_lemma_invention(monkeypatch) -> None:
+    # Attest only real lemmas in VESUM mock
+    def fake_verify(word: str, pos_filter: str | None = None, **kwargs) -> list[dict]:
+        if word == "абстрактно" and pos_filter in ("adv", None):
+            return [{"lemma": "абстрактно", "pos": "adv"}]
+        if word == "абстрактний" and pos_filter in ("adj", None):
+            return [{"lemma": "абстрактний", "pos": "adj"}]
+        return []
+
+    monkeypatch.setattr(reenrich, "verify_word", fake_verify)
+
     # 1. Made-up adverb lemma not in VESUM
     fake_adv_entry = {
         "lemma": "вигаданоневідомо",
@@ -564,8 +594,42 @@ def test_deadjectival_adverb_fallback_no_uk_lemma_invention(monkeypatch) -> None
     assert res2 is None
 
 
-def test_deadjectival_adverb_fallback_on_loaded_manifest_pair() -> None:
+def test_deadjectival_adverb_fallback_fails_closed_on_vesum_error(monkeypatch) -> None:
+    def raise_vesum_error(*args, **kwargs):
+        raise FileNotFoundError("vesum.db not found")
+
+    monkeypatch.setattr(reenrich, "verify_word", raise_vesum_error)
+
+    adv_entry = {
+        "lemma": "абстрактно",
+        "pos": "adverb",
+        "url_slug": "абстрактно",
+        "enrichment": {},
+    }
+    manifest_index = {
+        "абстрактний": {
+            "lemma": "абстрактний",
+            "pos": "adjective",
+            "enrichment": {"translation": {"en": ["abstract"], "source": "test"}},
+        }
+    }
+    res = reenrich._deadjectival_adverb_translation(adv_entry, manifest_index)
+    assert res is None
+
+
+def test_deadjectival_adverb_fallback_on_loaded_manifest_pair(monkeypatch) -> None:
     from scripts.lexicon.manifest_io import load_manifest
+
+    monkeypatch.setattr(
+        reenrich,
+        "verify_word",
+        lambda word, pos_filter=None, **kwargs: (
+            [{"lemma": word, "pos": pos_filter or "adv"}]
+            if (word == "абстрактно" and pos_filter in ("adv", None))
+            or (word == "абстрактний" and pos_filter in ("adj", None))
+            else []
+        ),
+    )
 
     manifest = load_manifest()
     by_lemma = {e.get("lemma"): e for e in manifest.get("entries", []) if isinstance(e, dict) and e.get("lemma")}
@@ -580,3 +644,4 @@ def test_deadjectival_adverb_fallback_on_loaded_manifest_pair() -> None:
             assert isinstance(res.get("en"), list)
             assert "abstractly" in res["en"][0]
             assert "base form абстрактний" in str(res.get("source"))
+

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -225,9 +226,7 @@ def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> 
     assert "translation" not in entry["enrichment"]
 
 
-def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(
-    tmp_path, monkeypatch
-) -> None:
+def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(tmp_path, monkeypatch) -> None:
     manifest_path = tmp_path / "lexicon-manifest.json"
     manifest_path.write_text(
         '{"richness_summary": {"poc_thin_pages": 2, "search_no_visible_gloss": 0, '
@@ -249,9 +248,7 @@ def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(
         "scripts.lexicon.publish_manifest.download_published_manifest",
         lambda **kwargs: baseline,
     )
-    monkeypatch.setattr(
-        reenrich, "gzip_manifest", lambda manifest, gzip_path: gzip_calls.append(manifest)
-    )
+    monkeypatch.setattr(reenrich, "gzip_manifest", lambda manifest, gzip_path: gzip_calls.append(manifest))
     monkeypatch.setattr(
         "scripts.audit.audit_atlas_poc_richness.audit_manifest",
         lambda manifest: manifest["richness_summary"],
@@ -359,7 +356,6 @@ def test_already_enriched_prefix_does_not_trip_circuit_breaker(monkeypatch) -> N
     assert summary["consecutive_misses"] == 0
 
 
-
 def test_write_target_snapshot(tmp_path: Path) -> None:
     targets = [{"url_slug": "вода"}, {"url_slug": "хліб"}]
     snapshot_path = tmp_path / "target_snapshot.json"
@@ -427,3 +423,160 @@ def test_full_catalog_target_and_categorical_binning(monkeypatch) -> None:
     assert layers["forms"] == 1
 
 
+def test_derive_adverb_en_gloss_patterns() -> None:
+    assert reenrich._derive_adverb_en_gloss("abstract") == "abstractly"
+    assert (
+        reenrich._derive_adverb_en_gloss("abstract (apart from practice or reality; not concrete)")
+        == "abstractly (apart from practice or reality; not concrete)"
+    )
+    assert reenrich._derive_adverb_en_gloss("heroic") == "heroically"
+    assert (
+        reenrich._derive_adverb_en_gloss("flexible (easily bent without breaking)")
+        == "flexibly (easily bent without breaking)"
+    )
+    assert reenrich._derive_adverb_en_gloss("cloudless (without any clouds)") == "cloudlessly (without any clouds)"
+    assert (
+        reenrich._derive_adverb_en_gloss("(literally) cloudless, unclouded, clear")
+        == "(literally) cloudlessly, uncloudedly, clearly"
+    )
+    assert reenrich._derive_adverb_en_gloss("colourful (UK), colorful (US)") == "colourfully (UK), colorfully (US)"
+    assert reenrich._derive_adverb_en_gloss("simple") == "simply"
+    assert reenrich._derive_adverb_en_gloss("easy") == "easily"
+    assert reenrich._derive_adverb_en_gloss("public") == "publicly"
+    assert reenrich._derive_adverb_en_gloss("whole") == "wholly"
+    assert reenrich._derive_adverb_en_gloss("full") == "fully"
+    assert reenrich._derive_adverb_en_gloss("true") == "truly"
+    assert reenrich._derive_adverb_en_gloss("good") == "well"
+
+
+def test_deadjectival_adverb_fallback_fills_abstractly(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "абстрактний",
+                "pos": "adjective",
+                "url_slug": "абстрактний",
+                "enrichment": {
+                    "translation": {
+                        "en": ["abstract (apart from practice or reality; not concrete)"],
+                        "source": "dmklinger",
+                        "pos": "adjective",
+                    },
+                    "sources": ["dmklinger"],
+                },
+            },
+            {
+                "lemma": "абстрактно",
+                "pos": "adverb",
+                "url_slug": "абстрактно",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    # Direct translation misses for both lemmas so adverb fallback triggers
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    adv_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 1
+    assert adv_entry["enrichment"]["translation"] == {
+        "en": ["abstractly (apart from practice or reality; not concrete)"],
+        "source": "dmklinger (base form абстрактний)",
+        "pos": "adverb",
+    }
+    assert "dmklinger (base form абстрактний)" in adv_entry["enrichment"]["sources"]
+
+
+def test_deadjectival_adverb_fallback_no_fill_when_adjective_missing_en(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "гамірний",
+                "pos": "adjective",
+                "url_slug": "гамірний",
+                "enrichment": {
+                    "sources": ["VESUM"],
+                },
+            },
+            {
+                "lemma": "гамірно",
+                "pos": "adverb",
+                "url_slug": "гамірно",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    adv_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 0
+    assert "translation" not in adv_entry["enrichment"]
+
+
+def test_deadjectival_adverb_fallback_no_uk_lemma_invention(monkeypatch) -> None:
+    # 1. Made-up adverb lemma not in VESUM
+    fake_adv_entry = {
+        "lemma": "вигаданоневідомо",
+        "pos": "adverb",
+        "url_slug": "вигаданоневідомо",
+        "enrichment": {},
+    }
+    manifest_index = {
+        "вигаданоневідомий": {
+            "lemma": "вигаданоневідомий",
+            "pos": "adjective",
+            "enrichment": {"translation": {"en": ["invented"], "source": "test"}},
+        }
+    }
+    res = reenrich._deadjectival_adverb_translation(fake_adv_entry, manifest_index)
+    assert res is None
+
+    # 2. Adverb attested in VESUM, but candidate adjective not in VESUM as adj / not in manifest
+    adv_entry = {
+        "lemma": "абстрактно",
+        "pos": "adverb",
+        "url_slug": "абстрактно",
+        "enrichment": {},
+    }
+    empty_index: dict[str, dict[str, Any]] = {}
+    res2 = reenrich._deadjectival_adverb_translation(adv_entry, empty_index)
+    assert res2 is None
+
+
+def test_deadjectival_adverb_fallback_on_loaded_manifest_pair() -> None:
+    from scripts.lexicon.manifest_io import load_manifest
+
+    manifest = load_manifest()
+    by_lemma = {e.get("lemma"): e for e in manifest.get("entries", []) if isinstance(e, dict) and e.get("lemma")}
+
+    if "абстрактно" in by_lemma and "абстрактний" in by_lemma:
+        abstr_adj = by_lemma["абстрактний"]
+        abstr_adv = by_lemma["абстрактно"]
+        adj_trans = abstr_adj.get("enrichment", {}).get("translation", {})
+        if adj_trans.get("en"):
+            res = reenrich._deadjectival_adverb_translation(abstr_adv, by_lemma)
+            assert res is not None
+            assert isinstance(res.get("en"), list)
+            assert "abstractly" in res["en"][0]
+            assert "base form абстрактний" in str(res.get("source"))


### PR DESCRIPTION
## Summary
Fail-closed fallback: adverb \`-о\`/\`-е\` gets EN from the same-manifest adjective base when that adjective already has sourced \`translation.en\`. VESUM-checks adverb and adjective. No invented UK lemmas. No EN when adjective lacks EN.

#6876 remains open (1311 residual; this targets the 291 adverb bucket).

X-Agent: agy/6876-adverb