### PR TITLE
fix(tests): remove checkout-venv dependency from codex driver and thread-restart suites (#6858)

### DIFF
--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import sqlite3
 import subprocess
+import sys
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -183,7 +184,7 @@ if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.orchestration.codex_transport
   fi
   exit "${{PROBE_STUB_EXIT:-0}}"
 fi
-exec {os.fspath(REPO_ROOT / ".venv" / "bin" / "python")!r} "$@"
+exec {sys.executable!r} "$@"
 """,
         encoding="utf-8",
     )

--- a/tests/test_start_codex_driver.py
+++ b/tests/test_start_codex_driver.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -52,7 +53,7 @@ if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.orchestration.codex_transport
   fi
   exit "${{PROBE_STUB_EXIT:-0}}"
 fi
-exec {os.fspath(REPO / ".venv" / "bin" / "python")!r} "$@"
+exec {sys.executable!r} "$@"
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
Part of the wave-2 worktree-hostile sweep tracked on #6858 (same class as PR #6874).

## Root cause
Both suites' probe/shim stubs fell back to the checkout's `.venv/bin/python` for any invocation that wasn't the stubbed `-m scripts.orchestration.codex_transport_health` module. Dispatch worktrees have no `.venv` by the shared-interpreter policy, so the shim died with exit 127 (`exec: …/.venv/bin/python: cannot execute: No such file or directory`) before the driver ever spawned the provider child — red locally, green on CI (which builds `.venv`).

## Fix (harness layer, no skips)
Copies PR #6874's template exactly: the fallback now execs `sys.executable` (the interpreter running pytest — always the shared project python), so the transport-health stub still intercepts `-m` calls while everything else delegates to the real interpreter, in any checkout.

## Evidence (#M-4) — both runs in this dispatch worktree (no `.venv`)
- Failing-before: `12 failed, 18 passed`; each failure quotes `…/.venv/bin/python: cannot execute: No such file or directory` from the shim.
- Passing-after: `30 passed` (11 + 19), twice consecutive.
- `ruff check` on both files: clean.

Files touched:
- `tests/test_start_codex_driver.py:55`
- `tests/orchestration/test_thread_restart_e2e.py:186`

🤖 Generated with opencode (deepseek delegate lane)