### PR TITLE
fix(bridge): registry-derived gemini default model (#6959)

### DIFF
--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -10,8 +10,7 @@ Configuration:
 - ``AB_CONTEXT_DIR``: defaults to ``{REPO_ROOT}/docs/agent-channels``.
 - ``AB_WAKE_DIR``: defaults to ``{REPO_ROOT}/.agent/wake``.
 - ``AB_MONITOR_URL``: defaults to empty string (Monitor API disabled).
-- ``AB_GEMINI_MODEL``: defaults to ``batch_gemini_config.FLASH_MODEL`` when importable,
-  else ``gemini-2.0-flash``.
+- ``AB_GEMINI_MODEL``: defaults to the AGY seat pin from the ACP participant registry.
 - ``AB_PIPELINE_ENV_KEY``: defaults to ``LEARN_UKRAINIAN_PIPELINE``.
 
 All public functions are re-exported here for backward compatibility.
@@ -46,10 +45,10 @@ from ._config import (
     CODEX_CLI,
     DB_PATH,
     GEMINI_CLI,
-    GEMINI_DEFAULT_MODEL,
     GH_CHAR_LIMIT,
     PID_DIR,
     REPO_ROOT,
+    default_gemini_model,
 )
 from ._db import get_db, get_session, init_db, set_session
 from ._gemini import ask_gemini, process_and_respond
@@ -112,6 +111,7 @@ __all__ = [
     "build_gemini_prompt",
     "check_inbox",
     "check_model",
+    "default_gemini_model",
     "detect_sender",
     "get_conversation",
     "get_db",
@@ -132,3 +132,11 @@ __all__ = [
     "send_to_gemini",
     "set_session",
 ]
+
+
+def __getattr__(name: str):
+    if name == "GEMINI_DEFAULT_MODEL":
+        from ._config import default_gemini_model
+
+        return default_gemini_model()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -15,9 +15,7 @@ if str(_local_repo_root) not in sys.path:
 from scripts.common.repo_root import resolve_repo_root
 
 # Repo root for path resolution
-REPO_ROOT = Path(
-    os.environ.get("AB_REPO_ROOT", str(Path(__file__).parent.parent.parent))
-)
+REPO_ROOT = Path(os.environ.get("AB_REPO_ROOT", str(Path(__file__).parent.parent.parent)))
 
 PRIMARY_REPO_ROOT = resolve_repo_root(Path(__file__), 2)
 
@@ -43,31 +41,55 @@ PID_DIR = Path(
 # Second probe: the default native install target ~/.local/bin/claude covers
 # callers whose PATH omits it (mirrors start-claude.sh:33; review-4881).
 _CLAUDE_BIN = shutil.which("claude") or (
-    str(Path.home() / ".local/bin/claude")
-    if (Path.home() / ".local/bin/claude").is_file()
-    else None
+    str(Path.home() / ".local/bin/claude") if (Path.home() / ".local/bin/claude").is_file() else None
 )
 CLAUDE_CMD = [_CLAUDE_BIN] if _CLAUDE_BIN else ["npx", "@anthropic-ai/claude-code@latest"]
 AGY_CLI = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"
-GEMINI_DEFAULT_MODEL = os.environ.get("AB_GEMINI_MODEL", "")
-if not GEMINI_DEFAULT_MODEL:
-    try:
-        from batch_gemini_config import FLASH_MODEL
 
-        GEMINI_DEFAULT_MODEL = FLASH_MODEL
-    except ImportError:
-        GEMINI_DEFAULT_MODEL = "gemini-2.0-flash"
+
+def default_gemini_model() -> str:
+    """Resolve the default Gemini model from environment or ACP registry pin (#6959).
+
+    Resolution chain:
+    1. ``AB_GEMINI_MODEL`` environment override.
+    2. AGY seat pin from the live ACP participant registry (``agent_runtime.adapters.acpx.ACPX_SUPPORTED_PARTICIPANTS``).
+
+    Raises RuntimeError if neither is configured (fails loudly rather than pinning
+    a stale literal fallback).
+    """
+    env_override = os.environ.get("AB_GEMINI_MODEL")
+    if env_override:
+        return env_override
+
+    try:
+        from ._acp_compat import registered_participant_model
+
+        pin = registered_participant_model("agy")
+        if pin:
+            return pin
+    except Exception:
+        pass
+
+    raise RuntimeError(
+        "No default Gemini model configured: 'AB_GEMINI_MODEL' is unset and "
+        "the ACP participant registry ('agy') has no model pin."
+    )
+
+
+def __getattr__(name: str):
+    if name == "GEMINI_DEFAULT_MODEL":
+        return default_gemini_model()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Snapshot environment for passing to detached children. Use a narrow env so
 # background bridge processes do not inherit shell tokens that agents can print.
 # Set GEMINI_SESSION so .bashrc disables hostile aliases (eza, bat, zoxide)
 _PARENT_ENV = build_agent_env(os.environ, repo_root=REPO_ROOT)
 _PARENT_ENV["GEMINI_SESSION"] = "1"
-_PIPELINE_ENV_KEY = os.environ.get(
-    "AB_PIPELINE_ENV_KEY", "LEARN_UKRAINIAN_PIPELINE"
-)
+_PIPELINE_ENV_KEY = os.environ.get("AB_PIPELINE_ENV_KEY", "LEARN_UKRAINIAN_PIPELINE")
 _PARENT_ENV[_PIPELINE_ENV_KEY] = "1"  # Suppress inbox hooks during pipeline runs
 
 # Model availability cache: {model: (available: bool, timestamp: float)}

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -37,8 +37,8 @@ from ._config import (
     _MODEL_CACHE,
     _MODEL_CACHE_TTL,
     _PARENT_ENV,
-    GEMINI_DEFAULT_MODEL,
     REPO_ROOT,
+    default_gemini_model,
 )
 from ._db import get_db
 from ._github import _post_review_to_github
@@ -54,50 +54,74 @@ from ._model import _detect_model_error
 from ._prompts import build_gemini_prompt
 
 
-def converse_gemini(content: str, task_id: str, model: str | None = None,
-                    skip_github: bool = False, auth_mode: str | None = None):
+def converse_gemini(
+    content: str, task_id: str, model: str | None = None, skip_github: bool = False, auth_mode: str | None = None
+):
     """Multi-turn conversation with Gemini. Includes conversation history in prompt.
 
     Each call adds to the conversation thread (via task_id) and Gemini sees
     all previous messages for context.
 
-    ``model`` defaults to the AGY seat's live ACP registry pin. Legacy
-    ``gemini*`` slugs remap through ``resolve_compat_model`` so a pin
-    rotation cannot leave converse on a stale default (#6929).
+    ``model`` defaults to the AGY seat's live ACP registry pin (or ``AB_GEMINI_MODEL``
+    env override). Legacy ``gemini*`` slugs remap through ``resolve_compat_model``
+    so a pin rotation cannot leave converse on a stale default (#6929/#6959).
     """
-    from ._acp_compat import registered_participant_model, resolve_compat_model
+    from ._acp_compat import resolve_compat_model
 
     selected = resolve_compat_model("gemini", model)
     if selected is None:
-        selected = registered_participant_model("agy")
+        selected = default_gemini_model()
 
     history, msg_count = get_conversation_context(task_id)
 
     if history:
-        full_content = (
-            f"## Conversation History\n\n{history}\n\n"
-            f"===\n\n## Current Message\n\n{content}"
-        )
+        full_content = f"## Conversation History\n\n{history}\n\n===\n\n## Current Message\n\n{content}"
         print(f"📜 Conversation '{task_id}' — turn {msg_count + 1}")
     else:
         full_content = content
         print(f"📜 Starting conversation '{task_id}'")
 
     return ask_gemini(
-        full_content, task_id=task_id, msg_type="query",
-        model=selected, skip_github=skip_github, auth_mode=auth_mode,
+        full_content,
+        task_id=task_id,
+        msg_type="query",
+        model=selected,
+        skip_github=skip_github,
+        auth_mode=auth_mode,
     )
 
 
-def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query",
-               data: str | None = None, model: str = GEMINI_DEFAULT_MODEL,
-               from_llm: str | None = None, from_model: str | None = None,
-               async_mode: bool = False, stdout_only: bool = False,
-               output_path: str | None = None, extract_tags: list | None = None,
-               skip_model_check: bool = False, allow_write: bool = False,
-               delimiters: str | None = None, skip_github: bool = False,
-               auth_mode: str | None = None, review: bool = False):
-    """Send message to Gemini AND optionally invoke Gemini to process it."""
+def ask_gemini(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str | None = None,
+    from_model: str | None = None,
+    async_mode: bool = False,
+    stdout_only: bool = False,
+    output_path: str | None = None,
+    extract_tags: list | None = None,
+    skip_model_check: bool = False,
+    allow_write: bool = False,
+    delimiters: str | None = None,
+    skip_github: bool = False,
+    auth_mode: str | None = None,
+    review: bool = False,
+):
+    """Send message to Gemini AND optionally invoke Gemini to process it.
+
+    ``model`` defaults to the AGY seat's live ACP registry pin (or ``AB_GEMINI_MODEL``
+    env override). Legacy ``gemini*`` slugs remap through ``resolve_compat_model``
+    (#6894/#6959).
+    """
+    from ._acp_compat import resolve_compat_model
+
+    selected = resolve_compat_model("gemini", model)
+    if selected is None:
+        selected = default_gemini_model()
+    model = selected
     # Model cache management
     if skip_model_check and model in _MODEL_CACHE:
         del _MODEL_CACHE[model]
@@ -120,8 +144,9 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
     _warn_long_handoff(content, msg_type, task_id)
 
     # Send the message
-    msg_id = _send_gemini_message(content, task_id, msg_type, data, from_llm,
-                                  from_model, model, stdout_only, output_path)
+    msg_id = _send_gemini_message(
+        content, task_id, msg_type, data, from_llm, from_model, model, stdout_only, output_path
+    )
 
     # Invoke Gemini or queue
     if async_mode:
@@ -131,10 +156,17 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
     else:
         if not stdout_only:
             print(f"\n🚀 Invoking Gemini to process message #{msg_id}...")
-        response = process_and_respond(msg_id, model, stdout_only=stdout_only,
-                                       output_path=output_path, allow_write=allow_write,
-                                       delimiters=delimiters, skip_github=skip_github,
-                                       auth_mode=auth_mode, review=review)
+        response = process_and_respond(
+            msg_id,
+            model,
+            stdout_only=stdout_only,
+            output_path=output_path,
+            allow_write=allow_write,
+            delimiters=delimiters,
+            skip_github=skip_github,
+            auth_mode=auth_mode,
+            review=review,
+        )
 
         # Post-process: extract delimited content
         if extract_tags is not None and response:
@@ -155,34 +187,45 @@ def _warn_long_handoff(content: str, msg_type: str, task_id: str | None):
         print()
 
 
-def _send_gemini_message(content, task_id, msg_type, data, from_llm, from_model, model,
-                         stdout_only, output_path):
+def _send_gemini_message(content, task_id, msg_type, data, from_llm, from_model, model, stdout_only, output_path):
     """Send the message and handle pre-acknowledgement."""
     if output_path:
         if from_llm:
             msg_id = send_message(
-                content, task_id, msg_type, data, from_llm=from_llm,
-                to_llm="gemini", from_model=from_model, to_model=model,
+                content,
+                task_id,
+                msg_type,
+                data,
+                from_llm=from_llm,
+                to_llm="gemini",
+                from_model=from_model,
+                to_model=model,
                 quiet=stdout_only,
             )
         else:
-            msg_id = send_to_gemini(content, task_id, msg_type, data,
-                                    from_model=from_model, to_model=model,
-                                    quiet=stdout_only)
+            msg_id = send_to_gemini(
+                content, task_id, msg_type, data, from_model=from_model, to_model=model, quiet=stdout_only
+            )
         acknowledge(msg_id, quiet=stdout_only)
         if not stdout_only:
             print("   Pre-acknowledged (file output mode — no broker traffic)")
     else:
         if from_llm:
             msg_id = send_message(
-                content, task_id, msg_type, data, from_llm=from_llm,
-                to_llm="gemini", from_model=from_model, to_model=model,
+                content,
+                task_id,
+                msg_type,
+                data,
+                from_llm=from_llm,
+                to_llm="gemini",
+                from_model=from_model,
+                to_model=model,
                 quiet=stdout_only,
             )
         else:
-            msg_id = send_to_gemini(content, task_id, msg_type, data,
-                                    from_model=from_model, to_model=model,
-                                    quiet=stdout_only)
+            msg_id = send_to_gemini(
+                content, task_id, msg_type, data, from_model=from_model, to_model=model, quiet=stdout_only
+            )
         if stdout_only:
             acknowledge(msg_id, quiet=stdout_only)
     register_ask(msg_id)
@@ -193,6 +236,7 @@ def _extract_and_print(response: str, extract_tags: list):
     """Extract delimited content from response and print it."""
     from gemini_output import ALL_TAGS, find_complete_pairs
     from gemini_output import extract_delimited as _extract
+
     tags = extract_tags if extract_tags else find_complete_pairs(response, ALL_TAGS)
     if tags:
         print(f"\n{'═' * 40}")
@@ -208,37 +252,59 @@ def _extract_and_print(response: str, extract_tags: list):
         print("\n⚠️  No complete delimiter pairs found in output.")
 
 
-def process_and_respond(message_id: int, model: str = GEMINI_DEFAULT_MODEL,
-                        fire_and_forget: bool = False, no_timeout: bool = False,
-                        stdout_only: bool = False, output_path: str | None = None,
-                        allow_write: bool = False, delimiters: str | None = None,
-                        skip_github: bool = False, auth_mode: str | None = None,
-                        review: bool = False):
+def process_and_respond(
+    message_id: int,
+    model: str | None = None,
+    fire_and_forget: bool = False,
+    no_timeout: bool = False,
+    stdout_only: bool = False,
+    output_path: str | None = None,
+    allow_write: bool = False,
+    delimiters: str | None = None,
+    skip_github: bool = False,
+    auth_mode: str | None = None,
+    review: bool = False,
+):
     """Read message, process with Gemini CLI, send response.
 
     Runs in sync mode by default (15 min timeout). On any failure, sends an
     error message back to the sender and always cleans up the PID file.
+
+    ``model`` defaults to the AGY seat's live ACP registry pin (or ``AB_GEMINI_MODEL``
+    env override). Legacy ``gemini*`` slugs remap through ``resolve_compat_model``
+    (#6894/#6959).
     """
+    from ._acp_compat import resolve_compat_model
+
+    selected = resolve_compat_model("gemini", model)
+    if selected is None:
+        selected = default_gemini_model()
+    model = selected
+
     msg = read_message(message_id, quiet=stdout_only)
     if not msg:
         return
 
-    prompt = build_gemini_prompt(
-        msg, stdout_only, output_path, allow_write, delimiters, review
-    )
+    prompt = build_gemini_prompt(msg, stdout_only, output_path, allow_write, delimiters, review)
 
     if fire_and_forget:
         _launch_gemini_background(msg, message_id, model, prompt, auth_mode=auth_mode)
     else:
-        return _run_gemini_sync(msg, message_id, model, prompt, no_timeout, stdout_only,
-                                output_path, allow_write, skip_github, auth_mode)
+        return _run_gemini_sync(
+            msg, message_id, model, prompt, no_timeout, stdout_only, output_path, allow_write, skip_github, auth_mode
+        )
 
 
 def _launch_gemini_background(
-    msg: dict, message_id: int, model: str, prompt: str, *, auth_mode: str | None,
+    msg: dict,
+    message_id: int,
+    model: str,
+    prompt: str,
+    *,
+    auth_mode: str | None,
 ):
     """Launch the bridge itself as a background process (fire-and-forget mode)."""
-    task_key = msg['task_id'] or str(message_id)
+    task_key = msg["task_id"] or str(message_id)
 
     if _is_task_locked("gemini", task_key):
         print(f"⏸️  Task '{task_key}' is already being processed by another Gemini bridge. Skipping.")
@@ -256,41 +322,53 @@ def _launch_gemini_background(
         # Use .venv/bin/python explicitly to avoid wrong interpreter
         venv_python = str(Path(__file__).parents[2] / ".venv" / "bin" / "python")
         bridge_cmd = [
-            venv_python, str(Path(__file__).parent / "__main__.py"),
-            "process", str(message_id),
-            "--model", model,
-            "--no-timeout"
+            venv_python,
+            str(Path(__file__).parent / "__main__.py"),
+            "process",
+            str(message_id),
+            "--model",
+            model,
+            "--no-timeout",
         ]
         if auth_mode:
             bridge_cmd.extend(["--auth", auth_mode])
         lf = open(log_file, "w")  # noqa: SIM115 — fd passed to Popen, closed after
         proc = subprocess.Popen(
-            bridge_cmd,
-            stdout=lf,
-            stderr=subprocess.STDOUT,
-            cwd=str(REPO_ROOT),
-            env=_PARENT_ENV,
-            start_new_session=True
+            bridge_cmd, stdout=lf, stderr=subprocess.STDOUT, cwd=str(REPO_ROOT), env=_PARENT_ENV, start_new_session=True
         )
         lf.close()
         print(f"   PID: {proc.pid}")
 
-        _write_pid_file("gemini", task_key, {
-            "message_id": message_id,
-            "task_id": msg.get('task_id'),
-            "model": model,
-            "mode": "fire-and-forget",
-        }, pid=proc.pid)
+        _write_pid_file(
+            "gemini",
+            task_key,
+            {
+                "message_id": message_id,
+                "task_id": msg.get("task_id"),
+                "model": model,
+                "mode": "fire-and-forget",
+            },
+            pid=proc.pid,
+        )
 
     except FileNotFoundError:
         print("❌ Python or bridge script not found")
 
 
-def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
-                     no_timeout: bool, stdout_only: bool, output_path: str | None,
-                     allow_write: bool, skip_github: bool, auth_mode: str | None):
+def _run_gemini_sync(
+    msg: dict,
+    message_id: int,
+    model: str,
+    prompt: str,
+    no_timeout: bool,
+    stdout_only: bool,
+    output_path: str | None,
+    allow_write: bool,
+    skip_github: bool,
+    auth_mode: str | None,
+):
     """Run Gemini synchronously with streaming output and retry logic."""
-    task_key = msg.get('task_id') or str(message_id)
+    task_key = msg.get("task_id") or str(message_id)
     timeout_val = None if no_timeout else 1800
     mode_label = "no-timeout" if no_timeout else "sync, 30 min timeout"
 
@@ -302,12 +380,16 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
         print(f"\n🤖 Processing with Gemini ({model}) [{mode_label}]...")
         sys.stdout.flush()
 
-    _write_pid_file("gemini", task_key, {
-        "message_id": message_id,
-        "task_id": msg.get('task_id'),
-        "model": model,
-        "mode": mode_label,
-    })
+    _write_pid_file(
+        "gemini",
+        task_key,
+        {
+            "message_id": message_id,
+            "task_id": msg.get("task_id"),
+            "model": model,
+            "mode": mode_label,
+        },
+    )
     atexit.register(_remove_pid_file, "gemini", task_key)
 
     max_retries = 5
@@ -322,10 +404,23 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
 
     try:
         for attempt in range(max_retries):
-            result = _run_gemini_attempt(msg, message_id, current_model, requested_model, prompt,
-                                         timeout_val, stdout_only, output_path, skip_github,
-                                         attempt, max_retries, base_delay, rate_limit_state,
-                                         auth_mode, allow_write)
+            result = _run_gemini_attempt(
+                msg,
+                message_id,
+                current_model,
+                requested_model,
+                prompt,
+                timeout_val,
+                stdout_only,
+                output_path,
+                skip_github,
+                attempt,
+                max_retries,
+                base_delay,
+                rate_limit_state,
+                auth_mode,
+                allow_write,
+            )
             if isinstance(result, dict) and result.get("action") == "fallback":
                 current_model = str(result["model"])
                 continue
@@ -345,9 +440,23 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
         _remove_pid_file("gemini", task_key)
 
 
-def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout_val,
-                        stdout_only, output_path, skip_github, attempt, max_retries,
-                        base_delay, rate_limit_state, auth_mode, allow_write=False):
+def _run_gemini_attempt(
+    msg,
+    message_id,
+    model,
+    requested_model,
+    prompt,
+    timeout_val,
+    stdout_only,
+    output_path,
+    skip_github,
+    attempt,
+    max_retries,
+    base_delay,
+    rate_limit_state,
+    auth_mode,
+    allow_write=False,
+):
     """Run a single Gemini CLI attempt via agent_runtime.
 
     Returns None to retry, False to stop, or (response, sent).
@@ -364,9 +473,12 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
         # preamble silently corrupts the parser — every score regex misses
         # and dims default to 0.0. The wiki review pipeline regressed this
         # way until the 2026-04-18 Phase A canary surfaced it.
-        prompt_preview = prompt[:200].replace('\n', ' ')
-        print(f"  [gemini] attempt {attempt+1}/{max_retries}, model={model}, "
-              f"prompt={len(prompt)} chars: {prompt_preview}...", flush=True)
+        prompt_preview = prompt[:200].replace("\n", " ")
+        print(
+            f"  [gemini] attempt {attempt + 1}/{max_retries}, model={model}, "
+            f"prompt={len(prompt)} chars: {prompt_preview}...",
+            flush=True,
+        )
 
     pre_snapshot = None
     if output_path:
@@ -393,8 +505,8 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
             task_id=msg.get("task_id"),
             initiator=msg.get("from"),
             session_id=None,  # Gemini CLI has no --resume; bridge multi-turn
-                              # is handled via conversation context injection
-                              # in the prompt builder, not CLI-level resume.
+            # is handled via conversation context injection
+            # in the prompt builder, not CLI-level resume.
             tool_config=tool_config,
             entrypoint="bridge",
             hard_timeout=max(timeout_val or 1800, 300),
@@ -413,7 +525,7 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
         # Rate-limited: treat as retryable per legacy behavior
         print(f"\n⏳ Gemini rate limited: {exc}")
         if attempt < max_retries - 1:
-            delay = base_delay * (2 ** attempt)
+            delay = base_delay * (2**attempt)
             print(f"⏳ Backing off for {delay}s...")
             time.sleep(delay)
             return None
@@ -463,8 +575,7 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
         _print_completion_status(output_path, response)
 
     # Route response
-    _route_gemini_response(msg, message_id, model, response, stdout_only, output_path,
-                           skip_github)
+    _route_gemini_response(msg, message_id, model, response, stdout_only, output_path, skip_github)
 
     acknowledge(message_id, quiet=stdout_only)
     return (response, True)
@@ -483,7 +594,7 @@ def _handle_gemini_error(stderr, model, attempt, max_retries, base_delay):
         return "stop"
 
     if "exhausted your capacity" in stderr or "429" in stderr or "quota" in stderr.lower():
-        delay = base_delay * (2 ** attempt)
+        delay = base_delay * (2**attempt)
         if attempt < max_retries - 1:
             print(f"\n⏳ Rate limited (attempt {attempt + 1}/{max_retries}). Waiting {delay}s...")
             sys.stdout.flush()
@@ -588,8 +699,7 @@ def _print_completion_status(output_path, response):
     sys.stdout.flush()
 
 
-def _route_gemini_response(msg, message_id, model, response, stdout_only, output_path,
-                           skip_github):
+def _route_gemini_response(msg, message_id, model, response, stdout_only, output_path, skip_github):
     """Route Gemini's response to the appropriate destination."""
     if output_path:
         if not stdout_only:
@@ -610,19 +720,29 @@ def _route_gemini_response(msg, message_id, model, response, stdout_only, output
         reply_to = msg.get("from", "claude")
         summary = f"[stdout-only] Gemini finished. {len(response)} chars output to stdout."
         send_message(
-            content=summary, task_id=msg['task_id'], msg_type="response",
-            from_llm="gemini", to_llm=reply_to, from_model=model, to_model=None,
-            quiet=stdout_only
+            content=summary,
+            task_id=msg["task_id"],
+            msg_type="response",
+            from_llm="gemini",
+            to_llm=reply_to,
+            from_model=model,
+            to_model=None,
+            quiet=stdout_only,
         )
     else:
         # Route reply back to the actual sender, not always to claude
         reply_to = msg.get("from", "claude")
         send_message(
-            content=response, task_id=msg['task_id'], msg_type="response",
-            from_llm="gemini", to_llm=reply_to, from_model=model, to_model=None
+            content=response,
+            task_id=msg["task_id"],
+            msg_type="response",
+            from_llm="gemini",
+            to_llm=reply_to,
+            from_model=model,
+            to_model=None,
         )
         if not skip_github:
-            _post_review_to_github(msg['task_id'], response, model)
+            _post_review_to_github(msg["task_id"], response, model)
 
 
 def _send_gemini_error(msg, message_id):
@@ -637,8 +757,11 @@ def _send_gemini_error(msg, message_id):
         reply_to = msg.get("from", "claude")
         send_message(
             content=f"[Bridge Error] Gemini process failed for message #{message_id}. Check logs.",
-            task_id=msg['task_id'], msg_type="error",
-            from_llm="gemini", to_llm=reply_to, from_model="gemini-bridge-error"
+            task_id=msg["task_id"],
+            msg_type="error",
+            from_llm="gemini",
+            to_llm=reply_to,
+            from_model="gemini-bridge-error",
         )
         record_ask_failure(message_id, f"Gemini process failed for message #{message_id}")
     except Exception:

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -271,15 +271,10 @@ def process_and_respond(
     error message back to the sender and always cleans up the PID file.
 
     ``model`` defaults to the AGY seat's live ACP registry pin (or ``AB_GEMINI_MODEL``
-    env override). Legacy ``gemini*`` slugs remap through ``resolve_compat_model``
-    (#6894/#6959).
+    env override) (#6959).
     """
-    from ._acp_compat import resolve_compat_model
-
-    selected = resolve_compat_model("gemini", model)
-    if selected is None:
-        selected = default_gemini_model()
-    model = selected
+    if model is None:
+        model = default_gemini_model()
 
     msg = read_message(message_id, quiet=stdout_only)
     if not msg:

--- a/tests/ai_agent_bridge/test_process_routing.py
+++ b/tests/ai_agent_bridge/test_process_routing.py
@@ -426,6 +426,23 @@ def test_ask_gemini_resolves_registry_pin_and_tracks_rotation(monkeypatch) -> No
     assert captured["model"] == "env-model-override"
 
 
+def test_ask_gemini_preserves_env_model_override_through_process_and_respond(bridge_db, monkeypatch) -> None:
+    """#6959: AB_GEMINI_MODEL override survives through ask_gemini -> process_and_respond -> _run_gemini_sync."""
+    from scripts.ai_agent_bridge._gemini import ask_gemini
+
+    monkeypatch.setenv("AB_GEMINI_MODEL", "gemini-3.1-pro-high")
+    captured: dict[str, object] = {}
+
+    def _fake_run_sync(msg, msg_id, model, *args, **kwargs):
+        captured["model"] = model
+        return "response text"
+
+    monkeypatch.setattr("scripts.ai_agent_bridge._gemini._run_gemini_sync", _fake_run_sync)
+
+    ask_gemini("hello", task_id="issue-6959")
+    assert captured["model"] == "gemini-3.1-pro-high"
+
+
 def test_process_model_override_must_match_registry(bridge_db, monkeypatch):
     """Explicit overrides pass through to registry validation (loud mismatch)."""
     message_id = _send("cursor")

--- a/tests/ai_agent_bridge/test_process_routing.py
+++ b/tests/ai_agent_bridge/test_process_routing.py
@@ -56,9 +56,7 @@ def _send(to: str, *, task_id: str = "task-6915", sender: str = "qa-engineer") -
 def _row(message_id: int):
     conn = get_db()
     try:
-        return conn.execute(
-            "SELECT acknowledged, status FROM messages WHERE id = ?", (message_id,)
-        ).fetchone()
+        return conn.execute("SELECT acknowledged, status FROM messages WHERE id = ?", (message_id,)).fetchone()
     finally:
         conn.close()
 
@@ -77,7 +75,10 @@ def _replies(message_id: int, task_id: str = "task-6915"):
 
 def _ok_result(response: str = "routed analysis", model: str = "registry-model"):
     return SimpleNamespace(
-        ok=True, response=response, model=model, stderr_excerpt=None,
+        ok=True,
+        response=response,
+        model=model,
+        stderr_excerpt=None,
         transport_outcome="ok",
     )
 
@@ -124,8 +125,7 @@ def test_process_gemini_recipient_resolves_to_agy_participant(bridge_db, monkeyp
     monkeypatch.setattr(
         _process,
         "run_compat_ask",
-        lambda target, content, **kwargs: captured.update(target=target, content=content, **kwargs)
-        or _ok_result(),
+        lambda target, content, **kwargs: captured.update(target=target, content=content, **kwargs) or _ok_result(),
     )
 
     assert _process.process_message_for_recipient(message_id) is not None
@@ -161,7 +161,10 @@ def test_process_failed_result_leaves_message_unconsumed(bridge_db, monkeypatch)
         _process,
         "run_compat_ask",
         lambda *a, **k: SimpleNamespace(
-            ok=False, response="", model="agy", stderr_excerpt="provider exploded",
+            ok=False,
+            response="",
+            model="agy",
+            stderr_excerpt="provider exploded",
             transport_outcome="error",
         ),
     )
@@ -263,7 +266,8 @@ def test_resolve_compat_model_tracks_pin_rotation(monkeypatch) -> None:
     from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
 
     monkeypatch.setitem(
-        ACPX_SUPPORTED_PARTICIPANTS, "agy",
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
         {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
     )
     assert registered_participant_model("agy") == "gemini-9.9-flash-high"
@@ -299,7 +303,8 @@ def test_converse_default_tracks_pin_rotation(monkeypatch) -> None:
     from scripts.ai_agent_bridge._gemini import converse_gemini
 
     monkeypatch.setitem(
-        ACPX_SUPPORTED_PARTICIPANTS, "agy",
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
         {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
     )
     captured: dict[str, object] = {}
@@ -308,9 +313,7 @@ def test_converse_default_tracks_pin_rotation(monkeypatch) -> None:
         captured.update(kwargs)
         return 1
 
-    monkeypatch.setattr(
-        "scripts.ai_agent_bridge._gemini.ask_gemini", _fake_ask_gemini
-    )
+    monkeypatch.setattr("scripts.ai_agent_bridge._gemini.ask_gemini", _fake_ask_gemini)
     monkeypatch.setattr(
         "scripts.ai_agent_bridge._gemini.get_conversation_context",
         lambda _task_id: ("", 0),
@@ -324,6 +327,103 @@ def test_converse_default_tracks_pin_rotation(monkeypatch) -> None:
 
     converse_gemini("hello", "t-1", model="not-a-gemini-model")
     assert captured["model"] == "not-a-gemini-model"
+
+
+def test_default_gemini_model_resolves_from_registry_and_tracks_rotation(monkeypatch) -> None:
+    """#6959: default_gemini_model resolves from the live ACP registry pin."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    import scripts.ai_agent_bridge as bridge
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    assert default_gemini_model() == registered_participant_model("agy")
+    assert registered_participant_model("agy") == bridge.GEMINI_DEFAULT_MODEL
+
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    assert default_gemini_model() == "gemini-9.9-flash-high"
+    assert bridge.GEMINI_DEFAULT_MODEL == "gemini-9.9-flash-high"
+
+
+def test_default_gemini_model_respects_env_override(monkeypatch) -> None:
+    """#6959: AB_GEMINI_MODEL environment override takes precedence."""
+    import scripts.ai_agent_bridge as bridge
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.setenv("AB_GEMINI_MODEL", "gemini-custom-override")
+    assert default_gemini_model() == "gemini-custom-override"
+    assert bridge.GEMINI_DEFAULT_MODEL == "gemini-custom-override"
+
+
+def test_default_gemini_model_missing_registry_pin_fails_loudly(monkeypatch) -> None:
+    """#6959: missing registry pin fails loudly instead of falling back to stale literal."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": None},
+    )
+    with pytest.raises(RuntimeError, match="No default Gemini model configured"):
+        default_gemini_model()
+
+
+def test_ask_gemini_and_process_and_respond_signatures_default_to_none() -> None:
+    """#6959: ask_gemini and process_and_respond signatures default model to None."""
+    import inspect
+
+    from scripts.ai_agent_bridge._gemini import ask_gemini, process_and_respond
+
+    assert inspect.signature(ask_gemini).parameters["model"].default is None
+    assert inspect.signature(process_and_respond).parameters["model"].default is None
+
+
+def test_ask_gemini_resolves_registry_pin_and_tracks_rotation(monkeypatch) -> None:
+    """#6959: ask_gemini resolves default from registry and remaps legacy slugs."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._gemini import ask_gemini
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini._send_gemini_message",
+        lambda *args: 101,
+    )
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini.process_and_respond",
+        lambda _msg_id, model=None, **kwargs: captured.update(model=model) or "resp",
+    )
+
+    # 1. Bare call (model=None) resolves to rotated pin
+    ask_gemini("hello", task_id="t-1")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    # 2. Legacy slug remaps to rotated pin
+    ask_gemini("hello", task_id="t-1", model="gemini-2.0-flash")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    # 3. Non-gemini model passes through
+    ask_gemini("hello", task_id="t-1", model="custom-provider/model-x")
+    assert captured["model"] == "custom-provider/model-x"
+
+    # 4. Env override takes precedence
+    monkeypatch.setenv("AB_GEMINI_MODEL", "env-model-override")
+    ask_gemini("hello", task_id="t-1")
+    assert captured["model"] == "env-model-override"
 
 
 def test_process_model_override_must_match_registry(bridge_db, monkeypatch):
@@ -347,9 +447,7 @@ def test_legacy_gemini_error_handler_never_acks(bridge_db):
     from scripts.ai_agent_bridge import _gemini
 
     message_id = _send("gemini")
-    _gemini._send_gemini_error(
-        {"task_id": "task-6915", "from": "qa-engineer"}, message_id
-    )
+    _gemini._send_gemini_error({"task_id": "task-6915", "from": "qa-engineer"}, message_id)
     acked, status = _row(message_id)
     assert acked == 0
     assert status.startswith("failed:")
@@ -392,9 +490,7 @@ def test_claude_fallback_error_never_acks(bridge_db):
     from scripts.ai_agent_bridge import _claude
 
     message_id = _send("claude")
-    _claude._send_claude_fallback_error(
-        {"task_id": "task-6915", "from": "qa-engineer"}, message_id
-    )
+    _claude._send_claude_fallback_error({"task_id": "task-6915", "from": "qa-engineer"}, message_id)
     acked, status = _row(message_id)
     assert acked == 0
     assert status.startswith("failed:")
@@ -405,8 +501,13 @@ def test_grok_incomplete_turn_never_acks(bridge_db):
 
     message_id = _send("grok")
     msg = {
-        "id": message_id, "task_id": "task-6915", "from": "qa-engineer",
-        "to": "grok", "type": "advisory", "content": "x", "data": None,
+        "id": message_id,
+        "task_id": "task-6915",
+        "from": "qa-engineer",
+        "to": "grok",
+        "type": "advisory",
+        "content": "x",
+        "data": None,
     }
     _grok_build._handle_grok_build_incomplete_turn(
         msg,
@@ -426,17 +527,20 @@ def test_opencode_incomplete_turn_never_acks(bridge_db):
 
     message_id = _send("glm")
     msg = {
-        "id": message_id, "task_id": "task-6915", "from": "qa-engineer",
-        "to": "glm", "type": "advisory", "content": "x", "data": None,
+        "id": message_id,
+        "task_id": "task-6915",
+        "from": "qa-engineer",
+        "to": "glm",
+        "type": "advisory",
+        "content": "x",
+        "data": None,
     }
     _opencode._handle_opencode_incomplete_turn(
         msg,
         message_id,
         "glm",
         "",
-        SimpleNamespace(
-            outcome="timeout", cancellation_category=None, reason="hard timeout"
-        ),
+        SimpleNamespace(outcome="timeout", cancellation_category=None, reason="hard timeout"),
         actual_model="glm-5.3",
         effort="high",
     )

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -23,8 +23,10 @@ from scripts.ai_agent_bridge._messaging import send_message
 @pytest.fixture
 def bridge_db(tmp_path):
     db_path = tmp_path / "messages.db"
-    with patch("scripts.ai_agent_bridge._config.DB_PATH", db_path), \
-         patch("scripts.ai_agent_bridge._db.DB_PATH", db_path):
+    with (
+        patch("scripts.ai_agent_bridge._config.DB_PATH", db_path),
+        patch("scripts.ai_agent_bridge._db.DB_PATH", db_path),
+    ):
         conn = init_db()
         conn.close()
         yield db_path
@@ -90,10 +92,12 @@ def test_run_gemini_sync_429_retries_same_model_then_falls_back_to_auto(
         ),
     ]
 
-    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
+    with (
+        patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False),
+        patch("scripts.ai_agent_bridge._gemini._write_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini._remove_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini.atexit.register"),
+    ):
         response = _run_gemini_sync(
             msg,
             message_id,
@@ -158,10 +162,12 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
         usage_record={},
     )
 
-    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
+    with (
+        patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False),
+        patch("scripts.ai_agent_bridge._gemini._write_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini._remove_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini.atexit.register"),
+    ):
         _run_gemini_sync(
             msg,
             message_id,
@@ -180,9 +186,18 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
 
 def _ok_result() -> Result:
     return Result(
-        ok=True, agent="gemini", model=PRO_MODEL, mode="read-only",
-        response="reply", stderr_excerpt=None, duration_s=0.1, session_id=None,
-        rate_limited=False, stalled=False, returncode=0, usage_record={},
+        ok=True,
+        agent="gemini",
+        model=PRO_MODEL,
+        mode="read-only",
+        response="reply",
+        stderr_excerpt=None,
+        duration_s=0.1,
+        session_id=None,
+        rate_limited=False,
+        stalled=False,
+        returncode=0,
+        usage_record={},
     )
 
 
@@ -194,27 +209,53 @@ def _ok_result() -> Result:
 @patch("scripts.ai_agent_bridge._gemini.acknowledge")
 @patch("scripts.ai_agent_bridge._gemini.runtime_invoke")
 def test_run_gemini_sync_derives_runtime_mode_from_allow_write(
-    mock_invoke, _ack, _route, bridge_db, allow_write, expected_mode,
+    mock_invoke,
+    _ack,
+    _route,
+    bridge_db,
+    allow_write,
+    expected_mode,
 ):
     """#4446: the runtime write-mode tracks write *intent* (``--allow-write``),
     not the CLI approval flag — plain Q&A runs ``read-only`` so an ``ask-gemini``
     query can no longer silently mutate the primary checkout."""
     message_id = send_message(
-        "Please review this", task_id="issue-4446", msg_type="query",
-        from_llm="claude", to_llm="gemini", to_model=PRO_MODEL, quiet=True,
+        "Please review this",
+        task_id="issue-4446",
+        msg_type="query",
+        from_llm="claude",
+        to_llm="gemini",
+        to_model=PRO_MODEL,
+        quiet=True,
     )
-    msg = {"id": message_id, "task_id": "issue-4446", "from": "claude",
-           "to": "gemini", "type": "query", "content": "x", "data": None}
+    msg = {
+        "id": message_id,
+        "task_id": "issue-4446",
+        "from": "claude",
+        "to": "gemini",
+        "type": "query",
+        "content": "x",
+        "data": None,
+    }
     mock_invoke.return_value = _ok_result()
 
-    with patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False), \
-         patch("scripts.ai_agent_bridge._gemini._write_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini._remove_pid_file"), \
-         patch("scripts.ai_agent_bridge._gemini.atexit.register"):
+    with (
+        patch("scripts.ai_agent_bridge._gemini._is_task_locked", return_value=False),
+        patch("scripts.ai_agent_bridge._gemini._write_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini._remove_pid_file"),
+        patch("scripts.ai_agent_bridge._gemini.atexit.register"),
+    ):
         _run_gemini_sync(
-            msg, message_id, PRO_MODEL, "bridge prompt", no_timeout=False,
-            stdout_only=True, output_path=None, allow_write=allow_write,
-            skip_github=True, auth_mode=None,
+            msg,
+            message_id,
+            PRO_MODEL,
+            "bridge prompt",
+            no_timeout=False,
+            stdout_only=True,
+            output_path=None,
+            allow_write=allow_write,
+            skip_github=True,
+            auth_mode=None,
         )
 
     assert mock_invoke.call_args.kwargs["mode"] == expected_mode
@@ -306,3 +347,133 @@ def test_converse_gemini_default_tracks_pin_rotation(monkeypatch) -> None:
 
     converse_gemini("hello", "t-1", model="not-a-gemini-model")
     assert captured["model"] == "not-a-gemini-model"
+
+
+def test_default_gemini_model_resolves_from_registry_and_tracks_rotation(monkeypatch) -> None:
+    """#6959: default_gemini_model resolves from the live ACP registry pin."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    import scripts.ai_agent_bridge as bridge
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    assert default_gemini_model() == registered_participant_model("agy")
+    assert registered_participant_model("agy") == bridge.GEMINI_DEFAULT_MODEL
+
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    assert default_gemini_model() == "gemini-9.9-flash-high"
+    assert bridge.GEMINI_DEFAULT_MODEL == "gemini-9.9-flash-high"
+
+
+def test_default_gemini_model_respects_env_override(monkeypatch) -> None:
+    """#6959: AB_GEMINI_MODEL environment override takes precedence."""
+    import scripts.ai_agent_bridge as bridge
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.setenv("AB_GEMINI_MODEL", "gemini-custom-override")
+    assert default_gemini_model() == "gemini-custom-override"
+    assert bridge.GEMINI_DEFAULT_MODEL == "gemini-custom-override"
+
+
+def test_default_gemini_model_missing_registry_pin_fails_loudly(monkeypatch) -> None:
+    """#6959: missing registry pin fails loudly instead of falling back to stale literal."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._config import default_gemini_model
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": None},
+    )
+    with pytest.raises(RuntimeError, match="No default Gemini model configured"):
+        default_gemini_model()
+
+
+def test_ask_gemini_and_process_and_respond_signatures_default_to_none() -> None:
+    """#6959: ask_gemini and process_and_respond signatures default model to None."""
+    import inspect
+
+    from scripts.ai_agent_bridge._gemini import ask_gemini, process_and_respond
+
+    assert inspect.signature(ask_gemini).parameters["model"].default is None
+    assert inspect.signature(process_and_respond).parameters["model"].default is None
+
+
+def test_ask_gemini_resolves_registry_pin_and_tracks_rotation(monkeypatch) -> None:
+    """#6959: ask_gemini resolves default from registry and remaps legacy slugs."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._gemini import ask_gemini
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini._send_gemini_message",
+        lambda *args: 101,
+    )
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._gemini.process_and_respond",
+        lambda _msg_id, model=None, **kwargs: captured.update(model=model) or "resp",
+    )
+
+    # 1. Bare call (model=None) resolves to rotated pin
+    ask_gemini("hello", task_id="t-1")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    # 2. Legacy slug remaps to rotated pin
+    ask_gemini("hello", task_id="t-1", model="gemini-2.0-flash")
+    assert captured["model"] == "gemini-9.9-flash-high"
+
+    # 3. Non-gemini model passes through
+    ask_gemini("hello", task_id="t-1", model="custom-provider/model-x")
+    assert captured["model"] == "custom-provider/model-x"
+
+    # 4. Env override takes precedence
+    monkeypatch.setenv("AB_GEMINI_MODEL", "env-model-override")
+    ask_gemini("hello", task_id="t-1")
+    assert captured["model"] == "env-model-override"
+
+
+def test_process_and_respond_resolves_registry_pin(bridge_db, monkeypatch) -> None:
+    """#6959: process_and_respond resolves default model from registry."""
+    from agent_runtime.adapters.acpx import ACPX_SUPPORTED_PARTICIPANTS
+
+    from scripts.ai_agent_bridge._gemini import process_and_respond
+
+    message_id = send_message(
+        "Test content",
+        task_id="issue-6959",
+        msg_type="query",
+        from_llm="claude",
+        to_llm="gemini",
+        quiet=True,
+    )
+
+    monkeypatch.delenv("AB_GEMINI_MODEL", raising=False)
+    monkeypatch.setitem(
+        ACPX_SUPPORTED_PARTICIPANTS,
+        "agy",
+        {"seat": "acpx-agy-shadow", "agent": "agy", "model": "gemini-9.9-flash-high"},
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_run_sync(msg, msg_id, model, *args, **kwargs):
+        captured["model"] = model
+        return "response text"
+
+    monkeypatch.setattr("scripts.ai_agent_bridge._gemini._run_gemini_sync", _fake_run_sync)
+
+    process_and_respond(message_id)
+    assert captured["model"] == "gemini-9.9-flash-high"

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -477,3 +477,20 @@ def test_process_and_respond_resolves_registry_pin(bridge_db, monkeypatch) -> No
 
     process_and_respond(message_id)
     assert captured["model"] == "gemini-9.9-flash-high"
+
+
+def test_ask_gemini_preserves_env_model_override_through_process_and_respond(bridge_db, monkeypatch) -> None:
+    """#6959: AB_GEMINI_MODEL override survives through ask_gemini -> process_and_respond -> _run_gemini_sync."""
+    from scripts.ai_agent_bridge._gemini import ask_gemini
+
+    monkeypatch.setenv("AB_GEMINI_MODEL", "gemini-3.1-pro-high")
+    captured: dict[str, object] = {}
+
+    def _fake_run_sync(msg, msg_id, model, *args, **kwargs):
+        captured["model"] = model
+        return "response text"
+
+    monkeypatch.setattr("scripts.ai_agent_bridge._gemini._run_gemini_sync", _fake_run_sync)
+
+    ask_gemini("hello", task_id="issue-6959")
+    assert captured["model"] == "gemini-3.1-pro-high"


### PR DESCRIPTION
Align the Gemini bridge default model chain with the registry-derived defaults pattern established in #6928 and #6932, eliminating the stale literal fallback (`"gemini-2.0-flash"`) from the fallback chain.

### Changes
- `scripts/ai_agent_bridge/_config.py`: Replace hardcoded fallback with `default_gemini_model()` which resolves `AB_GEMINI_MODEL` env override or the AGY participant registry pin (`registered_participant_model("agy")`), failing loudly (`RuntimeError`) if neither is configured.
- `scripts/ai_agent_bridge/_gemini.py`: Default `model` parameter to `None` in `ask_gemini` and `process_and_respond`, dynamically resolving against the live registry pin and remapping legacy `gemini*` slugs via `resolve_compat_model`.
- `scripts/ai_agent_bridge/__init__.py`: Expose `default_gemini_model` and dynamically evaluate `GEMINI_DEFAULT_MODEL` via `__getattr__`.
- `tests/test_gemini_bridge.py`, `tests/ai_agent_bridge/test_process_routing.py`: Add test coverage for registry-derived defaults, dynamic pin rotation, env overrides, and loud failure on missing registry pin.

Banked sibling follow-up to #6929 (comment).
Pattern provenance: #6928, #6932.

Fixes #6959