### PR TITLE
fix(runtime): pin grok liveness session onto plan.metadata (#6935)

### DIFF
--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -348,7 +348,6 @@ class GrokBuildAdapter:
 
         snapshot = self._reset_per_invocation_state(
             cwd=execution_cwd,
-            resume_session_id=resume_session_id,
             env_overrides={},
         )
         metadata: dict[str, object] = {
@@ -457,19 +456,21 @@ class GrokBuildAdapter:
         )
         if discovered_id and not bound:
             # Mutate the plan-owned dict (InvocationPlan is frozen, metadata
-            # contents are not) so subsequent polls keep this bind.
+            # contents are not) so subsequent polls keep this bind. Never pin
+            # onto adapter instance state — a shared adapter serving two plans
+            # would otherwise hand plan B the session id pinned for plan A.
             metadata[_META_LIVENESS_SESSION_ID] = discovered_id
-            self._liveness_session_id = discovered_id
         return paths
 
     def _bound_liveness_session_id(self, metadata: dict[str, object]) -> str | None:
-        """Return resume or pinned liveness session id, if any."""
+        """Return resume or pinned liveness session id from plan metadata only.
+
+        Instance-level bind is intentionally absent: a shared adapter can
+        poll multiple plans, and an instance pin contaminates unpinned peers
+        (#6935 FAIL delta).
+        """
         for key in (_META_RESUME_SESSION_ID, _META_LIVENESS_SESSION_ID):
             raw = metadata.get(key)
-            if isinstance(raw, str) and raw:
-                return raw
-        for attr in ("_resume_session_id", "_liveness_session_id"):
-            raw = getattr(self, attr, None)
             if isinstance(raw, str) and raw:
                 return raw
         return None
@@ -494,12 +495,9 @@ class GrokBuildAdapter:
         self,
         *,
         cwd: Path,
-        resume_session_id: str | None,
         env_overrides: dict[str, str],
     ) -> set[Path]:
         """Snapshot pre-existing cwd-scoped session dirs before launch."""
-        self._resume_session_id = resume_session_id
-        self._liveness_session_id = resume_session_id
         self._session_dir_snapshot = self._snapshot_preexisting_session_dirs(
             cwd, env_overrides=env_overrides
         )

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -106,6 +106,15 @@ _TRAIL_ISOLATION_TOOL_CONFIG_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# plan.metadata keys for liveness bind (#6935). Snapshot is the set of
+# cwd-scoped session *directory names* that already existed at
+# build_invocation; once a post-snapshot child is discovered, its id is
+# pinned so later same-cwd peers cannot steal the bind and a plan-only
+# poller can reproduce it without adapter instance state.
+_META_RESUME_SESSION_ID = "resume_session_id"
+_META_LIVENESS_SESSION_ID = "liveness_session_id"
+_META_LIVENESS_SNAPSHOT = "liveness_session_dir_snapshot"
+
 
 def validate_grok_effort(effort: str | None) -> str | None:
     """Return a native Grok effort after enforcing its CLI vocabulary.
@@ -337,14 +346,26 @@ class GrokBuildAdapter:
             effective_effort,
         )
 
-        self._reset_per_invocation_state(
+        snapshot = self._reset_per_invocation_state(
             cwd=execution_cwd,
             resume_session_id=resume_session_id,
             env_overrides={},
         )
-        liveness_paths = self._liveness_paths_for_cwd(
+        metadata: dict[str, object] = {
+            "entire_fleet": {
+                "requested_model": requested_model,
+                "actual_model": requested_model,
+            },
+            _META_RESUME_SESSION_ID: resume_session_id,
+            # Plan-owned snapshot so a plan-only / split-instance poller can
+            # exclude pre-existing same-cwd peers without adapter instance
+            # state (#6935).
+            _META_LIVENESS_SNAPSHOT: sorted(path.name for path in snapshot),
+        }
+        liveness_paths, _discovered = self._liveness_paths_for_cwd(
             execution_cwd,
-            resume_session_id=resume_session_id,
+            bound_session_id=resume_session_id,
+            snapshot=snapshot,
             env_overrides={},
         )
 
@@ -355,13 +376,7 @@ class GrokBuildAdapter:
             output_file=None,
             env_overrides={},
             liveness_paths=liveness_paths,
-            metadata={
-                "entire_fleet": {
-                    "requested_model": requested_model,
-                    "actual_model": requested_model,
-                },
-                "resume_session_id": resume_session_id,
-            },
+            metadata=metadata,
             host_harness="grok",
         )
 
@@ -416,19 +431,64 @@ class GrokBuildAdapter:
         cwd-keyed sessions parent plus this invocation's own session dir /
         ``events.jsonl`` (resume id, or a session dir created after the
         build-time snapshot).
+
+        Issue #6935: once a post-snapshot session is discovered, pin its id
+        onto ``plan.metadata`` so later same-cwd peers cannot steal the bind
+        and a plan-only poller (fresh adapter instance) can reproduce it.
+        The build-time child-name snapshot is also stored on the plan for the
+        same reason.
+
+        Startup window (accepted tradeoff vs #6933): if ``sessions_root``
+        already exists, its mtime is stale until **this** child is created.
+        Until then the only path is that parent — a hang before mkdir (auth,
+        first download) looks dead to the stall timer, which is the intended
+        direction. The mtime poller already baselines missing paths at ``0.0``,
+        so a not-yet-created ``sessions_root`` is tolerated; Grok usually
+        creates the session dir in seconds while stall timeouts are minutes.
         """
