### PR TITLE
fix(orchestration): stop worktree-cleanup launchd LWCR exit 78 (#6937)

### DIFF
--- a/docs/runbooks/launchd-inventory.md
+++ b/docs/runbooks/launchd-inventory.md
@@ -52,9 +52,11 @@ dispatch worktree.
 ### `com.learn-ukrainian.worktree-cleanup`
 
 - Purpose: Git hygiene backstop for both Learn Ukrainian repositories.
-- Program: the primary checkout's `.venv/bin/python
-  scripts/orchestration/scheduled_worktree_cleanup.py --apply` with both
-  repository roots passed explicitly.
+- Program: `/bin/bash --noprofile --norc
+  scripts/orchestration/run_scheduled_worktree_cleanup.sh --apply` with both
+  repository roots passed explicitly. The wrapper execs the primary
+  `.venv/bin/python`. `Program` must stay `/bin/bash` so a venv rebuild
+  cannot invalidate launchd LWCR (exit 78; #6937).
 - Schedule: at load and every 4 hours (`StartInterval=14400`).
 - Delete authority: removes only clean worktrees with exact merged-PR head
   evidence, the separately guarded terminal-dispatch class, and gone branches

--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -174,9 +174,13 @@ Render the plist without writing system configuration:
 .venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py render
 ```
 
-The job runs at load and every 4 hours. It uses the public checkout's exact
-`.venv/bin/python`, passes both repository roots explicitly, and persists logs
-under:
+The job runs at load and every 4 hours. launchd `Program` is `/bin/bash`
+(Apple-signed, survives a `.venv` rebuild) plus
+`scripts/orchestration/run_scheduled_worktree_cleanup.sh`, which execs the
+public checkout's `.venv/bin/python`. Pointing `Program` at the venv
+interpreter is what produced exit 78 (`Unable to get updated LWCR ... error
+0x3`) after the 2026-08-15 venv rewrite. The wrapper passes both repository
+roots explicitly and persists logs under:
 
 ```text
 ~/.codex/worktree-cleanup/logs/
@@ -204,7 +208,17 @@ Verify the persisted plist and live service:
 ```
 
 After installation, inspect the first receipt and confirm that protected
-worktrees appear as `skipped`, not `removed`.
+worktrees appear as `skipped`, not `removed`. A venv rebuild does not require
+reinstall anymore; `status` still verifies the plist still binds `Program` to
+`/bin/bash`.
+
+A red or missing scheduled run surfaces on the existing integrity canary
+(`/api/orient` `health.worktree_cleanup_integrity_ok`, plus the dispatch
+pre-flight warning). Probe:
+
+```bash
+.venv/bin/python scripts/audit/check_worktree_cleanup_integrity.py
+```
 
 ## Uninstall
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -1075,6 +1075,36 @@ def _venv_integrity_canary() -> bool:
     return ok
 
 
+def _worktree_cleanup_integrity_canary() -> bool:
+    """Read-only diagnostic for a dark/red worktree-cleanup LaunchAgent.
+
+    #6937 follow-up: launchd stopped starting the job after a venv rewrite
+    (LWCR init failure, exit 78) and no receipt landed for two days.
+    ALERT-only, same posture as `_venv_integrity_canary` — detects and
+    records, never reloads launchd. Never raises: the canary must not break
+    health collection.
+    """
+    try:
+        from scripts.audit.check_worktree_cleanup_integrity import (  # noqa: PLC0415 — script-path fallback
+            check_worktree_cleanup_integrity,
+        )
+    except ImportError:  # path-flavoured import for test/script contexts
+        from audit.check_worktree_cleanup_integrity import (  # noqa: PLC0415 — script-path fallback
+            check_worktree_cleanup_integrity,
+        )
+    try:
+        ok, message = check_worktree_cleanup_integrity(
+            PROJECT_ROOT,
+            tasks_dir=PROJECT_ROOT / "batch_state" / "tasks",
+        )
+    except Exception:
+        logger.exception("worktree-cleanup-integrity canary failed to run")
+        return True  # fail-open: don't raise a false alarm on canary error
+    if not ok:
+        logger.warning("worktree-cleanup-integrity canary: %s", message)
+    return ok
+
+
 def _collect_health_orient_data() -> dict:
     return {
         "api": True,
@@ -1086,6 +1116,7 @@ def _collect_health_orient_data() -> dict:
         "primary_integrity_ok": _primary_integrity_canary(),
         "node_modules_integrity_ok": _node_modules_integrity_canary(),
         "venv_integrity_ok": _venv_integrity_canary(),
+        "worktree_cleanup_integrity_ok": _worktree_cleanup_integrity_canary(),
     }
 
 

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -47,6 +47,8 @@ PRELOAD_MODULES = [
     "audit.check_node_modules_integrity",
     "scripts.audit.check_venv_integrity",
     "audit.check_venv_integrity",
+    "scripts.audit.check_worktree_cleanup_integrity",
+    "audit.check_worktree_cleanup_integrity",
     "scripts.build.phase_constants",
     "agent_runtime.adapters.gemini",
     "research_quality",

--- a/scripts/audit/check_worktree_cleanup_integrity.py
+++ b/scripts/audit/check_worktree_cleanup_integrity.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Detect a dark or red ``com.learn-ukrainian.worktree-cleanup`` launchd job.
+
+#6937: after the 2026-08-15 18:47 primary ``.venv`` rewrite, launchd stopped
+starting the job (``Unable to get updated LWCR ... error 0x3``, exit 78) and
+no receipt was written for two days. This probe is DETECTION ONLY, mirroring
+``check_venv_integrity.py``:
+
+- DETECT: the LaunchAgent is installed and either launchd last-exit is
+  non-zero / still needs an LWCR update, or the newest successful receipt is
+  older than two scheduled intervals (8h).
+- RECORD: every detection appends a JSONL event (same sibling watchdog
+  contract) with last-exit, LWCR flags, receipt age, and running dispatches.
+- ALERT ONLY, never repairs. Reloading launchd is an explicit operator
+  action from the merged primary checkout.
+
+Wired into the same three surfaces as the other integrity watchdogs: the
+``cmd_dispatch`` pre-dispatch warning, the post-worker sweep (both in
+``scripts/delegate.py``), and the Monitor API health-orient canary
+(``scripts/api/main.py``). Callers fail open on any probe exception.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def _load_sibling(module_name: str, filename: str):
+    """Load a sibling module by FILE PATH — see check_venv_integrity.py."""
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, Path(__file__).resolve().parent / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_check_primary_integrity = _load_sibling(
+    "_worktree_cleanup_integrity_check_primary_integrity",
+    "check_primary_integrity.py",
+)
+_append_event = _check_primary_integrity._append_event
+_resolve_main_root = _check_primary_integrity._resolve_main_root
+_running_dispatches = _check_primary_integrity._running_dispatches
+
+LABEL = "com.learn-ukrainian.worktree-cleanup"
+EX_CONFIG = 78
+# Two StartInterval periods of the 4-hour job. One missed tick is not
+# darkness; two days of no receipt is. 8h is the first "job is dark" bar.
+STALE_AFTER = timedelta(hours=8)
+_LAST_EXIT_RE = re.compile(r"last exit code = (-?\d+)")
+_LAUNCHCTL_LIVE = object()
+
+
+def plist_path(home: Path) -> Path:
+    return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def receipt_dir(home: Path) -> Path:
+    return home / ".codex" / "worktree-cleanup" / "receipts" / "v2"
+
+
+def parse_iso(raw: str) -> datetime | None:
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def parse_launchd_snapshot(text: str) -> dict[str, Any]:
+    match = _LAST_EXIT_RE.search(text)
+    return {
+        "last_exit": int(match.group(1)) if match else None,
+        "needs_lwcr_update": "needs LWCR update" in text,
+        "lwcr_init_failure": "Unable to get updated LWCR" in text,
+    }
+
+
+def latest_receipt_observed_at(receipts: Path) -> datetime | None:
+    if not receipts.is_dir():
+        return None
+    newest: datetime | None = None
+    for path in receipts.glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        raw = payload.get("observed_at")
+        if not isinstance(raw, str):
+            continue
+        parsed = parse_iso(raw)
+        if parsed is not None and (newest is None or parsed > newest):
+            newest = parsed
+    return newest
+
+
+def _launchctl_print() -> str | None:
+    try:
+        proc = subprocess.run(
+            ["/bin/launchctl", "print", f"gui/{os.getuid()}/{LABEL}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    combined = f"{proc.stdout}{proc.stderr}"
+    return combined or None
+
+
+def _age_label(age: timedelta) -> str:
+    seconds = int(age.total_seconds())
+    if seconds < 0:
+        seconds = 0
+    hours, rem = divmod(seconds, 3600)
+    minutes = rem // 60
+    if hours >= 48:
+        days, hours = divmod(hours, 24)
+        return f"{days}d{hours}h"
+    if hours:
+        return f"{hours}h{minutes}m"
+    return f"{minutes}m"
+
+
+def check_worktree_cleanup_integrity(
+    repo: Path,
+    *,
+    home: Path | None = None,
+    tasks_dir: Path | None = None,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    launchctl_text: Any = _LAUNCHCTL_LIVE,
+    platform: str | None = None,
+) -> tuple[bool, str]:
+    """Detect (never repair) a red or dark worktree-cleanup LaunchAgent.
+
+    Returns ``(ok, message)``. ``ok`` is False when the installed job's last
+    scheduled exit is non-zero, launchd still needs an LWCR update, or the
+    newest receipt is older than ``STALE_AFTER``. Callers must not block
+    dispatch or auto-reload launchd on this signal.
+    """
+    host_platform = platform if platform is not None else sys.platform
+    if not host_platform.startswith("darwin"):
+        return True, "worktree-cleanup integrity skipped (not macOS)"
+
+    main_root = _resolve_main_root(Path(repo))
+    home_root = (home or Path.home()).expanduser()
+    destination = plist_path(home_root)
+    if not destination.is_file():
+        return True, f"worktree-cleanup integrity skipped (job not installed: {destination})"
+
+    observed_now = now or datetime.now(UTC)
+    observed_now = (
+        observed_now.replace(tzinfo=UTC)
+        if observed_now.tzinfo is None
+        else observed_now.astimezone(UTC)
+    )
+
+    snapshot_text = _launchctl_print() if launchctl_text is _LAUNCHCTL_LIVE else launchctl_text
+    snapshot = parse_launchd_snapshot(snapshot_text) if snapshot_text else {
+        "last_exit": None,
+        "needs_lwcr_update": False,
+        "lwcr_init_failure": False,
+    }
+
+    last_observed = latest_receipt_observed_at(receipt_dir(home_root))
+    receipt_age = (observed_now - last_observed) if last_observed is not None else None
+    receipt_stale = last_observed is None or receipt_age >= STALE_AFTER
+    last_exit = snapshot["last_exit"]
+    launchd_red = bool(
+        snapshot["needs_lwcr_update"]
+        or snapshot["lwcr_init_failure"]
+        or (last_exit is not None and last_exit != 0)
+    )
+
+    if not launchd_red and not receipt_stale:
+        return True, (
+            f"worktree-cleanup integrity ok (last receipt {last_observed.isoformat().replace('+00:00', 'Z')})"
+        )
+
+    sdir = state_dir or (main_root / "data" / "telemetry" / "worktree-cleanup-integrity")
+    evidence: dict[str, Any] = {
+        "last_exit": last_exit,
+        "needs_lwcr_update": snapshot["needs_lwcr_update"],
+        "lwcr_init_failure": snapshot["lwcr_init_failure"],
+        "last_receipt_at": last_observed.isoformat().replace("+00:00", "Z") if last_observed else None,
+        "receipt_age_seconds": int(receipt_age.total_seconds()) if receipt_age is not None else None,
+        "plist_path": str(destination),
+        "running_dispatches": _running_dispatches(tasks_dir),
+    }
+    _append_event(sdir, "worktree_cleanup_integrity_alert", **evidence)
+
+    reasons: list[str] = []
+    if snapshot["lwcr_init_failure"] or snapshot["needs_lwcr_update"] or last_exit == EX_CONFIG:
+        reasons.append(
+            "launchd LWCR init failure (exit 78 / needs LWCR update) — Program was a "
+            "replaceable .venv python; reinstall binds Program to /bin/bash"
+        )
+    elif last_exit is not None and last_exit != 0:
+        reasons.append(f"last scheduled exit {last_exit}")
+    if last_observed is None:
+        reasons.append(f"no successful receipt under {receipt_dir(home_root)}")
+    elif receipt_stale:
+        reasons.append(
+            f"last successful receipt {last_observed.isoformat().replace('+00:00', 'Z')} "
+            f"is {_age_label(receipt_age)} old (stale after {_age_label(STALE_AFTER)})"
+        )
+    return False, (
+        "ALERT: worktree-cleanup scheduled job is red — "
+        f"{'; '.join(reasons)}. NOT repaired (detection only). "
+        "From the merged primary on main: "
+        ".venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py install. "
+        f"Evidence preserved under {sdir}/events.jsonl."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect a red or dark worktree-cleanup LaunchAgent (#6937).",
+    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="suppress the OK message (alerts still print)")
+    parser.add_argument(
+        "--repo", type=Path, default=Path(__file__).resolve().parents[2], help="repo path used to resolve telemetry state (default: this project root)"
+    )
+    parser.add_argument("--home", type=Path, default=None, help="home directory that owns the LaunchAgent (default: ~)")
+    parser.add_argument(
+        "--tasks-dir", type=Path, default=None, help="dispatch tasks dir for attribution (default: none)"
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help="watchdog state/log dir (default: <repo>/data/telemetry/worktree-cleanup-integrity)",
+    )
+    args = parser.parse_args(argv)
+
+    ok, message = check_worktree_cleanup_integrity(
+        args.repo,
+        home=args.home,
+        tasks_dir=args.tasks_dir,
+        state_dir=args.state_dir,
+    )
+    if not ok:
+        print(f"❌ {message}", file=sys.stderr)
+        return 1
+    if not args.quiet:
+        print(f"✅ {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1481,6 +1481,40 @@ def _warn_venv_integrity() -> None:
         print(f"⚠️  {message}", file=sys.stderr)
 
 
+def _warn_worktree_cleanup_integrity() -> None:
+    """Advisory-only worktree-cleanup launchd probe (#6937 follow-up).
+
+    A venv rebuild can leave launchd unable to start
+    ``com.learn-ukrainian.worktree-cleanup`` (LWCR init failure, exit 78)
+    with no new receipt for days. This probe DETECTS and RECORDS that
+    darkness; it never blocks a dispatch and never reloads launchd here —
+    reinstall is an explicit operator action from the merged primary.
+    Fails open on any probe error, same contract as the sibling integrity
+    watchdogs.
+    """
+    try:
+        try:
+            from scripts.audit.check_worktree_cleanup_integrity import (
+                check_worktree_cleanup_integrity,
+            )
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_worktree_cleanup_integrity import (
+                check_worktree_cleanup_integrity,
+            )
+
+        ok, message = check_worktree_cleanup_integrity(_REPO_ROOT, tasks_dir=_TASKS_DIR)
+    except Exception as exc:
+        print(
+            f"⚠️  worktree-cleanup-integrity probe errored ({type(exc).__name__}: {exc}); "
+            "proceeding — detection only, never blocks dispatch",
+            file=sys.stderr,
+        )
+        return
+
+    if not ok:
+        print(f"⚠️  {message}", file=sys.stderr)
+
+
 def _warn_node_modules_integrity() -> None:
     """Advisory-only node_modules symlink-corruption probe (#6818 follow-up).
 
@@ -4316,6 +4350,37 @@ def _run_worker(
             file=sys.stderr,
         )
 
+    # Post-worker worktree-cleanup-integrity sweep (#6937 follow-up): same
+    # shape as the venv-integrity sweep above, but for a dark/red scheduled
+    # LaunchAgent. ALERT-only — never blocks, never reloads launchd.
+    try:
+        try:
+            from scripts.audit.check_worktree_cleanup_integrity import (
+                check_worktree_cleanup_integrity,
+            )
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_worktree_cleanup_integrity import (
+                check_worktree_cleanup_integrity,
+            )
+
+        wci_ok, wci_message = check_worktree_cleanup_integrity(
+            _REPO_ROOT, tasks_dir=_TASKS_DIR
+        )
+        if not wci_ok:
+            _append_dispatch_event(
+                "worktree_cleanup_integrity_post_worker",
+                task_id=task_id,
+                agent=agent,
+                ok=wci_ok,
+                detail=wci_message,
+            )
+    except Exception as wci_exc:
+        print(
+            f"[delegate] WARNING: worktree-cleanup-integrity post-worker sweep failed: "
+            f"{type(wci_exc).__name__}: {wci_exc}",
+            file=sys.stderr,
+        )
+
     if timed_out:
         _append_dispatch_event(
             "dispatch_silence_timeout",
@@ -4456,6 +4521,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     _warn_node_modules_integrity()
     _warn_venv_integrity()
+    _warn_worktree_cleanup_integrity()
 
     _warn_if_monitor_api_unreachable()
     if bool(getattr(args, "dry_run", False)):

--- a/scripts/orchestration/install_worktree_cleanup_launchd.py
+++ b/scripts/orchestration/install_worktree_cleanup_launchd.py
@@ -22,6 +22,11 @@ from scripts.orchestration import scheduled_worktree_cleanup
 LABEL = "com.learn-ukrainian.worktree-cleanup"
 DEFAULT_INTERVAL_MINUTES = 240
 LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# launchd binds LWCR to ProgramArguments[0]. /bin/bash is Apple-signed and
+# survives a primary .venv rebuild; pointing Program at .venv/bin/python
+# is what produced exit 78 after the 2026-08-15 uv rewrite (#6937).
+STABLE_PROGRAM = "/bin/bash"
+WRAPPER_NAME = "run_scheduled_worktree_cleanup.sh"
 
 
 class LaunchdError(RuntimeError):
@@ -40,6 +45,10 @@ def state_dir(home: Path) -> Path:
     return home / ".codex" / "worktree-cleanup"
 
 
+def wrapper_path(public_repo: Path) -> Path:
+    return public_repo / "scripts" / "orchestration" / WRAPPER_NAME
+
+
 def build_plist(
     *,
     public_repo: Path,
@@ -54,13 +63,10 @@ def build_plist(
         "LowPriorityIO": True,
         "ProcessType": "Background",
         "ProgramArguments": [
-            str(public_repo / ".venv" / "bin" / "python"),
-            str(
-                public_repo
-                / "scripts"
-                / "orchestration"
-                / "scheduled_worktree_cleanup.py"
-            ),
+            STABLE_PROGRAM,
+            "--noprofile",
+            "--norc",
+            str(wrapper_path(public_repo)),
             "--apply",
             "--repo-root",
             str(public_repo),
@@ -148,6 +154,11 @@ def _validate_primary(repo_root: Path, *, require_interpreter: bool = False) -> 
         )
         if not cleanup_script.is_file():
             raise LaunchdError(f"cleanup script is missing: {cleanup_script}")
+        wrapper = wrapper_path(repo_root)
+        if not wrapper.is_file():
+            raise LaunchdError(f"cleanup wrapper is missing: {wrapper}")
+        if not os.access(STABLE_PROGRAM, os.X_OK):
+            raise LaunchdError(f"stable launchd program is missing: {STABLE_PROGRAM}")
 
 
 def install(

--- a/scripts/orchestration/run_scheduled_worktree_cleanup.sh
+++ b/scripts/orchestration/run_scheduled_worktree_cleanup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# launchd binds LWCR to ProgramArguments[0]. That must stay /bin/bash
+# (Apple-signed). Never put .venv/bin/python there: a venv rebuild
+# replaces the binary and launchd then fails with
+# "Unable to get updated LWCR ... error 0x3 - No such process" (exit 78).
+set -euo pipefail
+
+primary=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--repo-root" ]]; then
+    primary="${args[$((i + 1))]:-}"
+    break
+  fi
+done
+
+if [[ -z "${primary}" ]]; then
+  echo "worktree-cleanup: missing --repo-root (primary checkout)" >&2
+  exit 78
+fi
+
+python="${primary}/.venv/bin/python"
+cleanup="$(cd "$(dirname "$0")" && pwd)/scheduled_worktree_cleanup.py"
+
+if [[ ! -x "${python}" ]]; then
+  echo "worktree-cleanup: missing interpreter: ${python}" >&2
+  exit 78
+fi
+if [[ ! -f "${cleanup}" ]]; then
+  echo "worktree-cleanup: missing script: ${cleanup}" >&2
+  exit 78
+fi
+
+exec "${python}" "${cleanup}" "$@"

--- a/tests/orchestration/test_install_worktree_cleanup_launchd.py
+++ b/tests/orchestration/test_install_worktree_cleanup_launchd.py
@@ -26,9 +26,12 @@ def test_rendered_plist_runs_both_repositories_every_four_hours(
     assert payload["Label"] == launchd.LABEL
     assert payload["StartInterval"] == 14_400
     assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"][0] == launchd.STABLE_PROGRAM
     assert payload["ProgramArguments"] == [
-        str(public / ".venv" / "bin" / "python"),
-        str(public / "scripts" / "orchestration" / "scheduled_worktree_cleanup.py"),
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        str(public / "scripts" / "orchestration" / "run_scheduled_worktree_cleanup.sh"),
         "--apply",
         "--repo-root",
         str(public),
@@ -38,6 +41,7 @@ def test_rendered_plist_runs_both_repositories_every_four_hours(
         str(home / ".codex" / "worktree-cleanup" / "receipts" / "v2"),
     ]
     assert "/opt/homebrew/bin" in payload["EnvironmentVariables"]["PATH"]
+    assert not any(".venv/bin/python" in part for part in payload["ProgramArguments"])
 
 
 def test_status_rejects_modified_program_arguments(tmp_path: Path, monkeypatch) -> None:
@@ -87,6 +91,8 @@ def test_install_is_verified_and_idempotent(tmp_path: Path, monkeypatch) -> None
     script = public / "scripts" / "orchestration" / "scheduled_worktree_cleanup.py"
     script.parent.mkdir(parents=True)
     script.write_text("# cleanup\n", encoding="utf-8")
+    wrapper = public / "scripts" / "orchestration" / "run_scheduled_worktree_cleanup.sh"
+    wrapper.write_text("#!/bin/bash\n", encoding="utf-8")
     monkeypatch.setattr(
         launchd.subprocess,
         "run",
@@ -176,6 +182,41 @@ def test_uninstall_preserves_receipts(tmp_path: Path, monkeypatch) -> None:
     assert result["loaded"] is False
     assert not destination.exists()
     assert receipt.exists()
+
+
+def test_status_rejects_venv_python_as_program(tmp_path: Path, monkeypatch) -> None:
+    """Mutation-check: putting .venv/bin/python back in Program must fail status."""
+    public = tmp_path / "public"
+    private = tmp_path / "private"
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+    payload["ProgramArguments"][0] = str(public / ".venv" / "bin" / "python")
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result, return_code = launchd.status(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+
+    assert return_code == 1
+    assert result["valid_plist"] is False
+    assert result["loaded"] is True
 
 
 def test_positive_interval_rejects_zero() -> None:

--- a/tests/test_check_worktree_cleanup_integrity.py
+++ b/tests/test_check_worktree_cleanup_integrity.py
@@ -1,0 +1,254 @@
+"""Tests for the worktree-cleanup launchd red-run probe (#6937)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.audit.check_worktree_cleanup_integrity import (
+    STALE_AFTER,
+    check_worktree_cleanup_integrity,
+    latest_receipt_observed_at,
+    parse_launchd_snapshot,
+)
+from scripts.orchestration import install_worktree_cleanup_launchd as launchd
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts" / "orchestration" / "run_scheduled_worktree_cleanup.sh"
+
+
+def _events(state_dir: Path) -> list[dict]:
+    path = state_dir / "events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _write_plist(home: Path) -> Path:
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    destination.write_text("plist", encoding="utf-8")
+    return destination
+
+
+def _write_receipt(home: Path, observed_at: datetime) -> Path:
+    receipts = home / ".codex" / "worktree-cleanup" / "receipts" / "v2"
+    receipts.mkdir(parents=True)
+    stamp = observed_at.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = receipts / f"{stamp}-deadbeefcafe.json"
+    path.write_text(
+        json.dumps({"observed_at": observed_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_parse_launchd_snapshot_reads_exit_78_and_lwcr_flag() -> None:
+    snapshot = parse_launchd_snapshot(
+        "state = not running\n"
+        "last exit code = 78: EX_CONFIG\n"
+        "properties = runatload | needs LWCR update | managed LWCR | has LWCR\n"
+    )
+    assert snapshot["last_exit"] == 78
+    assert snapshot["needs_lwcr_update"] is True
+    assert snapshot["lwcr_init_failure"] is False
+
+
+def test_parse_launchd_snapshot_reads_lwcr_init_log_line() -> None:
+    snapshot = parse_launchd_snapshot(
+        "Service could not initialize: Unable to get updated LWCR for "
+        "(A630D90B-7E3C-433C-9340-21C494BE92AF, "
+        "/Users/example/Library/LaunchAgents/com.learn-ukrainian.worktree-cleanup.plist, "
+        "501), error 0x3 - No such process"
+    )
+    assert snapshot["lwcr_init_failure"] is True
+    assert snapshot["last_exit"] is None
+
+
+def test_skips_when_job_is_not_installed(tmp_path: Path) -> None:
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=tmp_path / "home",
+        state_dir=tmp_path / "state",
+        platform="darwin",
+        launchctl_text=None,
+    )
+    assert ok is True
+    assert "not installed" in message
+    assert _events(tmp_path / "state") == []
+
+
+def test_skips_on_non_darwin_even_with_installed_plist(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_plist(home)
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=home,
+        state_dir=tmp_path / "state",
+        platform="linux",
+        launchctl_text="last exit code = 78: EX_CONFIG",
+    )
+    assert ok is True
+    assert "not macOS" in message
+    assert _events(tmp_path / "state") == []
+
+
+def test_exit_78_alerts_even_with_fresh_receipt(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_plist(home)
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    _write_receipt(home, now - timedelta(minutes=10))
+
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=home,
+        state_dir=tmp_path / "state",
+        now=now,
+        platform="darwin",
+        launchctl_text="last exit code = 78: EX_CONFIG\nproperties = needs LWCR update",
+    )
+    assert ok is False
+    assert "LWCR" in message
+    alerts = [event for event in _events(tmp_path / "state") if event["event"] == "worktree_cleanup_integrity_alert"]
+    assert len(alerts) == 1
+    assert alerts[0]["last_exit"] == 78
+    assert alerts[0]["needs_lwcr_update"] is True
+
+
+def test_stale_receipt_alerts_when_launchd_exit_is_zero(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_plist(home)
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    _write_receipt(home, now - STALE_AFTER - timedelta(minutes=1))
+
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=home,
+        state_dir=tmp_path / "state",
+        now=now,
+        platform="darwin",
+        launchctl_text="last exit code = 0",
+    )
+    assert ok is False
+    assert "stale" in message
+    assert _events(tmp_path / "state")
+
+
+def test_fresh_receipt_under_stale_bar_is_ok(tmp_path: Path) -> None:
+    """Mutation-check: a receipt just inside the 8h bar must not alert."""
+    home = tmp_path / "home"
+    _write_plist(home)
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    _write_receipt(home, now - STALE_AFTER + timedelta(minutes=5))
+
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=home,
+        state_dir=tmp_path / "state",
+        now=now,
+        platform="darwin",
+        launchctl_text="last exit code = 0",
+    )
+    assert ok is True
+    assert "ok" in message
+    assert _events(tmp_path / "state") == []
+
+
+def test_missing_receipt_with_installed_job_is_red(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_plist(home)
+    ok, message = check_worktree_cleanup_integrity(
+        tmp_path / "repo",
+        home=home,
+        state_dir=tmp_path / "state",
+        now=datetime(2026, 8, 17, 12, 0, tzinfo=UTC),
+        platform="darwin",
+        launchctl_text="last exit code = 0",
+    )
+    assert ok is False
+    assert "no successful receipt" in message
+
+
+def test_latest_receipt_ignores_corrupt_files(tmp_path: Path) -> None:
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    (receipts / "broken.json").write_text("{not-json", encoding="utf-8")
+    (receipts / "20260815T144310Z-ok.json").write_text(
+        json.dumps({"observed_at": "2026-08-15T14:43:10Z"}),
+        encoding="utf-8",
+    )
+    assert latest_receipt_observed_at(receipts) == datetime(2026, 8, 15, 14, 43, 10, tzinfo=UTC)
+
+
+def test_wrapper_exits_78_without_repo_root() -> None:
+    proc = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(WRAPPER)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing --repo-root" in proc.stderr
+
+
+def test_wrapper_exits_78_when_interpreter_missing(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(WRAPPER),
+            "--repo-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing interpreter" in proc.stderr
+    assert str(tmp_path / ".venv" / "bin" / "python") in proc.stderr
+
+
+def test_wrapper_execs_primary_interpreter(tmp_path: Path) -> None:
+    """Mutation-check: the wrapper must exec primary .venv python, not PATH python."""
+    primary = tmp_path / "primary"
+    python = primary / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    marker = tmp_path / "ran"
+    python.write_text(
+        "#!/bin/sh\n"
+        f'echo "$1" > "{marker}"\n'
+        "printf '%s\\n' \"$@\"\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+    # The wrapper execs the cleanup script next to itself; provide a real file
+    # so the existence guard passes. The fake python records argv[1].
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(WRAPPER),
+            "--apply",
+            "--repo-root",
+            str(primary),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0
+    assert marker.read_text(encoding="utf-8").strip().endswith("scheduled_worktree_cleanup.py")
+    assert "--apply" in proc.stdout
+    assert str(primary) in proc.stdout

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -108,6 +108,27 @@ def _stub_venv_integrity_sweep(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _stub_worktree_cleanup_integrity_sweep(monkeypatch):
+    """Keep _run_worker/cmd_dispatch tests hermetic from the ambient host.
+
+    Same rationale as the venv stub (#6937 follow-up sweep, same shape): the
+    worktree-cleanup watchdog reads the real LaunchAgent and
+    ``~/.codex/worktree-cleanup/receipts/v2``. A host whose job is currently
+    red (exit 78 / stale receipt) would append
+    worktree_cleanup_integrity_post_worker to dispatch_events.jsonl and
+    break tests that assert on that file. The sweep itself is covered
+    against fixture homes in tests/test_check_worktree_cleanup_integrity.py.
+    """
+    import scripts.audit.check_worktree_cleanup_integrity as wci
+
+    monkeypatch.setattr(
+        wci,
+        "check_worktree_cleanup_integrity",
+        lambda *_args, **_kwargs: (True, "worktree-cleanup integrity ok (test stub)"),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _fixture_runtime_tmp_root(tmp_path, monkeypatch):
     """Keep dispatch-time orphan sweeps inside each test fixture only."""
     runtime_tmp = tmp_path / "runtime-tmp"

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -241,12 +241,21 @@ def test_orient_git_survives_primary_checkout_probe_failure(monkeypatch, tmp_pat
     assert git_info["primary_checkout"]["checked_cwd"] == str(repo)
 
 
-def test_health_includes_core_bare_canary():
+def test_health_includes_core_bare_canary(monkeypatch):
     """#2842: the health section surfaces the git core.bare detection canary."""
+    # Keep this collector hermetic from the host LaunchAgent (#6937).
+    monkeypatch.setattr(api_main, "_worktree_cleanup_integrity_canary", lambda: True)
     health = api_main._collect_health_orient_data()
     assert "git_core_bare_ok" in health
     # This repo has a working tree, so core.bare must be false → canary reports ok.
     assert health["git_core_bare_ok"] is True
+
+
+def test_health_includes_worktree_cleanup_canary(monkeypatch):
+    """#6937: a red scheduled cleanup run must surface on /api/orient health."""
+    monkeypatch.setattr(api_main, "_worktree_cleanup_integrity_canary", lambda: False)
+    health = api_main._collect_health_orient_data()
+    assert health["worktree_cleanup_integrity_ok"] is False
 
 
 def test_health_canaries_do_not_apply_general_repairs(monkeypatch):


### PR DESCRIPTION
Fixes #6937.

Authored by the grok lane (dispatch `infra-6937-cleanup-exit78`, commit `023640d6c4`); driver finalized push/PR (grok harness cannot run network git).

## Root cause
The launchd job registered `.venv/bin/python` as its `Program`. The 2026-08-15 venv rebuild (see #6830) invalidated that interpreter for launchd's LWCR, so every 4-hourly run since has died with exit 78 before reaching the cleanup script — silently, for ~45 hours.

## Fix
- Stable `/bin/bash --noprofile --norc` wrapper entrypoint (`run_scheduled_worktree_cleanup.sh`) that resolves the interpreter at run time — a venv rebuild can no longer strand the LaunchAgent.
- Red-run detection: an alert fires when the last successful receipt is older than two 4-hour intervals (detection only; never reloads launchd itself).

## Evidence (lane-run, quoted from the task result)
- Live failure quoted (exit 78, last success `2026-08-15T14:43:10Z`, 44h45m old at fix time).
- The exact new entrypoint proven with a real `--apply` pass against two isolated temp repos: `EXIT=0`, honest empty summary.
- `pytest` 41 passed (installer, watchdog, wrapper guards, related suites); `ruff` clean.

## Post-merge operator/driver step
The live LaunchAgent stays exit-78 until reinstalled from merged `main`:
`.venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py install`
(driver will run this after merge and verify a green scheduled pass). Sibling LaunchAgents with the same trap are banked as #6941.

X-Agent: grok/infra-6937-cleanup-exit78
