### PR TITLE
fix(delegate): refuse silent primary binding from sibling cwd (#6900)

### DIFF
--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -202,6 +202,38 @@ active environment; the merged-PR worktree reaper disposes of it safely.
 Workers implement inside `.worktrees/dispatch/<agent>/<task>/`. They do not
 become a second coordination plane.
 
+#### Sibling-repo dispatch
+
+`--worktree` and `--branch` always bind the Learn Ukrainian primary checkout
+that owns `scripts/delegate.py` (`_REPO_ROOT`). They do **not** follow the
+shell cwd. Invoking `dispatch --worktree` from a sibling repository (for
+example a private checkout next to this one) is refused: the worktree would
+otherwise be created under the primary while the brief still described the
+sibling.
+
+`--cwd` cannot be combined with `--worktree` or `--branch`. That refusal is
+intentional. The supported sibling-repo flow is:
+
+```bash
+# In the sibling repository — not via delegate --worktree:
+git -C /path/to/sibling worktree add .worktrees/dispatch/<agent>/<task> <base-or-branch>
+
+# Invoke this repo's delegate against that worktree (no --worktree).
+# Derive LU_PRIMARY from the Learn Ukrainian checkout, never from the sibling.
+LU_PRIMARY="$(dirname "$(git -C /path/to/learn-ukrainian rev-parse --path-format=absolute --git-common-dir)")"
+"$LU_PRIMARY/.venv/bin/python" "$LU_PRIMARY/scripts/delegate.py" dispatch \
+  --agent <lane> --task-id <id> --prompt-file <path> \
+  --mode workspace-write --cwd /path/to/sibling/.worktrees/dispatch/<agent>/<task>
+```
+
+`--branch` has the same primary-only binding: it fetches and attaches a branch
+from the primary remote, not from the sibling. Follow-up work on a sibling PR
+uses the same manual-worktree + `--cwd` path.
+
+First-class `--repo` / cwd-derived worktree creation is out of scope for this
+v1: task state, the worktree reaper, sparse-checkout, and data-symlink
+provisioning all assume `_REPO_ROOT`.
+
 ### Luna bounded execution
 
 For bounded implementation or investigation, read the machine-readable

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -899,7 +899,12 @@ def _derive_worktree_branch(agent: str, task_id: str) -> str:
 
 
 def _auto_worktree_path(agent: str, task_id: str) -> Path:
-    """Default worktree path for a fresh dispatch: ``.worktrees/dispatch/{agent}/{task}/``."""
+    """Default worktree path for a fresh dispatch: ``.worktrees/dispatch/{agent}/{task}/``.
+
+    Always under :data:`_REPO_ROOT`, never the invocation cwd. A sibling-repo
+    cwd therefore cannot retarget this path — :func:`_resolve_cross_repo_binding_error`
+    must refuse that case instead of letting the worker appear to run "here".
+    """
     normalized = _normalize_task_id(agent, task_id)
     # Slashes are fine in branch names but not in a single path component,
     # so flatten them here (task_id ``foo/bar`` → path ``foo-bar``).
@@ -1021,6 +1026,14 @@ _WRITE_WORKTREE_HINT = (
     "primary checkout. Preferred: pass bare `--worktree` to auto-create "
     ".worktrees/dispatch/<agent>/<task>/. Alternatively point `--cwd` at an "
     "existing added worktree there."
+)
+_CROSS_REPO_BINDING_HINT = (
+    "Dispatch binds the Learn Ukrainian primary checkout that owns this "
+    "script, not the invocation cwd. For a sibling repository, create a "
+    "worktree there manually (`git worktree add .worktrees/dispatch/"
+    "<agent>/<task> <base>`), then run `dispatch --mode workspace-write "
+    "--cwd <that-worktree>` without `--worktree` or `--branch`. See "
+    "docs/runbooks/agent-seat-onboarding.md (sibling-repo dispatch)."
 )
 
 
@@ -1169,6 +1182,62 @@ def _resolve_cwd_path(raw: str) -> Path:
     if not p.is_absolute():
         p = Path.cwd() / p
     return p.resolve()
+
+
+def _resolve_invocation_git_root(start: Path | str | None = None) -> Path | None:
+    """Primary checkout that owns ``start`` (default: process cwd), or None.
+
+    Walks ``.git`` on disk instead of calling ``git rev-parse``. The answer we
+    need is "same repository or a sibling?", and the filesystem shape already
+    distinguishes a primary ``.git`` directory from a linked worktree gitdir.
+    Avoiding a git subprocess also keeps this preflight independent of the
+    ``subprocess.Popen`` stubs used by dispatch tests and hook environments.
+    """
+    wc = _load_worktree_containment()
+    origin = wc.canonicalize(start if start is not None else Path.cwd())
+    probe = origin if origin.is_dir() else origin.parent
+    return wc._fs_main_root(probe)
+
+
+def _resolve_cross_repo_binding_error(
+    *,
+    worktree_arg: str | None,
+    cwd_arg: str | None,
+    requested_branch: str | None = None,
+    invocation_cwd: Path | str | None = None,
+) -> str | None:
+    """Refuse silent primary-repo binding when invoked from another git root.
+
+    ``--worktree`` and ``--branch`` always create or attach under
+    :data:`_REPO_ROOT` (see :func:`_auto_worktree_path`). An invocation cwd
+    whose git root is a sibling checkout used to look like "dispatch here"
+    while the worktree landed in the primary — issue #6900. First-class
+    ``--repo`` support would retarget fetch, ``git worktree add``, the
+    reaper, sparse-checkout, and data-symlink provisioning; v1 refuses
+    loudly and documents the existing manual-worktree + ``--cwd`` flow.
+    """
+    invocation_root = _resolve_invocation_git_root(invocation_cwd)
+    if invocation_root is None:
+        return None
+    wc = _load_worktree_containment()
+    primary = wc.canonicalize(_REPO_ROOT)
+    if invocation_root == primary:
+        return None
+    # Documented sibling flow: explicit --cwd, never --worktree/--branch.
+    # cmd_dispatch promotes a bare --branch to worktree_arg="auto" first.
+    if cwd_arg and not worktree_arg and not requested_branch:
+        return None
+    flags = [flag for flag, present in (("--worktree", worktree_arg), ("--branch", requested_branch)) if present]
+    flag_bit = (
+        " and ".join(flags) + " would silently create or attach a worktree under the primary"
+        if flags
+        else "the worker would silently run in the primary checkout"
+    )
+    return (
+        f"❌ dispatch targets the primary checkout ({primary}); "
+        f"invocation cwd resolves to a different git root ({invocation_root}). "
+        f"{flag_bit}.\n   {_CROSS_REPO_BINDING_HINT}"
+    )
 
 
 def _resolve_verified_worktree_path(path: Path) -> Path | None:
@@ -4350,6 +4419,18 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # #6900: --worktree/--branch (and the default worker cwd) always bind
+    # _REPO_ROOT. Invoking from a sibling git root used to create the
+    # worktree in the primary while the shell cwd said otherwise.
+    cross_repo_error = _resolve_cross_repo_binding_error(
+        worktree_arg=worktree_arg,
+        cwd_arg=args.cwd,
+        requested_branch=requested_branch,
+    )
+    if cross_repo_error:
+        print(cross_repo_error, file=sys.stderr)
+        return 2
+
     # Write-capable modes (workspace-write / danger) must resolve to a verified
     # added worktree — never the primary checkout (#4445). Read-only dispatches
     # stay exempt so repo-root preflight keeps working. Evaluated before any
@@ -5744,9 +5825,11 @@ def build_parser() -> argparse.ArgumentParser:
     d.add_argument(
         "--cwd",
         default=None,
-        help="Working directory for the worker (default: repo root). "
+        help="Working directory for the worker (default: primary checkout). "
         "For workspace-write/danger it must be a verified added "
-        "worktree, never the primary checkout — prefer --worktree.",
+        "worktree, never the primary checkout — prefer --worktree. "
+        "Supported sibling-repo flow: manual `git worktree add` in that "
+        "repo, then `--cwd <that-worktree>` without `--worktree`.",
     )
     d.add_argument(
         "--worktree",
@@ -5757,8 +5840,10 @@ def build_parser() -> argparse.ArgumentParser:
             "Run inside this git worktree (created on demand). Required for "
             "write-capable modes (workspace-write, danger). Pass `--worktree` "
             "alone (recommended) to auto-derive `.worktrees/dispatch/{agent}/"
-            "{task}/`, or `--worktree PATH` to reuse a specific added worktree "
-            "(validated against the expected dispatch branch before reuse)."
+            "{task}/` under the primary checkout that owns this script, or "
+            "`--worktree PATH` to reuse a specific added worktree "
+            "(validated against the expected dispatch branch before reuse). "
+            "Refuses when the invocation cwd is a different git root (#6900)."
         ),
     )
     d.add_argument(
@@ -5767,10 +5852,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="EXISTING",
         help=(
             "Attach the dispatch to this existing remote branch instead of creating "
-            "{agent}/{task}. Fetches and validates the branch, then creates/reuses "
-            "an isolated worktree on it (--branch implies --worktree). Refuses "
-            "protected branches (main/master) and branches checked out in another "
-            "worktree. --branch must omit origin/ and refs/ prefixes."
+            "{agent}/{task}. Fetches and validates the branch from the primary "
+            "checkout, then creates/reuses an isolated worktree on it (--branch "
+            "implies --worktree). Refuses protected branches (main/master), "
+            "branches checked out in another worktree, and invocation from a "
+            "different git root (#6900). --branch must omit origin/ and refs/ prefixes."
         ),
     )
     d.add_argument(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -5721,6 +5721,15 @@ def test_new_dispatch_uses_dispatch_subtree(tmp_tasks_dir, monkeypatch, capsys):
 # ---------------------------------------------------------------------------
 
 
+def _init_sibling_pair(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Two independent git roots: ``(primary, sibling, sibling_worktree)``."""
+    (tmp_path / "primary").mkdir()
+    (tmp_path / "sibling").mkdir()
+    primary, _ = _init_repo_with_worktree(tmp_path / "primary")
+    sibling, sibling_wt = _init_repo_with_worktree(tmp_path / "sibling")
+    return primary, sibling, sibling_wt
+
+
 def _init_repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
     """Build a real primary checkout + one registered dispatch worktree.
 
@@ -5802,6 +5811,7 @@ def _write_args(**overrides):
         "model": None,
         "cwd": None,
         "worktree": None,
+        "branch": None,
         "base": "main",
         "hard_timeout": 3600,
         "allow_merge": False,
@@ -5890,6 +5900,155 @@ def test_write_guard_rejects_explicit_worktree_pointing_at_primary(tmp_path):
     assert "primary checkout" in err
 
 
+# --- #6900 cross-repo binding (sibling git root vs _REPO_ROOT) --------------
+
+
+def test_auto_worktree_path_ignores_sibling_invocation_cwd(tmp_path, monkeypatch):
+    """#6900 repro: a second git root as cwd still derives under _REPO_ROOT."""
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    monkeypatch.chdir(sibling)
+
+    derived = delegate._auto_worktree_path("codex", "private-492-private-increment")
+
+    assert derived == (
+        primary / ".worktrees" / "dispatch" / "codex" / "private-492-private-increment"
+    )
+    assert derived.is_relative_to(primary)
+    assert not derived.is_relative_to(sibling)
+
+
+def test_cross_repo_guard_allows_primary_invocation(tmp_path, monkeypatch):
+    primary, _ = _init_repo_with_worktree(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    assert delegate._resolve_cross_repo_binding_error(
+        worktree_arg="auto",
+        cwd_arg=None,
+        requested_branch=None,
+        invocation_cwd=primary,
+    ) is None
+
+
+def test_cross_repo_guard_refuses_worktree_from_sibling(tmp_path, monkeypatch):
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    err = delegate._resolve_cross_repo_binding_error(
+        worktree_arg="auto",
+        cwd_arg=None,
+        requested_branch=None,
+        invocation_cwd=sibling,
+    )
+
+    assert err is not None
+    assert "different git root" in err
+    assert str(primary) in err
+    assert str(sibling) in err
+    assert "--worktree" in err
+    assert "primary checkout" in err
+
+
+def test_cross_repo_guard_refuses_branch_from_sibling(tmp_path, monkeypatch):
+    """--branch has the same primary-only fetch/attach blindness as --worktree."""
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    err = delegate._resolve_cross_repo_binding_error(
+        worktree_arg="auto",
+        cwd_arg=None,
+        requested_branch="codex/existing-pr",
+        invocation_cwd=sibling,
+    )
+
+    assert err is not None
+    assert "different git root" in err
+    assert "--branch" in err
+
+
+def test_cross_repo_guard_refuses_default_primary_cwd_from_sibling(tmp_path, monkeypatch):
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    err = delegate._resolve_cross_repo_binding_error(
+        worktree_arg=None,
+        cwd_arg=None,
+        requested_branch=None,
+        invocation_cwd=sibling,
+    )
+
+    assert err is not None
+    assert "silently run in the primary checkout" in err
+
+
+def test_cross_repo_guard_allows_explicit_cwd_from_sibling(tmp_path, monkeypatch):
+    primary, sibling, sibling_wt = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    assert delegate._resolve_cross_repo_binding_error(
+        worktree_arg=None,
+        cwd_arg=str(sibling_wt),
+        requested_branch=None,
+        invocation_cwd=sibling,
+    ) is None
+
+
+def test_cross_repo_guard_allows_non_git_invocation_cwd(tmp_path, monkeypatch):
+    (tmp_path / "primary").mkdir()
+    primary, _ = _init_repo_with_worktree(tmp_path / "primary")
+    loose = tmp_path / "not-a-repo"
+    loose.mkdir()
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    assert delegate._resolve_cross_repo_binding_error(
+        worktree_arg="auto",
+        cwd_arg=None,
+        invocation_cwd=loose,
+    ) is None
+
+
+def test_cross_repo_guard_allows_invocation_from_primary_worktree(tmp_path, monkeypatch):
+    """A dispatch worktree of the primary still resolves to the same git root."""
+    primary, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+
+    assert delegate._resolve_cross_repo_binding_error(
+        worktree_arg="auto",
+        cwd_arg=None,
+        requested_branch=None,
+        invocation_cwd=dispatch_wt,
+    ) is None
+
+
+def test_cross_repo_guard_mutation_check(tmp_path, monkeypatch):
+    """#6900 / #M-4: treating the sibling root as primary would re-silence the bind.
+
+    1. Current comparison: sibling cwd + --worktree refuses.
+    2. Mutate ``_fs_main_root`` to always return ``_REPO_ROOT``: the same call is silent.
+    3. Restore: the sibling call refuses again.
+    """
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    wc = delegate._load_worktree_containment()
+    original_resolve = wc._fs_main_root
+
+    def _call():
+        return delegate._resolve_cross_repo_binding_error(
+            worktree_arg="auto",
+            cwd_arg=None,
+            requested_branch=None,
+            invocation_cwd=sibling,
+        )
+
+    assert _call() is not None
+
+    monkeypatch.setattr(wc, "_fs_main_root", lambda _start: wc.canonicalize(primary))
+    assert _call() is None
+
+    monkeypatch.setattr(wc, "_fs_main_root", original_resolve)
+    assert _call() is not None
+
+
 def _primary_dirty_status(main: Path) -> dict:
     return delegate._load_worktree_containment().primary_checkout_dirty_status(main)
 
@@ -5960,6 +6119,7 @@ def test_dispatch_read_only_allows_dirty_primary_checkout(
     main, _ = _init_repo_with_worktree(tmp_path)
     (main / "tracked.txt").write_text("dirty\n")
     monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    monkeypatch.chdir(main)
     monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _GuardFakeProc())
     args = _write_args(task_id="ro-dirty-main", mode="read-only", cwd=None, worktree=None)
 
@@ -5977,6 +6137,7 @@ def test_dispatch_rejects_write_capable_when_primary_checkout_dirty(
     main, _ = _init_repo_with_worktree(tmp_path)
     (main / "tracked.txt").write_text("dirty\n")
     monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    monkeypatch.chdir(main)
     args = _write_args(
         task_id="dirty-main",
         mode="workspace-write",
@@ -6078,6 +6239,7 @@ def test_dispatch_accepts_explicit_added_worktree(tmp_tasks_dir, tmp_path, monke
     # Route delegate's worktree machinery at the throwaway repo so reuse
     # validation and provisioning never touch the real checkout or network.
     monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    monkeypatch.chdir(main)
     _patch_worker_popen(monkeypatch)
     args = _write_args(
         agent="codex",
@@ -6095,6 +6257,82 @@ def test_dispatch_accepts_explicit_added_worktree(tmp_tasks_dir, tmp_path, monke
     assert state is not None
     assert state["worktree_reused"] is True
     assert Path(state["cwd"]) == dispatch_wt
+
+
+def test_dispatch_refuses_worktree_from_sibling_repo(
+    tmp_tasks_dir, tmp_path, monkeypatch, capsys,
+):
+    """#6900: --worktree invoked from a sibling git root must not bind primary."""
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    monkeypatch.chdir(sibling)
+    args = _write_args(
+        task_id="sibling-misbind",
+        mode="workspace-write",
+        cwd=None,
+        worktree="auto",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 2
+    assert delegate._read_state(delegate._state_path("sibling-misbind")) is None
+    err = capsys.readouterr().err
+    assert "different git root" in err
+    assert "--worktree" in err
+    derived = primary / ".worktrees" / "dispatch" / "codex" / "sibling-misbind"
+    assert not derived.exists()
+
+
+def test_dispatch_refuses_branch_from_sibling_repo(
+    tmp_tasks_dir, tmp_path, monkeypatch, capsys,
+):
+    """#6900: --branch fetches/attaches in the primary, same silent bind."""
+    primary, sibling, _ = _init_sibling_pair(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    monkeypatch.chdir(sibling)
+    args = _write_args(
+        task_id="sibling-branch",
+        mode="workspace-write",
+        cwd=None,
+        worktree=None,
+        branch="codex/existing-pr",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 2
+    assert delegate._read_state(delegate._state_path("sibling-branch")) is None
+    err = capsys.readouterr().err
+    assert "different git root" in err
+    assert "--branch" in err
+    derived = primary / ".worktrees" / "dispatch" / "codex" / "sibling-branch"
+    assert not derived.exists()
+
+
+def test_dispatch_accepts_sibling_cwd_worktree_from_sibling_repo(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """Documented sibling flow: manual worktree + --cwd, no --worktree."""
+    primary, sibling, sibling_wt = _init_sibling_pair(tmp_path)
+    _sanitize_git_env_for_test(monkeypatch)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", primary)
+    monkeypatch.chdir(sibling)
+    _patch_worker_popen(monkeypatch)
+    args = _write_args(
+        task_id="sibling-cwd",
+        mode="workspace-write",
+        cwd=str(sibling_wt),
+        worktree=None,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("sibling-cwd"))
+    assert state is not None
+    assert Path(state["cwd"]) == sibling_wt
+    assert Path(state["worktree_path"]) == sibling_wt
 
 
 def test_dispatch_help_omits_deprecated_cwd_dot_example():


### PR DESCRIPTION
Fixes #6900.

Authored by the grok lane (dispatch `infra-6900-delegate-repo-binding`, commit `e7a337560a`); driver finalized push/PR (grok harness cannot run network git).

## Summary
`--worktree` / `--branch` always derive the dispatch worktree under `_REPO_ROOT`. Invoking `dispatch --worktree` with the shell cwd inside a sibling git root used to silently create the worktree in the primary repo (#6900's live repro).

**Shape chosen: (b) loud refusal**, not first-class `--repo`: fetch, `git worktree add`, the reaper, sparse-checkout, and data-symlink provisioning all assume `_REPO_ROOT`, so first-class multi-repo support would ripple through all of them. The already-working manual-worktree + `--cwd` sibling flow is now documented in `docs/runbooks/agent-seat-onboarding.md`.

`--branch` had the same cross-repo blindness — the new guard covers both entry points; explicit `--cwd` into a verified added worktree remains allowed.

## Evidence (lane-run, quoted from the task result)
- Before/after probe: silent `derived_under_primary=True` from a sibling cwd becomes `worktree_guard_refuses=True` with the "different git root" message; explicit `--cwd` still allowed.
- `pytest tests/test_delegate.py` → **262 passed**; ruff clean.
- Mutation check: forcing the new root-resolution helper to return `_REPO_ROOT` re-silences the bind and fails the guard tests; restore → refuses again.

X-Agent: grok/infra-6900-delegate-repo-binding