-        resume_session_id = None
-        if isinstance(plan.metadata, dict):
-            raw = plan.metadata.get("resume_session_id")
-            if isinstance(raw, str) and raw:
-                resume_session_id = raw
-        if resume_session_id is None:
-            resume_session_id = getattr(self, "_resume_session_id", None)
-        return self._liveness_paths_for_cwd(
+        metadata = plan.metadata if isinstance(plan.metadata, dict) else {}
+        bound = self._bound_liveness_session_id(metadata)
+        snapshot = self._snapshot_paths_for_plan(plan)
+        paths, discovered_id = self._liveness_paths_for_cwd(
             plan.cwd,
-            resume_session_id=resume_session_id,
+            bound_session_id=bound,
+            snapshot=snapshot,
             env_overrides=plan.env_overrides or {},
         )
+        if discovered_id and not bound:
+            # Mutate the plan-owned dict (InvocationPlan is frozen, metadata
+            # contents are not) so subsequent polls keep this bind.
+            metadata[_META_LIVENESS_SESSION_ID] = discovered_id
+            self._liveness_session_id = discovered_id
+        return paths
+
+    def _bound_liveness_session_id(self, metadata: dict[str, object]) -> str | None:
+        """Return resume or pinned liveness session id, if any."""
+        for key in (_META_RESUME_SESSION_ID, _META_LIVENESS_SESSION_ID):
+            raw = metadata.get(key)
+            if isinstance(raw, str) and raw:
+                return raw
+        for attr in ("_resume_session_id", "_liveness_session_id"):
+            raw = getattr(self, attr, None)
+            if isinstance(raw, str) and raw:
+                return raw
+        return None
+
+    def _snapshot_paths_for_plan(self, plan: InvocationPlan) -> set[Path]:
+        """Resolve the build-time session-dir snapshot for this plan.
+
+        Prefer ``plan.metadata`` so a fresh adapter instance can still exclude
+        pre-existing same-cwd peers; fall back to instance state for callers
+        that have not yet stamped the plan.
+        """
+        metadata = plan.metadata if isinstance(plan.metadata, dict) else {}
+        raw = metadata.get(_META_LIVENESS_SNAPSHOT)
+        if isinstance(raw, (list, tuple)):
+            grok_home = resolve_grok_home(env=plan.env_overrides or {})
+            sessions_root = grok_cwd_sessions_dir(grok_home, plan.cwd)
+            names = [name for name in raw if isinstance(name, str) and name]
+            return {sessions_root / name for name in names}
+        return set(getattr(self, "_session_dir_snapshot", set()) or set())
 
     def _reset_per_invocation_state(
         self,
@@ -436,12 +496,14 @@ class GrokBuildAdapter:
         cwd: Path,
         resume_session_id: str | None,
         env_overrides: dict[str, str],
-    ) -> None:
+    ) -> set[Path]:
         """Snapshot pre-existing cwd-scoped session dirs before launch."""
         self._resume_session_id = resume_session_id
+        self._liveness_session_id = resume_session_id
         self._session_dir_snapshot = self._snapshot_preexisting_session_dirs(
             cwd, env_overrides=env_overrides
         )
+        return self._session_dir_snapshot
 
     def _snapshot_preexisting_session_dirs(
         self,
@@ -463,26 +525,36 @@ class GrokBuildAdapter:
         self,
         cwd: Path,
         *,
-        resume_session_id: str | None = None,
+        bound_session_id: str | None = None,
+        snapshot: set[Path] | None = None,
         env_overrides: dict[str, str] | None = None,
-    ) -> tuple[Path, ...]:
+    ) -> tuple[tuple[Path, ...], str | None]:
+        """Return ``(liveness_paths, newly_discovered_session_id_or_None)``.
+
+        When ``bound_session_id`` is set (resume or a prior #6935 pin), watch
+        only that session dir + ``events.jsonl``. Otherwise watch
+        ``sessions_root`` as a startup signal and, once a post-snapshot child
+        appears, bind the newest one — the caller must pin that id onto
+        ``plan.metadata`` so a later same-cwd sibling cannot steal it.
+        """
         overrides = env_overrides or {}
         grok_home = resolve_grok_home(env=overrides)
         sessions_root = grok_cwd_sessions_dir(grok_home, cwd)
