### PR TITLE
fix(security): clear CodeQL stack-trace exposure in comms channel endpoint

### DIFF
--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -1360,8 +1360,10 @@ async def get_channel_endpoint(name: str):
 
     try:
         safe_name = _ch.require_safe_channel_name(name)
-    except ValueError as exc:
-        return JSONResponse(status_code=400, content={"error": str(exc)})
+    except ValueError:
+        # Stable client message only — never return exception text
+        # (CodeQL py/stack-trace-exposure).
+        return JSONResponse(status_code=400, content={"error": "invalid_channel_name"})
 
     conn = _get_db()
     if not conn:


### PR DESCRIPTION
## Summary
- `/api/comms/channels/{name}` now returns a stable `invalid_channel_name` error instead of `str(exc)` when channel-name validation fails.
- Clears open CodeQL alert [#416](https://github.com/learn-ukrainian/learn-ukrainian.github.io/security/code-scanning/416) (`py/stack-trace-exposure`).

## Test plan
- [ ] CI green
- [ ] Post-merge CodeQL on `main` closes alert #416


Made with [Cursor](https://cursor.com)