### PR TITLE
fix(atlas): allow reenrich jobs on hramatka alongside atlas-runner

### DIFF
--- a/docs/runbooks/atlas-job-protocol.md
+++ b/docs/runbooks/atlas-job-protocol.md
@@ -12,13 +12,37 @@ and not a Hetzner snapshot.
 
 ## Hosts
 
+Atlas jobs may run on **both** `atlas-runner` and `hramatka` (operator GO
+2026-08-17). Each host is its own mutex — `submit` refuses a second active
+`atlas-job-*` unit on the *same* host, but the two hosts may run concurrently.
+
 | Host | Use | Never |
 | --- | --- | --- |
 | `atlas-runner` | Reenrich, later ULIF / slovnyk migrate | Teacher API, GH runners |
-| `hramatka` | Teacher API, Caddy, CI runners | Catalog reenrich / slovnyk refetch |
+| `hramatka` | Reenrich (class-B, memory-capped) **and** teacher API, Caddy, CI runners | Writing under `/opt/hramatka` or `/srv` (teacher-service data) |
 
-Default `ATLAS_RUNNER_HOST` is **`atlas-runner`**. A plan that puts `reenrich`
-on `hramatka` is rejected (no override).
+Default `ATLAS_RUNNER_HOST` is **`atlas-runner`**; pass `host: hramatka` (or
+the `vps` ssh alias — same machine, see `scripts/config/trails/estate.v1.yaml`)
+to target the other host. Unknown host strings are still rejected.
+
+Per-host default work root (only used when the plan omits `workdir`, and
+overridable via `ATLAS_RUN_ROOT`):
+
+| Host | Default root |
+| --- | --- |
+| `atlas-runner` | `/home/ops/atlas-runner` |
+| `hramatka` / `vps` | `/home/ops/atlas-jobs` (does not exist yet on the host — `submit`/the launcher `mkdir -p` it on first use) |
+
+`hramatka`'s reenrich work root is deliberately separate from its
+teacher-facing `/opt/hramatka` and `/srv` trees — never point a job's
+`workdir` there.
+
+**Memory on hramatka.** The class-B launcher (`launch_reenrich_class_b.sh`)
+already pins `systemd-run --property=MemoryHigh=1536M --property=MemoryMax=2048M`
+regardless of host — this is intentionally conservative on hramatka so a
+reenrich run cannot starve the teacher API / Caddy / GH runners sharing that
+box. Do not raise these limits for hramatka jobs without checking headroom
+against the resident services first.
 
 SSH aliases live in the operator `~/.ssh/config`. IAC: private
 `hramatka/ops/iac/` (merged #495).
@@ -110,11 +134,16 @@ Use the shared project interpreter (never bare `python`):
 .venv/bin/python -m scripts.lexicon.runner.atlas_job list
 ```
 
-`submit` refuses a second active `atlas-job-*` unit on the host. `close` seals
-a result after the unit is dead (or records `needs_finalize` when evidence is
-missing).
+`--host` accepts `atlas-runner` or `hramatka` (`vps` alias) everywhere above.
+`submit` refuses a second active `atlas-job-*` unit on that host — the other
+host may still have its own job running. `close` seals a result after the
+unit is dead (or records `needs_finalize` when evidence is missing).
 
 ## Memory
 
-The existing launcher still pins `MemoryHigh=1.5G` / `MemoryMax=2G` on the
-cx33. One heavy job. Two full-catalogs need a later host or a queue.
+The class-B launcher pins `MemoryHigh=1.5G` / `MemoryMax=2G` on every host —
+one heavy job at a time per host. On `hramatka` this cap is load-bearing (see
+Hosts above): it exists so a reenrich run cannot starve the teacher API / GH
+runners on the same box. Two full-catalog runs on one host need a later host
+or a queue; two hosts running one campaign each is the supported dual-host
+shape.

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -1347,6 +1347,11 @@ def pull(
         workdir = require_safe_workdir(workdir, host=host)
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
+    # Mirror submit(): forward the per-host default run root so the
+    # remote pull resolves workdirs under the host actually targeted
+    # (e.g. /home/ops/atlas-jobs on hramatka), not atlas-runner's
+    # default, when ATLAS_RUN_ROOT isn't already set by the caller.
+    env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
     if workdir:
         env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
     if job_id:

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -2,10 +2,13 @@
 
 **systemd on the host is truth; the local registry is a journal/mirror.**
 
-Batch kinds run on atlas-runner only. Registry lives under batch_state/atlas-jobs/
-(restic-covered). Close writes a fail-closed result receipt; large artifacts go
-through durable_mirror + backup-data.sh. Publish/pointer flip is never this module. Submit enforces a host free-disk
-floor (default 5 GiB, ATLAS_MIN_FREE_DISK_BYTES / ATLAS_MIN_FREE_DISK_GIB).
+Batch kinds run on atlas-runner or hramatka (each host is its own mutex —
+submit refuses a second active unit on the SAME host; the two hosts may run
+concurrently). Registry lives under batch_state/atlas-jobs/ (restic-covered).
+Close writes a fail-closed result receipt; large artifacts go through
+durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
+Submit enforces a host free-disk floor (default 5 GiB,
+ATLAS_MIN_FREE_DISK_BYTES / ATLAS_MIN_FREE_DISK_GIB).
 """
 
 from __future__ import annotations
@@ -26,8 +29,10 @@ from typing import Any, Protocol
 SCHEMA = "atlas-job.v1"
 RESULT_SCHEMA = "atlas-job-result.v1"
 BATCH_KINDS = frozenset({"reenrich"})
-ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"})}
+# "vps" is the operator ssh alias for the hramatka host (hramatka-api's box;
+# see scripts/config/trails/estate.v1.yaml) — same machine, same allowance.
 HRAMATKA_ALIASES = frozenset({"hramatka", "vps"})
+ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"}) | HRAMATKA_ALIASES}
 RESULT_SINKS = frozenset({"git", "restic", "both"})
 RESUME_MODES = frozenset({"idempotent", "checkpoint", "never"})
 DRIVER_NEEDLES = (
@@ -75,6 +80,14 @@ _HOSTNAME_HINT = re.compile(
 )
 DEFAULT_TIMEOUT_SECONDS = 86400
 DEFAULT_RUN_ROOT = "/home/ops/atlas-runner"
+# hramatka's work root is separate from its teacher-facing /opt/hramatka and
+# /srv trees — reenrich jobs never touch those. Dir does not exist yet on the
+# host; submit/launcher mkdir it on first use.
+DEFAULT_HRAMATKA_RUN_ROOT = "/home/ops/atlas-jobs"
+DEFAULT_RUN_ROOTS = {
+    "atlas-runner": DEFAULT_RUN_ROOT,
+    "hramatka": DEFAULT_HRAMATKA_RUN_ROOT,
+}
 DEFAULT_MIN_FREE_DISK_BYTES = 5 * 1024 * 1024 * 1024  # 5 GiB host floor
 # Same operator env file as ~/.local/bin/learn-ukrainian-backup (launchd wrapper).
 DEFAULT_BACKUP_ENV_FILE = Path.home() / ".secrets" / "learn-ukrainian-backup.env"
@@ -247,7 +260,7 @@ class SshHostAdapter:
         return proc.returncode == 0
 
     def free_disk_bytes(self, host: str, path: str | None = None) -> int:
-        target = path or str(_run_root())
+        target = path or str(_run_root(host))
         remote = (
             "python3 - <<'PY'\n"
             "import shutil\n"
@@ -337,8 +350,19 @@ def require_safe_job_id(job_id: object) -> str:
     return matched.group(0)
 
 
-def _run_root() -> Path:
-    return Path(os.environ.get("ATLAS_RUN_ROOT", DEFAULT_RUN_ROOT))
+def _canonical_host(host: str | None) -> str:
+    """Map ssh-alias variants (``vps``) onto the canonical host name."""
+    if host in HRAMATKA_ALIASES:
+        return "hramatka"
+    return host or "atlas-runner"
+
+
+def _run_root(host: str | None = None) -> Path:
+    override = os.environ.get("ATLAS_RUN_ROOT")
+    if override:
+        return Path(override)
+    canonical = _canonical_host(host)
+    return Path(DEFAULT_RUN_ROOTS.get(canonical, DEFAULT_RUN_ROOT))
 
 
 def _safe_id_token(part: str) -> str:
@@ -365,14 +389,14 @@ def _path_under(root: Path, *parts: str) -> Path:
     return Path(candidate)
 
 
-def require_safe_workdir(workdir: object) -> str:
+def require_safe_workdir(workdir: object, host: str | None = None) -> str:
     """Fail closed for plan/registry workdirs used in path and SSH contexts.
 
-    Rejects ``..``, absolute paths outside ``ATLAS_RUN_ROOT`` / default run
-    root, and any path whose segments are not ``_SAFE_ID`` tokens.
-    Returns a newly constructed path from validated tokens (or
-    ``str(resolved)`` for absolute paths under the run root), never the
-    original relative ``workdir`` string.
+    Rejects ``..``, absolute paths outside ``ATLAS_RUN_ROOT`` / the
+    per-host default run root (see ``DEFAULT_RUN_ROOTS``), and any path
+    whose segments are not ``_SAFE_ID`` tokens. Returns a newly constructed
+    path from validated tokens (or ``str(resolved)`` for absolute paths
+    under the run root), never the original relative ``workdir`` string.
     """
     if not isinstance(workdir, str) or not workdir:
         raise ValueError("workdir must be a non-empty safe token path")
@@ -381,7 +405,7 @@ def require_safe_workdir(workdir: object) -> str:
     raw = Path(workdir)
     if ".." in raw.parts:
         raise ValueError("workdir must not contain ..")
-    run_root = _run_root()
+    run_root = _run_root(host)
     if raw.is_absolute():
         # CodeQL-recognized containment (realpath + startswith), not relative_to.
         run_root_real = os.path.realpath(str(run_root))
@@ -429,9 +453,10 @@ def unit_name(job_id: str) -> str:
 
 def work_dir_for(job_id: str, plan: dict[str, Any] | None = None) -> str:
     safe = require_safe_job_id(job_id)
+    host = plan.get("host") if plan else None
     if plan and isinstance(plan.get("workdir"), str) and plan["workdir"]:
-        return require_safe_workdir(plan["workdir"])
-    run_root = str(_run_root()).rstrip("/")
+        return require_safe_workdir(plan["workdir"], host=host)
+    run_root = str(_run_root(host)).rstrip("/")
     return f"{run_root}/run-atlas-job-{safe}"
 
 
@@ -462,15 +487,13 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     if not isinstance(job_id, str) or _SAFE_ID.fullmatch(job_id) is None:
         errors.append("id must be a filesystem/systemd-safe token")
     host = plan.get("host")
-    if host not in {"atlas-runner", "hramatka"}:
-        errors.append("host must be atlas-runner or hramatka")
+    if host != "atlas-runner" and host not in HRAMATKA_ALIASES:
+        errors.append("host must be atlas-runner, hramatka, or vps")
     kind = plan.get("kind")
     if kind not in BATCH_KINDS:
         errors.append(f"kind must be one of {sorted(BATCH_KINDS)}")
     elif host is not None and host not in ALLOWED_HOSTS[kind]:
         errors.append(f"kind {kind} cannot run on {host}")
-    if host in HRAMATKA_ALIASES and kind in BATCH_KINDS:
-        errors.append("batch kinds must not target hramatka/vps")
     if plan.get("pointer_write") is not False:
         errors.append("pointer_write must be false (publish is a separate gate)")
     sink = plan.get("result_sink")
@@ -507,7 +530,7 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     workdir = plan.get("workdir")
     if workdir is not None:
         try:
-            require_safe_workdir(workdir)
+            require_safe_workdir(workdir, host=host if isinstance(host, str) else None)
         except ValueError as exc:
             errors.append(str(exc))
     return errors
@@ -997,6 +1020,11 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
         args.append("--no-poll")
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
+    # Forward the per-host default run root so the remote launcher's
+    # REMOTE_REPO derivation (RUN_ROOT/repo) matches the host actually
+    # targeted, not atlas-runner's default, when ATLAS_RUN_ROOT isn't
+    # already set by the caller.
+    env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
     env["ATLAS_RE_ENRICH_UNIT"] = unit
     env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
     env["ATLAS_RE_ENRICH_OUT_DIR"] = str(local_pull_dir(job_id))
@@ -1241,9 +1269,6 @@ def _unit_is_active(unit: dict[str, Any]) -> bool:
 
 
 def status(*, host: str, audit: bool = False, host_adapter: HostAdapter | None = None) -> int:
-    if host in HRAMATKA_ALIASES:
-        print("status for batch jobs must use atlas-runner", file=sys.stderr)
-        return 2
     adapter = host_adapter or get_host_adapter()
     try:
         if not adapter.reachable(host):
@@ -1316,13 +1341,10 @@ def pull(
     job_id: str | None = None,
     workdir: str | None = None,
 ) -> int:
-    if host in HRAMATKA_ALIASES:
-        print("pull for batch jobs must use atlas-runner", file=sys.stderr)
-        return 2
     if job_id is not None:
         job_id = require_safe_job_id(job_id)
     if workdir:
-        workdir = require_safe_workdir(workdir)
+        workdir = require_safe_workdir(workdir, host=host)
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
     if workdir:

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -53,10 +53,19 @@ def test_submit_dry_run_via_api(_isolate: atlas_job.FakeHostAdapter) -> None:
     assert resp.json()["exit_code"] == 0
 
 
-def test_submit_rejects_hramatka(_isolate: atlas_job.FakeHostAdapter) -> None:
+def test_submit_allows_hramatka(_isolate: atlas_job.FakeHostAdapter) -> None:
     resp = client.post(
         "/api/atlas-jobs/submit",
         json={"plan": _plan(host="hramatka"), "dry_run": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+
+def test_submit_rejects_unknown_host(_isolate: atlas_job.FakeHostAdapter) -> None:
+    resp = client.post(
+        "/api/atlas-jobs/submit",
+        json={"plan": _plan(host="mystery-host"), "dry_run": True},
     )
     assert resp.status_code == 400
 

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -407,6 +407,21 @@ def test_pull_accepts_hramatka(monkeypatch: pytest.MonkeyPatch) -> None:
     assert launched
 
 
+def test_pull_forwards_per_host_run_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """hramatka pull must forward /home/ops/atlas-jobs (mirrors submit)."""
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    captured_env: dict[str, str] = {}
+
+    def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
+        captured_env.update(kwargs.get("env") or {})
+        return 0
+
+    monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
+    rc = atlas_job.pull(host="hramatka")
+    assert rc == 0
+    assert captured_env["ATLAS_RUN_ROOT"] == "/home/ops/atlas-jobs"
+
+
 def test_git_receipt_rejects_absolute_paths() -> None:
     bad = {
         "schema": "atlas-job-result.v1",

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -48,9 +48,18 @@ def test_valid_plan_is_ok() -> None:
     assert atlas_job.validate_plan(_plan()) == []
 
 
-def test_rejects_hramatka_for_reenrich() -> None:
-    errors = atlas_job.validate_plan(_plan(host="hramatka"))
-    assert any("cannot run" in e or "must not target" in e for e in errors)
+def test_allows_hramatka_for_reenrich() -> None:
+    assert atlas_job.validate_plan(_plan(host="hramatka")) == []
+
+
+def test_allows_vps_alias_for_reenrich() -> None:
+    # "vps" is the ssh alias for the hramatka host — same allowance.
+    assert atlas_job.validate_plan(_plan(host="vps")) == []
+
+
+def test_rejects_unknown_host() -> None:
+    errors = atlas_job.validate_plan(_plan(host="mystery-host"))
+    assert any("host" in e for e in errors)
 
 
 def test_rejects_pointer_write() -> None:
@@ -124,8 +133,36 @@ def test_submit_dry_run_sets_host_and_workdir(capsys: pytest.CaptureFixture[str]
     assert "run-atlas-job-missing-tr-example" in out
 
 
+def test_submit_dry_run_hramatka_uses_atlas_jobs_workdir(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = atlas_job.submit(_plan(id="hramatka-dry", host="hramatka"), dry_run=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "hramatka" in out
+    assert "/home/ops/atlas-jobs/run-atlas-job-hramatka-dry" in out
+
+
+def test_submit_forwards_per_host_run_root_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    captured_env: dict[str, str] = {}
+
+    def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
+        captured_env.update(kwargs.get("env") or {})
+        return 0
+
+    monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
+    plan = _plan(id="hramatka-run-root", host="hramatka")
+    rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
+    assert rc == 0
+    assert captured_env["ATLAS_RUN_ROOT"] == "/home/ops/atlas-jobs"
+
+
 def test_submit_invalid_plan_exits_2() -> None:
-    assert atlas_job.submit(_plan(host="hramatka"), dry_run=True) == 2
+    assert atlas_job.submit(_plan(host="mystery-host"), dry_run=True) == 2
 
 
 def test_submit_checks_host_units(
@@ -349,6 +386,27 @@ def test_status_reconciles_inactive_unit_to_needs_finalize(
     assert row["state"] == "needs_finalize"
 
 
+def test_status_accepts_hramatka(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    rc = atlas_job.status(host="hramatka", host_adapter=_isolate_host)
+    assert rc == 0
+
+
+def test_pull_accepts_hramatka(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: list[list[str]] = []
+
+    def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
+        launched.append(cmd)
+        return 0
+
+    monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
+    rc = atlas_job.pull(host="hramatka")
+    assert rc == 0
+    assert launched
+
+
 def test_git_receipt_rejects_absolute_paths() -> None:
     bad = {
         "schema": "atlas-job-result.v1",
@@ -484,6 +542,20 @@ def test_workdir_honored_only_when_safe(tmp_path: Path, monkeypatch: pytest.Monk
         atlas_job.require_safe_workdir("/home/ops/atlas-runner/run-atlas-job-test")
         == "/home/ops/atlas-runner/run-atlas-job-test"
     )
+
+
+def test_work_dir_for_uses_per_host_default_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    assert atlas_job.work_dir_for("ar-job", _plan(id="ar-job")) == (
+        "/home/ops/atlas-runner/run-atlas-job-ar-job"
+    )
+    assert atlas_job.work_dir_for(
+        "hramatka-job", _plan(id="hramatka-job", host="hramatka")
+    ) == "/home/ops/atlas-jobs/run-atlas-job-hramatka-job"
+    # "vps" is the same physical host as "hramatka" — same default root.
+    assert atlas_job.work_dir_for(
+        "vps-job", _plan(id="vps-job", host="vps")
+    ) == "/home/ops/atlas-jobs/run-atlas-job-vps-job"
 
 
 def test_close_and_cli_reject_unsafe_job_id(


### PR DESCRIPTION
## Summary

Operator GO 2026-08-17: atlas jobs may run on both `atlas-runner` and
`hramatka`, not `atlas-runner` only.

- `ALLOWED_HOSTS['reenrich']` now includes `atlas-runner`, `hramatka`, and
  the `vps` ssh alias (confirmed same machine via
  `scripts/config/trails/estate.v1.yaml`: `vps` is `pilot-vps`, which also
  hosts `hramatka-api`).
- Dropped the `validate_plan` reject that refused batch kinds on
  hramatka/vps. Unknown host strings are still rejected (new test).
- Per-host default work root: `atlas-runner` keeps `/home/ops/atlas-runner`;
  `hramatka`/`vps` default to a new `/home/ops/atlas-jobs` (does not exist
  yet — submit/launcher `mkdir -p` it on first use). Kept separate from
  hramatka's teacher-facing `/opt/hramatka` and `/srv` trees — nothing here
  writes there. `require_safe_workdir` / `work_dir_for` / `_run_root` now
  take an optional `host` and forward it consistently; `submit()` also
  forwards `ATLAS_RUN_ROOT` to the remote launcher's env so
  `REMOTE_REPO` derivation matches the host actually targeted (complements
  #6946, which teaches the bash launchers the same per-host default).
- Fixed a latent bug in `SshHostAdapter.free_disk_bytes`: it ignored `host`
  when deriving its default probe path, which would have silently probed
  atlas-runner's root even for a hramatka disk-floor check.
- `status`/`pull` no longer refuse `hramatka`/`vps`.
- MemoryHigh/MemoryMax stay at the existing conservative 1.5G/2G on the
  class-B launcher (host-agnostic already) — documented in the runbook why
  that's load-bearing on hramatka (protects the teacher API/GH runners
  sharing that box).

## Test plan
- `pytest tests/test_atlas_job_protocol.py tests/api/test_atlas_jobs_router.py -q` — 54 passed
- `ruff check` on all changed files — clean

Refs #6876.