### PR TITLE
fix(ops): wrapper entrypoints for monitor-api + codex-archived-thread-cleanup LaunchAgents (#6941)

### DIFF
--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -28,6 +28,10 @@ mode) under a per-user macOS LaunchAgent:
   subprocesses that preserve their parent environment, so runtime imports
   cannot add `__pycache__` files that invalidate the release manifest.
 - Label: `com.learn-ukrainian.monitor-api`
+- launchd `Program` is `/bin/bash` plus
+  `scripts/api/run_monitor_api_supervisor.sh`, which execs the primary
+  `.venv/bin/python -m scripts.api.launchd_supervisor`. Binding `Program` to
+  the venv interpreter is the LWCR exit-78 trap (#6937, #6941).
 - Restart policy: `KeepAlive.SuccessfulExit=false`; the foreground runner turns
   any unexpected API exit, including an unexpected zero exit, into a failed
   launch-agent run.

--- a/docs/runbooks/archived-thread-cleanup.md
+++ b/docs/runbooks/archived-thread-cleanup.md
@@ -93,12 +93,18 @@ The installer atomically writes:
 ~/Library/LaunchAgents/com.learn-ukrainian.codex-archived-thread-cleanup.plist
 ```
 
-Its `ProgramArguments` use the checkout's explicit `.venv/bin/python` to run
-`scripts/orchestration/archived_thread_cleanup.py --apply --repo-root <checkout> --retention-days 30
---observation-interval-days 7`. The installer also resolves the supported Codex CLI to an absolute,
-executable path and persists it through `--codex-binary`; the scheduled job does not depend on
-`launchd`'s minimal `PATH`. Installation is idempotent: an unchanged loaded job is left in place; a
-changed job is unloaded, rewritten, loaded, and verified through `launchctl print`.
+Its `Program` is `/bin/bash` (Apple-signed, survives a `.venv` rebuild) plus
+`scripts/orchestration/run_archived_thread_cleanup.sh`, which execs the checkout's
+`.venv/bin/python` against `archived_thread_cleanup.py --apply --repo-root
+<checkout> --retention-days 30 --observation-interval-days 7`. Pointing `Program`
+at the venv interpreter is what produced exit 78 (`Unable to get updated LWCR
+... error 0x3`) after the 2026-08-15 venv rewrite (#6937, #6941). The installer
+also resolves the supported Codex CLI to an absolute, executable path and
+persists it through `--codex-binary`; the scheduled job does not depend on
+`launchd`'s minimal `PATH`. Installation is idempotent: an unchanged loaded job
+is left in place; a changed job is unloaded, rewritten, loaded, and verified
+through `launchctl print`. A venv rebuild does not require reinstall anymore;
+`status` still verifies the plist still binds `Program` to `/bin/bash`.
 
 If `codex` is not on the interactive shell's `PATH`, provide its absolute path explicitly:
 

--- a/docs/runbooks/launchd-inventory.md
+++ b/docs/runbooks/launchd-inventory.md
@@ -23,8 +23,11 @@ dispatch worktree.
 ### `com.learn-ukrainian.monitor-api`
 
 - Purpose: keeps the Monitor API running under launchd supervision.
-- Program: the primary checkout's `.venv/bin/python -m
-  scripts.api.launchd_supervisor run --repo-root <primary checkout>`.
+- Program: `/bin/bash --noprofile --norc
+  scripts/api/run_monitor_api_supervisor.sh run --repo-root <primary
+  checkout>`. The wrapper execs the primary `.venv/bin/python -m
+  scripts.api.launchd_supervisor`. `Program` must stay `/bin/bash` so a
+  venv rebuild cannot invalidate launchd LWCR (exit 78; #6937, #6941).
 - Schedule: `RunAtLoad`; `KeepAlive.SuccessfulExit=false` restarts only
   unexpected exits; `ThrottleInterval=30` bounds crash-loop respawns.
 - Delete authority: none. It starts and restarts the API only.
@@ -74,9 +77,11 @@ dispatch worktree.
 ### `com.learn-ukrainian.codex-archived-thread-cleanup`
 
 - Purpose: deterministic cleanup of old archived Codex threads.
-- Program: the primary checkout's `.venv/bin/python
-  scripts/orchestration/archived_thread_cleanup.py --apply --retention-days 30
-  --observation-interval-days 7` with an absolute `--codex-binary`.
+- Program: `/bin/bash --noprofile --norc
+  scripts/orchestration/run_archived_thread_cleanup.sh --apply` with both
+  `--repo-root` and an absolute `--codex-binary`. The wrapper execs the
+  primary `.venv/bin/python`. `Program` must stay `/bin/bash` so a venv
+  rebuild cannot invalidate launchd LWCR (exit 78; #6937, #6941).
 - Schedule: Sundays at 03:00 local (`StartCalendarInterval`, weekday 0);
   `RunAtLoad` is false.
 - Delete authority: `codex delete --force` through the supported Codex CLI,

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -28,6 +28,11 @@ LABEL = "com.learn-ukrainian.monitor-api"
 PORT = 8765
 THROTTLE_INTERVAL_SECONDS = 30
 _LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# launchd binds LWCR to ProgramArguments[0]. /bin/bash is Apple-signed and
+# survives a primary .venv rebuild; pointing Program at .venv/bin/python
+# is what produced exit 78 after the 2026-08-15 uv rewrite (#6937, #6941).
+STABLE_PROGRAM = "/bin/bash"
+WRAPPER_NAME = "run_monitor_api_supervisor.sh"
 _LOG_ROTATE_BYTES = 10 * 1024 * 1024
 _STOP_UNLOAD_TIMEOUT_SECONDS = 12.0
 _STOP_UNLOAD_POLL_SECONDS = 0.1
@@ -50,6 +55,11 @@ def default_home() -> Path:
 def plist_path(home: Path) -> Path:
     """Return the per-user LaunchAgent location."""
     return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def wrapper_path(repo_root: Path) -> Path:
+    """Return the stable bash wrapper launchd executes."""
+    return repo_root / "scripts" / "api" / WRAPPER_NAME
 
 
 def _pid_dir(repo_root: Path) -> Path:
@@ -128,14 +138,14 @@ def atomic_write(path: Path, content: bytes, *, mode: int = 0o600) -> bool:
 def build_plist(*, repo_root: Path) -> dict[str, object]:
     """Build the persistent LaunchAgent configuration without side effects."""
     root = repo_root.resolve()
-    interpreter = root / ".venv" / "bin" / "python"
     return {
         "Label": LABEL,
         "ProcessType": "Background",
         "ProgramArguments": [
-            str(interpreter),
-            "-m",
-            "scripts.api.launchd_supervisor",
+            STABLE_PROGRAM,
+            "--noprofile",
+            "--norc",
+            str(wrapper_path(root)),
             "run",
             "--repo-root",
             str(root),
@@ -161,10 +171,15 @@ def render_plist(*, repo_root: Path) -> bytes:
 def _validate_runtime(repo_root: Path) -> None:
     interpreter = repo_root / ".venv" / "bin" / "python"
     supervisor = repo_root / "scripts" / "api" / "launchd_supervisor.py"
+    wrapper = wrapper_path(repo_root)
     if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
         raise LaunchdError(f"required interpreter is missing or not executable: {interpreter}")
     if not supervisor.is_file():
         raise LaunchdError(f"required API supervisor is missing: {supervisor}")
+    if not wrapper.is_file():
+        raise LaunchdError(f"required API wrapper is missing: {wrapper}")
+    if not os.access(STABLE_PROGRAM, os.X_OK):
+        raise LaunchdError(f"stable launchd program is missing: {STABLE_PROGRAM}")
 
 
 def install(*, repo_root: Path, home: Path) -> dict[str, object]:
@@ -328,12 +343,18 @@ def status(*, home: Path) -> tuple[dict[str, object], int]:
     if installed:
         try:
             payload = plistlib.loads(destination.read_bytes())
+            arguments = payload.get("ProgramArguments") if isinstance(payload, dict) else None
             valid_plist = (
                 isinstance(payload, dict)
                 and payload.get("Label") == LABEL
                 and payload.get("KeepAlive") == {"SuccessfulExit": False}
                 and payload.get("ThrottleInterval") == THROTTLE_INTERVAL_SECONDS
                 and payload.get("EnvironmentVariables") == {"PATH": _LAUNCHD_PATH}
+                and isinstance(arguments, list)
+                and arguments
+                and arguments[0] == STABLE_PROGRAM
+                and WRAPPER_NAME in str(arguments)
+                and not any(".venv/bin/python" in str(part) for part in arguments)
             )
         except (OSError, ValueError, plistlib.InvalidFileException) as exc:
             parse_error = str(exc)

--- a/scripts/api/run_monitor_api_supervisor.sh
+++ b/scripts/api/run_monitor_api_supervisor.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# launchd binds LWCR to ProgramArguments[0]. That must stay /bin/bash
+# (Apple-signed). Never put .venv/bin/python there: a venv rebuild
+# replaces the binary and launchd then fails with
+# "Unable to get updated LWCR ... error 0x3 - No such process" (exit 78).
+set -euo pipefail
+
+primary=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--repo-root" ]]; then
+    primary="${args[$((i + 1))]:-}"
+    break
+  fi
+done
+
+if [[ -z "${primary}" ]]; then
+  echo "monitor-api: missing --repo-root (primary checkout)" >&2
+  exit 78
+fi
+
+python="${primary}/.venv/bin/python"
+supervisor="$(cd "$(dirname "$0")" && pwd)/launchd_supervisor.py"
+
+if [[ ! -x "${python}" ]]; then
+  echo "monitor-api: missing interpreter: ${python}" >&2
+  exit 78
+fi
+if [[ ! -f "${supervisor}" ]]; then
+  echo "monitor-api: missing script: ${supervisor}" >&2
+  exit 78
+fi
+
+cd "${primary}"
+exec "${python}" -m scripts.api.launchd_supervisor "$@"

--- a/scripts/orchestration/install_archived_thread_cleanup_launchd.py
+++ b/scripts/orchestration/install_archived_thread_cleanup_launchd.py
@@ -16,6 +16,11 @@ from pathlib import Path
 LABEL = "com.learn-ukrainian.codex-archived-thread-cleanup"
 DEFAULT_WEEKDAY = "sunday"
 DEFAULT_HOUR = 3
+# launchd binds LWCR to ProgramArguments[0]. /bin/bash is Apple-signed and
+# survives a primary .venv rebuild; pointing Program at .venv/bin/python
+# is what produced exit 78 after the 2026-08-15 uv rewrite (#6937, #6941).
+STABLE_PROGRAM = "/bin/bash"
+WRAPPER_NAME = "run_archived_thread_cleanup.sh"
 WEEKDAYS = {
     "sunday": 0,
     "monday": 1,
@@ -57,6 +62,11 @@ def plist_path(home: Path) -> Path:
     return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
 
 
+def wrapper_path(repo_root: Path) -> Path:
+    """Return the stable bash wrapper launchd executes."""
+    return repo_root / "scripts" / "orchestration" / WRAPPER_NAME
+
+
 def state_dir(home: Path) -> Path:
     """Return the durable scheduler log and cleanup-state directory."""
     return home / ".codex" / "thread-cleanup"
@@ -82,16 +92,16 @@ def build_plist(
     *, repo_root: Path, home: Path, codex_binary: Path, weekday: str, hour: int
 ) -> dict[str, object]:
     """Build the launchd configuration without touching disk or launchd."""
-    cleanup_script = repo_root / "scripts" / "orchestration" / "archived_thread_cleanup.py"
-    interpreter = repo_root / ".venv" / "bin" / "python"
     log_dir = state_dir(home) / "logs"
     return {
         "Label": LABEL,
         "LowPriorityIO": True,
         "ProcessType": "Background",
         "ProgramArguments": [
-            str(interpreter),
-            str(cleanup_script),
+            STABLE_PROGRAM,
+            "--noprofile",
+            "--norc",
+            str(wrapper_path(repo_root)),
             "--apply",
             "--repo-root",
             str(repo_root),
@@ -193,10 +203,15 @@ def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdEr
 def _validate_runtime(repo_root: Path, codex_binary: Path) -> None:
     interpreter = repo_root / ".venv" / "bin" / "python"
     cleanup_script = repo_root / "scripts" / "orchestration" / "archived_thread_cleanup.py"
+    wrapper = wrapper_path(repo_root)
     if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
         raise LaunchdError(f"required interpreter is missing or not executable: {interpreter}")
     if not cleanup_script.is_file():
         raise LaunchdError(f"cleanup script is missing: {cleanup_script}")
+    if not wrapper.is_file():
+        raise LaunchdError(f"cleanup wrapper is missing: {wrapper}")
+    if not os.access(STABLE_PROGRAM, os.X_OK):
+        raise LaunchdError(f"stable launchd program is missing: {STABLE_PROGRAM}")
     if not codex_binary.is_file() or not os.access(codex_binary, os.X_OK):
         raise LaunchdError(f"Codex CLI is missing or not executable: {codex_binary}")
 
@@ -280,10 +295,13 @@ def status(*, home: Path) -> tuple[dict[str, object], int]:
             valid_plist = (
                 parsed.get("Label") == LABEL
                 and isinstance(arguments, list)
-                and len(arguments) >= 3
+                and len(arguments) >= 5
                 and all(isinstance(argument, str) for argument in arguments)
-                and Path(arguments[1]).name == "archived_thread_cleanup.py"
+                and arguments[0] == STABLE_PROGRAM
+                and Path(arguments[3]).name == WRAPPER_NAME
                 and "--apply" in arguments
+                and "--repo-root" in arguments
+                and not any(".venv/bin/python" in argument for argument in arguments)
                 and isinstance(schedule, dict)
                 and isinstance(schedule.get("Weekday"), int)
             )

--- a/scripts/orchestration/run_archived_thread_cleanup.sh
+++ b/scripts/orchestration/run_archived_thread_cleanup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# launchd binds LWCR to ProgramArguments[0]. That must stay /bin/bash
+# (Apple-signed). Never put .venv/bin/python there: a venv rebuild
+# replaces the binary and launchd then fails with
+# "Unable to get updated LWCR ... error 0x3 - No such process" (exit 78).
+set -euo pipefail
+
+primary=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--repo-root" ]]; then
+    primary="${args[$((i + 1))]:-}"
+    break
+  fi
+done
+
+if [[ -z "${primary}" ]]; then
+  echo "archived-thread-cleanup: missing --repo-root (primary checkout)" >&2
+  exit 78
+fi
+
+python="${primary}/.venv/bin/python"
+cleanup="$(cd "$(dirname "$0")" && pwd)/archived_thread_cleanup.py"
+
+if [[ ! -x "${python}" ]]; then
+  echo "archived-thread-cleanup: missing interpreter: ${python}" >&2
+  exit 78
+fi
+if [[ ! -f "${cleanup}" ]]; then
+  echo "archived-thread-cleanup: missing script: ${cleanup}" >&2
+  exit 78
+fi
+
+exec "${python}" "${cleanup}" "$@"

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import json
 import os
 import plistlib
+import stat
 import subprocess
+import sys
 from pathlib import Path
 
 from scripts.api import launchd_supervisor as supervisor
-
-_ROOT = Path(__file__).resolve().parents[2]
-_VENV_PYTHON = _ROOT / ".venv" / "bin" / "python"
 
 
 def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> None:
@@ -25,14 +24,17 @@ def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> 
         "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     }
     assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"][0] == supervisor.STABLE_PROGRAM
     assert payload["ProgramArguments"] == [
-        str(repo / ".venv" / "bin" / "python"),
-        "-m",
-        "scripts.api.launchd_supervisor",
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        str(repo.resolve() / "scripts" / "api" / "run_monitor_api_supervisor.sh"),
         "run",
         "--repo-root",
-        str(repo),
+        str(repo.resolve()),
     ]
+    assert not any(".venv/bin/python" in part for part in payload["ProgramArguments"])
 
 
 def test_api_child_disables_bytecode_writes(tmp_path: Path, monkeypatch) -> None:
@@ -57,7 +59,7 @@ def test_api_child_disables_bytecode_writes(tmp_path: Path, monkeypatch) -> None
 
     inherited = subprocess.run(
         [
-            str(_VENV_PYTHON),
+            sys.executable,
             "-B",
             "-c",
             (
@@ -84,6 +86,8 @@ def test_install_and_uninstall_preserve_crash_evidence(tmp_path: Path, monkeypat
     interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
     interpreter.chmod(0o755)
     implementation.write_text("# installed by test\n", encoding="utf-8")
+    wrapper = repo / "scripts" / "api" / "run_monitor_api_supervisor.sh"
+    wrapper.write_text("#!/bin/bash\n", encoding="utf-8")
     home = tmp_path / "home"
 
     installed = supervisor.install(repo_root=repo, home=home)
@@ -200,7 +204,7 @@ def test_unexpected_exit_records_signal_and_stderr_tail(tmp_path: Path) -> None:
     ) -> tuple[list[str], Path, dict[str, str], str]:
         return (
             [
-                str(_VENV_PYTHON),
+                sys.executable,
                 "-c",
                 "import os, sys; sys.stderr.write('fatal before kill\\n'); sys.stderr.flush(); os.kill(os.getpid(), 9)",
             ],
@@ -226,7 +230,7 @@ def test_unexpected_clean_exit_is_recorded_and_restarted_by_launchd_contract(tmp
         _live: bool,
         _port: int,
     ) -> tuple[list[str], Path, dict[str, str], str]:
-        return [str(_VENV_PYTHON), "-c", "raise SystemExit(0)"], repo, os.environ.copy(), "test launch"
+        return [sys.executable, "-c", "raise SystemExit(0)"], repo, os.environ.copy(), "test launch"
 
     assert supervisor.run_managed_api(repo_root=repo, prepare_command=fake_prepare) == 1
 
@@ -245,3 +249,96 @@ def test_runner_rotates_api_log_before_each_launch(tmp_path: Path) -> None:
     rotated = log_path.with_name("api.log.1")
     assert rotated.exists()
     assert rotated.stat().st_size == supervisor._LOG_ROTATE_BYTES + 1
+
+
+def test_status_rejects_venv_python_as_program(tmp_path: Path, monkeypatch) -> None:
+    """Mutation-check: putting .venv/bin/python back in Program must fail status."""
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    destination = supervisor.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = supervisor.build_plist(repo_root=repo)
+    payload["ProgramArguments"][0] = str(repo / ".venv" / "bin" / "python")
+    destination.write_bytes(plistlib.dumps(payload))
+    monkeypatch.setattr(
+        supervisor,
+        "_loaded_readback",
+        lambda: subprocess.CompletedProcess(["launchctl", "print"], 0, "loaded", ""),
+    )
+
+    result, return_code = supervisor.status(home=home)
+
+    assert return_code == 1
+    assert result["valid_plist"] is False
+    assert result["loaded"] is True
+
+
+_WRAPPER = Path(__file__).resolve().parents[2] / "scripts" / "api" / "run_monitor_api_supervisor.sh"
+
+
+def test_wrapper_exits_78_without_repo_root() -> None:
+    proc = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(_WRAPPER)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing --repo-root" in proc.stderr
+
+
+def test_wrapper_exits_78_when_interpreter_missing(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(_WRAPPER),
+            "run",
+            "--repo-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing interpreter" in proc.stderr
+    assert str(tmp_path / ".venv" / "bin" / "python") in proc.stderr
+
+
+def test_wrapper_execs_primary_interpreter(tmp_path: Path) -> None:
+    """Mutation-check: the wrapper must exec primary .venv python, not PATH python."""
+    primary = tmp_path / "primary"
+    python = primary / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\"\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(_WRAPPER),
+            "run",
+            "--repo-root",
+            str(primary),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0
+    assert "-m" in proc.stdout
+    assert "scripts.api.launchd_supervisor" in proc.stdout
+    assert "run" in proc.stdout
+    assert str(primary) in proc.stdout

--- a/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
+++ b/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import os
 import plistlib
 import stat
+import subprocess
 from pathlib import Path
 
 from scripts.orchestration import install_archived_thread_cleanup_launchd as launchd
 
+_WRAPPER = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "orchestration"
+    / "run_archived_thread_cleanup.sh"
+)
 
-def test_rendered_plist_invokes_code_directly_once_per_week(tmp_path: Path) -> None:
+
+def test_rendered_plist_uses_bash_wrapper_once_per_week(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     home = tmp_path / "home"
     codex_binary = tmp_path / "bin" / "codex"
@@ -26,9 +35,12 @@ def test_rendered_plist_invokes_code_directly_once_per_week(tmp_path: Path) -> N
     )
 
     assert payload["Label"] == launchd.LABEL
+    assert payload["ProgramArguments"][0] == launchd.STABLE_PROGRAM
     assert payload["ProgramArguments"] == [
-        str(repo / ".venv" / "bin" / "python"),
-        str(repo / "scripts" / "orchestration" / "archived_thread_cleanup.py"),
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        str(repo / "scripts" / "orchestration" / "run_archived_thread_cleanup.sh"),
         "--apply",
         "--repo-root",
         str(repo),
@@ -39,6 +51,7 @@ def test_rendered_plist_invokes_code_directly_once_per_week(tmp_path: Path) -> N
         "--codex-binary",
         str(codex_binary),
     ]
+    assert not any(".venv/bin/python" in part for part in payload["ProgramArguments"])
     assert payload["StartCalendarInterval"] == {"Hour": 3, "Minute": 0, "Weekday": 0}
     assert "prompt" not in str(payload).lower()
 
@@ -107,3 +120,101 @@ def test_status_rejects_loaded_plist_that_does_not_run_cleanup_code(
     assert return_code == 1
     assert status["loaded"] is True
     assert status["valid_plist"] is False
+
+
+def test_status_rejects_venv_python_as_program(tmp_path: Path, monkeypatch) -> None:
+    """Mutation-check: putting .venv/bin/python back in Program must fail status."""
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        repo_root=tmp_path / "repo",
+        home=home,
+        codex_binary=tmp_path / "bin" / "codex",
+        weekday="sunday",
+        hour=3,
+    )
+    payload["ProgramArguments"][0] = str(tmp_path / "repo" / ".venv" / "bin" / "python")
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    status, return_code = launchd.status(home=home)
+
+    assert return_code == 1
+    assert status["valid_plist"] is False
+    assert status["loaded"] is True
+
+
+def test_wrapper_exits_78_without_repo_root() -> None:
+    proc = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(_WRAPPER)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing --repo-root" in proc.stderr
+
+
+def test_wrapper_exits_78_when_interpreter_missing(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(_WRAPPER),
+            "--apply",
+            "--repo-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 78
+    assert "missing interpreter" in proc.stderr
+    assert str(tmp_path / ".venv" / "bin" / "python") in proc.stderr
+
+
+def test_wrapper_execs_primary_interpreter(tmp_path: Path) -> None:
+    """Mutation-check: the wrapper must exec primary .venv python, not PATH python."""
+    primary = tmp_path / "primary"
+    python = primary / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    marker = tmp_path / "ran"
+    python.write_text(
+        "#!/bin/sh\n"
+        f'echo "$1" > "{marker}"\n'
+        "printf '%s\\n' \"$@\"\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(_WRAPPER),
+            "--apply",
+            "--repo-root",
+            str(primary),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0
+    assert marker.read_text(encoding="utf-8").strip().endswith("archived_thread_cleanup.py")
+    assert "--apply" in proc.stdout
+    assert str(primary) in proc.stdout


### PR DESCRIPTION
Fixes #6941.

Applies the #6937/#6942 wrapper-entrypoint pattern to the two remaining LaunchAgents that still pinned `.venv/bin/python` as their launchd `Program` — the LWCR exit-78 trap that killed worktree-cleanup when the venv was rebuilt on 08-15:

- `com.learn-ukrainian.monitor-api` → new `scripts/api/run_monitor_api_supervisor.sh` stable bash wrapper, run-time interpreter resolution
- `com.learn-ukrainian.codex-archived-thread-cleanup` → new `scripts/orchestration/run_archived_thread_cleanup.sh` + installer update

Tests: 22 passed (launchd supervisor + installer suites), ruff clean.

**Live reinstall is deliberately OUT of this PR** — post-merge driver step via the sanctioned installers; monitor-api is the live api service and gets the #M-19 window + merge-specific probe.

Refs #6937 #6942 #6830.

Worker: grok (lane dispatch infra-6941-launchagent-lwcr); driver finalized push (grok harness cannot push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)