### PR TITLE
fix(ci): use merge-base scope for frontend cheap-exit on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,13 +728,23 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # fetch-depth: 0 (full history) so merge-base(base, head) resolves for
+      # PR/merge_group scope (#6930). Do not shallow this job without also
+      # deepening/fetching the base ref in the scope step.
       - name: Decide whether frontend work is in scope
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          # Event head — not checkout HEAD. PR checkouts are the merge commit;
+          # three-dot/merge-base against that invents main-side denominator hits.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          python3 scripts/ci/frontend_change_scope.py --base "${BASE_SHA:-}"
+          python3 scripts/ci/frontend_change_scope.py \
+            --base "${BASE_SHA:-}" \
+            --head "${HEAD_SHA:-HEAD}" \
+            --event "${EVENT_NAME:-}"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.scope.outputs.run == 'true'
@@ -820,15 +830,20 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # Same denominator / cheap-exit as `frontend` (#6917). Not in
+      # Same denominator / cheap-exit as `frontend` (#6917 / #6930). Not in
       # ci-gate.needs — the win is runner slots, not the merge bit.
       - name: Decide whether frontend work is in scope
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          python3 scripts/ci/frontend_change_scope.py --base "${BASE_SHA:-}"
+          python3 scripts/ci/frontend_change_scope.py \
+            --base "${BASE_SHA:-}" \
+            --head "${HEAD_SHA:-HEAD}" \
+            --event "${EVENT_NAME:-}"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.scope.outputs.run == 'true'

