### PR TITLE
feat(lexicon): wire diminutive/augmentative EN fallback into reenrich

### DIFF
--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -33,6 +33,10 @@ from scripts.audit.audit_atlas_thin_enriched import (
     thin_old_gate_entries,
 )
 from scripts.lexicon import enrich_manifest
+from scripts.lexicon.derived_en_fallback import (
+    derived_translation_fallback,
+    manifest_lemma_index,
+)
 from scripts.lexicon.manifest_io import load_manifest
 from scripts.lexicon.publish_manifest import (
     DEFAULT_GZIP,
@@ -460,7 +464,10 @@ def _translation_for_entry(
         if translation:
             return enrich_manifest._with_base_source_label(translation, fallback_base)
     if manifest_index is not None:
-        return _deadjectival_adverb_translation(entry, manifest_index)
+        adv_translation = _deadjectival_adverb_translation(entry, manifest_index)
+        if adv_translation:
+            return adv_translation
+        return derived_translation_fallback(entry, manifest_index)
     return None
 
 
@@ -565,7 +572,7 @@ def reenrich_thin_entries(
     if not refresh_wiki:
         enrich_manifest._wiki_reference = lambda *args, **kwargs: None
 
-    manifest_index = {str(e["lemma"]): e for e in manifest.get("entries", []) if isinstance(e, dict) and e.get("lemma")}
+    manifest_index = manifest_lemma_index(manifest)
 
     changed = 0
     gained_anchor = 0

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -223,7 +223,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "35b632889cea598aef2334b292972f4ad19f10c33e8396d86bfdad445dc152de"
+        "sha256": "c0ebd40f96d0271eb9f2394bf955ac83bb5ac5c7aded0e73b559ec524a5e968c"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -645,3 +645,240 @@ def test_deadjectival_adverb_fallback_on_loaded_manifest_pair(monkeypatch) -> No
             assert "abstractly" in res["en"][0]
             assert "base form абстрактний" in str(res.get("source"))
 
+
+def test_diminutive_fallback_fills_in_reenrich_thin_entries(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "білка",
+                "pos": "noun",
+                "url_slug": "білка",
+                "enrichment": {
+                    "translation": {
+                        "en": ["squirrel"],
+                        "source": "dmklinger",
+                    },
+                    "sources": ["dmklinger"],
+                },
+            },
+            {
+                "lemma": "білочка",
+                "pos": "noun",
+                "url_slug": "білочка",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    dim_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 1
+    assert dim_entry["enrichment"]["translation"] == {
+        "en": ["squirrel (diminutive)"],
+        "source": "dmklinger (diminutive of білка)",
+    }
+    assert "dmklinger (diminutive of білка)" in dim_entry["enrichment"]["sources"]
+
+
+def test_augmentative_fallback_fills_in_reenrich_thin_entries(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "вовк",
+                "pos": "noun",
+                "url_slug": "вовк",
+                "enrichment": {
+                    "translation": {
+                        "en": ["wolf"],
+                        "source": "slovnyk.me: fixture",
+                    },
+                    "sources": ["slovnyk.me: fixture"],
+                },
+            },
+            {
+                "lemma": "вовчище",
+                "pos": "noun",
+                "url_slug": "вовчище",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    aug_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 1
+    assert aug_entry["enrichment"]["translation"] == {
+        "en": ["wolf (augmentative)"],
+        "source": "slovnyk.me: fixture (augmentative of вовк)",
+    }
+    assert "slovnyk.me: fixture (augmentative of вовк)" in aug_entry["enrichment"]["sources"]
+
+
+def test_diminutive_fallback_no_fill_when_base_missing_en(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "білка",
+                "pos": "noun",
+                "url_slug": "білка",
+                "enrichment": {
+                    "sources": ["VESUM"],
+                },
+            },
+            {
+                "lemma": "білочка",
+                "pos": "noun",
+                "url_slug": "білочка",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    dim_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 0
+    assert "translation" not in dim_entry.get("enrichment", {})
+
+
+def test_diminutive_fallback_precedence_after_direct_and_base_lookup(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "білка",
+                "pos": "noun",
+                "url_slug": "білка",
+                "enrichment": {
+                    "translation": {
+                        "en": ["squirrel"],
+                        "source": "dmklinger",
+                    },
+                    "sources": ["dmklinger"],
+                },
+            },
+            {
+                "lemma": "білочка",
+                "pos": "noun",
+                "url_slug": "білочка",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    # Case 1: Direct translation succeeds -> direct wins
+    def direct_trans(conn, lemma, *args, **kwargs):
+        if lemma == "білочка":
+            return {"en": ["little squirrel"], "source": "direct source"}
+        return None
+
+    monkeypatch.setattr(enrich_manifest, "_translation", direct_trans)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    manifest_index = reenrich.manifest_lemma_index(manifest)
+    with sqlite3.connect(":memory:") as conn:
+        trans = reenrich._translation_for_entry(
+            conn,
+            manifest["entries"][1],
+            {},
+            manifest_index=manifest_index,
+        )
+
+    assert trans == {"en": ["little squirrel"], "source": "direct source"}
+
+    # Case 2: Direct misses, base lookup succeeds -> base lookup wins
+    def base_trans(conn, lemma, *args, **kwargs):
+        if lemma == "білка_base":
+            return {"en": ["squirrel base"], "source": "base source"}
+        return None
+
+    monkeypatch.setattr(enrich_manifest, "_translation", base_trans)
+    monkeypatch.setattr(
+        enrich_manifest, "_base_lookup_for_entry", lambda lemma, pos: "білка_base" if lemma == "білочка" else None
+    )
+
+    with sqlite3.connect(":memory:") as conn:
+        trans2 = reenrich._translation_for_entry(
+            conn,
+            manifest["entries"][1],
+            {},
+            manifest_index=manifest_index,
+        )
+
+    assert trans2 == {"en": ["squirrel base"], "source": "base source (base form білка_base)"}
+
+
+def test_diminutive_fallback_fails_closed_when_vesum_rejects(monkeypatch) -> None:
+    import scripts.verification.vesum
+
+    manifest = {
+        "entries": [
+            {
+                "lemma": "неіснуючабілка",
+                "pos": "noun",
+                "url_slug": "неіснуючабілка",
+                "enrichment": {
+                    "translation": {
+                        "en": ["fake squirrel"],
+                        "source": "fixture",
+                    },
+                },
+            },
+            {
+                "lemma": "неіснуючабілочка",
+                "pos": "noun",
+                "url_slug": "неіснуючабілочка",
+                "enrichment": {},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(enrich_manifest, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+    # Mock verify_word in scripts.verification.vesum: return empty list for fake words
+    monkeypatch.setattr(scripts.verification.vesum, "verify_word", lambda word, pos_filter=None: [])
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    dim_entry = manifest["entries"][1]
+    assert summary["filled_translation"] == 0
+    assert "translation" not in dim_entry.get("enrichment", {})


### PR DESCRIPTION
## Summary
Wire `derived_translation_fallback` into `reenrich_thin_manifest_entries` after direct/base/adverb layers. Fail-closed when base EN or VESUM is missing. Fingerprint sidecar updated.

## Test plan
- [x] pytest `tests/test_derived_en_fallback.py` `tests/test_reenrich_thin_manifest_entries.py`
- [ ] CI green

Refs #6876