### PR TITLE
fix(ci): cheap-exit frontend when change denominator untouched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,7 +710,11 @@ jobs:
           printf '%s' "$PR_BODY" | .venv/bin/python scripts/audit/lint_pr_closing_references.py --stdin
 
   # ---------------------------------------------------------------------
-  # 4. frontend — build + vitest. Unconditional.
+  # 4. frontend — build + vitest. Unconditional job start (#6917): never
+  #    job-level if:/skip. First real step cheap-exits 0 (success) when the
+  #    diff misses scripts/ci/frontend_change_denominator.json; remaining
+  #    steps are gated on steps.scope.outputs.run so CI Gate still sees
+  #    success, not skipped.
   # ---------------------------------------------------------------------
   frontend:
     name: Frontend (build + vitest)
@@ -722,24 +726,37 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Decide whether frontend work is in scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/frontend_change_scope.py --base "${BASE_SHA:-}"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.scope.outputs.run == 'true'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.scope.outputs.run == 'true'
         with:
           python-version-file: '.python-version'
 
       - name: Create Python venv
+        if: steps.scope.outputs.run == 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install jsonschema PyYAML
 
       - name: Restore Atlas lexicon manifest cache
+        if: steps.scope.outputs.run == 'true'
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -747,29 +764,34 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        if: steps.scope.outputs.run == 'true'
         run: |
           .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        if: steps.scope.outputs.run == 'true' && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: site/src/data/lexicon-manifest.json
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm ci
 
       - name: Build site
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm run build
 
       - name: Run vitest unit tests
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm run test:unit
 
       - name: Run built-output quality gates
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm run test:built-output
 
@@ -796,18 +818,32 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      # Same denominator / cheap-exit as `frontend` (#6917). Not in
+      # ci-gate.needs — the win is runner slots, not the merge bit.
+      - name: Decide whether frontend work is in scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/frontend_change_scope.py --base "${BASE_SHA:-}"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.scope.outputs.run == 'true'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.scope.outputs.run == 'true'
         with:
           python-version-file: '.python-version'
 
       - name: Create Python venv
+        if: steps.scope.outputs.run == 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
@@ -816,6 +852,7 @@ jobs:
           .venv/bin/python -m pip install PyYAML jsonschema
 
       - name: Restore Atlas lexicon manifest cache
+        if: steps.scope.outputs.run == 'true'
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -823,29 +860,34 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        if: steps.scope.outputs.run == 'true'
         run: |
           .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        if: steps.scope.outputs.run == 'true' && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: site/src/data/lexicon-manifest.json
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm ci
 
       - name: Install Playwright browser
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npx playwright install --with-deps chromium
 
       - name: Build site for Playwright preview
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npm run build
 
       - name: Run Playwright E2E
+        if: steps.scope.outputs.run == 'true'
         working-directory: site
         run: npx playwright test
 

--- a/scripts/ci/frontend_change_denominator.json
+++ b/scripts/ci/frontend_change_denominator.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "frontend_change_denominator_v1",
   "version": "1",
-  "description": "Changed-path denominator for frontend / frontend-e2e cheap-exit (#6917). Jobs stay unconditionally scheduled; a first-step path check exits 0 when nothing here changed. Prefixes end with /; other entries are exact paths.",
+  "description": "Changed-path denominator for frontend / frontend-e2e cheap-exit (#6917). Jobs stay unconditionally scheduled; a first-step path check exits 0 when nothing here changed. Prefixes end with /; other entries are exact paths. Hardening: the hydrate-entrypoint resolver only matches plain `npm run <name>` (not `npm run -s` / `npm run --silent`) and does not expand `npx` invocations — keep hydrate scripts on the covered forms or extend the resolver before adding those.",
   "paths": [
     "site/",
     "scripts/atlas/",

--- a/scripts/ci/frontend_change_denominator.json
+++ b/scripts/ci/frontend_change_denominator.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "frontend_change_denominator_v1",
+  "version": "1",
+  "description": "Changed-path denominator for frontend / frontend-e2e cheap-exit (#6917). Jobs stay unconditionally scheduled; a first-step path check exits 0 when nothing here changed. Prefixes end with /; other entries are exact paths.",
+  "paths": [
+    "site/",
+    "scripts/atlas/",
+    "scripts/lexicon/",
+    "scripts/audit/generate_search_index.py",
+    "scripts/audit/generate_daily_pool.py",
+    ".python-version",
+    ".github/workflows/ci.yml"
+  ]
+}

