### PR TITLE
fix(lexicon): fail-closed inject_approved_gloss guard (#5411)

### DIFF
--- a/scripts/lexicon/generate_needs_review_ledger.py
+++ b/scripts/lexicon/generate_needs_review_ledger.py
@@ -4,8 +4,9 @@
 Reads grow ``needs_review`` candidates plus ``needs-review-triage.json`` and emits
 a fail-closed ``atlas_grow_needs_review_decisions`` YAML ledger: one decision per
 held entry, bound to both file SHA digests. CODE maps triage actions only —
-``promote_with_gloss`` → approve (+ approved_gloss), ``truly_missing`` /
-``heritage_flag`` → deferred (heritage rows carry ``heritage: true``).
+``promote_with_gloss`` → approve (+ approved_gloss) when the gloss passes the
+#5411 inject guard, otherwise deferred; ``truly_missing`` / ``heritage_flag`` →
+deferred (heritage rows carry ``heritage: true``).
 
 When to use: after triage has ranked held grow lemmas and before
 ``promote_grow_candidates.py --needs-review-ledger`` promotes the approve set.
@@ -31,9 +32,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.lexicon.build_data_manifest import _slug_for_url
 from scripts.lexicon.promote_grow_candidates import (
     NEEDS_REVIEW_LEDGER_KIND,
     _held_rows,
+    approved_gloss_refusal_reason,
     index_by_decision_key,
     require_exact_decision_coverage,
 )
@@ -102,8 +105,26 @@ def decision_from_triage(row: Mapping[str, Any]) -> dict[str, Any]:
         source = str(gloss.get("source") or "").strip()
         if not text or not source:
             raise ValueError(f"promote_with_gloss best_gloss incomplete: {lemma!r}")
+        matched_lemma = str(gloss.get("lemma") or lemma).strip()
+        matched_slug = str(gloss.get("slug") or gloss.get("url_slug") or "").strip()
+        if not matched_slug:
+            matched_slug = _slug_for_url(matched_lemma)
+        approved_gloss: dict[str, str] = {
+            "text": text,
+            "source": source,
+            "lemma": matched_lemma,
+            "slug": matched_slug,
+        }
+        # Fail-closed (#5411): do not emit approve rows that inject would refuse.
+        candidate = {"lemma": lemma, "pos": pos, "url_slug": _slug_for_url(lemma)}
+        refusal = approved_gloss_refusal_reason(candidate, approved_gloss)
+        if refusal is not None:
+            base["decision"] = "deferred"
+            base["reason"] = refusal
+            base["held_reason"] = f"inject_guard:{refusal}"
+            return base
         base["decision"] = "approve"
-        base["approved_gloss"] = {"text": text, "source": source}
+        base["approved_gloss"] = approved_gloss
         return base
 
     if action == MACHINE_MISSING:

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -24,6 +24,7 @@ import argparse
 import bisect
 import hashlib
 import json
+import re
 import sys
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
@@ -714,7 +715,10 @@ def _approved_needs_review_entries(
                 raise ValueError(f"needs-review ledger approved_gloss.text is empty: {key!r}")
             if not source:
                 raise ValueError(f"needs-review ledger approved_gloss.source is empty: {key!r}")
-            approved.append(inject_approved_gloss(row.entry, {"text": text, "source": source}))
+            gloss_payload = dict(gloss)
+            gloss_payload["text"] = text
+            gloss_payload["source"] = source
+            approved.append(inject_approved_gloss(row.entry, gloss_payload))
             approve_count += 1
         else:
             # deferred / reject stay held; heritage rows are always deferred by generator.
@@ -837,20 +841,102 @@ def require_exact_decision_coverage(
     raise ValueError(f"{ledger_label} does not exactly cover {scope_label} ({', '.join(details)})")
 
 
+_LATIN_LETTER_RE = re.compile(r"[A-Za-z]")
+_CYRILLIC_LETTER_RE = re.compile(r"[А-Яа-яЁёЄєІіЇїҐґ]")
+# СУМ-11 cross-ref / participle stubs are never learner-English anchors (#5411).
+_SUM11_STUB_MARKER_RE = re.compile(
+    r"(?i)(?:дієпр|див\.|те\s+саме,?\s+що)",
+)
+
+
+def approved_gloss_refusal_reason(
+    candidate: Mapping[str, Any],
+    approved_gloss: Mapping[str, Any],
+) -> str | None:
+    """Return a stable refusal reason, or None when inject is allowed (#5411).
+
+    Blocks three defect classes only:
+    1. no Latin / overwhelmingly Cyrillic text (Russian or Ukrainian definition
+       shipped as ``translation.en``)
+    2. СУМ-11 stub shapes (``дієпр`` / ``див.`` / ``те саме, що``) with no Latin
+    3. approved lemma/slug that does not match the candidate lemma/slug
+    """
+    text = str(approved_gloss.get("text") or "").strip()
+    if not text:
+        return "empty_gloss"
+
+    latin_n = len(_LATIN_LETTER_RE.findall(text))
+    cyrillic_n = len(_CYRILLIC_LETTER_RE.findall(text))
+
+    # Stub classification precedes the generic non-English gate so callers can
+    # distinguish СУМ-11 cross-ref rows from other Cyrillic definitions.
+    if latin_n == 0 and _SUM11_STUB_MARKER_RE.search(text):
+        return "sum11_stub_gloss"
+
+    if latin_n == 0 or cyrillic_n > latin_n:
+        return "non_english_gloss"
+
+    candidate_lemma = strip_acute_stress(_candidate_lemma(candidate))
+    candidate_slug = str(candidate.get("url_slug") or "").strip() or _slug_for_url(candidate_lemma)
+
+    approved_lemma = str(approved_gloss.get("lemma") or "").strip()
+    if approved_lemma and _lemma_key(strip_acute_stress(approved_lemma)) != _lemma_key(candidate_lemma):
+        return "lemma_mismatch"
+
+    approved_slug = str(
+        approved_gloss.get("slug") or approved_gloss.get("url_slug") or ""
+    ).strip()
+    if approved_slug and _slug_for_url(approved_slug) != _slug_for_url(candidate_slug):
+        return "lemma_mismatch"
+
+    return None
+
+
+def require_injectable_approved_gloss(
+    candidate: Mapping[str, Any],
+    approved_gloss: Mapping[str, Any],
+) -> str:
+    """Validate approved gloss for inject; return stripped text or raise."""
+    text = str(approved_gloss.get("text") or "").strip()
+    if not text:
+        raise ValueError("approved_gloss.text must be non-empty")
+    reason = approved_gloss_refusal_reason(candidate, approved_gloss)
+    if reason == "non_english_gloss":
+        raise ValueError(
+            "approved_gloss.text must be learner English (Latin letters; "
+            "not overwhelmingly Cyrillic)"
+        )
+    if reason == "sum11_stub_gloss":
+        raise ValueError(
+            "approved_gloss.text looks like a СУМ-11 stub "
+            "(дієпр / див. / те саме, що) and is not learner English"
+        )
+    if reason == "lemma_mismatch":
+        raise ValueError(
+            "approved_gloss lemma/slug does not match candidate lemma/slug"
+        )
+    if reason == "empty_gloss":
+        raise ValueError("approved_gloss.text must be non-empty")
+    if reason is not None:
+        raise ValueError(f"approved_gloss refused: {reason}")
+    return text
+
+
 def inject_approved_gloss(
     candidate: Mapping[str, Any],
-    approved_gloss: Mapping[str, str],
+    approved_gloss: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Inject ledger-approved gloss as definition/anchor on a needs_review entry.
 
     Sets top-level ``gloss`` (satisfies the learner-English anchor check) and
     seeds ``enrichment.meaning`` / ``enrichment.translation`` so the existing
     anchor-fill short-circuit and attribution pass see a grounded definition.
+
+    Fail-closed for #5411: refuses Cyrillic/non-English anchors, СУМ-11 stubs,
+    and lemma/slug mismatches from prefix-fallback dictionary hits.
     """
-    text = str(approved_gloss.get("text") or "").strip()
+    text = require_injectable_approved_gloss(candidate, approved_gloss)
     source = str(approved_gloss.get("source") or "").strip()
-    if not text:
-        raise ValueError("approved_gloss.text must be non-empty")
     entry = dict(candidate)
     entry["gloss"] = text
     enrichment_raw = entry.get("enrichment")

--- a/scripts/lexicon/triage_needs_review.py
+++ b/scripts/lexicon/triage_needs_review.py
@@ -29,6 +29,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.lexicon.build_data_manifest import _slug_for_url
 from scripts.lexicon.lemma_normalization import strip_acute_stress
 from scripts.verification.vesum import verify_words
 from scripts.wiki import sources_db as sdb
@@ -148,15 +149,34 @@ def extract_gloss_text(source_key: str, hit: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _hit_matched_lemma(hit: Mapping[str, Any]) -> str | None:
+    """Dictionary headword that produced this hit (exact or prefix-fallback)."""
+    for key in ("word", "lemma", "headword", "canonical_headword"):
+        value = str(hit.get(key) or "").strip()
+        if value:
+            return strip_acute_stress(value)
+    return None
+
+
 def choose_best_gloss(
     hits_by_source: Mapping[str, Sequence[Mapping[str, Any]]],
 ) -> dict[str, str] | None:
-    """First non-empty gloss in GLOSS_SOURCE_PRIORITY order."""
+    """First non-empty gloss in GLOSS_SOURCE_PRIORITY order.
+
+    Attaches the matched dictionary headword as ``lemma`` / ``slug`` so the
+    needs_review inject guard can refuse prefix-fallback mismatches (#5411).
+    """
     for source_key in GLOSS_SOURCE_PRIORITY:
         for hit in hits_by_source.get(source_key) or []:
             text = extract_gloss_text(source_key, hit)
-            if text:
-                return {"text": text, "source": source_key}
+            if not text:
+                continue
+            gloss: dict[str, str] = {"text": text, "source": source_key}
+            matched = _hit_matched_lemma(hit)
+            if matched:
+                gloss["lemma"] = matched
+                gloss["slug"] = _slug_for_url(matched)
+            return gloss
     return None
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -127,7 +127,7 @@
       },
       {
         "path": "scripts/lexicon/generate_needs_review_ledger.py",
-        "sha256": "6bc9a7fb4977a57e5d39a5a11af13842b8efd1b42ea203c9c0b5647b91079663"
+        "sha256": "bb2327ff06ca34a188c4c7398f3c3fdccfb9b9b3a83a3b931616752a155e1cb5"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",
@@ -211,7 +211,7 @@
       },
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
-        "sha256": "d3d2f6a53de33af9653616d07ad68df7e91415f42065df93e5ad39e1215f9aa7"
+        "sha256": "8470daefaacadd1829977b97ad1cadeac6713409ce6c3acabeb22512b2f5eb16"
       },
       {
         "path": "scripts/lexicon/promote_teacher_lesson_intake.py",
@@ -251,7 +251,7 @@
       },
       {
         "path": "scripts/lexicon/triage_needs_review.py",
-        "sha256": "f9f954fdbebca4490702cf3bee46a774c87da23386a26c4634f7b81a7d4c2225"
+        "sha256": "412f7456d42f6adcfbc3f44157d2bbfb9d35b22b879620e258bf76ff3c2091eb"
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",

--- a/tests/test_generate_needs_review_ledger.py
+++ b/tests/test_generate_needs_review_ledger.py
@@ -49,7 +49,12 @@ def test_generator_round_trip_maps_actions(tmp_path: Path) -> None:
 
     by_lemma = {row["lemma"]: row for row in payload["decisions"]}
     assert by_lemma["хата"]["decision"] == "approve"
-    assert by_lemma["хата"]["approved_gloss"] == {"text": "house; home", "source": "dmklinger"}
+    assert by_lemma["хата"]["approved_gloss"] == {
+        "text": "house; home",
+        "source": "dmklinger",
+        "lemma": "хата",
+        "slug": "хата",
+    }
     assert by_lemma["абонплата"]["decision"] == "deferred"
     assert by_lemma["абонплата"]["reason"] == "truly_missing"
     assert by_lemma["верф"]["decision"] == "deferred"
@@ -234,7 +239,7 @@ def test_inject_approved_gloss_sets_anchor_fields() -> None:
     }
     injected = promote.inject_approved_gloss(
         candidate,
-        {"text": "house", "source": "sum11"},
+        {"text": "house", "source": "sum11", "lemma": "хата", "slug": "хата"},
     )
     assert injected["gloss"] == "house"
     assert injected["enrichment"]["meaning"]["definitions"] == ["house"]
@@ -242,6 +247,104 @@ def test_inject_approved_gloss_sets_anchor_fields() -> None:
     assert injected["enrichment"]["translation"]["en"] == ["house"]
     assert "sum11" in injected["enrichment"]["sources"]
     assert injected["enrichment"]["cefr"] == {"level": "A1"}
+
+
+def test_inject_approved_gloss_refuses_russian_cyrillic_definition() -> None:
+    candidate = {"lemma": "а-а-а", "pos": "interjection", "url_slug": "а-а-а"}
+    with pytest.raises(ValueError, match="learner English"):
+        promote.inject_approved_gloss(
+            candidate,
+            {
+                "text": "Колыбельный припев: бай-бай!",
+                "source": "grinchenko",
+                "lemma": "а-а-а",
+            },
+        )
+
+
+def test_inject_approved_gloss_refuses_sum11_stub() -> None:
+    candidate = {"lemma": "атакуючи", "pos": "adverb", "url_slug": "атакуючи"}
+    with pytest.raises(ValueError, match="СУМ-11 stub"):
+        promote.inject_approved_gloss(
+            candidate,
+            {
+                "text": "Дієпр. акт. теп. ч. до атакува́ти",
+                "source": "sum11",
+                "lemma": "атакуючи",
+            },
+        )
+
+
+def test_inject_approved_gloss_refuses_lemma_mismatch() -> None:
+    candidate = {"lemma": "багатити", "pos": "verb", "url_slug": "багатити"}
+    with pytest.raises(ValueError, match="lemma/slug"):
+        promote.inject_approved_gloss(
+            candidate,
+            {
+                "text": "to enrich; to make wealthy",
+                "source": "grinchenko",
+                "lemma": "багатитися",
+                "slug": "багатитися",
+            },
+        )
+
+
+def test_inject_approved_gloss_allows_dictionary_style_english_note() -> None:
+    candidate = {"lemma": "баль", "pos": "noun", "url_slug": "баль"}
+    note = (
+        "historical spelling of бал ('ball, dance'); older orthography note"
+    )
+    injected = promote.inject_approved_gloss(
+        candidate,
+        {"text": note, "source": "wiktionary", "lemma": "баль", "slug": "баль"},
+    )
+    assert injected["gloss"] == note
+    assert injected["enrichment"]["translation"]["en"] == [note]
+
+
+def test_generator_defers_non_injectable_promote_with_gloss(tmp_path: Path) -> None:
+    held = [
+        {
+            "entry": _candidate("а-а-а", enrichment={"sources": ["VESUM"]}),
+            "reason": "missing dictionary definition",
+        }
+    ]
+    candidates_path = _write_candidates(tmp_path, [], held)
+    triage_path = tmp_path / "triage.json"
+    triage_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "lemma": "а-а-а",
+                        "pos": "noun",
+                        "held_reason": "missing dictionary definition",
+                        "best_gloss": {
+                            "text": "Колыбельный припев: бай-бай!",
+                            "source": "grinchenko",
+                            "lemma": "а-а-а",
+                        },
+                        "machine_action": "promote_with_gloss",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=tmp_path / "ledger.yaml",
+        write=True,
+    )
+    assert result.approve_count == 0
+    assert result.deferred_count == 1
+    payload = yaml.safe_load((tmp_path / "ledger.yaml").read_text(encoding="utf-8"))
+    assert payload["decisions"][0]["decision"] == "deferred"
+    assert payload["decisions"][0]["reason"] == "non_english_gloss"
 
 
 def test_needs_review_and_auto_merge_ledgers_compose(tmp_path: Path) -> None:

--- a/tests/test_triage_needs_review.py
+++ b/tests/test_triage_needs_review.py
@@ -54,7 +54,12 @@ def test_gloss_priority_order_sum11_over_dmklinger() -> None:
     )
     assert len(records) == 1
     rec = records[0]
-    assert rec["best_gloss"] == {"text": "СУМ gloss", "source": "sum11"}
+    assert rec["best_gloss"] == {
+        "text": "СУМ gloss",
+        "source": "sum11",
+        "lemma": "хата",
+        "slug": "хата",
+    }
     assert rec["machine_action"] == triage.MACHINE_PROMOTE
     assert rec["cefr"] == "A1"
     assert rec["vesum_valid"] is True
@@ -79,7 +84,12 @@ def test_gloss_priority_falls_through_to_dmklinger() -> None:
         lookups=lookups,
         vesum_fn=lambda words: {w: [] for w in words},
     )
-    assert records[0]["best_gloss"] == {"text": "work", "source": "dmklinger"}
+    assert records[0]["best_gloss"] == {
+        "text": "work",
+        "source": "dmklinger",
+        "lemma": "робота",
+        "slug": "робота",
+    }
     assert records[0]["machine_action"] == triage.MACHINE_PROMOTE
     assert records[0]["vesum_valid"] is False
 


### PR DESCRIPTION
## Summary
- Harden `inject_approved_gloss` to refuse Cyrillic/non-English anchors, СУМ-11 stub shapes, and approved lemma/slug mismatches (#5411).
- Ledger generate maps `promote_with_gloss` → deferred when the same inject guard would refuse, so those approve rows are never emitted.
- Triage attaches matched dictionary headword as `lemma`/`slug` on `best_gloss` so prefix-fallback mismatches are detectable.

## Changes
- `scripts/lexicon/promote_grow_candidates.py` — shared refusal reasons + fail-closed inject
- `scripts/lexicon/generate_needs_review_ledger.py` — do not emit non-injectable approve rows
- `scripts/lexicon/triage_needs_review.py` — carry matched headword on best gloss
- Tests for Russian gloss, СУМ-11 stub, lemma mismatch rejects + dictionary-style English note OK

## Testing
- [x] `pytest tests/test_generate_needs_review_ledger.py tests/test_triage_needs_review.py tests/test_promote_grow_candidates.py`
- [x] `ruff check` on touched files
- [ ] Modules pass audit (`scripts/audit_module.py`) — N/A (lexicon tooling only)
- [ ] Website builds without errors (`cd site && npm run build`) — N/A
- [ ] Ukrainian text reviewed for naturalness — N/A (no content/manifest edits)

## Related Issues
Closes #5411


Made with [Cursor](https://cursor.com)