### PR TITLE
fix(atlas): per-host ATLAS_RUN_ROOT default for hramatka jobs

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -2,7 +2,7 @@
 # Detached, idempotent launcher for #6369 Class-B residual EN re-enrich.
 # Mirrors launch_enrich.sh under MemoryHigh=1.5G MemoryMax=2.0G.
 #
-# Runs entirely against the atlas-runner *work-dir* — it never mutates the
+# Runs entirely against the remote-host *work-dir* — it never mutates the
 # VPS repo checkout at $REPO. This matters because the checkout there is
 # routinely stale/dirty (large data/ dirs deliberately deleted for disk
 # headroom); this launcher only ever reads from it (sources.db, kaikki
@@ -30,13 +30,26 @@
 #   scripts/lexicon/runner/launch_reenrich_class_b.sh --limit 5   # smoke
 #
 # Env overrides:
-#   ATLAS_RUN_ROOT, ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
+#   ATLAS_RUN_ROOT (default per host: /home/ops/atlas-jobs on hramatka/vps,
+#   /home/ops/atlas-runner otherwise), ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
 #   ATLAS_RE_ENRICH_CODE_ROOT, ATLAS_RE_ENRICH_RUNNER_PYTHON,
 #   ATLAS_RE_ENRICH_UNIT, ATLAS_RE_ENRICH_DRIVER, ATLAS_RE_ENRICH_SLUGS_FILE,
 #   ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON, ATLAS_LIVE_MANIFEST
 set -euo pipefail
 
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+# Per-host run root (#6876): the Mac-side wrapper always forwards an explicit
+# ATLAS_RUN_ROOT, so this default only matters for direct on-host invocation.
+# hramatka/vps keep their run tree under /home/ops/atlas-jobs; every other
+# host keeps /home/ops/atlas-runner.
+if [[ -n "${ATLAS_RUN_ROOT:-}" ]]; then
+  RUN_ROOT="$ATLAS_RUN_ROOT"
+else
+  case "$(hostname -s 2>/dev/null || hostname)" in
+    hramatka*|vps*) RUN_ROOT="/home/ops/atlas-jobs" ;;
+    *) RUN_ROOT="/home/ops/atlas-runner" ;;
+  esac
+fi
+
 REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
 CODE_ROOT="${ATLAS_RE_ENRICH_CODE_ROOT:-$WORK_DIR}"

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Mac-side orchestrator for #6369 Class-B residual EN re-enrich. Runs the job
-# on the pilot VPS (atlas-runner), never on this laptop.
+# on the remote Atlas host (atlas-runner by default, hramatka/vps per #6876),
+# never on this laptop.
 #
 # The VPS repo checkout is routinely stale (large data/ dirs deliberately
 # deleted for disk headroom, uncommitted local diffs) — this script never
@@ -20,7 +21,9 @@
 #   scripts/lexicon/runner/launch_reenrich_class_b_remote.sh --pull-only  # just pull artifacts back
 #
 # Env overrides:
-#   ATLAS_RUNNER_HOST (default atlas-runner), ATLAS_RUN_ROOT, ATLAS_REPO,
+#   ATLAS_RUNNER_HOST (default atlas-runner), ATLAS_RUN_ROOT (default per
+#   host: /home/ops/atlas-jobs for hramatka/vps, /home/ops/atlas-runner
+#   otherwise), ATLAS_REPO,
 #   ATLAS_PRIMARY_ROOT (default: primary checkout from shared .git common dir),
 #   ATLAS_RE_ENRICH_WORK_DIR, ATLAS_RE_ENRICH_RESIDUAL (local slugs dump),
 #   ATLAS_LOCAL_VESUM_DB, ATLAS_LOCAL_SLOVNYK_CACHE
@@ -51,7 +54,14 @@ PRIMARY_ROOT="${ATLAS_PRIMARY_ROOT:-$(cd "$_primary_common_dir/.." && pwd)}"
 PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-$PRIMARY_ROOT/.venv/bin/python}"
 
 HOST="${ATLAS_RUNNER_HOST:-atlas-runner}"
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+# Per-host run root (#6876): jobs on hramatka/vps live under
+# /home/ops/atlas-jobs; every other host keeps /home/ops/atlas-runner. An
+# explicit ATLAS_RUN_ROOT always wins.
+case "$HOST" in
+  hramatka|vps) DEFAULT_RUN_ROOT="/home/ops/atlas-jobs" ;;
+  *) DEFAULT_RUN_ROOT="/home/ops/atlas-runner" ;;
+esac
+RUN_ROOT="${ATLAS_RUN_ROOT:-$DEFAULT_RUN_ROOT}"
 REMOTE_REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 REMOTE_WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
 
@@ -112,6 +122,10 @@ if ! ssh_q "true" 2>/dev/null; then
   echo "cannot reach $HOST over SSH (BatchMode); check ~/.ssh/config" >&2
   exit 1
 fi
