### PR TITLE
fix(delegate): ignore concurrent sibling sandboxes in read-only guard

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2279,6 +2279,11 @@ _READ_ONLY_RUNTIME_STATE_SUFFIXES = (
     ".sqlite3-wal",
 )
 _READ_ONLY_UNTRACKED_OR_IGNORED_STATUSES = frozenset({"??", "!!"})
+# Dispatch sandboxes live at ``.worktrees/dispatch/<agent>/<task>/`` (layout A).
+# Concurrent ``git worktree add`` under that prefix must not false-fail a
+# read-only task that is scanning the shared primary checkout (#6938).
+_READ_ONLY_DISPATCH_SANDBOX_PREFIX = (".worktrees", "dispatch")
+_READ_ONLY_DISPATCH_SANDBOX_ROOT_PARTS = 4  # .worktrees / dispatch / agent / task
 
 
 def _normalize_read_only_relpath(path: str) -> str:
@@ -2286,7 +2291,7 @@ def _normalize_read_only_relpath(path: str) -> str:
     normalized = path.replace("\\", "/")
     while normalized.startswith("./"):
         normalized = normalized[2:]
-    return normalized
+    return normalized.rstrip("/")
 
 
 def _is_read_only_runtime_telemetry_path(path: str) -> bool:
@@ -2314,6 +2319,45 @@ def _is_read_only_runtime_state_path(path: str) -> bool:
     if any(part in _READ_ONLY_RUNTIME_STATE_DIR_NAMES for part in parts):
         return True
     return any(normalized.endswith(suffix) for suffix in _READ_ONLY_RUNTIME_STATE_SUFFIXES)
+
+
+def _read_only_dispatch_sandbox_root(path: str) -> str | None:
+    """Return ``.worktrees/dispatch/<agent>/<task>`` when *path* is under one.
+
+    Paths outside the dispatch sandbox layout (including other ``.worktrees/``
+    entries) return ``None`` so the guard still sees them as ordinary mutations.
+    """
+    normalized = _normalize_read_only_relpath(path)
+    parts = tuple(part for part in normalized.split("/") if part and part != ".")
+    if len(parts) < _READ_ONLY_DISPATCH_SANDBOX_ROOT_PARTS:
+        return None
+    if parts[:2] != _READ_ONLY_DISPATCH_SANDBOX_PREFIX:
+        return None
+    return "/".join(parts[:_READ_ONLY_DISPATCH_SANDBOX_ROOT_PARTS])
+
+
+def _read_only_dispatch_sandbox_roots(snapshot: dict[str, str]) -> frozenset[str]:
+    """Collect dispatch sandbox roots visible in a read-only checkout snapshot."""
+    return frozenset(
+        root
+        for path in snapshot
+        if (root := _read_only_dispatch_sandbox_root(path)) is not None
+    )
+
+
+def _is_read_only_new_sibling_dispatch_sandbox_path(
+    path: str, *, before_roots: frozenset[str]
+) -> bool:
+    """Return whether *path* belongs to a sibling sandbox absent from *before*.
+
+    Only newly appeared ``.worktrees/dispatch/<agent>/<task>/`` trees are
+    exempt (#6938). A write under a sandbox root that already appeared in the
+    pre-snapshot still counts as a mutation when the root checkout can see it.
+    """
+    root = _read_only_dispatch_sandbox_root(path)
+    if root is None:
+        return False
+    return root not in before_roots
 
 
 def _is_read_only_untracked_or_ignored_status(state: str | None) -> bool:
