### PR TITLE
ci: retry network-touching stanza steps (#6968)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,11 @@ jobs:
       # cold runner does not redownload it in every CI run. Version the key and
       # couple it to the lockfile: a model cache is valid only for the Stanza
       # dependency set that produced it.
+      # Cache-service errors are recoverable: continue to the provision path.
+      # A restore miss or outage must not kill the shard; provision is the gate.
       - name: Restore Stanza Ukrainian model cache
         id: stanza-model-cache
+        continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/stanza_resources
@@ -274,11 +277,23 @@ jobs:
 
       # Run this smoke regardless of cache state. Besides provisioning a cold
       # cache, it verifies a restored archive before pytest workers can start
-      # lazy model downloads.
+      # lazy model downloads. Bounded retry absorbs transient Hugging Face /
+      # GitHub network blips (3 attempts, 10s then 30s backoff).
       - name: Provision and verify Stanza Ukrainian model
         run: |
           set -euo pipefail
-          .venv/bin/python -c "from scripts.pipeline.stress_annotator import annotate_stress; print(annotate_stress('Мама читає книжку.'))"
+          for attempt in 1 2 3; do
+            echo "stanza provision attempt ${attempt}/3"
+            if .venv/bin/python -c "from scripts.pipeline.stress_annotator import annotate_stress; print(annotate_stress('Мама читає книжку.'))"; then
+              exit 0
+            fi
+            case "${attempt}" in
+              1) sleep 10 ;;
+              2) sleep 30 ;;
+            esac
+          done
+          echo "::error::Provision and verify Stanza Ukrainian model failed after 3 attempts" >&2
+          exit 1
 
       - name: Save Stanza Ukrainian model cache
         if: steps.stanza-model-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Unit 1 of #6968 (CI outage-amplification fixes).

Today's GitHub outage killed pytest shards on first transient at exactly two steps: the Stanza model cache restore (Actions cache service) and the model provision smoke. This PR:
- cache restore step becomes non-fatal on service error (falls through to the provision path)
- provision smoke wrapped in a bounded 3-attempt retry (10s/30s backoff, loud failure after), reusing the repo's existing playground-step retry shape

No other workflow logic touched (cheap-exit arc #6917 untouched). actionlint clean, YAML parses. Refs #6968 (units 2-3 in flight separately).

Worker: grok (dispatch infra-6968-ci-step-retries); driver finalized push+PR (grok harness cannot push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)