+
+# Materialize the per-host run root before any scp/rsync writes into it — a
+# fresh hramatka/vps layout has no /home/ops/atlas-jobs yet (#6876).
+ssh_q "mkdir -p $(printf '%q' "$RUN_ROOT")"
 
 # HARD GATE — sources.db on VPS must match local Mac (operator 2026-08-06).
 # Stale VPS DBs silently underfill EN residual. Compare byte size; rsync if

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -220,3 +220,136 @@ def test_remote_wrapper_primary_root_override_wins() -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout == "/tmp/custom-primary"
+
+
+def _remote_run_root_block(source: str) -> str:
+    """Extract the per-host RUN_ROOT default block verbatim."""
+    start = source.index('case "$HOST" in')
+    end = source.index("\n\n", start)
+    return source[start:end]
+
+
+@pytest.mark.parametrize(
+    "host,expected_run_root",
+    [
+        ("atlas-runner", "/home/ops/atlas-runner"),
+        ("hramatka", "/home/ops/atlas-jobs"),
+        ("vps", "/home/ops/atlas-jobs"),
+        ("hramatka-2", "/home/ops/atlas-runner"),
+        ("some-other-host", "/home/ops/atlas-runner"),
+    ],
+)
+def test_remote_wrapper_run_root_defaults_per_host(host: str, expected_run_root: str) -> None:
+    """#6876: hramatka/vps (exact aliases) run under /home/ops/atlas-jobs;
+    every other host keeps /home/ops/atlas-runner."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    block = _remote_run_root_block(source)
+    proc = subprocess.run(
+        ["bash", "-c", f"HOST={host!r}\n{block}\nprintf '%s' \"$RUN_ROOT\""],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == expected_run_root
+
+
+def test_remote_wrapper_run_root_override_wins() -> None:
+    """An explicit ATLAS_RUN_ROOT beats the per-host default."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    block = _remote_run_root_block(source)
+    proc = subprocess.run(
+        ["bash", "-c", "HOST=hramatka\n" + block + "\nprintf '%s' \"$RUN_ROOT\""],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": "/usr/bin:/bin", "ATLAS_RUN_ROOT": "/custom/run-root"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "/custom/run-root"
+
+
+def test_remote_wrapper_mkdirs_run_root_before_first_transfer() -> None:
+    """The per-host run root must be materialized on the remote before any
+    scp/rsync writes into it (a fresh hramatka layout has no atlas-jobs dir)."""
+    source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
+    mkdir_marker = 'ssh_q "mkdir -p $(printf \'%q\' "$RUN_ROOT")"'
+    assert mkdir_marker in source
+    mkdir_idx = source.index(mkdir_marker)
+    # Before the first outbound transfer in program order (sources.db rsync)
+    # and before the unconditional driver scp.
+    assert mkdir_idx < source.index('rsync -a --copy-links --partial "$LOCAL_SOURCES_DB"')
+    assert mkdir_idx < source.index('scp_q "$LOCAL_DRIVER"')
+    # But only after SSH reachability is confirmed.
+    assert mkdir_idx > source.index('ssh_q "true"')
+
+
+def test_launchers_never_reference_opt_hramatka() -> None:
+    """Job space is /home/ops/*; the /opt/hramatka tree must never be written."""
+    for launcher in (REMOTE_LAUNCHER, LOCAL_LAUNCHER):
+        assert "/opt/hramatka" not in launcher.read_text(encoding="utf-8")
+
+
+def _local_run_root_block(source: str) -> str:
+    """Extract the on-host RUN_ROOT default block verbatim."""
+    start = source.index('if [[ -n "${ATLAS_RUN_ROOT:-}" ]]; then')
+    end = source.index("\n\n", start)
+    return source[start:end]
+
+
+@pytest.mark.parametrize(
+    "hostname,expected_run_root",
+    [
+        ("hramatka", "/home/ops/atlas-jobs"),
+        ("hramatka.example.com", "/home/ops/atlas-jobs"),
+        ("vps", "/home/ops/atlas-jobs"),
+        ("atlas-runner", "/home/ops/atlas-runner"),
+        ("some-random-host", "/home/ops/atlas-runner"),
+    ],
+)
+def test_local_launcher_run_root_defaults_by_hostname(
+    tmp_path: Path, hostname: str, expected_run_root: str
+) -> None:
+    """Direct on-host invocation (no forwarded ATLAS_RUN_ROOT) must still
+    resolve the per-host run root from the machine's own hostname (#6876)."""
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    block = _local_run_root_block(source)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_hostname = fake_bin / "hostname"
+    fake_hostname.write_text(f"#!/bin/sh\necho {hostname}\n", encoding="utf-8")
+    fake_hostname.chmod(0o755)
+    proc = subprocess.run(
+        ["bash", "-c", block + "\nprintf '%s' \"$RUN_ROOT\""],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": f"{fake_bin}:/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == expected_run_root
+
+
+def test_local_launcher_run_root_override_wins(tmp_path: Path) -> None:
+    """An explicit ATLAS_RUN_ROOT beats hostname-based defaulting."""
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    block = _local_run_root_block(source)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_hostname = fake_bin / "hostname"
+    fake_hostname.write_text("#!/bin/sh\necho hramatka\n", encoding="utf-8")
+    fake_hostname.chmod(0o755)
+    proc = subprocess.run(
+        ["bash", "-c", block + "\nprintf '%s' \"$RUN_ROOT\""],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": f"{fake_bin}:/usr/bin:/bin", "ATLAS_RUN_ROOT": "/custom/run-root"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "/custom/run-root"


### PR DESCRIPTION
## Summary
Remote/local class-B launchers default `ATLAS_RUN_ROOT` to `/home/ops/atlas-jobs` on `hramatka`/`vps`, otherwise `/home/ops/atlas-runner`. The remote wrapper `mkdir -p`s that root before scp. Nothing writes under `/opt/hramatka`.

## Test plan
- [x] `tests/test_launch_reenrich_target_detection.py` added/extended in the same commit
- [ ] CI green

Refs #6876