### PR TITLE
test(bridge): hermetic review-pr thrash-guard probe (#6962 part 1)

### DIFF
--- a/tests/ai_agent_bridge/conftest.py
+++ b/tests/ai_agent_bridge/conftest.py
@@ -7,9 +7,35 @@ runs changed files alone and failed collection (#6800). Prime it here so any
 subset of this package collects standalone.
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+
+import pytest
 
 _SCRIPTS = str(Path(__file__).resolve().parents[2] / "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
+
+# review-pr CLI suites call evaluate_formal_cf_thrash, which live-queries
+# githubstatus unless pinned. Keep those suites hermetic (#6962). Do not apply
+# package-wide: test_review_pr_thrash.py exercises the real probe parser.
+_REVIEW_PR_CLI_THRASH_PIN_MODULES = frozenset(
+    {
+        "test_review_pr.py",
+        "test_review_pr_lifecycle.py",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _pin_review_pr_thrash_probe_healthy(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    """Pin githubstatus Actions probe to healthy for review-pr CLI suites."""
+    path = getattr(request.node, "path", None)
+    if path is None or Path(path).name not in _REVIEW_PR_CLI_THRASH_PIN_MODULES:
+        return
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._review_pr_thrash.github_actions_outaged",
+        lambda **_kwargs: False,
+    )

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -180,6 +180,45 @@ def _run_invalid_response_lifecycle(
         pass
 
 
+def test_actions_outage_thrash_guard_exits_before_provider_spend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI path: degraded Actions probe → exit 2 + thrash stderr (pinned mock)."""
+    from scripts.ai_agent_bridge import _review_worktree
+
+    checkout = SimpleNamespace(
+        sha="a" * 40,
+        base_sha="b" * 40,
+        patch_digest="c" * 64,
+        changed_paths=("src/app.py",),
+        changed_line_numbers={"src/app.py": frozenset({1})},
+        path=tmp_path,
+        review_prompt_evidence=lambda _engine: "sealed-metadata",
+        sealed_acp_tool_config=lambda **_kwargs: tmp_path / "sealed.json",
+        sealed_evidence_input_bytes=lambda: 123,
+    )
+
+    @contextmanager
+    def provision(*_args, **_kwargs):
+        yield checkout
+
+    monkeypatch.setattr(_review_worktree, "provision_review_worktree", provision)
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._review_pr_thrash._load_approved_heads",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "scripts.ai_agent_bridge._review_pr_thrash.github_actions_outaged",
+        lambda **_kwargs: True,
+    )
+
+    assert review_pr.handle_review_pr(_invalid_response_args()) == 2
+    err = capsys.readouterr().err
+    assert "review-pr: thrash guard: GitHub Actions is in outage/degraded (githubstatus)" in err
+
+
 def test_invalid_json_is_captured_before_live_lease_failure_settlement(monkeypatch, tmp_path, capsys) -> None:
     code, events, formal_jobs = _run_invalid_response_lifecycle(
         monkeypatch,


### PR DESCRIPTION
## Summary

Make `test_review_pr.py` / `test_review_pr_lifecycle.py` hermetic against the live githubstatus Actions probe so an Actions outage no longer turns main CI and unrelated PR shards red (`assert 2 == 1`).

## Changes

- Autouse pin in `tests/ai_agent_bridge/conftest.py` scoped to the two CLI suites: `github_actions_outaged` → healthy (`False`)
- New CLI-path coverage: degraded probe → exit 2 + thrash stderr message
- No CLI / thrash-guard behavior change

## Testing

- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/ai_agent_bridge/test_review_pr.py tests/ai_agent_bridge/test_review_pr_lifecycle.py -q` → 37 passed
- [x] `ruff check` on changed files → clean
- [x] `test_review_pr_thrash.py` still green (package-wide pin deliberately avoided)

## Related Issues

Refs #6962

This PR leaves #6962 open (part 1 only — hermetic pin; sealed-machinery deletion vs repair remains for part 2).

Made with [Cursor](https://cursor.com)