### PR TITLE
fix(bridge): resolve converse gemini default via the live registry pin

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -965,7 +965,12 @@ def _build_parser() -> argparse.ArgumentParser:
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     converse_parser.add_argument("--task-id", required=True, help="Conversation thread ID (e.g., 'a1-1-planning')")
-    converse_parser.add_argument("--model", default="gemini-3.1-pro-preview", help="Gemini model")
+    converse_parser.add_argument(
+        "--model",
+        default=None,
+        help="Legacy Gemini model slug; mapped to the AGY seat's live registry pin "
+        "(default: the pin itself — never an independently hardcoded slug)",
+    )
     converse_parser.add_argument(
         "--no-github", dest="no_github", action="store_true", help="Skip auto-posting to GitHub"
     )
@@ -1342,8 +1347,13 @@ def _dispatch_command(args):
     elif args.command == "ask-kimi":
         _handle_ask_kimi(args)
     elif args.command == "converse":
+        from ._acp_compat import resolve_compat_model
+
         content = sys.stdin.read() if args.content == "-" else args.content
-        converse_gemini(content, args.task_id, args.model, getattr(args, "no_github", False))
+        # None (the default) lets converse_gemini apply the live registry pin;
+        # legacy gemini* slugs map to that same pin (#6929).
+        selected = resolve_compat_model("gemini", getattr(args, "model", None))
+        converse_gemini(content, args.task_id, selected, getattr(args, "no_github", False))
     elif args.command == "process-all":
         process_all_gemini(args.model)
     elif args.command == "process-claude-all":

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -54,13 +54,23 @@ from ._model import _detect_model_error
 from ._prompts import build_gemini_prompt
 
 