-        paths: list[Path] = []
 
-        if resume_session_id:
-            session_dir = grok_session_dir(grok_home, cwd, resume_session_id)
-            paths.append(session_dir)
-            paths.append(session_dir / "events.jsonl")
-            return tuple(paths)
+        if bound_session_id:
+            session_dir = grok_session_dir(grok_home, cwd, bound_session_id)
+            return (session_dir, session_dir / "events.jsonl"), None
 
         # Startup signal: a new child session directory bumps this parent.
         # Never return ``grok_home`` itself — that is the #6933 contamination
         # channel (logs/, active_sessions.json, peer sessions, …).
-        paths.append(sessions_root)
+        # Until the child mkdir, an already-existing sessions_root is a
+        # stale-only signal against the stall timer (#6935 startup window).
+        paths: list[Path] = [sessions_root]
 
-        snapshot: set[Path] = getattr(self, "_session_dir_snapshot", set()) or set()
+        known: set[Path] = set(snapshot) if snapshot is not None else (
+            set(getattr(self, "_session_dir_snapshot", set()) or set())
+        )
         try:
             children = (
                 [path for path in sessions_root.iterdir() if path.is_dir()]
@@ -492,7 +564,8 @@ class GrokBuildAdapter:
         except OSError:
             children = []
 
-        new_sessions = [path for path in children if path not in snapshot]
+        new_sessions = [path for path in children if path not in known]
+        discovered_id: str | None = None
         if new_sessions:
             def _mtime(path: Path) -> float:
                 try:
@@ -503,9 +576,10 @@ class GrokBuildAdapter:
             newest = max(new_sessions, key=_mtime)
             paths.append(newest)
             paths.append(newest / "events.jsonl")
+            discovered_id = newest.name
 
         # Preserve order while dropping duplicates.
-        return tuple(dict.fromkeys(paths))
+        return tuple(dict.fromkeys(paths)), discovered_id
 
 
 def _translate_mcp_prefix_for_grok_build(prompt: str) -> str:

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -572,3 +572,132 @@ def test_liveness_respects_grok_home_override(tmp_path, monkeypatch):
         metadata={"liveness_session_dir_snapshot": []},
     )
     assert GrokBuildAdapter().liveness_signal_paths(plan_override) == (override_root,)
