### PR TITLE
fix(registry): anchor infra-harness on #6943; drop closed #5331

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -59,10 +59,10 @@ is the single source of truth for membership (auditor:
 
 | Stream | Epic(s) | Scope |
 | --- | --- | --- |
-| atlas-practice | #4387, #4700, #5331 | Word Atlas + Practice Hub product & UX |
+| atlas-practice | #4387, #4700 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378, #5224 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
-| infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
+| infra-harness | #6943 (successor to closed #4707) | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
 | open-model-data | #6321 (successor to closed #6164 and #6056) | Build evidence-bearing prepared Ukrainian data products on the completed Foundry engine. Community usefulness is primary; adoption is secondary evidence, not a gate. Every shipped artifact names a concrete consumer decision/use case. Current truth: #6375 is the active Phase 3 v2.1 functional-role and runtime rebinding task; #6333 is historical `ENGINE_READY` evidence only and establishes no linguistic, source, consumer, or completion status; Phase 4 remains blocked. |

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -12,7 +12,7 @@ schema_version: 1
 streams:
   atlas-practice:
     title: "Word Atlas + Practice Hub product"
-    epics: [4387, 4700, 5331]  # umbrella + UX-quality-wave + #5331 fill_local divergence
+    epics: [4387, 4700]  # umbrella + UX-quality-wave (closed #5331 fill_local divergence removed)
   atlas-intake:
     title: "Word Atlas full-corpus intake"
     epics: [4220, 4378, 5224]        # intake epic + entry-model DB epic
@@ -21,7 +21,7 @@ streams:
     epics: [4706]
   infra-harness:
     title: "Infra & fleet reliability (hooks, dispatch, routing)"
-    epics: [4707]
+    epics: [6943]  # successor to closed #4707
   devops:
     title: "DevOps automation, CI, release & launcher reliability"
     epics: [5703]

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -139,7 +139,7 @@ def test_unknown_selector_fails_closed() -> None:
 def test_devops_epic_is_registered_separately_from_infra() -> None:
     registry = yaml.safe_load(_ISSUE_STREAMS.read_text(encoding="utf-8"))["streams"]
 
-    assert registry["infra-harness"]["epics"] == [4707]
+    assert registry["infra-harness"]["epics"] == [6943]
     assert registry["devops"]["epics"] == [5703]
 
 

--- a/tests/test_lexicon_runner_pr2_ledger.py
+++ b/tests/test_lexicon_runner_pr2_ledger.py
@@ -900,13 +900,16 @@ def test_500_lemma_slice_resume_from_interrupted_run(tmp_path: Path, monkeypatch
     assert len(candidate["entries"]) == 500
 
 
-def test_issue_streams_registers_5331_under_atlas_practice() -> None:
+def test_issue_streams_atlas_practice_drops_closed_5331() -> None:
     import yaml
 
     doc = yaml.safe_load(Path("scripts/config/issue_streams.yaml").read_text(encoding="utf-8"))
     epics = doc["streams"]["atlas-practice"]["epics"]
-    assert 5331 in epics
+    assert 5331 not in epics
     assert 4387 in epics
-    # Do not claim infra's issue.
+    assert 4700 in epics
+    # Do not claim infra's issue; infra anchors on successor #6943.
     infra = doc["streams"]["infra-harness"]["epics"]
     assert 5331 not in infra
+    assert 6943 in infra
+    assert 4707 not in infra

--- a/tests/test_session_streams_dual_write_status.py
+++ b/tests/test_session_streams_dual_write_status.py
@@ -27,7 +27,7 @@ def test_inventory_covers_repo_issue_streams():
     assert len(records) >= 10
     ids = {r.stream_id for r in records}
     assert "epic:4387" in ids
-    assert "epic:4707" in ids
+    assert "epic:6943" in ids
     assert "epic:4542" in ids
     assert "epic:2836" in ids  # folk — was not in the hard-coded four
 

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -7,16 +7,31 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+import yaml
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
 from agents_extensions.shared.session_streams.model import LeaseHolder
 from agents_extensions.shared.session_streams.store import LeaseConflictError, SessionStreamStore
 from scripts.session_supervisor import LaunchRole, SessionSupervisor, SupervisorError, main, strip_lease_credentials
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ISSUE_STREAMS = _REPO_ROOT / "scripts" / "config" / "issue_streams.yaml"
+
+
+def _infra_harness_stream_id() -> str:
+    """Anchor on the live infra-harness epic so succession cannot stale this suite."""
+    doc = yaml.safe_load(_ISSUE_STREAMS.read_text(encoding="utf-8"))
+    epics = doc["streams"]["infra-harness"]["epics"]
+    assert epics, "infra-harness must list at least one epic in issue_streams.yaml"
+    return f"epic:{int(epics[0])}"
+
+
+INFRA_STREAM_ID = _infra_harness_stream_id()
+
 
 def _supervisor(tmp_path: Path) -> SessionSupervisor:
     store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
-    return SessionSupervisor(store, repo_root=Path.cwd())
+    return SessionSupervisor(store, repo_root=_REPO_ROOT)
 
 
 def _holder() -> LeaseHolder:
@@ -33,14 +48,14 @@ def test_driver_open_heartbeat_close_and_capsule_are_fenced(tmp_path: Path) -> N
     supervisor = _supervisor(tmp_path)
     lease = supervisor.open_driver(
         role=LaunchRole.DRIVER,
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=_holder(),
         lineage_id="lineage-supervisor-test",
         ttl_seconds=300,
     )
 
-    capsule = supervisor.build_capsule(role=LaunchRole.DRIVER, stream_id="epic:4707", lease=lease).as_dict()
-    assert capsule["identity"]["stream_id"] == "epic:4707"
+    capsule = supervisor.build_capsule(role=LaunchRole.DRIVER, stream_id=INFRA_STREAM_ID, lease=lease).as_dict()
+    assert capsule["identity"]["stream_id"] == INFRA_STREAM_ID
     assert capsule["identity"]["lease"]["lease_id"] == lease.lease_id
     assert capsule["identity"]["lease_credentials_exported"] is False
     assert capsule["diagnostics"]["lease_actions"] == "supervisor-only"
@@ -58,7 +73,7 @@ def test_workers_cannot_acquire_or_receive_driver_lease(tmp_path: Path) -> None:
     with pytest.raises(SupervisorError, match="workers cannot acquire"):
         supervisor.open_driver(
             role=LaunchRole.WORKER,
-            stream_id="epic:4707",
+            stream_id=INFRA_STREAM_ID,
             holder=_holder(),
             lineage_id="lineage-worker-refusal",
             ttl_seconds=300,
@@ -66,18 +81,18 @@ def test_workers_cannot_acquire_or_receive_driver_lease(tmp_path: Path) -> None:
 
     lease = supervisor.open_driver(
         role="driver",
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=_holder(),
         lineage_id="lineage-worker-capsule",
         ttl_seconds=300,
     )
     with pytest.raises(SupervisorError, match="cannot receive"):
-        supervisor.build_capsule(role="worker", stream_id="epic:4707", lease=lease)
+        supervisor.build_capsule(role="worker", stream_id=INFRA_STREAM_ID, lease=lease)
 
-    worker = supervisor.build_capsule(role="worker", stream_id="epic:4707").as_dict()
+    worker = supervisor.build_capsule(role="worker", stream_id=INFRA_STREAM_ID).as_dict()
     assert worker["identity"]["lease"] is None
     with pytest.raises(SupervisorError, match="require an exact"):
-        supervisor.build_capsule(role="driver", stream_id="epic:4707")
+        supervisor.build_capsule(role="driver", stream_id=INFRA_STREAM_ID)
 
 
 def test_worker_environment_strips_every_lease_credential() -> None:
@@ -101,7 +116,7 @@ def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:
 
     opened_at = utc_now() - timedelta(hours=7)
     supervisor.store.open_session(
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=LeaseHolder(
             agent="grok",
             harness="grok-tui",
@@ -115,7 +130,7 @@ def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:
     )
     successor = supervisor.open_driver(
         role="driver",
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=LeaseHolder(
             agent="grok",
             harness="grok-tui",
@@ -142,7 +157,7 @@ def test_open_driver_auto_recovers_unexpired_dead_holder(tmp_path: Path) -> None
 
     # Opened moments ago with 6h launcher TTL; process already gone.
     supervisor.store.open_session(
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=LeaseHolder(
             agent="grok",
             harness="grok-tui",
@@ -156,7 +171,7 @@ def test_open_driver_auto_recovers_unexpired_dead_holder(tmp_path: Path) -> None
     )
     successor = supervisor.open_driver(
         role="driver",
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=LeaseHolder(
             agent="grok",
             harness="grok-tui",
@@ -174,7 +189,7 @@ def test_open_driver_refuses_live_unexpired_holder(tmp_path: Path) -> None:
     supervisor = _supervisor(tmp_path)
     live = supervisor.open_driver(
         role="driver",
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=_holder(),
         lineage_id="lineage-live",
         ttl_seconds=3600,
@@ -182,7 +197,7 @@ def test_open_driver_refuses_live_unexpired_holder(tmp_path: Path) -> None:
     with pytest.raises(SupervisorError, match="already has live session"):
         supervisor.open_driver(
             role="driver",
-            stream_id="epic:4707",
+            stream_id=INFRA_STREAM_ID,
             holder=LeaseHolder(
                 agent="grok",
                 harness="grok-tui",
@@ -204,7 +219,7 @@ def test_recover_expired_driver_force_closes_claimable(tmp_path: Path) -> None:
     dead_pid = 999_999_002
     assert not _pid_alive(dead_pid)
     supervisor.store.open_session(
-        stream_id="epic:4707",
+        stream_id=INFRA_STREAM_ID,
         holder=LeaseHolder(
             agent="grok",
             harness="grok-tui",
@@ -222,11 +237,11 @@ def test_recover_expired_driver_force_closes_claimable(tmp_path: Path) -> None:
         process_id=os.getpid(),
     )
     assert supervisor.recover_expired_driver(
-        role="driver", stream_id="epic:4707", holder=holder
+        role="driver", stream_id=INFRA_STREAM_ID, holder=holder
     ) is True
     # Second recover finds nothing open.
     assert supervisor.recover_expired_driver(
-        role="driver", stream_id="epic:4707", holder=holder
+        role="driver", stream_id=INFRA_STREAM_ID, holder=holder
     ) is False
 
 
@@ -246,12 +261,12 @@ def test_cli_refuses_worker_open_attempt(tmp_path: Path, capsys: pytest.CaptureF
             "--db",
             str(tmp_path / "streams.sqlite3"),
             "--repo-root",
-            str(Path.cwd()),
+            str(_REPO_ROOT),
             "open",
             "--role",
             "worker",
             "--stream",
-            "epic:4707",
+            INFRA_STREAM_ID,
             "--agent",
             "agy",
             "--harness",


### PR DESCRIPTION
## Summary
- Point `infra-harness` at successor epic #6943 (remove closed #4707) and drop closed #5331 from `atlas-practice` in `scripts/config/issue_streams.yaml`.
- Mirror the Streams table in `docs/WORKSTREAMS.md`; update registry pin tests.

## Audit evidence

**Before** (cache under old registry; live `--check` timed out on GraphQL for #4700):
```
ok: False
closed_or_missing_epics: [4707, 5331]
orphans: [6013, 6142, 6370, 6371, 6460, 6818, 6830, 6863, 6870, 6876, 6892, 6937, 6941]
multi_homed: [#5230 in atlas-intake, atlas-practice]
streams.infra-harness: [4707]
streams.atlas-practice: [4387, 4700, 5331]
```

**After** (live `--check`, exit 1 — residual multi-home only):
```
open issues: 81 · streams: 12 · ok: False
closed_or_missing_epics: []
orphans: []
multi-homed (3):
  #5230 in atlas-intake, atlas-practice   (#4387 + #5224 body refs — not the closed 5331)
  #5880 in atlas-practice, infra-harness  (#4387 + #6943 body refs)
  #5885 in atlas-practice, infra-harness  (#4387 + #6943 body refs)
```

Former infra orphans (#6013 #6818 #6830 #6863 #6870 #6892 #6937 #6941) and program issues (#5535 etc.) are `infra-harness` members via #6943. Atlas orphans #6142 #6460 #6876 are `atlas-practice` via #4387; #6370 #6371 are `atlas-intake` via #4220. Epic bodies not edited (out of scope).

## Test plan
- [x] `issue_stream_audit --check` — closed/orphan failures cleared; remaining multi-home is epic-body residual
- [x] pytest: `test_handoff_identity` pin, `test_session_streams_dual_write_status` inventory, `test_lexicon_runner_pr2_ledger` atlas pin, `test_issue_stream_audit` (54 passed)
- [x] ruff clean on changed Python tests

Closes nothing; registry wiring for #6943.

Made with [Cursor](https://cursor.com)