--- a/scripts/ci/frontend_change_scope.py
+++ b/scripts/ci/frontend_change_scope.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Frontend / frontend-e2e changed-path scope for CI cheap-exit (#6917).
+"""Frontend / frontend-e2e changed-path scope for CI cheap-exit (#6917 / #6930).
 
 Required jobs stay unconditionally scheduled. After checkout, this helper
 decides whether the diff touches the single-source denominator. Out of scope
 → exit 0 with a loud auditable decision (job stays ``success``). In scope →
 continue the remaining job steps.
+
+PR / merge_group events use merge-base range semantics against the *event*
+head SHA (not the synthetic merge-commit checkout). Push keeps linear
+two-dot ``before..after``. Unresolvable merge-base fails open to ``run``.
 
 Stdlib only so GitHub runners can invoke it with system ``python3`` before
 ``actions/setup-python``.
@@ -25,10 +29,18 @@ DENOMINATOR_REL = "scripts/ci/frontend_change_denominator.json"
 PACKAGE_JSON_REL = "site/package.json"
 HYDRATE_ROOT_SCRIPT = "hydrate"
 
+# pull_request / merge_group: only the branch side of the fork counts (#6930).
+# push: linear before..after two-dot (three-dot would be wrong on non-ancestry).
+_MERGE_BASE_EVENTS = frozenset({"pull_request", "merge_group"})
+
 _NPM_RUN_RE = re.compile(r"\bnpm\s+run\s+([A-Za-z0-9:_-]+)")
 _NODE_SCRIPT_RE = re.compile(r"\bnode(?:\s+--experimental-strip-types)?\s+(\./scripts/[^\s]+|scripts/[^\s]+)")
 _PYTHON_MODULE_RE = re.compile(r"(?:^|[\s\"'])-m\s+(scripts(?:\.[A-Za-z0-9_]+)+)")
 _PYTHON_FILE_RE = re.compile(r"(?:^|[\s\"'])(scripts/[A-Za-z0-9_./-]+\.py)\b")
+
+
+class MergeBaseError(RuntimeError):
+    """Raised when ``git merge-base`` cannot resolve (shallow clone, missing refs)."""
 
 
 def repo_root() -> Path:
@@ -70,8 +82,61 @@ def matching_paths(changed: Iterable[str], patterns: Sequence[str]) -> list[str]
     return sorted({path for path in changed if path_in_denominator(path, patterns)})
 
 
+def range_mode_for_event(event_name: str) -> str:
+    """Map ``github.event_name`` to diff range mode."""
+    return "merge-base" if (event_name or "").strip() in _MERGE_BASE_EVENTS else "two-dot"
+
+
 def comparison_range(base: str, head: str = "HEAD") -> str:
+    """Legacy three-dot helper (merge-base semantics). Prefer ``resolve_git_range``."""
     return base if "..." in base else f"{base}...{head}"
+
+
+def two_dot_range(base: str, head: str = "HEAD") -> str:
+    """Linear ``base..head`` tree/range diff for push events."""
+    if ".." in base:
+        return base
+    return f"{base}..{head}"
+
+
+def git_merge_base(base: str, head: str, *, cwd: Path | None = None) -> str:
+    """Return the merge-base SHA, or raise ``MergeBaseError`` if unresolvable."""
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", base, head],
+            check=True,
+            capture_output=True,
+            text=True,
+            # Prefer process cwd (CI checkout / test fixture) over this file's tree.
+            cwd=cwd or Path.cwd(),
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip() or f"exit={exc.returncode}"
+        raise MergeBaseError(detail) from exc
+    mb = (result.stdout or "").strip()
+    if not mb:
+        raise MergeBaseError("empty merge-base")
+    return mb
+
+
+def resolve_git_range(
+    base: str,
+    head: str = "HEAD",
+    *,
+    mode: str = "merge-base",
+    cwd: Path | None = None,
+) -> str:
+    """Build the ``git diff`` range for the event mode.
+
+    ``merge-base``: ``$(git merge-base base head)..head`` (PR / merge_group).
+    ``two-dot``: ``base..head`` (push linear history).
+    """
+    if mode == "two-dot":
+        return two_dot_range(base, head)
+    if "..." in base:
+        return base
+    mb = git_merge_base(base, head, cwd=cwd)
+    return f"{mb}..{head}"
 
 
 def _parse_nul_delimited_paths(raw: bytes) -> list[str]:
@@ -95,7 +160,7 @@ def changed_files(git_range: str, *, cwd: Path | None = None) -> list[str]:
         ],
         check=True,
         capture_output=True,
-        cwd=cwd or repo_root(),
+        cwd=cwd or Path.cwd(),
     )
     return _parse_nul_delimited_paths(result.stdout)
 
@@ -222,7 +287,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         default="",
         help="base SHA/ref (pull_request.base.sha || merge_group.base_sha || before)",
     )
-    parser.add_argument("--head", default="HEAD", help="head SHA/ref (default: HEAD)")
+    parser.add_argument(
+        "--head",
+        default="HEAD",
+        help=(
+            "head SHA/ref (pull_request.head.sha || merge_group.head_sha || github.sha). "
+            "Must be the event head — not the PR merge commit checkout HEAD (#6930)."
+        ),
+    )
+    parser.add_argument(
+        "--event",
+        default="",
+        help="github.event_name: pull_request|merge_group → merge-base; push → two-dot",
+    )
     parser.add_argument(
         "--denominator",
         type=Path,
@@ -233,6 +310,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     denominator = load_denominator(args.denominator)
     base = (args.base or "").strip()
+    head = (args.head or "HEAD").strip() or "HEAD"
+    mode = range_mode_for_event(args.event)
     if not base or set(base) == {"0"}:
         line = decision_line(
             decision="run",
@@ -248,7 +327,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     try:
-        changed = changed_files(comparison_range(base, args.head))
+        git_range = resolve_git_range(base, head, mode=mode)
+        changed = changed_files(git_range)
+    except MergeBaseError:
+        line = (
+            f"frontend-scope: decision=run denominator_version={denominator['version']} "
+            f"changed_files=-1 matched=-1 reason=merge_base_unresolvable mode={mode}"
+        )
+        print(line, file=sys.stderr)
+        write_step_summary(line)
+        write_github_output(True)
+        return 0
     except subprocess.CalledProcessError as exc:
         line = (
             f"frontend-scope: decision=run denominator_version={denominator['version']} "

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -1,4 +1,4 @@
-"""Drift guard + unit coverage for frontend CI cheap-exit (#6917)."""
+"""Drift guard + unit coverage for frontend CI cheap-exit (#6917 / #6930)."""
 
 from __future__ import annotations
 
@@ -16,6 +16,68 @@ from scripts.ci import frontend_change_scope as scope
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CI = _REPO_ROOT / ".github/workflows/ci.yml"
 _DENOMINATOR = _REPO_ROOT / scope.DENOMINATOR_REL
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=cwd, text=True).strip()
+
+
+def _init_fixture_repo(root: Path) -> dict[str, str]:
+    """Build a mini repo that reproduces the #6930 moved-base over-count.
+
+    Returns SHAs: fork_point, base_tip (main after denom advance), branch_head
+    (out-of-scope only), branch_head_in_scope (touches site/).
+    """
+    _git(root, "init")
+    _git(root, "config", "user.email", "ci@example.com")
+    _git(root, "config", "user.name", "ci")
+    (root / "docs").mkdir()
+    (root / "site").mkdir()
+    (root / "docs" / "a.md").write_text("docs\n", encoding="utf-8")
+    (root / "site" / "index.html").write_text("site\n", encoding="utf-8")
+    denom = {
+        "schema_version": "frontend_change_denominator_v1",
+        "version": "1",
+        "paths": ["site/", "scripts/lexicon/"],
+    }
+    (root / "scripts" / "ci").mkdir(parents=True)
+    (root / "scripts" / "ci" / "frontend_change_denominator.json").write_text(
+        json.dumps(denom),
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", "root")
+    fork = _git(root, "rev-parse", "HEAD")
+    _git(root, "branch", "-M", "main")
+
+    _git(root, "checkout", "-b", "feature")
+    (root / "docs" / "feature.md").write_text("feature only\n", encoding="utf-8")
+    _git(root, "add", "docs/feature.md")
+    _git(root, "commit", "-m", "feature docs")
+    branch_out = _git(root, "rev-parse", "HEAD")
+
+    (root / "site" / "extra.html").write_text("in scope\n", encoding="utf-8")
+    _git(root, "add", "site/extra.html")
+    _git(root, "commit", "-m", "feature site")
+    branch_in = _git(root, "rev-parse", "HEAD")
+
+    # Reset feature tip to out-of-scope-only for the cheap_exit scenario, but
+    # keep branch_in SHA reachable via the object store.
+    _git(root, "reset", "--hard", branch_out)
+
+    _git(root, "checkout", "main")
+    (root / "site" / "package.json").write_text('{"name":"moved-base"}\n', encoding="utf-8")
+    _git(root, "add", "site/package.json")
+    _git(root, "commit", "-m", "main advances with denominator file")
+    base_tip = _git(root, "rev-parse", "HEAD")
+
+    return {
+        "fork": fork,
+        "base_tip": base_tip,
+        "branch_out": branch_out,
+        "branch_in": branch_in,
+        "denominator": str(root / "scripts" / "ci" / "frontend_change_denominator.json"),
+    }
 
 
 def test_denominator_is_single_source_and_loadable() -> None:
@@ -110,12 +172,175 @@ def test_git_diff_failed_writes_step_summary(tmp_path: Path, monkeypatch: pytest
     def boom(*_args: object, **_kwargs: object) -> None:
         raise subprocess.CalledProcessError(128, ["git", "diff"])
 
-    with patch.object(scope, "changed_files", side_effect=boom):
-        assert scope.main(["--base", "abc123"]) == 0
+    with (
+        patch.object(scope, "resolve_git_range", return_value="abc...HEAD"),
+        patch.object(scope, "changed_files", side_effect=boom),
+    ):
+        assert scope.main(["--base", "abc123", "--event", "pull_request"]) == 0
 
     text = summary.read_text(encoding="utf-8")
     assert "reason=git_diff_failed" in text
     assert "decision=run" in text
+
+
+def test_range_mode_for_event() -> None:
+    assert scope.range_mode_for_event("pull_request") == "merge-base"
+    assert scope.range_mode_for_event("merge_group") == "merge-base"
+    assert scope.range_mode_for_event("push") == "two-dot"
+    assert scope.range_mode_for_event("") == "two-dot"
+
+
+def test_moved_base_out_of_scope_cheap_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#6930: main advanced with a denominator file; branch only docs → cheap_exit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shas = _init_fixture_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    two_dot = scope.changed_files(f"{shas['base_tip']}..{shas['branch_out']}", cwd=repo)
+    mb_range = scope.resolve_git_range(
+        shas["base_tip"],
+        shas["branch_out"],
+        mode="merge-base",
+        cwd=repo,
+    )
+    merge_base_files = scope.changed_files(mb_range, cwd=repo)
+
+    # Quote the over-count: two-dot includes main's site/package.json.
+    assert "site/package.json" in two_dot
+    assert "docs/feature.md" in two_dot
+    assert "site/package.json" not in merge_base_files
+    assert merge_base_files == ["docs/feature.md"]
+
+    assert (
+        scope.main(
+            [
+                "--base",
+                shas["base_tip"],
+                "--head",
+                shas["branch_out"],
+                "--event",
+                "pull_request",
+                "--denominator",
+                shas["denominator"],
+            ],
+        )
+        == 0
+    )
+
+
+def test_moved_base_out_of_scope_prints_cheap_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shas = _init_fixture_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    scope.main(
+        [
+            "--base",
+            shas["base_tip"],
+            "--head",
+            shas["branch_out"],
+            "--event",
+            "pull_request",
+            "--denominator",
+            shas["denominator"],
+        ],
+    )
+    out = capsys.readouterr().out
+    assert "decision=cheap_exit" in out
+    assert "matched=0" in out
+
+
+def test_moved_base_branch_touches_denominator_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Inverse: branch itself touches site/ after base moved → run."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shas = _init_fixture_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    scope.main(
+        [
+            "--base",
+            shas["base_tip"],
+            "--head",
+            shas["branch_in"],
+            "--event",
+            "pull_request",
+            "--denominator",
+            shas["denominator"],
+        ],
+    )
+    out = capsys.readouterr().out
+    assert "decision=run" in out
+    assert "matched=" in out
+    assert "matched=0" not in out
+
+
+def test_two_dot_mutation_defeats_moved_base_cheap_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mutation check: force two-dot on a PR-shaped event → cheap_exit guard fails."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shas = _init_fixture_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    with patch.object(scope, "range_mode_for_event", return_value="two-dot"):
+        scope.main(
+            [
+                "--base",
+                shas["base_tip"],
+                "--head",
+                shas["branch_out"],
+                "--event",
+                "pull_request",
+                "--denominator",
+                shas["denominator"],
+            ],
+        )
+    out = capsys.readouterr().out
+    # Two-dot sees main's site/package.json → falsely decides run.
+    assert "decision=run" in out
+    assert "matched=0" not in out
+
+
+def test_merge_base_unresolvable_fails_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    with patch.object(scope, "git_merge_base", side_effect=scope.MergeBaseError("shallow")):
+        assert scope.main(["--base", "abc123", "--head", "def456", "--event", "pull_request"]) == 0
+
+    text = summary.read_text(encoding="utf-8")
+    assert "reason=merge_base_unresolvable" in text
+    assert "decision=run" in text
+
+
+def test_push_event_uses_two_dot_range(tmp_path: Path) -> None:
+    assert scope.resolve_git_range("aaa", "bbb", mode="two-dot", cwd=tmp_path) == "aaa..bbb"
 
 
 def test_resolve_hydrate_entrypoints_from_package_json() -> None:
@@ -169,6 +394,12 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
         assert "pull_request.base.sha" in scope_step["env"]["BASE_SHA"]
         assert "merge_group.base_sha" in scope_step["env"]["BASE_SHA"]
         assert "github.event.before" in scope_step["env"]["BASE_SHA"]
+        assert "pull_request.head.sha" in scope_step["env"]["HEAD_SHA"]
+        assert "merge_group.head_sha" in scope_step["env"]["HEAD_SHA"]
+        assert "github.sha" in scope_step["env"]["HEAD_SHA"]
+        assert scope_step["env"]["EVENT_NAME"] == "${{ github.event_name }}"
+        assert "--event" in scope_step["run"]
+        assert "--head" in scope_step["run"]
 
         checkout = steps[0]
         assert checkout["with"]["fetch-depth"] == 0

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -19,7 +19,7 @@ _DENOMINATOR = _REPO_ROOT / scope.DENOMINATOR_REL
 
 
 def _git(cwd: Path, *args: str) -> str:
-    return subprocess.check_output(["git", *args], cwd=cwd, text=True).strip()
+    return subprocess.check_output(["git", *args], cwd=cwd, text=True, timeout=30).strip()
 
 
 def _init_fixture_repo(root: Path) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- Frontend / frontend-e2e scope now uses **merge-base** range semantics for `pull_request` / `merge_group`, and keeps linear **two-dot** `before..after` for `push`.
- Scope step passes the **event head SHA** (`pull_request.head.sha` / `merge_group.head_sha`), not checkout `HEAD` (the PR merge commit). Diffing against the merge commit was the live failure mode on #6928 / run 32010756237.
- Unresolvable merge-base fails open to `decision=run`. Checkout already uses `fetch-depth: 0` (full history); comments document that shallowing this job would break merge-base unless the base ref is deepened/fetched.

## Evidence (PR #6928 refs)
- BEFORE (base…merge-commit): 30 files, denom hits `site/package.json`, `site/package-lock.json`, `scripts/lexicon/runner/atlas_job.py` → `decision=run`
- AFTER (`--event pull_request --head <pr.head.sha>`): 15 files, matched=0 → `decision=cheap_exit`
- Mutation: force two-dot on the moved-base fixture → falsely `decision=run` (guard test)

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_frontend_change_scope.py`
- [x] ruff check/format clean on owned paths
- [x] actionlint on `.github/workflows/ci.yml`
- [ ] CI green on this PR (frontend should cheap-exit if only helper/tests/workflow-scope touched — note: this PR **does** touch `.github/workflows/ci.yml`, which is in the denominator, so frontend **will run** here by design)

Fixes #6930

Made with [Cursor](https://cursor.com)