+
+
+def test_liveness_shared_adapter_two_plans_no_cross_pin(tmp_path, monkeypatch):
+    """#6935 delta: shared adapter must not hand plan A's pin to unpinned plan B.
+
+    Fleet shape: both plans already built, then interleaved polls. Plan B's
+    snapshot is stamped to exclude A's session as "new" so the only way B
+    can watch A's dir is via the forbidden instance bind.
+
+    Mutation check: restoring instance ``_liveness_session_id`` /
+    ``_resume_session_id`` fallback in ``_bound_liveness_session_id`` plus
+    writing the discover pin onto ``self._liveness_session_id`` makes plan B
+    resolve to A's session id (false-LIVE contamination).
+    """
+    from urllib.parse import quote
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    grok_home = resolve_grok_home()
+    sessions_root = grok_home / "sessions" / quote(str(project.resolve()), safe="")
+
+    adapter = GrokBuildAdapter()
+    with patch(
+        "agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK
+    ):
+        plan_a = adapter.build_invocation(
+            prompt="plan A",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+        plan_b = adapter.build_invocation(
+            prompt="plan B",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+
+    # Treat A's forthcoming session as already known to B (peer / prior run),
+    # so unpinned B correctly stays on sessions_root unless instance-bound.
+    plan_b.metadata["liveness_session_dir_snapshot"] = ["plan-a-session"]
+
+    session_a = grok_session_dir(grok_home, project, "plan-a-session")
+    session_a.mkdir(parents=True)
+    (session_a / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    assert session_a in adapter.liveness_signal_paths(plan_a)
+    assert plan_a.metadata["liveness_session_id"] == "plan-a-session"
+    assert adapter.liveness_signal_paths(plan_a) == (
+        session_a,
+        session_a / "events.jsonl",
+    )
+
+    # Instance bind would hand B A's id here.
+    paths_b = adapter.liveness_signal_paths(plan_b)
+    assert paths_b == (sessions_root,)
+    assert session_a not in paths_b
+    assert "liveness_session_id" not in plan_b.metadata
+
+    session_b = grok_session_dir(grok_home, project, "plan-b-session")
+    session_b.mkdir(parents=True)
+    (session_b / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    paths_b_bound = adapter.liveness_signal_paths(plan_b)
+    assert session_b in paths_b_bound
+    assert plan_b.metadata["liveness_session_id"] == "plan-b-session"
+    assert session_a not in paths_b_bound
+    assert adapter.liveness_signal_paths(plan_b) == (
+        session_b,
+        session_b / "events.jsonl",
+    )
+    assert plan_a.metadata["liveness_session_id"] == "plan-a-session"
+
+
+def test_liveness_pinned_dir_deleted_mid_run_stays_bound(tmp_path, monkeypatch):
+    """#6935: deleted pinned session dir stays bound (false-dead OK).
+
+    Watching the missing path is preferred over re-picking a peer and going
+    false-LIVE — the stall timer will correctly treat the deleted pin as dead.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    grok_home = resolve_grok_home()
+
+    adapter = GrokBuildAdapter()
+    with patch(
+        "agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK
+    ):
+        plan = adapter.build_invocation(
+            prompt="supervised",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+
+    pinned = grok_session_dir(grok_home, project, "pinned-then-gone")
+    pinned.mkdir(parents=True)
+    (pinned / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    assert pinned in adapter.liveness_signal_paths(plan)
+    assert plan.metadata["liveness_session_id"] == "pinned-then-gone"
+    assert adapter.liveness_signal_paths(plan) == (pinned, pinned / "events.jsonl")
+
+    shutil.rmtree(pinned)
+    peer = grok_session_dir(grok_home, project, "alive-peer")
+    peer.mkdir(parents=True)
+    (peer / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    peer.touch()
+
+    after = adapter.liveness_signal_paths(plan)
+    assert after == (pinned, pinned / "events.jsonl")
+    assert peer not in after
+    assert plan.metadata["liveness_session_id"] == "pinned-then-gone"

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -365,6 +365,7 @@ def test_liveness_signal_paths_ignore_peer_session_and_shared_home(tmp_path, mon
         )
     # Peer was snapshotted at build_invocation — must not bind as ours.
     assert peer in adapter._session_dir_snapshot
+    assert "peer-session-aaaa" in plan.metadata["liveness_session_dir_snapshot"]
 
     ours = grok_session_dir(grok_home, project, "our-session-bbbb")
     ours.mkdir(parents=True)
@@ -386,6 +387,7 @@ def test_liveness_signal_paths_ignore_peer_session_and_shared_home(tmp_path, mon
     assert sessions_root in paths
     assert ours in paths
     assert our_events in paths
+    assert plan.metadata["liveness_session_id"] == "our-session-bbbb"
 
 
 def test_liveness_signal_paths_resume_binds_exact_session(tmp_path, monkeypatch):
@@ -415,3 +417,158 @@ def test_liveness_signal_paths_resume_binds_exact_session(tmp_path, monkeypatch)
     assert paths == (target, target / "events.jsonl")
     assert grok_home not in paths
     assert peer not in paths
+
+
+def test_liveness_newest_post_snapshot_cannot_steal_bound_session(tmp_path, monkeypatch):
+    """#6935: pin the first post-snapshot child; a later sibling must not steal.
+
+    Mutation check: clearing ``liveness_session_id`` and re-picking newest on
+    every poll makes ``assert later not in paths_after`` fail.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    grok_home = resolve_grok_home()
+
+    adapter = GrokBuildAdapter()
+    with patch(
+        "agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK
+    ):
+        plan = adapter.build_invocation(
+            prompt="supervised",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+
+    ours = grok_session_dir(grok_home, project, "bound-first")
+    ours.mkdir(parents=True)
+    (ours / "events.jsonl").write_text("{}\n", encoding="utf-8")
+
+    paths_first = adapter.liveness_signal_paths(plan)
+    assert ours in paths_first
+    assert plan.metadata["liveness_session_id"] == "bound-first"
+
+    # Later same-cwd peer is newer; unpinned re-pick would bind it.
+    later = grok_session_dir(grok_home, project, "later-peer")
+    later.mkdir(parents=True)
+    (later / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    # Ensure later wins a pure-mtime newest contest.
+    later.touch()
+
+    paths_after = adapter.liveness_signal_paths(plan)
+    assert paths_after == (ours, ours / "events.jsonl")
+    assert later not in paths_after
+    assert plan.metadata["liveness_session_id"] == "bound-first"
+
+
+def test_liveness_split_instance_non_resume_uses_plan_snapshot(tmp_path, monkeypatch):
+    """#6935: plan-only poller must not treat pre-existing peers as new.
+
+    Mutation check: dropping ``liveness_session_dir_snapshot`` from metadata
+    makes a fresh adapter bind the pre-existing peer before ours appears.
+    """
+    from urllib.parse import quote
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    grok_home = resolve_grok_home()
+    peer = grok_session_dir(grok_home, project, "preexisting-peer")
+    peer.mkdir(parents=True)
+    (peer / "events.jsonl").write_text("{}\n", encoding="utf-8")
+
+    builder = GrokBuildAdapter()
+    with patch(
+        "agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK
+    ):
+        plan = builder.build_invocation(
+            prompt="supervised",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+    assert "preexisting-peer" in plan.metadata["liveness_session_dir_snapshot"]
+
+    poller = GrokBuildAdapter()
+    sessions_root = grok_home / "sessions" / quote(str(project.resolve()), safe="")
+    before = poller.liveness_signal_paths(plan)
+    assert before == (sessions_root,)
+    assert peer not in before
+    assert "liveness_session_id" not in plan.metadata
+
+    ours = grok_session_dir(grok_home, project, "ours-after-build")
+    ours.mkdir(parents=True)
+    (ours / "events.jsonl").write_text("{}\n", encoding="utf-8")
+
+    after = poller.liveness_signal_paths(plan)
+    assert peer not in after
+    assert ours in after
+    assert plan.metadata["liveness_session_id"] == "ours-after-build"
+
+    # Pin must survive yet another fresh instance + a newer sibling.
+    later = grok_session_dir(grok_home, project, "even-later")
+    later.mkdir(parents=True)
+    (later / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    later.touch()
+    pinned = GrokBuildAdapter().liveness_signal_paths(plan)
+    assert pinned == (ours, ours / "events.jsonl")
+    assert later not in pinned
+
+
+def test_liveness_respects_grok_home_override(tmp_path, monkeypatch):
+    """#6935: liveness paths follow GROK_HOME (env and plan.env_overrides)."""
+    from urllib.parse import quote
+
+    default_home = tmp_path / "default-home"
+    default_home.mkdir()
+    monkeypatch.setenv("HOME", str(default_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+    custom = tmp_path / "custom-grok-home"
+    custom.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setenv("GROK_HOME", str(custom))
+    adapter = GrokBuildAdapter()
+    with patch(
+        "agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK
+    ):
+        plan = adapter.build_invocation(
+            prompt="env home",
+            mode="danger",
+            cwd=project,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+    sessions_root = custom / "sessions" / quote(str(project.resolve()), safe="")
+    assert adapter.liveness_signal_paths(plan) == (sessions_root,)
+    assert not str(sessions_root).startswith(str(default_home / ".grok"))
+
+    override_home = tmp_path / "override-grok-home"
+    override_home.mkdir()
+    override_root = override_home / "sessions" / quote(str(project.resolve()), safe="")
+    plan_override = InvocationPlan(
+        cmd=[],
+        cwd=project,
+        env_overrides={"GROK_HOME": str(override_home)},
+        metadata={"liveness_session_dir_snapshot": []},
+    )
+    assert GrokBuildAdapter().liveness_signal_paths(plan_override) == (override_root,)


### PR DESCRIPTION
## Summary
- Pin the first post-snapshot Grok session id onto `plan.metadata` once discovered, and stamp the build-time child-name snapshot on the plan, so later same-cwd peers cannot steal the liveness bind and a plan-only poller can reproduce it.
- Document the accepted pre-mkdir startup window against the stall timer (stale `sessions_root` until this child appears; missing paths already baseline at `0.0`).
- Add mutation-checked guards: newest-steals-bind, split-instance non-resume, and `GROK_HOME` / `env_overrides`.

## Changes
- `scripts/agent_runtime/adapters/grok_build.py`: metadata keys `liveness_session_id` + `liveness_session_dir_snapshot`; bound-id path after pin/resume
- `tests/test_grok_build_adapter.py`: three new #6935 guards + pin assertion on the peer/home test

## Testing
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_grok_build_adapter.py` — 36 passed
- [x] `ruff check` on touched files — clean
- [x] Mutation checks: clearing the pin lets a later sibling steal; dropping the plan snapshot lets a fresh adapter bind a preexisting peer; ignoring `GROK_HOME` resolves under `~/.grok`

## Related Issues
Fixes #6935
Refs #6934 #6933

Made with [Cursor](https://cursor.com)