-def converse_gemini(content: str, task_id: str, model: str = "gemini-3.1-pro-preview",
+def converse_gemini(content: str, task_id: str, model: str | None = None,
                     skip_github: bool = False, auth_mode: str | None = None):
     """Multi-turn conversation with Gemini. Includes conversation history in prompt.
 
     Each call adds to the conversation thread (via task_id) and Gemini sees
     all previous messages for context.
+
+    ``model`` defaults to the AGY seat's live ACP registry pin. Legacy
+    ``gemini*`` slugs remap through ``resolve_compat_model`` so a pin
+    rotation cannot leave converse on a stale default (#6929).
     """
+    from ._acp_compat import registered_participant_model, resolve_compat_model
+
+    selected = resolve_compat_model("gemini", model)
+    if selected is None:
+        selected = registered_participant_model("agy")
+
     history, msg_count = get_conversation_context(task_id)
 
     if history:
@@ -75,7 +85,7 @@ def converse_gemini(content: str, task_id: str, model: str = "gemini-3.1-pro-pre
 
     return ask_gemini(
         full_content, task_id=task_id, msg_type="query",
-        model=model, skip_github=skip_github, auth_mode=auth_mode,
+        model=selected, skip_github=skip_github, auth_mode=auth_mode,
     )
 
 

--- a/tests/ai_agent_bridge/test_process_routing.py
+++ b/tests/ai_agent_bridge/test_process_routing.py
@@ -275,6 +275,57 @@ def test_resolve_compat_model_tracks_pin_rotation(monkeypatch) -> None:
     assert resolve_compat_model("cursor", "composer-2") == "composer-2"
 
 
+def test_converse_default_model_is_none_so_registry_pin_applies() -> None:
+    """A bare converse carries no model slug; converse_gemini applies the pin."""
+    import inspect
+
+    from scripts.ai_agent_bridge import _cli
+    from scripts.ai_agent_bridge._gemini import converse_gemini
+
+    parser = _cli._build_parser()
+    args = parser.parse_args(["converse", "hello", "--task-id", "t-1"])
+    assert args.model is None
+    assert resolve_compat_model("gemini", args.model) is None
+    # Mutation-check: a restored hardcoded slug on either surface is a miss.
+    assert inspect.signature(converse_gemini).parameters["model"].default is None
+    route = resolve_inter_agent_route("agy")
+    assert route.model == registered_participant_model("agy")
+
+
+def test_converse_default_tracks_pin_rotation(monkeypatch) -> None:
+    """Rotating the registry pin moves converse's default with it (#6929)."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._gemini import converse_gemini
+
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS, "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_ask_gemini(*_a, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini.ask_gemini", _fake_ask_gemini
+    )
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini.get_conversation_context",
+        lambda _task_id: ("", 0),
+    )
+
+    converse_gemini("hello", "t-1")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    converse_gemini("hello", "t-1", model="gemini-3.1-pro-preview")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    converse_gemini("hello", "t-1", model="not-a-gemini-model")
+    assert captured["model"] == "not-a-gemini-model"
+
+
 def test_process_model_override_must_match_registry(bridge_db, monkeypatch):
     """Explicit overrides pass through to registry validation (loud mismatch)."""
     message_id = _send("cursor")

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -257,3 +257,52 @@ def test_handle_ask_gemini_routes_to_agy(monkeypatch):
     assert captured["kwargs"]["model"] == registered_participant_model("agy")
     assert captured["kwargs"]["stdout_only"] is False
     assert captured["kwargs"]["output_path"] is None
+
+
+def test_converse_default_model_is_none_so_registry_pin_applies() -> None:
+    """#6929: a bare converse carries no independently hardcoded slug."""
+    import inspect
+
+    from scripts.ai_agent_bridge import _cli
+    from scripts.ai_agent_bridge._acp_compat import resolve_compat_model
+    from scripts.ai_agent_bridge._gemini import converse_gemini
+
+    parser = _cli._build_parser()
+    args = parser.parse_args(["converse", "hello", "--task-id", "t-1"])
+    assert args.model is None
+    assert resolve_compat_model("gemini", args.model) is None
+    assert inspect.signature(converse_gemini).parameters["model"].default is None
+    assert registered_participant_model("agy") is not None
+
+
+def test_converse_gemini_default_tracks_pin_rotation(monkeypatch) -> None:
+    """#6929: rotating the AGY pin moves converse's default with it."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._gemini import converse_gemini
+
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_ask_gemini(*_args, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr("scripts.ai_agent_bridge._gemini.ask_gemini", _fake_ask_gemini)
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini.get_conversation_context",
+        lambda _task_id: ("", 0),
+    )
+
+    converse_gemini("hello", "t-1")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    converse_gemini("hello", "t-1", model="gemini-3.1-pro-preview")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    converse_gemini("hello", "t-1", model="not-a-gemini-model")
+    assert captured["model"] == "not-a-gemini-model"


### PR DESCRIPTION
Fixes #6929

## Root cause

Author-declared residual from PR #6928: the `converse` command still hardcoded `gemini-3.1-pro-preview` on both the CLI `--model` default and `converse_gemini()`'s signature. Same drift class as #6894 — an independently hardcoded slug that goes stale on every AGY pin rotation.

## Change

No new mechanism. Alignment onto the #6928 resolver:

- `converse --model` defaults to `None` (never an independently hardcoded slug).
- The handler runs `resolve_compat_model("gemini", model)` so legacy `gemini*` slugs remap to the live AGY pin.
- `converse_gemini()` applies that same resolver, then `registered_participant_model("agy")` when the caller omitted `--model`.

Converse path slug sweep: the only other hardcoded model strings in this path were those two defaults. Nearby `--from default="gemini"` is a seat name, not a model slug. `ask_gemini` / `process_and_respond` still default to `GEMINI_DEFAULT_MODEL` (FLASH / `gemini-2.0-flash`) — out of converse scope, not this PR.

## Tests

- Bare `converse` parser default is `None`; `converse_gemini` signature default is `None` (mutation-checked).
- Simulated pin rotation (`gemini-9.9-flash-high`) moves the converse default and remaps `gemini-3.1-pro-preview`; non-legacy slugs pass through.
- Coverage lives in `tests/ai_agent_bridge/test_process_routing.py` and the top-level flat `tests/test_gemini_bridge.py` that #6928's selection missed.

Mutation-check: restoring the hardcoded default turns all four new tests red.

## Verification

- `ruff check` clean on all touched files.
- Targeted: `tests/test_gemini_bridge.py` + `tests/test_codex_bridge.py` + `tests/ai_agent_bridge/test_process_routing.py` → **60 passed**.
- Broader `tests/ai_agent_bridge/` → **447 passed**, 1 failed: `test_sealed_acp_config_is_parent_owned_and_snapshot_pinned` (`sealed_acp_python_missing` looking for a worktree `.venv`). Same environmental failure #6928 recorded on unmodified main; worktree contract forbids creating `.venv` here.

No auto-merge armed; workers neither merge nor arm.