--- a/scripts/ci/frontend_change_scope.py
+++ b/scripts/ci/frontend_change_scope.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Frontend / frontend-e2e changed-path scope for CI cheap-exit (#6917).
+
+Required jobs stay unconditionally scheduled. After checkout, this helper
+decides whether the diff touches the single-source denominator. Out of scope
+→ exit 0 with a loud auditable decision (job stays ``success``). In scope →
+continue the remaining job steps.
+
+Stdlib only so GitHub runners can invoke it with system ``python3`` before
+``actions/setup-python``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+DENOMINATOR_REL = "scripts/ci/frontend_change_denominator.json"
+PACKAGE_JSON_REL = "site/package.json"
+HYDRATE_ROOT_SCRIPT = "hydrate"
+
+_NPM_RUN_RE = re.compile(r"\bnpm\s+run\s+([A-Za-z0-9:_-]+)")
+_NODE_SCRIPT_RE = re.compile(
+    r"\bnode(?:\s+--experimental-strip-types)?\s+(\./scripts/[^\s]+|scripts/[^\s]+)"
+)
+_PYTHON_MODULE_RE = re.compile(r"(?:^|[\s\"'])-m\s+(scripts(?:\.[A-Za-z0-9_]+)+)")
+_PYTHON_FILE_RE = re.compile(r"(?:^|[\s\"'])(scripts/[A-Za-z0-9_./-]+\.py)\b")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def denominator_path(root: Path | None = None) -> Path:
+    return (root or repo_root()) / DENOMINATOR_REL
+
+
+def load_denominator(path: Path | None = None) -> dict:
+    target = path or denominator_path()
+    data = json.loads(target.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{target}: expected a JSON object")
+    paths = data.get("paths")
+    if not isinstance(paths, list) or not paths or not all(isinstance(p, str) and p for p in paths):
+        raise ValueError(f"{target}: 'paths' must be a non-empty list of strings")
+    version = data.get("version")
+    if version is None or version == "":
+        raise ValueError(f"{target}: missing 'version'")
+    return data
+
+
+def path_in_denominator(path: str, patterns: Sequence[str]) -> bool:
+    """Return True when a repo-relative POSIX path matches any denominator entry."""
+    text = PurePosixPath(path).as_posix()
+    for pattern in patterns:
+        if pattern.endswith("/"):
+            prefix = pattern.rstrip("/")
+            if text == prefix or text.startswith(pattern):
+                return True
+        elif text == pattern:
+            return True
+    return False
+
+
+def matching_paths(changed: Iterable[str], patterns: Sequence[str]) -> list[str]:
+    return sorted({path for path in changed if path_in_denominator(path, patterns)})
+
+
+def comparison_range(base: str, head: str = "HEAD") -> str:
+    return base if "..." in base else f"{base}...{head}"
+
+
+def changed_files(git_range: str, *, cwd: Path | None = None) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--name-only",
+            git_range,
+        ],
+        check=True,
+        capture_output=True,
+        cwd=cwd or repo_root(),
+        text=True,
+    )
+    return sorted(path for path in result.stdout.splitlines() if path)
+
+
+def _module_to_path(module: str) -> str:
+    return "/".join(module.split(".")) + ".py"
+
+
+def _normalize_site_script(raw: str) -> str:
+    cleaned = raw[2:] if raw.startswith("./") else raw
+    if cleaned.startswith("scripts/"):
+        return f"site/{cleaned}"
+    return cleaned
+
+
+def resolve_script_command(command: str, scripts: dict[str, str], *, _stack: frozenset[str] | None = None) -> set[str]:
+    """Resolve one npm script command string into repo-relative file paths."""
+    found: set[str] = set()
+    stack = _stack or frozenset()
+
+    for name in _NPM_RUN_RE.findall(command):
+        if name in stack:
+            continue
+        nested = scripts.get(name)
+        if nested is None:
+            continue
+        found.update(resolve_script_command(nested, scripts, _stack=stack | {name}))
+
+    for node_path in _NODE_SCRIPT_RE.findall(command):
+        found.add(_normalize_site_script(node_path))
+
+    for module in _PYTHON_MODULE_RE.findall(command):
+        found.add(_module_to_path(module))
+
+    for py_path in _PYTHON_FILE_RE.findall(command):
+        found.add(py_path)
+
+    return found
+
+
+def resolve_hydrate_entrypoints(package_json: Path | None = None) -> list[str]:
+    """Resolve hydrate entrypoints that ``site/package.json`` actually invokes."""
+    path = package_json or (repo_root() / PACKAGE_JSON_REL)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        raise ValueError(f"{path}: missing scripts object")
+    hydrate = scripts.get(HYDRATE_ROOT_SCRIPT)
+    if not isinstance(hydrate, str) or not hydrate.strip():
+        raise ValueError(f"{path}: missing scripts.{HYDRATE_ROOT_SCRIPT}")
+    return sorted(resolve_script_command(hydrate, {k: str(v) for k, v in scripts.items()}))
+
+
+def assert_hydrate_entrypoints_in_denominator(
+    *,
+    denominator: dict | None = None,
+    package_json: Path | None = None,
+) -> list[str]:
+    """Fail when any hydrate-resolved path escapes the denominator."""
+    data = denominator or load_denominator()
+    patterns = list(data["paths"])
+    entrypoints = resolve_hydrate_entrypoints(package_json)
+    escaped = [path for path in entrypoints if not path_in_denominator(path, patterns)]
+    if escaped:
+        raise AssertionError(
+            "hydrate entrypoints outside frontend change denominator: "
+            + ", ".join(escaped)
+            + f" (denominator version={data['version']})"
+        )
+    return entrypoints
+
+
+def decision_line(*, decision: str, version: object, changed_count: int, matched_count: int) -> str:
+    return (
+        f"frontend-scope: decision={decision} denominator_version={version} "
+        f"changed_files={changed_count} matched={matched_count}"
+    )
+
+
+def write_github_output(run: bool, path: Path | None = None) -> None:
+    output = path
+    if output is None:
+        raw = os.environ.get("GITHUB_OUTPUT")
+        if not raw:
+            return
+        output = Path(raw)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(f"run={'true' if run else 'false'}\n")
+
+
+def write_step_summary(line: str, path: Path | None = None) -> None:
+    summary = path
+    if summary is None:
+        raw = os.environ.get("GITHUB_STEP_SUMMARY")
+        if not raw:
+            return
+        summary = Path(raw)
+    with summary.open("a", encoding="utf-8") as handle:
+        handle.write("## Frontend change scope (#6917)\n\n")
+        handle.write(f"`{line}`\n")
+
+
+def decide_from_changed(
+    changed: Sequence[str],
+    *,
+    denominator: dict | None = None,
+) -> tuple[bool, str, list[str]]:
+    data = denominator or load_denominator()
+    matched = matching_paths(changed, list(data["paths"]))
+    run = bool(matched)
+    line = decision_line(
+        decision="run" if run else "cheap_exit",
+        version=data["version"],
+        changed_count=len(changed),
+        matched_count=len(matched),
+    )
+    return run, line, matched
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="",
+        help="base SHA/ref (pull_request.base.sha || merge_group.base_sha || before)",
+    )
+    parser.add_argument("--head", default="HEAD", help="head SHA/ref (default: HEAD)")
+    parser.add_argument(
+        "--denominator",
+        type=Path,
+        default=None,
+        help=f"denominator JSON (default: {DENOMINATOR_REL})",
+    )
+    args = parser.parse_args(argv)
+
+    denominator = load_denominator(args.denominator)
+    base = (args.base or "").strip()
+    if not base or set(base) == {"0"}:
+        line = decision_line(
+            decision="run",
+            version=denominator["version"],
+            changed_count=-1,
+            matched_count=-1,
+        )
+        # Fail open when the event gives no usable base — never silent cheap-exit.
+        line = f"{line} reason=missing_base_sha"
+        print(line)
+        write_step_summary(line)
+        write_github_output(True)
+        return 0
+
+    try:
+        changed = changed_files(comparison_range(base, args.head))
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"frontend-scope: decision=run denominator_version={denominator['version']} "
+            f"changed_files=-1 matched=-1 reason=git_diff_failed exit={exc.returncode}",
+            file=sys.stderr,
+        )
+        write_github_output(True)
+        return 0
+
+    run, line, _matched = decide_from_changed(changed, denominator=denominator)
+    print(line)
+    write_step_summary(line)
+    write_github_output(run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/frontend_change_scope.py
+++ b/scripts/ci/frontend_change_scope.py
@@ -26,9 +26,7 @@ PACKAGE_JSON_REL = "site/package.json"
 HYDRATE_ROOT_SCRIPT = "hydrate"
 
 _NPM_RUN_RE = re.compile(r"\bnpm\s+run\s+([A-Za-z0-9:_-]+)")
-_NODE_SCRIPT_RE = re.compile(
-    r"\bnode(?:\s+--experimental-strip-types)?\s+(\./scripts/[^\s]+|scripts/[^\s]+)"
-)
+_NODE_SCRIPT_RE = re.compile(r"\bnode(?:\s+--experimental-strip-types)?\s+(\./scripts/[^\s]+|scripts/[^\s]+)")
 _PYTHON_MODULE_RE = re.compile(r"(?:^|[\s\"'])-m\s+(scripts(?:\.[A-Za-z0-9_]+)+)")
 _PYTHON_FILE_RE = re.compile(r"(?:^|[\s\"'])(scripts/[A-Za-z0-9_./-]+\.py)\b")
 
@@ -76,21 +74,30 @@ def comparison_range(base: str, head: str = "HEAD") -> str:
     return base if "..." in base else f"{base}...{head}"
 
 
+def _parse_nul_delimited_paths(raw: bytes) -> list[str]:
+    """Decode ``git diff --name-only -z`` bytes without misparsing odd filenames."""
+    return sorted(path.decode("utf-8", errors="surrogateescape") for path in raw.split(b"\0") if path)
+
+
 def changed_files(git_range: str, *, cwd: Path | None = None) -> list[str]:
+    # core.quotePath=false + -z: non-ASCII / quote / backslash names stay literal
+    # (default quotePath C-quotes them and breaks denominator prefix matching).
     result = subprocess.run(
         [
             "git",
+            "-c",
+            "core.quotePath=false",
             "diff",
             "--no-ext-diff",
             "--name-only",
+            "-z",
             git_range,
         ],
         check=True,
         capture_output=True,
         cwd=cwd or repo_root(),
-        text=True,
     )
-    return sorted(path for path in result.stdout.splitlines() if path)
+    return _parse_nul_delimited_paths(result.stdout)
 
 
 def _module_to_path(module: str) -> str:
@@ -243,11 +250,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         changed = changed_files(comparison_range(base, args.head))
     except subprocess.CalledProcessError as exc:
-        print(
+        line = (
             f"frontend-scope: decision=run denominator_version={denominator['version']} "
-            f"changed_files=-1 matched=-1 reason=git_diff_failed exit={exc.returncode}",
-            file=sys.stderr,
+            f"changed_files=-1 matched=-1 reason=git_diff_failed exit={exc.returncode}"
         )
+        print(line, file=sys.stderr)
+        write_step_summary(line)
         write_github_output(True)
         return 0
 

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -60,6 +62,60 @@ def test_site_touch_runs_frontend() -> None:
     assert run is True
     assert matched == ["site/src/pages/index.astro"]
     assert "decision=run" in line
+
+
+def test_cyrillic_site_path_runs_frontend() -> None:
+    """Non-ASCII under site/ must decide run (F1: quotePath must not C-quote it away)."""
+    path = "site/src/слово.ts"
+    run, line, matched = scope.decide_from_changed([path])
+    assert run is True
+    assert matched == [path]
+    assert "decision=run" in line
+
+
+def test_changed_files_uses_quote_path_false_and_nul_split(tmp_path: Path) -> None:
+    """NUL-split + quotePath=false keeps Cyrillic / quote / backslash names literal."""
+    cyrillic = "site/src/слово.ts"
+    quoted_name = 'site/src/weird"name.ts'
+    backslash_name = r"site/src/weird\name.ts"
+    payload = "\0".join([cyrillic, quoted_name, backslash_name, ""]).encode("utf-8")
+
+    fake = MagicMock()
+    fake.stdout = payload
+    fake.returncode = 0
+
+    with patch("subprocess.run", return_value=fake) as run_mock:
+        paths = scope.changed_files("base...HEAD", cwd=tmp_path)
+
+    assert paths == sorted([cyrillic, quoted_name, backslash_name])
+    cmd = run_mock.call_args.args[0]
+    assert cmd[:3] == ["git", "-c", "core.quotePath=false"]
+    assert "--name-only" in cmd
+    assert "-z" in cmd
+    assert run_mock.call_args.kwargs.get("text") is not True
+
+
+def test_changed_files_rejects_c_quoted_octal_as_site_prefix() -> None:
+    """Guard: C-quoted octal (legacy quotePath=true) must NOT match site/."""
+    # What default quotePath emits for site/src/слово.ts — must not cheap-exit-match.
+    c_quoted = '"site/src/\\321\\201\\320\\273\\320\\276\\320\\262\\320\\276.ts"'
+    assert not scope.path_in_denominator(c_quoted, ["site/"])
+
+
+def test_git_diff_failed_writes_step_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(128, ["git", "diff"])
+
+    with patch.object(scope, "changed_files", side_effect=boom):
+        assert scope.main(["--base", "abc123"]) == 0
+
+    text = summary.read_text(encoding="utf-8")
+    assert "reason=git_diff_failed" in text
+    assert "decision=run" in text
 
 
 def test_resolve_hydrate_entrypoints_from_package_json() -> None:

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -1,0 +1,122 @@
+"""Drift guard + unit coverage for frontend CI cheap-exit (#6917)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ci import frontend_change_scope as scope
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI = _REPO_ROOT / ".github/workflows/ci.yml"
+_DENOMINATOR = _REPO_ROOT / scope.DENOMINATOR_REL
+
+
+def test_denominator_is_single_source_and_loadable() -> None:
+    data = scope.load_denominator(_DENOMINATOR)
+    assert data["schema_version"] == "frontend_change_denominator_v1"
+    assert data["version"] == "1"
+    assert "site/" in data["paths"]
+    assert "scripts/atlas/" in data["paths"]
+    assert "scripts/lexicon/" in data["paths"]
+    assert "scripts/audit/generate_search_index.py" in data["paths"]
+    assert "scripts/audit/generate_daily_pool.py" in data["paths"]
+    assert ".python-version" in data["paths"]
+    assert ".github/workflows/ci.yml" in data["paths"]
+
+
+def test_path_matching_covers_prefixes_and_exact_entries() -> None:
+    patterns = scope.load_denominator()["paths"]
+    assert scope.path_in_denominator("site/package.json", patterns)
+    assert scope.path_in_denominator("scripts/atlas/atlas_db.py", patterns)
+    assert scope.path_in_denominator("scripts/lexicon/manifest_io.py", patterns)
+    assert scope.path_in_denominator("scripts/audit/generate_search_index.py", patterns)
+    assert scope.path_in_denominator(".python-version", patterns)
+    assert scope.path_in_denominator(".github/workflows/ci.yml", patterns)
+    assert not scope.path_in_denominator("scripts/services.sh", patterns)
+    assert not scope.path_in_denominator("dashboards/work.html", patterns)
+    assert not scope.path_in_denominator("package.json", patterns)
+    assert not scope.path_in_denominator("scripts/audit/meta_validator.py", patterns)
+
+
+def test_docs_only_change_cheap_exits() -> None:
+    run, line, matched = scope.decide_from_changed(
+        ["docs/runbooks/ci-gate.md", "scripts/services.sh"],
+    )
+    assert run is False
+    assert matched == []
+    assert "decision=cheap_exit" in line
+    assert "denominator_version=1" in line
+    assert "changed_files=2" in line
+    assert "matched=0" in line
+
+
+def test_site_touch_runs_frontend() -> None:
+    run, line, matched = scope.decide_from_changed(["site/src/pages/index.astro"])
+    assert run is True
+    assert matched == ["site/src/pages/index.astro"]
+    assert "decision=run" in line
+
+
+def test_resolve_hydrate_entrypoints_from_package_json() -> None:
+    entrypoints = scope.resolve_hydrate_entrypoints()
+    assert "site/scripts/hydrate-manifest.mjs" in entrypoints
+    assert "site/scripts/hydrate-practice-deck.mjs" in entrypoints
+    assert "site/scripts/hydrate-lexicon-api-shards.ts" in entrypoints
+    assert "scripts/atlas/atlas_db.py" in entrypoints
+    assert "scripts/audit/generate_search_index.py" in entrypoints
+    assert "scripts/audit/generate_daily_pool.py" in entrypoints
+
+
+def test_hydrate_entrypoints_stay_inside_denominator() -> None:
+    entrypoints = scope.assert_hydrate_entrypoints_in_denominator()
+    assert entrypoints  # non-empty proof the resolver engaged package.json
+
+
+def test_removing_denominator_entry_fails_hydrate_guard(tmp_path: Path) -> None:
+    """Mutation check: drop an outside-site hydrate path → guard must fail."""
+    original = scope.load_denominator()
+    mutated = copy.deepcopy(original)
+    mutated["paths"] = [p for p in mutated["paths"] if p != "scripts/atlas/"]
+    assert "scripts/atlas/" not in mutated["paths"]
+
+    denom_path = tmp_path / "denominator.json"
+    denom_path.write_text(json.dumps(mutated), encoding="utf-8")
+    loaded = scope.load_denominator(denom_path)
+
+    with pytest.raises(AssertionError, match=r"scripts/atlas/atlas_db\.py"):
+        scope.assert_hydrate_entrypoints_in_denominator(denominator=loaded)
+
+
+def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> None:
+    workflow = yaml.safe_load(_CI.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    assert "if" not in jobs["frontend"]
+    assert set(jobs["ci-gate"]["needs"]) == {
+        "pytest-plan",
+        "pytest-fastlane",
+        "python",
+        "contracts",
+        "frontend",
+        "coverage-floor",
+    }
+
+    for job_name in ("frontend", "frontend-e2e"):
+        steps = jobs[job_name]["steps"]
+        scope_step = next(s for s in steps if s.get("id") == "scope")
+        assert "frontend_change_scope.py" in scope_step["run"]
+        assert "pull_request.base.sha" in scope_step["env"]["BASE_SHA"]
+        assert "merge_group.base_sha" in scope_step["env"]["BASE_SHA"]
+        assert "github.event.before" in scope_step["env"]["BASE_SHA"]
+
+        checkout = steps[0]
+        assert checkout["with"]["fetch-depth"] == 0
+
+        gated = [s for s in steps[2:] if s.get("if")]
+        assert gated, f"{job_name} must gate post-scope steps"
+        assert all("steps.scope.outputs.run == 'true'" in str(s["if"]) for s in gated)


### PR DESCRIPTION
## Summary
- Keep `frontend` / `frontend-e2e` **unconditionally scheduled** (no job-level `if:` skip) so CI Gate still sees `success`, never `skipped`.
- After checkout, a first-step path check (`scripts/ci/frontend_change_scope.py`) diffs against `pull_request.base.sha || merge_group.base_sha || github.event.before`; out-of-scope diffs log one loud decision line + `$GITHUB_STEP_SUMMARY` and exit 0; remaining steps are gated on `steps.scope.outputs.run`.
- Single-source denominator: `scripts/ci/frontend_change_denominator.json` (`site/`, `scripts/atlas/`, `scripts/lexicon/`, hydrate audit entrypoints, `.python-version`, `.github/workflows/ci.yml`).
- Drift guard pytest resolves hydrate entrypoints from `site/package.json` and asserts each resolved path stays inside that denominator. Pytest plan/shards and `ci-gate.needs` are unchanged.

Fixes #6917

## Changes
- `.github/workflows/ci.yml` — scope step + step-level gates on `frontend` / `frontend-e2e` (`fetch-depth: 0`)
- `scripts/ci/frontend_change_denominator.json` — shared denominator
- `scripts/ci/frontend_change_scope.py` — matcher, hydrate resolver, CI CLI
- `tests/test_frontend_change_scope.py` — unit + drift guard + workflow shape assertions

## Testing
- [x] `actionlint .github/workflows/ci.yml` — green
- [x] `ruff check scripts/ci/frontend_change_scope.py tests/test_frontend_change_scope.py` — clean
- [x] `pytest tests/test_frontend_change_scope.py tests/test_ci_queue_starvation.py tests/test_ci_changed_tests.py` — 25 passed
- [ ] CI green on this PR

### Mutation check (#M-4)
Remove `scripts/atlas/` from the denominator locally → guard fails; restore → guard passes:

```
=== MUTATION CHECK (remove scripts/atlas/ from denominator) ===
GUARD FAILED AS EXPECTED:
hydrate entrypoints outside frontend change denominator: scripts/atlas/atlas_db.py (denominator version=1)

=== RESTORE (full denominator) ===
GUARD PASSED after restore; entrypoints=['scripts/atlas/atlas_db.py', 'scripts/audit/generate_daily_pool.py', 'scripts/audit/generate_search_index.py', 'site/scripts/hydrate-lexicon-api-shards.ts', 'site/scripts/hydrate-manifest.mjs', 'site/scripts/hydrate-practice-deck.mjs']
```

`pytest tests/test_frontend_change_scope.py::test_removing_denominator_entry_fails_hydrate_guard` — passed.

## Related Issues
Fixes #6917
Refs #5762 #5744

Made with [Cursor](https://cursor.com)