@@ -2348,7 +2392,14 @@ def _read_only_mutation_paths(
     untracked: the runtime owns those writes, so they are not evidence that a
     read-only worker mutated the tree (#6803, #6860). Tracked paths under the
     same prefixes (including force-added files) still trip the guard.
+
+    Newly appeared sibling dispatch sandboxes under
+    ``.worktrees/dispatch/<agent>/<task>/`` are also excluded (#6938): concurrent
+    ``git worktree add`` on the shared primary checkout is not this task's
+    mutation. Writes under a sandbox that already existed in the pre-snapshot
+    remain visible.
     """
+    before_roots = _read_only_dispatch_sandbox_roots(before)
     return sorted(
         path
         for path in set(before) | set(after)
@@ -2357,6 +2408,9 @@ def _read_only_mutation_paths(
             path,
             before_state=before.get(path),
             after_state=after.get(path),
+        )
+        and not _is_read_only_new_sibling_dispatch_sandbox_path(
+            path, before_roots=before_roots
         )
     )
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2750,6 +2750,204 @@ def test_read_only_deploy_target_dir_exemption_mutation_check(monkeypatch):
     ]
 
 
+_SIBLING_DISPATCH_SANDBOX = ".worktrees/dispatch/cursor/codeql-path-injection-fix"
+_SIBLING_DISPATCH_SANDBOX_PATHS = (
+    f"{_SIBLING_DISPATCH_SANDBOX}/",
+    f"{_SIBLING_DISPATCH_SANDBOX}/README.md",
+    f"{_SIBLING_DISPATCH_SANDBOX}/scripts/foo.py",
+)
+
+
+def test_read_only_dispatch_sandbox_root_classification():
+    """#6938: only layout-A dispatch sandboxes map to a sibling-root key."""
+    assert (
+        delegate._read_only_dispatch_sandbox_root(f"{_SIBLING_DISPATCH_SANDBOX}/README.md")
+        == _SIBLING_DISPATCH_SANDBOX
+    )
+    assert (
+        delegate._read_only_dispatch_sandbox_root(f"{_SIBLING_DISPATCH_SANDBOX}/")
+        == _SIBLING_DISPATCH_SANDBOX
+    )
+    assert delegate._read_only_dispatch_sandbox_root(".worktrees/other/sandbox/file") is None
+    assert delegate._read_only_dispatch_sandbox_root("tracked.txt") is None
+    assert delegate._read_only_dispatch_sandbox_root(".worktrees/dispatch/cursor") is None
+
+
+def test_read_only_mutation_paths_ignore_new_sibling_dispatch_sandbox_only():
+    """#6938 unit half: new sibling sandbox is empty; own writes and existing-sibling writes stay."""
+    before: dict[str, str] = {}
+    after_sibling = {path: "!!" for path in _SIBLING_DISPATCH_SANDBOX_PATHS}
+    assert delegate._read_only_mutation_paths(before, after_sibling) == []
+
+    after_mixed = {**after_sibling, "tracked.txt": " M"}
+    assert delegate._read_only_mutation_paths(before, after_mixed) == ["tracked.txt"]
+
+    existing = f"{_SIBLING_DISPATCH_SANDBOX}/README.md"
+    planted = f"{_SIBLING_DISPATCH_SANDBOX}/evil.txt"
+    assert delegate._read_only_mutation_paths(
+        {existing: "!!"},
+        {existing: "!!", planted: "!!"},
+    ) == [planted]
+
+
+def test_read_only_dispatch_allows_concurrent_sibling_worktree_add(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#6938: concurrent ``git worktree add`` under ``.worktrees/`` must not fail read-only."""
+    checkout = (tmp_path / "repo-root").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+    gitignore = checkout / ".gitignore"
+    gitignore.write_text(gitignore.read_text(encoding="utf-8") + ".worktrees/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=checkout, check=True, timeout=30)
+    subprocess.run(
+        ["git", "commit", "-m", "ignore worktrees"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    # Detach HEAD so ``git worktree add -b`` can create a sibling branch without
+    # fighting the fixture branch checked out in this repo.
+    subprocess.run(
+        ["git", "checkout", "--detach", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    task_id = "read-only-concurrent-sibling-worktree"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+
+    sibling = checkout / ".worktrees" / "dispatch" / "cursor" / "codeql-path-injection-fix"
+
+    def concurrent_sibling_worktree(*_args, **_kwargs):
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                "cursor/codeql-path-injection-fix",
+                str(sibling),
+                "HEAD",
+            ],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        return _finalize_mock_result()
+
+    with patch("agent_runtime.runner.invoke", side_effect=concurrent_sibling_worktree):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="Inventory thin-mode sources without editing the tree.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["read_only_mutation_paths"] == []
+    assert state["last_error"] is None
+    assert sibling.exists()
+    post = state["read_only_checkout_post"]
+    assert any(
+        delegate._read_only_dispatch_sandbox_root(path) == _SIBLING_DISPATCH_SANDBOX
+        for path in post
+    )
+
+
+def test_read_only_dispatch_still_fails_on_task_authored_write_with_sibling_worktree(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#6938 inverse: a file the read-only task itself writes still fails the guard."""
+    checkout = (tmp_path / "repo-root").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+    gitignore = checkout / ".gitignore"
+    gitignore.write_text(gitignore.read_text(encoding="utf-8") + ".worktrees/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=checkout, check=True, timeout=30)
+    subprocess.run(
+        ["git", "commit", "-m", "ignore worktrees"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "checkout", "--detach", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    task_id = "read-only-sibling-plus-task-write"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+
+    sibling = checkout / ".worktrees" / "dispatch" / "cursor" / "codeql-path-injection-fix"
+
+    def sibling_plus_task_write(*_args, **_kwargs):
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                "cursor/codeql-path-injection-fix",
+                str(sibling),
+                "HEAD",
+            ],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        (checkout / "tracked.txt").write_text("task authored edit\n", encoding="utf-8")
+        return _finalize_mock_result()
+
+    with patch("agent_runtime.runner.invoke", side_effect=sibling_plus_task_write):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="Inventory thin-mode sources without editing the tree.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 1
+    assert state is not None
+    assert state["status"] == "failed"
+    assert state["read_only_mutation_paths"] == ["tracked.txt"]
+    assert state["last_error"] == "read-only checkout mutation detected: tracked.txt"
+    assert sibling.exists()
+
+
 def test_run_worker_does_not_flag_legitimate_noop_write_dispatch(
     tmp_tasks_dir,
     tmp_path,


### PR DESCRIPTION
## Summary
- Read-only mutation guard no longer false-fails when a concurrent sibling `git worktree add` appears under `.worktrees/dispatch/<agent>/<task>/` (#6938).
- Scoping choice: exempt only **newly appeared** layout-A sandbox roots (absent from the pre-snapshot), not a blanket `.worktrees/**` exclude — so a write into an **already-visible** sibling sandbox still trips the guard when the root checkout can see it.
- Residual: writes into a sandbox created in the same window as the concurrent add are indistinguishable from sandbox creation and are not attributed; tasks whose cwd is already inside their own worktree never see sibling paths in the snapshot anyway.

## Changes
- `scripts/delegate.py`: detect `.worktrees/dispatch/<agent>/<task>` roots; skip mutations under roots that were absent pre-run.
- `tests/test_delegate.py`: unit mutation-check + concurrent `git worktree add` stays `done` + inverse task file write still `failed`.

## Testing
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py` — 266 passed
- [x] `ruff check scripts/delegate.py tests/test_delegate.py` — clean
- [ ] Website builds without errors (`cd site && npm run build`) — N/A (delegate-only)
- [ ] Ukrainian text reviewed for naturalness — N/A

## Related Issues
Fixes #6938

Made with [Cursor](https://cursor.com)