### PR TITLE
fix(bridge): route process/ask-gemini via the live ACP participant registry

### DIFF
--- a/scripts/ai_agent_bridge/_acp_compat.py
+++ b/scripts/ai_agent_bridge/_acp_compat.py
@@ -44,6 +44,43 @@ def require_compat_target(command_target: str) -> str:
         ) from exc
 
 
+def registered_participant_model(participant: str) -> str | None:
+    """Return the live model pin for an ACP participant from the adapter registry.
+
+    The registry (``ACPX_SUPPORTED_PARTICIPANTS``) is the single source of
+    truth the route resolver enforces; consumers must read it instead of
+    carrying an independently hardcoded slug that goes stale on every model
+    rotation (#6894). Returns None for unknown or deliberately unpinned seats.
+    """
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    entry = ACPX_SUPPORTED_PARTICIPANTS.get(participant)
+    if not entry:
+        return None
+    model = entry.get("model")
+    return str(model) if model else None
+
+
+def resolve_compat_model(command_target: str, model: str | None) -> str | None:
+    """Resolve a legacy ``--model`` value against the live participant registry.
+
+    ``None`` stays ``None`` so the route resolver applies the participant's
+    registered pin — a default can never drift from the registry (#6894).
+    Legacy ``gemini*`` slugs (including retired display labels) aimed at the
+    AGY seat map to that seat's current pin, the only model the seat accepts.
+    Anything else passes through unchanged and is validated loudly by the
+    route resolver.
+    """
+    participant = require_compat_target(command_target)
+    if not model:
+        return None
+    if participant == "agy":
+        pin = registered_participant_model("agy")
+        if pin and model != pin and model.strip().lower().startswith("gemini"):
+            return pin
+    return model
+
+
 # Per-seat default hard timeouts for compat asks (#6877). The generic 300s
 # ceiling is mis-sized for Kimi: K3 is a max-effort-only model whose long
 # deliberation before first output is designed behavior, and the fleet routes

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -42,7 +42,20 @@ from ._review_worktree import (
 
 _DEFAULT_AGY_BRIDGE_TIMEOUT_SECONDS = 900
 _NO_TIMEOUT_AGY_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
-_DEFAULT_AGY_MODEL = "gemini-3.7-flash-high"
+
+
+def _default_agy_model() -> str:
+    """The AGY seat's model, read from the live ACP participant registry.
+
+    Never an independently hardcoded slug: the registry pin is what the route
+    resolver enforces, so deriving the default from it makes stale-slug drift
+    impossible (#6894).
+    """
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    pin = ACPX_SUPPORTED_PARTICIPANTS["agy"]["model"]
+    assert pin is not None  # the agy participant is always pinned
+    return pin
 
 
 def _agy_ask_scratch_cwd() -> Path:
@@ -124,7 +137,7 @@ def ask_agy(
         # Refuse formal/exact-target review on AGY before any worktree or send.
         raise ValueError(AGY_SEALED_REVIEW_UNSUPPORTED)
     effective_model = resolve_model_selection(
-        lane="ask-agy", to_model=to_model, model=None, default=_DEFAULT_AGY_MODEL
+        lane="ask-agy", to_model=to_model, model=None, default=_default_agy_model()
     )
     msg_id = send_message(
         content,
@@ -188,7 +201,7 @@ def process_for_agy(
 
     _ = new_session  # No-op for now; Agy bridge calls are always fresh.
     timeout_val = _resolve_agy_bridge_timeout(no_timeout)
-    model = _extract_target_model(msg) or _DEFAULT_AGY_MODEL
+    model = _extract_target_model(msg) or _default_agy_model()
     effort = requested_effort(msg)
     effort_applied, effort_reason = unsupported_effort_note(
         lane="agy",
@@ -387,7 +400,11 @@ def _extract_target_model(msg: dict) -> str | None:
 
 
 def _handle_agy_error(msg: dict, message_id: int, reason: str) -> None:
-    """Record an Agy failure as a response message and acknowledge."""
+    """Record an Agy failure as a response message; no ack (#6915).
+
+    The inbound message stays unacknowledged so the failure is retryable;
+    acknowledgement happens only after a successful routed reply.
+    """
     print(f"\n❌ Agy error for message #{message_id}: {reason}")
     from ._ask_contract import failed_response_provenance
 
@@ -403,7 +420,6 @@ def _handle_agy_error(msg: dict, message_id: int, reason: str) -> None:
         data=data,
         from_model=from_model,
     )
-    acknowledge(message_id)
     record_ask_failure(
         message_id,
         reason,

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -346,7 +346,6 @@ def _run_claude_sync_via_runtime(
             data=provenance_data, from_model=from_model,
         )
         _response_sent = True
-        acknowledge(message_id)
         record_ask_failure(message_id, str(exc))
     except (AgentStalledError, AgentTimeoutError) as exc:
         timeout_mins = timeout_val // 60
@@ -362,7 +361,6 @@ def _run_claude_sync_via_runtime(
             data=provenance_data, from_model=from_model,
         )
         _response_sent = True
-        acknowledge(message_id)
         record_ask_failure(message_id, str(exc), timed_out=True)
     except AgentUnavailableError:
         print("❌ claude CLI not found. Is it installed?")
@@ -374,7 +372,8 @@ def _run_claude_sync_via_runtime(
             data=provenance_data, from_model=from_model,
         )
         _response_sent = True
-        acknowledge(message_id)  # Must ack incoming msg to prevent stuck queue
+        # No ack on failure (#6915): the message stays unconsumed/retryable;
+        # broker_cleanup force-acks only after the stuck-age threshold.
         record_ask_failure(message_id, "Claude CLI not found")
     except ReviewWorktreeError as exc:
         provenance_data, from_model = _claude_error_provenance(
@@ -387,7 +386,6 @@ def _run_claude_sync_via_runtime(
             data=provenance_data, from_model=from_model,
         )
         _response_sent = True
-        acknowledge(message_id)
         record_ask_failure(message_id, str(exc))
     finally:
         if not _response_sent:
@@ -526,7 +524,11 @@ def _launch_claude_background(msg, message_id, new_session):
 
 
 def _handle_claude_error(msg, message_id, stderr):
-    """Handle Claude CLI non-zero exit. Returns True (response_sent)."""
+    """Handle Claude CLI non-zero exit. Returns True (response_sent).
+
+    Sends the honest typed-error reply but never acknowledges the inbound
+    message (#6915): a failed processing leaves it unconsumed/retryable.
+    """
     error_msg = redact_text(stderr.strip()) or "Unknown error"
     print(f"\n❌ Claude CLI error: {error_msg[:500]}")
     sys.stdout.flush()
@@ -537,7 +539,6 @@ def _handle_claude_error(msg, message_id, stderr):
         task_id=msg['task_id'], msg_type="error",
         from_llm="claude", to_llm=msg['from'], data=provenance_data, from_model=from_model
     )
-    acknowledge(message_id)
     record_ask_failure(message_id, error_msg)
     return True
 
@@ -551,7 +552,6 @@ def _send_claude_fallback_error(msg, message_id):
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'], data=provenance_data, from_model=from_model
         )
-        acknowledge(message_id)
         record_ask_failure(message_id, "Claude process failed unexpectedly")
     except Exception:
         pass

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -19,7 +19,6 @@ from ._codex import (
     process_all_codex,
     process_for_codex,
 )
-from ._config import GEMINI_DEFAULT_MODEL
 from ._cursor import CURSOR_DEFAULT_MODEL
 from ._db import get_db
 from ._dispatch_wrappers import (
@@ -28,7 +27,7 @@ from ._dispatch_wrappers import (
     handle_dispatch_fix,
     handle_review_deep,
 )
-from ._gemini import converse_gemini, process_and_respond
+from ._gemini import converse_gemini
 from ._grok_build import (
     GROK_BUILD_DEFAULT_MODEL,
     process_for_grok_build,
@@ -52,6 +51,7 @@ from ._opencode import (
     POOL_DEFAULT_VARIANT,
     POOL_MODEL,
 )
+from ._process import process_message_for_recipient
 
 _CALLER_IDENTITY_ENV_HINTS = (
     # Order mirrors _detect_caller_identity_from_env; SESSION_HANDOFF_AGENT is
@@ -65,20 +65,6 @@ _CALLER_IDENTITY_ENV_HINTS = (
     "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS",
     "GEMINI_SESSION",
 )
-
-_LEGACY_GEMINI_TO_AGY_MODEL = {
-    "gemini-3.1-pro-preview": "gemini-3.1-pro-high",
-    "gemini-3.0-flash-preview": "gemini-3.7-flash-high",
-    "gemini-3.5-flash": "gemini-3.5-flash-high",
-    "gemini-3.6-flash": "gemini-3.6-flash-high",
-    "gemini-3.7-flash": "gemini-3.7-flash-high",
-}
-
-
-def _map_legacy_gemini_model_to_agy(model: str | None) -> str | None:
-    if not model:
-        return None
-    return _LEGACY_GEMINI_TO_AGY_MODEL.get(model, model)
 
 
 def _detect_caller_identity_from_env() -> str | None:
@@ -183,13 +169,18 @@ def _dispatch_interactive(action: str, parts: list[str]):
     elif action == "conv" and len(parts) > 1:
         get_conversation(parts[1])
     elif action == "process" and len(parts) > 1:
-        process_and_respond(int(parts[1]))
+        process_message_for_recipient(int(parts[1]))
     else:
         print("Unknown command or missing arguments.")
 
 
-def process_all_gemini(model: str = GEMINI_DEFAULT_MODEL):
-    """Process ALL unread messages for Gemini in batch."""
+def process_all_gemini(model: str | None = None):
+    """Process ALL unread messages for the Gemini seat (routed to AGY via ACP).
+
+    Each message is routed through its recipient seat's registered ACP
+    participant (#6915); a message is consumed only when the routed seat
+    replies successfully, so failures stay in the inbox for retry.
+    """
     conn = get_db()
     cursor = conn.cursor()
 
@@ -218,9 +209,12 @@ def process_all_gemini(model: str = GEMINI_DEFAULT_MODEL):
         print(f"━━━ Processing [{msg_id}] from {from_llm}: {preview}...")
 
         try:
-            process_and_respond(msg_id, model)
-            success += 1
-            print("    ✅ Done\n")
+            if process_message_for_recipient(msg_id, model=model):
+                success += 1
+                print("    ✅ Done\n")
+            else:
+                failed += 1
+                print("    ❌ Failed (message left unconsumed)\n")
         except Exception as e:
             failed += 1
             print(f"    ❌ Failed: {e}\n")
@@ -517,10 +511,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     thread_parser.add_argument("identifier", help="Task ID or numeric message ID")
 
-    # process (for Gemini)
-    proc_parser = subparsers.add_parser("process", help="Process message with Gemini and respond")
+    # process — recipient-derived: routes via the message's To: seat (#6915)
+    proc_parser = subparsers.add_parser(
+        "process",
+        help="Process a broker message via its recipient seat's registered ACP route",
+    )
     proc_parser.add_argument("message_id", type=int, help="Message ID to process")
-    proc_parser.add_argument("--model", default=GEMINI_DEFAULT_MODEL, help="Gemini model")
+    proc_parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model override; must equal the recipient seat's registered ACP pin",
+    )
     proc_parser.add_argument(
         "--no-timeout",
         dest="no_timeout",
@@ -655,7 +656,10 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_gemini_parser.add_argument("--type", default="query", help="Message type (default: query)")
     ask_gemini_parser.add_argument("--data", help="Path to data file to attach")
     ask_gemini_parser.add_argument(
-        "--model", default=GEMINI_DEFAULT_MODEL, help="Legacy Gemini model slug; mapped to AGY where needed"
+        "--model",
+        default=None,
+        help="Legacy Gemini model slug; mapped to the AGY seat's live registry pin "
+        "(default: the pin itself — never an independently hardcoded slug)",
     )
     ask_gemini_parser.add_argument("--from-model", dest="from_model", help="Exact sender model ID")
     ask_gemini_parser.add_argument(
@@ -721,7 +725,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ask_agy_parser.add_argument("--from-model", dest="from_model", help="Exact sender model ID")
     ask_agy_parser.add_argument(
-        "--to-model", dest="to_model", help="Target Agy model ID (default: gemini-3.7-flash-high)"
+        "--to-model",
+        dest="to_model",
+        help="Target Agy model ID (default: the agy seat's live ACP registry pin)",
     )
     ask_agy_parser.add_argument("--effort", choices=EFFORT_CHOICES, help="Requested reasoning effort")
     ask_agy_parser.add_argument(
@@ -965,8 +971,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # process-all
-    proc_all_parser = subparsers.add_parser("process-all", help="Process ALL unread messages with Gemini")
-    proc_all_parser.add_argument("--model", default=GEMINI_DEFAULT_MODEL, help="Gemini model")
+    proc_all_parser = subparsers.add_parser(
+        "process-all",
+        help="Process ALL unread messages for the Gemini seat via its ACP route (agy)",
+    )
+    proc_all_parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model override; must equal the seat's registered ACP pin",
+    )
 
     # process-claude-all
     proc_claude_all_parser = subparsers.add_parser("process-claude-all", help="Process ALL unread messages with Claude")
@@ -1279,7 +1292,9 @@ def _dispatch_command(args):
     elif args.command == "thread":
         resolve_thread(args.identifier)
     elif args.command == "process":
-        process_and_respond(args.message_id, args.model, no_timeout=args.no_timeout)
+        process_message_for_recipient(
+            args.message_id, model=args.model, no_timeout=args.no_timeout
+        )
     elif args.command == "process-claude":
         process_for_claude(args.message_id, args.new_session, args.fire_and_forget, args.no_timeout)
     elif args.command == "process-codex":
@@ -1559,7 +1574,11 @@ def _handle_ask_gemini(args):
     """Compatibility shim: ask-gemini is retired and delegates to ask-agy."""
     if not getattr(args, "stdout_only", False):
         print("⚠️ ask-gemini is retired; routing through ACP participant agy.", file=sys.stderr)
-    args.to_model = _map_legacy_gemini_model_to_agy(getattr(args, "model", None)) or "gemini-3.7-flash-high"
+    from ._acp_compat import resolve_compat_model
+
+    # None (the default) lets the route resolver apply the AGY seat's live
+    # registry pin; legacy gemini* slugs map to that same pin (#6894).
+    args.to_model = resolve_compat_model("gemini", getattr(args, "model", None))
     _handle_acp_compat(args, "gemini")
 
 

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -486,7 +486,11 @@ def _extract_effort(msg: dict) -> str | None:
 
 
 def _handle_codex_error(msg: dict, message_id: int, error_msg: str) -> None:
-    """Send bridge error back to sender."""
+    """Send bridge error back to sender; the inbound row stays unacknowledged.
+
+    No ack on failure (#6915): the message remains unconsumed/retryable, the
+    same deferral shape as the rate-limited path below.
+    """
     print(f"\n❌ Codex CLI error: {error_msg[:500]}")
     from ._ask_contract import failed_response_provenance
 
@@ -502,7 +506,6 @@ def _handle_codex_error(msg: dict, message_id: int, error_msg: str) -> None:
         data=data,
         from_model=from_model,
     )
-    acknowledge(message_id)
     record_ask_failure(
         message_id,
         error_msg,

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -25,7 +25,7 @@ from agent_runtime.runner import invoke as runtime_invoke
 from batch_gemini_config import FALLBACK_MODEL, PRO_MODEL
 from secret_redactor import redact_text
 
-from ._ask_lifecycle import register_ask
+from ._ask_lifecycle import record_ask_failure, register_ask
 from ._broker import (
     _git_status_snapshot,
     _is_task_locked,
@@ -616,7 +616,12 @@ def _route_gemini_response(msg, message_id, model, response, stdout_only, output
 
 
 def _send_gemini_error(msg, message_id):
-    """Send error message when Gemini process fails without sending a response."""
+    """Notify the sender when Gemini processing fails WITHOUT consuming the message.
+
+    The inbound message stays unacknowledged so a later drain can retry it
+    (#6915): acking here made the queue look drained while no analysis
+    happened.
+    """
     try:
         # Route error back to the actual sender, not always to claude
         reply_to = msg.get("from", "claude")
@@ -625,6 +630,6 @@ def _send_gemini_error(msg, message_id):
             task_id=msg['task_id'], msg_type="error",
             from_llm="gemini", to_llm=reply_to, from_model="gemini-bridge-error"
         )
-        acknowledge(message_id)
+        record_ask_failure(message_id, f"Gemini process failed for message #{message_id}")
     except Exception:
         pass

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -505,7 +505,8 @@ def _handle_grok_build_incomplete_turn(
         data=json.dumps(metadata, sort_keys=True),
         from_model=actual_model,
     )
-    acknowledge(message_id)
+    # No ack on failure (#6915): an incomplete turn leaves the inbound
+    # message unconsumed/retryable; only a completed reply consumes it.
     record_ask_failure(message_id, f"native Grok turn not completed: {detail}")
 
 
@@ -602,7 +603,11 @@ Standing rules for bridge Q&A:
 
 
 def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
-    """Record a Grok Build failure as a response message and acknowledge."""
+    """Record a Grok Build failure as a response message; no ack (#6915).
+
+    The inbound message stays unacknowledged so the failure is retryable;
+    acknowledgement happens only after a successful routed reply.
+    """
     print(f"\nGrok Build error for message #{message_id}: {reason}")
     from ._ask_contract import failed_response_provenance
 
@@ -618,7 +623,6 @@ def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
         data=data,
         from_model=from_model,
     )
-    acknowledge(message_id)
     record_ask_failure(
         message_id,
         reason,

--- a/scripts/ai_agent_bridge/_kimi.py
+++ b/scripts/ai_agent_bridge/_kimi.py
@@ -182,7 +182,11 @@ def _build_kimi_prompt(
 
 
 def _handle_kimi_error(msg: dict, message_id: int, reason: str) -> None:
-    """Persist a terminal Kimi failure and unblock the original ask."""
+    """Persist a terminal Kimi failure and notify the sender; no ack (#6915).
+
+    The inbound message stays unacknowledged so a later drain can retry it;
+    acknowledgement happens only after a successful routed reply.
+    """
     from ._ask_contract import failed_response_provenance
 
     data, from_model = failed_response_provenance(
@@ -192,5 +196,4 @@ def _handle_kimi_error(msg: dict, message_id: int, reason: str) -> None:
         content=f"[Kimi error] {reason}", task_id=msg["task_id"], msg_type="error",
         from_llm="kimi", to_llm=msg["from"], data=data, from_model=from_model,
     )
-    acknowledge(message_id)
     record_ask_failure(message_id, reason, timed_out="timeout" in reason.lower() or "stalled" in reason.lower())

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -578,7 +578,8 @@ def _handle_opencode_incomplete_turn(
         data=json.dumps(metadata, sort_keys=True),
         from_model=actual_model,
     )
-    acknowledge(message_id)
+    # No ack on failure (#6915): an aborted turn leaves the inbound message
+    # unconsumed/retryable; only a completed reply consumes it.
     record_ask_failure(message_id, f"opencode turn aborted ({detail}: {reason})")
 
 

--- a/scripts/ai_agent_bridge/_process.py
+++ b/scripts/ai_agent_bridge/_process.py
@@ -1,0 +1,158 @@
+"""Recipient-derived message processing over the ACP participant registry.
+
+This is the generic ``process <id>`` / ``process-all`` drain path. Routing and
+model selection derive from the message's ``To:`` seat through the same ACP
+compatibility layer the ask-* commands use (#6915): no per-command hardcoded
+model slugs and no retired provider CLIs. The inbound message is acknowledged
+only after a successful routed reply; a failed processing attempt notifies the
+sender with a typed error but leaves the original message unconsumed and
+retryable — the queue must never look drained when no analysis happened.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+from ._acp_compat import require_compat_target, resolve_compat_model, run_compat_ask
+from ._ask_lifecycle import ask_target_model, record_ask_failure, record_ask_reply
+from ._db import get_db
+from ._messaging import acknowledge, read_message, send_message
+
+_NO_TIMEOUT_CEILING_S = 86400
+
+
+def recipient_has_acp_route(recipient: str) -> bool:
+    """Return True when a broker recipient seat resolves to an ACP participant."""
+    try:
+        require_compat_target(recipient.strip().lower())
+    except (ValueError, AttributeError):
+        return False
+    return True
+
+
+def _message_acknowledged(message_id: int) -> bool:
+    conn = get_db()
+    try:
+        row = conn.execute(
+            "SELECT acknowledged FROM messages WHERE id = ?", (message_id,)
+        ).fetchone()
+        return bool(row and row[0])
+    finally:
+        conn.close()
+
+
+def _build_routed_prompt(msg: dict) -> str:
+    """Construct the recipient-seat prompt for a drained broker message."""
+    prompt = (
+        f"You are {str(msg['to']).title()}, receiving a message from "
+        f"{str(msg['from']).title()} via the message broker.\n\n"
+        f"---\nTask ID: {msg['task_id'] or 'none'}\nType: {msg['type']}\n"
+        f"From: {msg['from']}\n\n{msg['content']}\n"
+    )
+    if msg.get("data"):
+        prompt += f"\n---\nAttached data:\n{msg['data']}\n"
+    prompt += (
+        "\n---\n\nStanding rules for bridge Q&A:\n"
+        "- Respond directly and concisely.\n"
+        "- Do NOT use broker or MCP messaging tools to send your response; "
+        "output it directly.\n"
+    )
+    return prompt
+
+
+def _notify_processing_failure(
+    msg: dict, message_id: int, participant: str, reason: str
+) -> None:
+    """Notify the sender of a failed processing attempt WITHOUT consuming.
+
+    The honest typed-error reply is preserved, but the original message is
+    never acknowledged here: it must remain unconsumed/retryable (#6915).
+    """
+    with contextlib.suppress(Exception):
+        send_message(
+            content=(
+                f"[Bridge Error] Processing message #{message_id} via "
+                f"{participant} failed: {reason}. The original message was "
+                "NOT acknowledged and remains in the recipient's inbox."
+            ),
+            task_id=msg.get("task_id"),
+            msg_type="error",
+            from_llm=str(msg.get("to") or "bridge"),
+            to_llm=str(msg.get("from") or "user"),
+            from_model=f"{participant}-bridge-error",
+        )
+    record_ask_failure(message_id, reason)
+
+
+def process_message_for_recipient(
+    message_id: int,
+    *,
+    model: str | None = None,
+    no_timeout: bool = False,
+) -> str | None:
+    """Process one broker message via the route its ``To:`` seat registers.
+
+    Returns the routed seat's response on success (after replying to the
+    sender and acknowledging the inbound message); returns None on any
+    failure, leaving the message unacknowledged and retryable.
+    """
+    msg = read_message(message_id)
+    if not msg:
+        return None
+    if _message_acknowledged(message_id):
+        print(f"⏭️  Message {message_id} is already acknowledged; skipping.")
+        return None
+
+    recipient = str(msg.get("to") or "").strip().lower()
+    try:
+        participant = require_compat_target(recipient)
+    except ValueError:
+        reason = f"recipient seat {recipient!r} has no enabled ACP route"
+        print(f"❌ {reason}; message left unconsumed")
+        _notify_processing_failure(msg, message_id, recipient or "unknown", reason)
+        return None
+
+    selected_model = resolve_compat_model(recipient, model or ask_target_model(msg))
+    task_id = msg.get("task_id") or f"process-{message_id}"
+    print(
+        f"🤖 Routing message #{message_id} to ACP participant "
+        f"{participant!r} (recipient seat {recipient!r}, "
+        f"model={selected_model or 'registry pin'})..."
+    )
+    try:
+        result = run_compat_ask(
+            recipient,
+            _build_routed_prompt(msg),
+            task_id=task_id,
+            source=msg.get("from"),
+            model=selected_model,
+            hard_timeout=_NO_TIMEOUT_CEILING_S if no_timeout else None,
+        )
+    except Exception as exc:
+        reason = f"{type(exc).__name__}: {exc}"
+        print(f"❌ Processing failed: {reason}")
+        _notify_processing_failure(msg, message_id, participant, reason)
+        return None
+
+    response = str(getattr(result, "response", "") or "").strip()
+    if not getattr(result, "ok", False) or not response:
+        reason = str(
+            getattr(result, "stderr_excerpt", None)
+            or "empty response from routed seat"
+        )
+        print(f"❌ Processing failed: {reason}")
+        _notify_processing_failure(msg, message_id, participant, reason)
+        return None
+
+    reply_id = send_message(
+        content=response,
+        task_id=msg.get("task_id"),
+        msg_type="response",
+        from_llm=msg["to"],
+        to_llm=msg["from"],
+        from_model=getattr(result, "model", None),
+    )
+    acknowledge(message_id)
+    record_ask_reply(message_id, reply_id)
+    print(f"✅ Message {message_id} processed by {participant} and acknowledged")
+    return response

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -179,19 +179,18 @@ def test_ask_codex_infers_from_claude_agent_name(
     assert captured["from_llm"] == "claude"
 
 
-def test_legacy_gemini_model_slugs_map_to_agy_slugs() -> None:
-    assert (
-        _cli._map_legacy_gemini_model_to_agy("gemini-3.1-pro-preview")
-        == "gemini-3.1-pro-high"
-    )
-    assert (
-        _cli._map_legacy_gemini_model_to_agy("gemini-3.0-flash-preview")
-        == "gemini-3.7-flash-high"
-    )
-    assert (
-        _cli._map_legacy_gemini_model_to_agy("Gemini 3.1 Pro (High)")
-        == "Gemini 3.1 Pro (High)"
-    )
+def test_legacy_gemini_model_slugs_map_to_live_agy_pin() -> None:
+    """Legacy gemini* slugs resolve to the AGY seat's live registry pin (#6894)."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._acp_compat import resolve_compat_model
+
+    pin = ACPX_SUPPORTED_PARTICIPANTS["agy"]["model"]
+    assert resolve_compat_model("gemini", "gemini-3.1-pro-preview") == pin
+    assert resolve_compat_model("gemini", "gemini-3.0-flash-preview") == pin
+    assert resolve_compat_model("gemini", "Gemini 3.1 Pro (High)") == pin
+    # No explicit model → None, so the route resolver applies the pin itself.
+    assert resolve_compat_model("gemini", None) is None
 
 
 def test_ask_gemini_shim_routes_to_agy_with_mapped_model(
@@ -223,6 +222,9 @@ def test_ask_gemini_shim_routes_to_agy_with_mapped_model(
     assert captured["content"] == "hello"
     assert captured["task_id"] == "task-1"
     assert captured["source"] == "codex"
-    assert captured["model"] == "gemini-3.1-pro-high"
+    # Legacy slugs map to the AGY seat's live registry pin, not a static slug.
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    assert captured["model"] == ACPX_SUPPORTED_PARTICIPANTS["agy"]["model"]
     assert captured["target"] == "gemini"
     assert captured["stdout_only"] is True

--- a/tests/ai_agent_bridge/test_process_routing.py
+++ b/tests/ai_agent_bridge/test_process_routing.py
@@ -1,0 +1,412 @@
+"""Regression coverage for #6915 and #6894.
+
+#6915: the generic ``process <id>`` path must derive its route from the
+message's ``To:`` seat via the live ACP participant registry (never the
+retired gemini CLI, never a hardcoded recipient), and must acknowledge the
+inbound message ONLY after a successful routed reply — a failed processing
+attempt leaves the message unconsumed/retryable.
+
+#6894: bridge model defaults derive from the live ACP participant registry
+pin, so a bare ``ask-gemini`` can never drift stale against the agy pin.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent_runtime.runner import InterAgentTransportError, resolve_inter_agent_route
+
+from scripts.ai_agent_bridge import _process
+from scripts.ai_agent_bridge._acp_compat import (
+    registered_participant_model,
+    require_compat_target,
+    resolve_compat_model,
+)
+from scripts.ai_agent_bridge._db import get_db, init_db
+from scripts.ai_agent_bridge._messaging import acknowledge, send_message
+
+
+@pytest.fixture
+def bridge_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "messages.db"
+    monkeypatch.setattr("scripts.ai_agent_bridge._config.DB_PATH", db_path)
+    monkeypatch.setattr("scripts.ai_agent_bridge._db.DB_PATH", db_path)
+    conn = init_db()
+    conn.close()
+    return db_path
+
+
+def _send(to: str, *, task_id: str = "task-6915", sender: str = "qa-engineer") -> int:
+    return send_message(
+        "Advisor note: please analyze.",
+        task_id=task_id,
+        msg_type="advisory",
+        from_llm=sender,
+        to_llm=to,
+        quiet=True,
+    )
+
+
+def _row(message_id: int):
+    conn = get_db()
+    try:
+        return conn.execute(
+            "SELECT acknowledged, status FROM messages WHERE id = ?", (message_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _replies(message_id: int, task_id: str = "task-6915"):
+    conn = get_db()
+    try:
+        return conn.execute(
+            "SELECT from_llm, to_llm, message_type, content FROM messages "
+            "WHERE task_id = ? AND id != ? ORDER BY id ASC",
+            (task_id, message_id),
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _ok_result(response: str = "routed analysis", model: str = "registry-model"):
+    return SimpleNamespace(
+        ok=True, response=response, model=model, stderr_excerpt=None,
+        transport_outcome="ok",
+    )
+
+
+# ── #6915: recipient-derived routing ────────────────────────────────────
+
+
+def test_process_routes_by_recipient_seat(bridge_db, monkeypatch, capsys):
+    """A message addressed to cursor is routed to the cursor ACP seat (#6915)."""
+    message_id = _send("cursor")
+    captured: dict[str, object] = {}
+
+    def fake_ask(target, content, **kwargs):
+        captured.update(target=target, content=content, **kwargs)
+        return _ok_result()
+
+    monkeypatch.setattr(_process, "run_compat_ask", fake_ask)
+
+    response = _process.process_message_for_recipient(message_id)
+
+    assert response == "routed analysis"
+    assert captured["target"] == "cursor"
+    assert captured["source"] == "qa-engineer"
+    # No per-command model slug: the registry pin applies downstream.
+    assert captured["model"] is None
+    assert "Cursor" in captured["content"]
+
+    acked, _status = _row(message_id)
+    assert acked == 1
+    replies = _replies(message_id)
+    assert len(replies) == 1
+    assert (replies[0][0], replies[0][1], replies[0][2]) == (
+        "cursor",
+        "qa-engineer",
+        "response",
+    )
+    assert replies[0][3] == "routed analysis"
+
+
+def test_process_gemini_recipient_resolves_to_agy_participant(bridge_db, monkeypatch):
+    """Legacy gemini-addressed mail routes to the agy participant (#6915)."""
+    message_id = _send("gemini")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        _process,
+        "run_compat_ask",
+        lambda target, content, **kwargs: captured.update(target=target, content=content, **kwargs)
+        or _ok_result(),
+    )
+
+    assert _process.process_message_for_recipient(message_id) is not None
+    assert captured["target"] == "gemini"
+    assert require_compat_target(captured["target"]) == "agy"
+
+
+def test_process_success_acks_only_after_routed_reply(bridge_db, monkeypatch):
+    """Mutation check: ack must follow the routed reply, never precede it."""
+    message_id = _send("kimi")
+    events: list[str] = []
+    monkeypatch.setattr(
+        _process,
+        "run_compat_ask",
+        lambda *a, **k: events.append("ask") or _ok_result(),
+    )
+    monkeypatch.setattr(
+        _process,
+        "acknowledge",
+        lambda *a, **k: events.append("ack"),
+    )
+
+    assert _process.process_message_for_recipient(message_id) is not None
+    assert events == ["ask", "ack"]
+
+
+# ── #6915: ack strictly conditional on success ──────────────────────────
+
+
+def test_process_failed_result_leaves_message_unconsumed(bridge_db, monkeypatch):
+    message_id = _send("cursor")
+    monkeypatch.setattr(
+        _process,
+        "run_compat_ask",
+        lambda *a, **k: SimpleNamespace(
+            ok=False, response="", model="agy", stderr_excerpt="provider exploded",
+            transport_outcome="error",
+        ),
+    )
+
+    assert _process.process_message_for_recipient(message_id) is None
+    acked, status = _row(message_id)
+    assert acked == 0  # never consumed on failure
+    assert status.startswith("failed:")
+    # Honest typed-error reply is preserved.
+    replies = _replies(message_id)
+    assert len(replies) == 1
+    assert replies[0][2] == "error"
+    assert replies[0][1] == "qa-engineer"
+    assert "NOT acknowledged" in replies[0][3]
+
+
+def test_process_transport_error_leaves_message_unconsumed(bridge_db, monkeypatch):
+    message_id = _send("agy")
+
+    def boom(*a, **k):
+        raise InterAgentTransportError("ACP participant 'agy' is unsupported")
+
+    monkeypatch.setattr(_process, "run_compat_ask", boom)
+
+    assert _process.process_message_for_recipient(message_id) is None
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+    assert _replies(message_id)[0][2] == "error"
+
+
+def test_process_empty_response_leaves_message_unconsumed(bridge_db, monkeypatch):
+    message_id = _send("cursor")
+    monkeypatch.setattr(
+        _process,
+        "run_compat_ask",
+        lambda *a, **k: _ok_result(response="   "),
+    )
+
+    assert _process.process_message_for_recipient(message_id) is None
+    acked, _status = _row(message_id)
+    assert acked == 0
+
+
+def test_process_unroutable_recipient_never_invokes(bridge_db, monkeypatch):
+    """A recipient seat with no ACP route fails loudly and stays unconsumed."""
+    message_id = _send("qwen")
+    called = False
+
+    def spy(*a, **k):
+        nonlocal called
+        called = True
+        return _ok_result()
+
+    monkeypatch.setattr(_process, "run_compat_ask", spy)
+
+    assert _process.process_message_for_recipient(message_id) is None
+    assert called is False
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+    assert _replies(message_id)[0][2] == "error"
+
+
+def test_process_already_acknowledged_message_skips(bridge_db, monkeypatch):
+    message_id = _send("cursor")
+    acknowledge(message_id, quiet=True)
+    spy_called = False
+
+    def spy(*a, **k):
+        nonlocal spy_called
+        spy_called = True
+        return _ok_result()
+
+    monkeypatch.setattr(_process, "run_compat_ask", spy)
+
+    assert _process.process_message_for_recipient(message_id) is None
+    assert spy_called is False
+
+
+# ── #6894: model defaults derive from the live registry pin ─────────────
+
+
+def test_ask_gemini_default_model_is_none_so_registry_pin_applies() -> None:
+    """A bare ask-gemini carries no model slug; the route applies the pin."""
+    from scripts.ai_agent_bridge import _cli
+
+    parser = _cli._build_parser()
+    args = parser.parse_args(["ask-gemini", "hello", "--task-id", "t-1"])
+    assert args.model is None
+    assert resolve_compat_model("gemini", args.model) is None
+    # The route resolver then applies the live pin — and accepts it.
+    route = resolve_inter_agent_route("agy")
+    assert route.model == registered_participant_model("agy")
+
+
+def test_resolve_compat_model_tracks_pin_rotation(monkeypatch) -> None:
+    """Rotating the registry pin moves every legacy default with it (#6894)."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS, "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    assert registered_participant_model("agy") == "gemini-9.9-flash-high"
+    assert resolve_compat_model("gemini", "gemini-3-flash-preview") == "gemini-9.9-flash-high"
+    assert resolve_compat_model("gemini", "gemini-3.7-flash") == "gemini-9.9-flash-high"
+    # Non-legacy slugs pass through for the route resolver to judge loudly.
+    assert resolve_compat_model("gemini", "not-a-gemini-model") == "not-a-gemini-model"
+    # Non-agy seats never get rewritten.
+    assert resolve_compat_model("cursor", "composer-2") == "composer-2"
+
+
+def test_process_model_override_must_match_registry(bridge_db, monkeypatch):
+    """Explicit overrides pass through to registry validation (loud mismatch)."""
+    message_id = _send("cursor")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        _process,
+        "run_compat_ask",
+        lambda target, content, **kwargs: captured.update(**kwargs) or _ok_result(),
+    )
+
+    assert _process.process_message_for_recipient(message_id, model="composer-2") is not None
+    assert captured["model"] == "composer-2"
+
+
+# ── #6915 sibling sweep: every process-* error handler is ack-free ──────
+
+
+def test_legacy_gemini_error_handler_never_acks(bridge_db):
+    from scripts.ai_agent_bridge import _gemini
+
+    message_id = _send("gemini")
+    _gemini._send_gemini_error(
+        {"task_id": "task-6915", "from": "qa-engineer"}, message_id
+    )
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+    assert _replies(message_id)[0][2] == "error"
+
+
+@pytest.mark.parametrize("seat", ["claude", "codex", "grok", "kimi", "agy"])
+def test_native_error_handlers_never_ack(bridge_db, seat):
+    """Mutation check: removing the no-ack guard turns every one of these red."""
+    from scripts.ai_agent_bridge import _agy, _claude, _codex, _grok_build, _kimi
+
+    message_id = _send(seat)
+    msg = {
+        "id": message_id,
+        "task_id": "task-6915",
+        "from": "qa-engineer",
+        "to": seat,
+        "type": "advisory",
+        "content": "x",
+        "data": None,
+    }
+    if seat == "claude":
+        _claude._handle_claude_error(msg, message_id, "boom")
+    elif seat == "codex":
+        _codex._handle_codex_error(msg, message_id, "boom")
+    elif seat == "grok":
+        _grok_build._handle_grok_build_error(msg, message_id, "boom")
+    elif seat == "kimi":
+        _kimi._handle_kimi_error(msg, message_id, "boom")
+    elif seat == "agy":
+        _agy._handle_agy_error(msg, message_id, "boom")
+
+    acked, status = _row(message_id)
+    assert acked == 0, f"{seat} error handler consumed a failed message"
+    assert status.startswith("failed:")
+    assert _replies(message_id)[0][2] == "error"
+
+
+def test_claude_fallback_error_never_acks(bridge_db):
+    from scripts.ai_agent_bridge import _claude
+
+    message_id = _send("claude")
+    _claude._send_claude_fallback_error(
+        {"task_id": "task-6915", "from": "qa-engineer"}, message_id
+    )
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+
+
+def test_grok_incomplete_turn_never_acks(bridge_db):
+    from scripts.ai_agent_bridge import _grok_build
+
+    message_id = _send("grok")
+    msg = {
+        "id": message_id, "task_id": "task-6915", "from": "qa-engineer",
+        "to": "grok", "type": "advisory", "content": "x", "data": None,
+    }
+    _grok_build._handle_grok_build_incomplete_turn(
+        msg,
+        message_id,
+        "partial text",
+        {"outcome": "cancelled", "cancellation_category": "timeout"},
+        actual_model="grok-4.6",
+        effort="high",
+    )
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+
+
+def test_opencode_incomplete_turn_never_acks(bridge_db):
+    from scripts.ai_agent_bridge import _opencode
+
+    message_id = _send("glm")
+    msg = {
+        "id": message_id, "task_id": "task-6915", "from": "qa-engineer",
+        "to": "glm", "type": "advisory", "content": "x", "data": None,
+    }
+    _opencode._handle_opencode_incomplete_turn(
+        msg,
+        message_id,
+        "glm",
+        "",
+        SimpleNamespace(
+            outcome="timeout", cancellation_category=None, reason="hard timeout"
+        ),
+        actual_model="glm-5.3",
+        effort="high",
+    )
+    acked, status = _row(message_id)
+    assert acked == 0
+    assert status.startswith("failed:")
+
+
+def test_process_all_gemini_counts_failures_without_consuming(bridge_db, monkeypatch, capsys):
+    """Batch drain: a failed message stays in the inbox and is counted failed."""
+    from scripts.ai_agent_bridge import _cli
+
+    ok_id = _send("gemini", task_id="task-ok")
+    bad_id = _send("gemini", task_id="task-bad")
+
+    def fake_process(message_id, *, model=None):
+        return "done" if message_id == ok_id else None
+
+    monkeypatch.setattr(_cli, "process_message_for_recipient", fake_process)
+    _cli.process_all_gemini()
+
+    assert _row(bad_id)[0] == 0
+    out = capsys.readouterr().out
+    assert "1 succeeded, 1 failed" in out

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -759,7 +759,10 @@ def test_rate_limit_error_defers_message(bridge_db):
     assert int(reply[6]) == 0
 
 
-def test_other_errors_still_ack_inbound(bridge_db):
+def test_other_errors_leave_inbound_unconsumed(bridge_db):
+    """#6915: a stalled Codex run no longer acks the inbound message — the
+    message stays unconsumed/retryable while the sender still gets the honest
+    error reply."""
     task_id = "issue-1183-stalled"
     message_id = send_message(
         "Please handle stall",
@@ -786,14 +789,16 @@ def test_other_errors_still_ack_inbound(bridge_db):
     ):
         process_for_codex(message_id)
 
-    assert _message_acknowledged(message_id) == 1
+    # New contract (#6915): no ack on failure — the inbound message stays
+    # unconsumed/retryable, same as the rate-limited path above.
+    assert _message_acknowledged(message_id) == 0
 
     rows = _task_messages(task_id)
     assert len(rows) == 2
     reply = rows[1]
     assert reply[3] == "codex-bridge-error"
     assert "[Bridge Error] Codex CLI failed:" in reply[5]
-    # Re-prove inbound-ack guarantee: inbound message_id was acked (1 above), error reply is NOT acked (0)
+    # The error reply is itself NOT acked.
     assert int(reply[6]) == 0
 
 

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -429,10 +429,12 @@ class TestSendGeminiError:
         with (
             patch("scripts.ai_agent_bridge._gemini.send_message", return_value=99) as sm,
             patch("scripts.ai_agent_bridge._gemini.acknowledge") as ack,
+            patch("scripts.ai_agent_bridge._gemini.record_ask_failure"),
         ):
             f(msg, 42)
             sm.assert_called_once()
-            ack.assert_called_once_with(42)
+            # #6915: a failed processing must NOT consume the inbound message.
+            ack.assert_not_called()
 
     def test_exception_suppressed(self):
         f = self._import()

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -13,6 +13,7 @@ from agent_runtime.errors import RateLimitedError
 from agent_runtime.result import Result
 from batch_gemini_config import FALLBACK_MODEL, PRO_MODEL
 
+from scripts.ai_agent_bridge._acp_compat import registered_participant_model
 from scripts.ai_agent_bridge._cli import _handle_ask_gemini
 from scripts.ai_agent_bridge._db import get_db, init_db
 from scripts.ai_agent_bridge._gemini import _run_gemini_sync
@@ -251,6 +252,8 @@ def test_handle_ask_gemini_routes_to_agy(monkeypatch):
     _handle_ask_gemini(_Args())
     assert captured["args"] == ("gemini", "hello")
     assert captured["kwargs"]["task_id"] == "task-1"
-    assert captured["kwargs"]["model"] == "gemini-3.6-flash-high"
+    # #6894: legacy gemini* slugs map to the live registry pin, so assert
+    # against that pin — never a literal slug that goes stale on rotation.
+    assert captured["kwargs"]["model"] == registered_participant_model("agy")
     assert captured["kwargs"]["stdout_only"] is False
     assert captured["kwargs"]["output_path"] is None


### PR DESCRIPTION
Fixes #6915
Fixes #6894

## Root cause (one family, both issues)

Bridge legacy paths carried their own hardcoded routing/model state that drifted from the live ACP participant registry (`ACPX_SUPPORTED_PARTICIPANTS`, `scripts/agent_runtime/adapters/acpx.py:585`).

## Reproductions (unit level, before → after)

**#6915** — cursor-addressed advisor note from qa-engineer, transport fails:
- Before: routed to the retired gemini CLI with `gemini-3-flash-preview` regardless of `To: cursor`; sent `[Bridge Error]` reply AND `✓ Message acknowledged` — `acked=1` after total failure.
- After: `Routing message #N to ACP participant 'cursor' (recipient seat 'cursor', model=registry pin)...` → failure leaves `acked=0`, typed error reply still sent, status recorded `failed:...`. Success path: routed reply delivered to sender, then ack.

**#6894** — bare `ask-gemini`:
- Before: default `--model = 'gemini-3-flash-preview'` → `InterAgentTransportError: ACP participant 'agy' only supports its registered model pin 'gemini-3.7-flash-high'`.
- After: default is `None` → the route resolver applies the live registry pin (`route accepted with registry pin: 'gemini-3.7-flash-high'`); legacy `gemini*` slugs map to the current pin.

## Changes

- **New `scripts/ai_agent_bridge/_process.py`** — `process_message_for_recipient`: derives the route from the message's `To:` seat via `_acp_compat` (same layer the ask-* ACP routes use), defaults model to the registry pin, acks only after a successful routed reply, leaves failures unconsumed/retryable with the honest typed-error reply preserved. Already-acked messages are skipped.
- **`_cli.py`** — `process`, `process-all`, and interactive `process` rewired to the recipient-derived processor; `--model` defaults removed (`None` = registry pin); static `_LEGACY_GEMINI_TO_AGY_MODEL` table deleted; `ask-gemini` maps legacy slugs via `resolve_compat_model`; `ask-agy --to-model` help no longer hardcodes the pin.
- **`_acp_compat.py`** — new `registered_participant_model` / `resolve_compat_model`: defaults derive from the live registry; pin rotation is covered by test (simulated rotation moves every legacy default with it).
- **`_agy.py`** — `_DEFAULT_AGY_MODEL` hardcode replaced by `_default_agy_model()` reading the registry pin.
- **Ack-on-failure sweep (all process-* variants audited):** removed `acknowledge()` from every failure handler — `_gemini._send_gemini_error`, `_claude` (rate-limit/timeout/unavailable/review-checkout/generic/fallback), `_codex._handle_codex_error`, `_grok_build` error + incomplete-turn, `_kimi._handle_kimi_error`, `_agy._handle_agy_error`, `_opencode` incomplete-turn. All retain the typed error reply + `record_ask_failure`. `_cursor`/`_hermes` already raised without acking. Stuck rows remain reclaimable via `broker_cleanup --max-age`.

## Tests

- New `tests/ai_agent_bridge/test_process_routing.py` (21 tests): recipient-derived routing (cursor, gemini→agy), ack-only-after-reply ordering, failure/exception/empty-response/unroutable-recipient all leave the message unconsumed, already-acked skip, registry-pin default, simulated pin rotation, per-seat error-handler no-ack sweep.
- Mutation-checked: re-adding `acknowledge()` to a failure path turns 3+ of these tests red (verified for `_process._notify_processing_failure` and `_codex._handle_codex_error`).
- Updated `test_ab_discuss_bugs.py` (mapping now asserts live pin) and `test_coverage_misc.py` (`_send_gemini_error` must not ack).

## Verification

- `pytest tests/ai_agent_bridge/ tests/test_coverage_misc.py tests/test_kimi_integration.py tests/test_legacy_bridge_telemetry.py tests/agent_runtime/test_acpx_adapter.py` → **739 passed, 1 failed**; `tests/agent_runtime/ tests/test_dispatch_telemetry.py` → **394 passed, 2 failed**. All 3 failures reproduce on unmodified `main` in this worktree (`sealed_acp_python_missing` and 2 agy writer-prompt tests — environmental: dispatch worktrees have no `.venv`, which the worktree contract forbids creating).
- `ruff check` clean on all touched files.

## Known residuals (out of scope, not regressions)

- `converse` still uses the module-level legacy gemini path with a hardcoded `gemini-3.1-pro-preview` default — same drift class, but it is neither a `process-*` variant nor an `ask-*` seat.
- qa-engineer's reply surface (send-only identity) stays as-is: error replies to QA land in the broker while QA's monitored surface is its GitHub loci; deciding QA's reply surface explicitly is a policy call left to the operator (see #6915 comment).

No auto-merge armed; workers neither merge nor arm.
