### PR TITLE
test(work): FX traceability annotations on non-dashboard proofs (#6920)

### DIFF
--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -999,6 +999,10 @@ button, input, select { font: inherit; }
   function formatAdmittedPrivateMeta(priv) {
     // Glanceable private inventory on the private card only (R-UI-2). Never
     // claim stream completeness; never print the private endpoint URL.
+    // Admitted unavailable: status only — zero section counts are not inventory.
+    if (priv.status === 'unavailable') {
+      return 'status=' + priv.status;
+    }
     const sections = (priv && priv.sections) || {};
     return 'status=' + priv.status
       + ' · issues=' + sectionCount(sections, 'issues')
@@ -1007,7 +1011,8 @@ button, input, select { font: inherit; }
 
   function isPlaceholderPrivateSource(priv) {
     if (!priv || priv.source_id !== PRIVATE_SOURCE_ID) return true;
-    if (priv.status === 'unavailable') return true;
+    // Public not_configured placeholder only — admitted status=unavailable still
+    // uses formatAdmittedPrivateMeta (status without issues=0 · prs=0).
     if (priv.reason === 'not_configured') return true;
     return false;
   }

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -123,6 +123,7 @@ def _sections_with_canary() -> dict[str, SectionResult]:
 
 
 def test_capabilities_and_health_endpoints():
+    """FX-10 design-only: capabilities/health advertise mutation:false."""
     caps = client.get("/api/work/v1/capabilities")
     assert caps.status_code == 200
     data = caps.json()
@@ -171,6 +172,7 @@ def test_projection_endpoint_with_injected_sources(monkeypatch):
 
 
 def test_projection_rejects_private_filter_keys(monkeypatch):
+    """FX-09: public projection rejects private_endpoint and free-text saved-view keys."""
     cache_invalidate("work:v1:projection")
 
     def fake_build(**_kwargs):
@@ -252,6 +254,7 @@ def test_duplicate_multivalue_filters_share_cache_entry(monkeypatch):
 
 
 def test_independent_degradation_when_one_section_fails(monkeypatch):
+    """FX-02 adjacent: optional section failure degrades the public envelope, not unavailable."""
     cache_invalidate("work:v1:projection")
     sections = _sections_with_canary()
     sections["fleet_reviews"] = SectionResult("fleet_reviews", "timeout", reason="fleet_reviews_timeout")

--- a/tests/test_work_contract.py
+++ b/tests/test_work_contract.py
@@ -37,6 +37,7 @@ REPO = "learn-ukrainian/learn-ukrainian.github.io"
 
 
 def test_schema_loads_and_fixture_validates():
+    """FX-10 design-only: fixture projection stays mutation:false / FOUNDATION_COMPLETE."""
     schema = load_schema()
     assert schema["properties"]["schema_version"]["const"] == SCHEMA_VERSION
     payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
@@ -47,6 +48,7 @@ def test_schema_loads_and_fixture_validates():
 
 
 def test_identity_serialization_is_collision_safe():
+    """FX-01: work_id serialization stays collision-safe across sources."""
     a = make_work_id("public-monitor", REPO, "issue", "1")
     b = make_work_id("private-local-adapter", REPO, "issue", "1")
     assert a != b
@@ -55,6 +57,7 @@ def test_identity_serialization_is_collision_safe():
 
 
 def test_saved_view_rejects_free_text_and_private_keys():
+    """FX-09: saved-view allowlist rejects free-text and private endpoint keys."""
     with pytest.raises(SchemaValidationError):
         parse_saved_view_params({"q": "secret search"})
     with pytest.raises(SchemaValidationError):
@@ -1731,6 +1734,7 @@ def test_fleet_reviews_repository_filter_before_hard_cap():
 
 
 def test_relations_and_cycle_detection():
+    """FX-04: relationship extraction and dependency-cycle detection."""
     body = "This blocks #2 and is blocked by #3. Duplicate of #4. Superseded-by: #5"
     rels = extract_body_relations(body, repository_id=REPO, self_number=1)
     types = {r["type"] for r in rels}
@@ -1841,6 +1845,7 @@ def test_match_dispatch_requires_boundary_safe_issue_and_pr_ids():
 
 
 def test_health_never_uses_activity_and_pr_rules():
+    """FX-05: health is rule-derived; activity volume is never health evidence."""
     pr_fail = {
         "resource_kind": "pr",
         "lifecycle": "open",
@@ -2100,7 +2105,7 @@ def test_fetch_fleet_reviews_production_default_loader():
 
 
 def test_public_source_envelope_independent_degradation_matrix():
-    """Verify source envelope status classification under various section health states (#6849)."""
+    """FX-02 adjacent: public source envelope degrades independently per section (#6849)."""
 
     def _base_sections(issues_st="ok", prs_st="ok"):
         return {
@@ -2155,7 +2160,9 @@ def test_public_source_envelope_independent_degradation_matrix():
 
 
 def test_missing_streams_cache_and_simulated_restart_behavior():
-    """Simulate missing streams cache at Monitor start:
+    """FX-03 adjacent: missing streams → UNKNOWN health; envelope stays degraded (#6849).
+
+    Simulate missing streams cache at Monitor start:
     - issues derive UNKNOWN health / INSPECT_UNKNOWN action (honest health)
     - public PRs with real signals sort ahead of UNKNOWN issues
     - source envelope is degraded (not unavailable)

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -167,6 +167,26 @@ def test_work_page_shareable_url_strips_private_selectors():
     assert "value !== PUBLIC_SOURCE_ID" in html
 
 
+def test_work_page_admitted_unavailable_private_meta_omits_zero_counts():
+    """Admitted private status=unavailable shows status without issues=0 · prs=0."""
+    html = WORK.read_text(encoding="utf-8")
+    fmt_start = html.index("function formatAdmittedPrivateMeta(")
+    fmt_end = html.index("function isPlaceholderPrivateSource(", fmt_start)
+    fmt_body = html[fmt_start:fmt_end]
+    assert "priv.status === 'unavailable'" in fmt_body
+    assert "issues=" in fmt_body
+    assert "prs=" in fmt_body
+    # Early return for unavailable must precede the issues=/prs= inventory line.
+    assert fmt_body.index("priv.status === 'unavailable'") < fmt_body.index("' · issues='")
+
+    ph_start = html.index("function isPlaceholderPrivateSource(")
+    ph_end = html.index("function installView(", ph_start)
+    ph_body = html[ph_start:ph_end]
+    assert "not_configured" in ph_body
+    # Admitted unavailable is not a placeholder; only not_configured is.
+    assert "priv.status === 'unavailable'" not in ph_body
+
+
 def test_work_page_actionable_default_view_contracts():
     html = WORK.read_text(encoding="utf-8")
     assert 'id="filter-view"' in html

--- a/tests/test_work_privacy.py
+++ b/tests/test_work_privacy.py
@@ -46,6 +46,7 @@ def _load_canaries() -> list[str]:
 
 
 def test_fx07_canaries_never_enter_public_api_payload(monkeypatch):
+    """FX-07: injected private canaries never appear in the public projection payload."""
     canaries = _load_canaries()
     cache_invalidate("work:v1:projection")
     body_canary, secret_canary, path_canary, *_rest = [*canaries, ""]
@@ -190,6 +191,7 @@ def test_owned_paths_and_work_html_have_no_canaries_or_private_paths():
 
 
 def test_work_html_is_read_only_and_browser_local_private_only():
+    """FX-10 + FX-09 adjacent: work.html stays read-only; private URL is fixed/non-configurable."""
     html = (ROOT / "dashboards" / "work.html").read_text(encoding="utf-8")
     assert 'data-read-only="true"' in html
     assert "FOUNDATION_COMPLETE" in html


### PR DESCRIPTION
## Summary
- Annotate non-dashboard Work proofs with frozen FX ids (R-TEST-1 style), including the three named `test_work_contract.py` cases (FX-01 / FX-04 / FX-05) plus clear FX-02/03/09/10 matches and sibling API/privacy proofs.
- Cosmetic nit from the same #6899 review: admitted private `status=unavailable` renders `status=unavailable` without `issues=0 · prs=0` (placeholder remains `not_configured` only).

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_work_contract.py tests/test_work_dashboard.py tests/test_work_api.py tests/test_work_privacy.py -q` → **75 passed**
- [x] `ruff check` clean on touched Python tests
- [ ] CI green on this PR

Fixes #6920

Made with [Cursor](https://cursor.com)