### PR TITLE
fix(transport): cursor C0 acpx/node repair + attested receipts (#6953)

### DIFF
--- a/docs/runbooks/cursor-driver.md
+++ b/docs/runbooks/cursor-driver.md
@@ -63,3 +63,47 @@ The following tools and frameworks are explicitly rejected and must not be vendo
 - **No Benny:** No external automated workflow bots.
 - **No N-Implementation Arenas (`/arena`):** Contest is handled via `ab discuss`, followed by a single dispatched owner.
 - **No Second Comms Bus:** No `cursor-discuss` or custom socket daemon; comms uses the existing C0 fleet-comms plane.
+
+## Fleet-comms (C0)
+
+Cursor TUI drivers talk to the **existing** message plane only. Entry point is
+the primary interpreter + bridge module (same bus as every other seat — not a
+second discuss API):
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python \
+  scripts/ai_agent_bridge/__main__.py discuss <channel> "<topic>" \
+  --with <a>,<b> [--max-rounds N]
+```
+
+| Verb | How |
+| --- | --- |
+| **inbox** | `… __main__.py inbox show\|ack …` (fleet-comms dual-write) |
+| **dispatch** | `scripts/delegate.py dispatch --agent <non-cursor> …` (Cursor driver holds concurrency 1 — do not self-dispatch) |
+| **discuss** | `ab discuss` via the venv bridge above → ACPX controller (`LU_ACPX_TRANSPORT=active`) on the same plane |
+| **receipts** | `batch_state/tasks/<task-id>.json` + channel/thread ids; Cursor receipts must carry `resolved_model` / `resolved_model_known` / `resolved_model_source` |
+
+### ACPX / Node jail (#6953)
+
+`node_modules/.bin/acpx` is a `#!/usr/bin/env node` shim. A jail PATH of
+`/usr/bin:/bin` (no Homebrew) fails as `env: node: No such file or directory`
+in ~8s / 0 tokens. The ACPX adapter now:
+
+1. Resolves an absolute host `node` (PATH, then `/opt/homebrew/bin`,
+   `/usr/local/bin`, `~/.hermes/node/bin`).
+2. Spawns `[node, <acpx-entry>, …]` so the shebang is never consulted.
+3. Prepends Node's directory onto the child `PATH` for nested agent shebangs.
+
+No deploy step outside the worktree is required for this repair — it is code
+on the adapter path. If `node` is absent on the host entirely, discuss fails
+closed with an actionable refusal (install Node; do not invent a second bus).
+
+### Attestation on receipts
+
+- Attested: concrete `resolved_model` (e.g. `composer-2.5`) +
+  `resolved_model_known: true` + source (`cursor-stream-json` / transcript /
+  stderr-json).
+- Unattested Auto: `resolved_model: "unattested-harness"`,
+  `resolved_model_known: false`, `resolved_model_source: "unattested-harness"`.
+  That session is **not** driver-of-record. CF for unknown-Auto worker PRs
+  still follows the allowlist-union / #6489 rules in `model-assignment.md`.

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -197,11 +197,17 @@ _DEFAULT_ACPX_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 _ACPX_BINARY = _DEFAULT_ACPX_BINARY
 # Fixed host install locations for Node. Ambient PATH alone is not enough:
 # Cursor sandboxes / review jails often set PATH=/usr/bin:/bin, and the
-# project-local acpx shim is ``#!/usr/bin/env node`` (#6953).
+# project-local acpx shim is ``#!/usr/bin/env node`` (#6953). Linked
+# Homebrew ``node`` is often newer than ``.nvmrc``; keg-only
+# ``node@<major>`` paths are appended at resolve time from that contract.
 _NODE_HOST_BIN_DIRS = (
     Path("/opt/homebrew/bin"),
     Path("/usr/local/bin"),
     Path.home() / ".hermes" / "node" / "bin",
+)
+# ``node --version`` prints a single line like ``v22.23.2``.
+_NODE_VERSION_LINE_RE = re.compile(
+    r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$"
 )
 _CLAUDE_ACP_PACKAGE = "@agentclientprotocol/claude-agent-acp"
 _CLAUDE_ACP_MIN_VERSION = (0, 64, 2)
@@ -841,18 +847,75 @@ class AcpxShadowRefusalError(ValueError):
         self.failure_code = failure_code
 
 
-def _resolve_host_node_binary(*, adapter_label: str = "ACPX") -> Path:
-    """Resolve an absolute ``node`` for ACPX shebang scripts.
+def _required_node_major(*, adapter_label: str = "ACPX") -> int:
+    """Return the repo Node major from ``.nvmrc`` (engines pin the same major).
 
-    Prefer PATH when it already contains a usable ``node``, then fall back to
-    fixed host install locations. Never invent a Node runtime or consult an
-    unreviewed global acpx install as a substitute.
+    Read from the adapter source checkout (``Path(__file__)``), not the
+    patchable ``_REPO_ROOT`` used for project-local acpx binary resolution.
     """
+    nvmrc = Path(__file__).resolve().parents[3] / ".nvmrc"
+    try:
+        raw = nvmrc.read_text(encoding="utf-8").strip().splitlines()[0].strip()
+    except (OSError, IndexError) as exc:
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: cannot read Node major from {nvmrc}",
+        ) from exc
+    raw = raw.lstrip("vV").strip()
+    major_token = raw.split(".", 1)[0]
+    if not major_token.isdigit():
+        raise AcpxShadowRefusalError(
+            f"{adapter_label}: .nvmrc Node major is not an integer: {raw!r}",
+        )
+    return int(major_token)
+
+
+def _versioned_node_keg_dirs(required_major: int) -> tuple[Path, ...]:
+    """Homebrew keg-only ``node@<major>`` bins (not linked into ``*/bin``)."""
+    return (
+        Path(f"/opt/homebrew/opt/node@{required_major}/bin"),
+        Path(f"/usr/local/opt/node@{required_major}/bin"),
+    )
+
+
+def _probe_node_semver(candidate: Path) -> tuple[int, int, int] | None:
+    """Run ``<candidate> --version`` once; return semver if it is Node-shaped."""
+    try:
+        proc = subprocess.run(
+            [str(candidate), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    observed = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+    if not observed:
+        return None
+    first = observed.splitlines()[0].strip()
+    match = _NODE_VERSION_LINE_RE.fullmatch(first)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _resolve_host_node_binary(*, adapter_label: str = "ACPX") -> Path:
+    """Resolve an absolute contract-matching ``node`` for ACPX shebang scripts.
+
+    Prefer PATH when it already contains a usable ``node``, then fall back
+    through Homebrew keg-only ``node@<major>`` (from ``.nvmrc``) and the
+    fixed host install locations. Each candidate is validated once via
+    ``node --version`` (Node semver + major contract). Never invent a Node
+    runtime or consult an unreviewed global acpx install as a substitute.
+    """
+    required_major = _required_node_major(adapter_label=adapter_label)
     candidates: list[Path] = []
     which = shutil.which("node")
     if which:
         candidates.append(Path(which))
-    for root in _NODE_HOST_BIN_DIRS:
+    for root in (*_versioned_node_keg_dirs(required_major), *_NODE_HOST_BIN_DIRS):
         candidates.append(root / "node")
     seen: set[str] = set()
     for candidate in candidates:
@@ -864,12 +927,21 @@ def _resolve_host_node_binary(*, adapter_label: str = "ACPX") -> Path:
         if key in seen:
             continue
         seen.add(key)
-        if resolved.is_file() and os.access(resolved, os.X_OK):
-            return resolved
+        if not (resolved.is_file() and os.access(resolved, os.X_OK)):
+            continue
+        version = _probe_node_semver(resolved)
+        if version is None:
+            continue
+        if version[0] != required_major:
+            continue
+        return resolved
     raise AcpxShadowRefusalError(
-        f"{adapter_label}: node binary not found on PATH or fixed host install "
-        "locations (/opt/homebrew/bin, /usr/local/bin, ~/.hermes/node/bin); "
-        "required by the project-local acpx ``#!/usr/bin/env node`` shim (#6953)"
+        f"{adapter_label}: no Node {required_major}.x binary found on PATH or "
+        "fixed host install locations (Homebrew node@{major} keg, "
+        "/opt/homebrew/bin, /usr/local/bin, ~/.hermes/node/bin); each candidate "
+        "must report a Node semver via --version matching .nvmrc "
+        f"(required major {required_major}); required by the project-local acpx "
+        "``#!/usr/bin/env node`` shim (#6953)"
     )
 
 

--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -79,6 +79,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+from collections.abc import Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -194,6 +195,14 @@ _DEFAULT_ACPX_BINARY = _REPO_ROOT / "node_modules" / ".bin" / "acpx"
 # Keep this separately patchable for hermetic adapter tests.  An explicit
 # override is authoritative and must never silently fall back to another tree.
 _ACPX_BINARY = _DEFAULT_ACPX_BINARY
+# Fixed host install locations for Node. Ambient PATH alone is not enough:
+# Cursor sandboxes / review jails often set PATH=/usr/bin:/bin, and the
+# project-local acpx shim is ``#!/usr/bin/env node`` (#6953).
+_NODE_HOST_BIN_DIRS = (
+    Path("/opt/homebrew/bin"),
+    Path("/usr/local/bin"),
+    Path.home() / ".hermes" / "node" / "bin",
+)
 _CLAUDE_ACP_PACKAGE = "@agentclientprotocol/claude-agent-acp"
 _CLAUDE_ACP_MIN_VERSION = (0, 64, 2)
 _CLAUDE_ACP_MAX_VERSION = (1, 0, 0)
@@ -832,17 +841,118 @@ class AcpxShadowRefusalError(ValueError):
         self.failure_code = failure_code
 
 
+def _resolve_host_node_binary(*, adapter_label: str = "ACPX") -> Path:
+    """Resolve an absolute ``node`` for ACPX shebang scripts.
+
+    Prefer PATH when it already contains a usable ``node``, then fall back to
+    fixed host install locations. Never invent a Node runtime or consult an
+    unreviewed global acpx install as a substitute.
+    """
+    candidates: list[Path] = []
+    which = shutil.which("node")
+    if which:
+        candidates.append(Path(which))
+    for root in _NODE_HOST_BIN_DIRS:
+        candidates.append(root / "node")
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return resolved
+    raise AcpxShadowRefusalError(
+        f"{adapter_label}: node binary not found on PATH or fixed host install "
+        "locations (/opt/homebrew/bin, /usr/local/bin, ~/.hermes/node/bin); "
+        "required by the project-local acpx ``#!/usr/bin/env node`` shim (#6953)"
+    )
+
+
+def _shebang_uses_env_node(path: Path) -> bool:
+    """True when ``path`` is a script that resolves Node via ``/usr/bin/env``."""
+    try:
+        with path.open("rb") as handle:
+            first = handle.readline(120)
+    except OSError:
+        return False
+    if not first.startswith(b"#!"):
+        return False
+    text = first[2:].decode("ascii", errors="ignore").strip()
+    parts = text.split()
+    if len(parts) < 2 or not parts[0].endswith("env"):
+        return False
+    # ``#!/usr/bin/env node`` or ``#!/usr/bin/env -S node --…``
+    return "node" in parts[1:]
+
+
+def _acpx_spawn_argv(binary: str, *, adapter_label: str = "ACPX") -> list[str]:
+    """Return argv that can exec ``binary`` even when PATH lacks ``node``.
+
+    Project-local ``node_modules/.bin/acpx`` is a Node shebang script. Spawning
+    it under a jail PATH of ``/usr/bin:/bin`` fails with
+    ``env: node: No such file or directory`` (#6953). Pin absolute ``node`` +
+    the script path so the shebang is never consulted. Non-Node stubs (hermetic
+    tests) keep a single-element argv.
+    """
+    path = Path(binary)
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return [binary]
+    if not _shebang_uses_env_node(resolved):
+        return [str(resolved)]
+    node = _resolve_host_node_binary(adapter_label=adapter_label)
+    return [str(node), str(resolved)]
+
+
+def _acpx_path_with_node(node: Path, existing: str | None = None) -> str:
+    """Prepend Node's directory so ACPX child shebangs can still find ``node``."""
+    node_dir = str(node.parent)
+    parts = [node_dir]
+    for part in (existing or os.environ.get("PATH", "")).split(os.pathsep):
+        if part and part not in parts:
+            parts.append(part)
+    # Always keep the minimal system dirs so PATH never collapses to node-only.
+    for system in ("/usr/bin", "/bin"):
+        if system not in parts:
+            parts.append(system)
+    return os.pathsep.join(parts)
+
+
+def _acpx_runtime_env_overrides(
+    extra: Mapping[str, str] | None = None,
+    *,
+    adapter_label: str = "ACPX",
+) -> dict[str, str]:
+    """Merge seat env overrides with a Node-bearing PATH for ACPX children."""
+    node = _resolve_host_node_binary(adapter_label=adapter_label)
+    env: dict[str, str] = {"PATH": _acpx_path_with_node(node)}
+    if extra:
+        for key, value in extra.items():
+            if key == "PATH":
+                env["PATH"] = _acpx_path_with_node(node, value)
+            else:
+                env[key] = value
+    return env
+
+
 def _probe_acpx_version(binary: str) -> str:
     """Return ``<binary> --version`` output, or ``"unknown"`` on failure."""
     try:
         proc = subprocess.run(
-            [binary, "--version"],
+            [*_acpx_spawn_argv(binary), "--version"],
             capture_output=True,
             text=True,
             timeout=10,
             check=False,
+            env=_acpx_runtime_env_overrides(),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired, AcpxShadowRefusalError):
         return "unknown"
     observed = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
     return observed.splitlines()[0][:100] if proc.returncode == 0 and observed else "unknown"
@@ -852,13 +962,14 @@ def _probe_cli_help(binary: str, *args: str) -> str:
     """Return one exact command's help surface, or an empty string."""
     try:
         proc = subprocess.run(
-            [binary, *args, "--help"],
+            [*_acpx_spawn_argv(binary), *args, "--help"],
             capture_output=True,
             text=True,
             timeout=10,
             check=False,
+            env=_acpx_runtime_env_overrides(),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired, AcpxShadowRefusalError):
         return ""
     if proc.returncode != 0:
         return ""
@@ -1289,7 +1400,7 @@ def _confinement_prefix_argv(
             sealed_review_mcp_config,
         ]
     return [
-        binary,
+        *_acpx_spawn_argv(binary),
         "--cwd",
         str(cwd),
         "--format",
@@ -1629,11 +1740,7 @@ def _build_text_agent_command(
         executable,
         adapter_label=adapter_label,
     )
-    node_binary = shutil.which("node")
-    if not node_binary:
-        raise AcpxShadowRefusalError(
-            f"{adapter_label}: node binary not found on PATH; required by the text ACP server"
-        )
+    node_binary = str(_resolve_host_node_binary(adapter_label=adapter_label))
     node_path = Path(node_binary).resolve()
     if not node_path.is_file():
         raise AcpxShadowRefusalError(
@@ -1786,7 +1893,10 @@ class AcpxAdapter:
             # Non-secret selector for the existing Codex ChatGPT login. The
             # sanitizer allowlists only this literal route marker; no token is
             # read, stored, or forwarded by the controller.
-            env_overrides={"ACPX_AUTH_CHAT_GPT": "1"},
+            env_overrides=_acpx_runtime_env_overrides(
+                {"ACPX_AUTH_CHAT_GPT": "1"},
+                adapter_label="AcpxAdapter",
+            ),
             liveness_paths=(),
             metadata=metadata,
         )
@@ -2148,7 +2258,8 @@ class _AcpxDiscussionAdapter:
         sealed_review_mcp_config: str | None = None,
     ) -> dict[str, str]:
         _ = sealed_review_mcp_config
-        return {} if self.auth_env is None else {self.auth_env: "1"}
+        seat = {} if self.auth_env is None else {self.auth_env: "1"}
+        return _acpx_runtime_env_overrides(seat, adapter_label=type(self).__name__)
 
     def _env_unsets(self) -> tuple[str, ...]:
         return ()
@@ -2411,14 +2522,17 @@ class AcpxGlmShadowAdapter(_AcpxDiscussionAdapter):
         *,
         sealed_review_mcp_config: str | None = None,
     ) -> dict[str, str]:
-        return {
-            GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
-            "OPENCODE_CONFIG_CONTENT": (
-                _OPENCODE_SEALED_REVIEW_CONFIG
-                if sealed_review_mcp_config is not None
-                else _OPENCODE_DENY_ALL_CONFIG
-            ),
-        }
+        return _acpx_runtime_env_overrides(
+            {
+                GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
+                "OPENCODE_CONFIG_CONTENT": (
+                    _OPENCODE_SEALED_REVIEW_CONFIG
+                    if sealed_review_mcp_config is not None
+                    else _OPENCODE_DENY_ALL_CONFIG
+                ),
+            },
+            adapter_label=type(self).__name__,
+        )
 
 
 class AcpxGemmaShadowAdapter(_AcpxDiscussionAdapter):
@@ -2456,10 +2570,13 @@ class AcpxGemmaShadowAdapter(_AcpxDiscussionAdapter):
         sealed_review_mcp_config: str | None = None,
     ) -> dict[str, str]:
         _ = sealed_review_mcp_config
-        return {
-            GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
-            "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
-        }
+        return _acpx_runtime_env_overrides(
+            {
+                GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
+                "OPENCODE_CONFIG_CONTENT": _OPENCODE_DENY_ALL_CONFIG,
+            },
+            adapter_label=type(self).__name__,
+        )
 
 
 class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
@@ -2510,14 +2627,17 @@ class AcpxDeepSeekShadowAdapter(_AcpxDiscussionAdapter):
         *,
         sealed_review_mcp_config: str | None = None,
     ) -> dict[str, str]:
-        return {
-            GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
-            "OPENCODE_CONFIG_CONTENT": (
-                _OPENCODE_SEALED_REVIEW_CONFIG
-                if sealed_review_mcp_config is not None
-                else _OPENCODE_DENY_ALL_CONFIG
-            ),
-        }
+        return _acpx_runtime_env_overrides(
+            {
+                GLM_AUTH_OPENCODE_LOGIN_ENV: "1",
+                "OPENCODE_CONFIG_CONTENT": (
+                    _OPENCODE_SEALED_REVIEW_CONFIG
+                    if sealed_review_mcp_config is not None
+                    else _OPENCODE_DENY_ALL_CONFIG
+                ),
+            },
+            adapter_label=type(self).__name__,
+        )
 
 
 class AcpxGrokShadowAdapter:
@@ -2690,7 +2810,10 @@ class AcpxGrokShadowAdapter:
             cwd=cwd,
             stdin_payload=prompt,
             output_file=None,
-            env_overrides={GROK_AUTH_CACHED_TOKEN_ENV: "1"},
+            env_overrides=_acpx_runtime_env_overrides(
+                {GROK_AUTH_CACHED_TOKEN_ENV: "1"},
+                adapter_label="AcpxGrokShadowAdapter",
+            ),
             env_unsets=_GROK_XAI_API_KEY_ENV_UNSETS,
             liveness_paths=(),
             metadata=metadata,

--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -59,7 +59,9 @@ _GITHUB_SECONDARY_RATE_LIMIT_MARKER = "agent-gh-shim: github_secondary_rate_limi
 # this boundary structural: assistant prose, tool input, and arbitrary log
 # text must never become model evidence merely because they contain the word
 # "model".
-_NON_CONCRETE_MODEL_VALUES = frozenset({"", "auto", "default", "unknown", "none", "null", "n/a"})
+_NON_CONCRETE_MODEL_VALUES = frozenset(
+    {"", "auto", "default", "unknown", "none", "null", "n/a", "unattested-harness"}
+)
 _MODEL_KEYS = frozenset(
     {
         "model",
@@ -466,13 +468,12 @@ class CursorAdapter:
             "requested_model": requested_model,
             "actual_provider": "cursor",
             # Keep the raw actual value empty when no trusted model was
-            # reported. The dispatch layer adds the human-readable
-            # ``resolved_model: unknown`` companion field without turning
-            # unknown into a fake provider/model route.
+            # reported. The dispatch layer records the explicit
+            # ``resolved_model: unattested-harness`` companion field (#6953).
             "actual_model": resolved_model,
             "actual_model_known": bool(resolved_model),
             "substituted": bool(resolved_model and resolved_model != requested_model),
-            "source": resolved_model_source or "unknown",
+            "source": resolved_model_source or "unattested-harness",
             "marker": None,
         }
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -954,8 +954,12 @@ _WRITE_SHAPED_PROMPT_RE = re.compile(
     """,
 )
 _NO_DELIVERABLE_STATUS = "no_deliverable"
-_CURSOR_UNKNOWN_MODEL = "unknown"
-_NON_CONCRETE_MODEL_VALUES = frozenset({"", "auto", "default", "unknown", "none", "null", "n/a"})
+# Explicit unattested classification for Cursor Auto when no concrete model was
+# extracted (#6964 / #6953). Never record a bare ``"unknown"`` here.
+_CURSOR_UNKNOWN_MODEL = "unattested-harness"
+_NON_CONCRETE_MODEL_VALUES = frozenset(
+    {"", "auto", "default", "unknown", "none", "null", "n/a", "unattested-harness"}
+)
 
 
 def _cursor_model_state(
@@ -982,7 +986,7 @@ def _cursor_model_state(
         }
 
     actual_model: object = None
-    source = "unknown"
+    source = "unattested-harness"
     known_raw: object = None
     if isinstance(substitution, dict):
         actual_model = substitution.get("actual_model")
@@ -996,6 +1000,10 @@ def _cursor_model_state(
     explicitly_unknown = str(known_raw).strip().casefold() in {"false", "0", "no"}
     resolved_model = concrete if is_concrete and not explicitly_unknown else _CURSOR_UNKNOWN_MODEL
     known = resolved_model != _CURSOR_UNKNOWN_MODEL
+    if not known and source.casefold() in {"unknown", "pending", ""}:
+        # Receipts must carry the explicit unattested classification, not a
+        # bare "unknown" placeholder (#6953 / #6964).
+        source = _CURSOR_UNKNOWN_MODEL
 
     state = {
         "resolved_model": resolved_model,

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -106,8 +106,12 @@ UNRESOLVED_AUTHOR_FAMILIES: frozenset[str] = frozenset(
 # Cursor-as-reviewer is ineligible against authors in {xAI, Moonshot}.
 CURSOR_AUTO_UNION_FAMILY = "cursor-auto-union"
 CURSOR_AUTO_UNION_FAMILIES: frozenset[str] = frozenset({"xai", "moonshot"})
-CURSOR_AUTO_MODEL_TOKENS: frozenset[str] = frozenset({"auto", "unknown"})
-CURSOR_AUTO_HARNESS_SEATS: frozenset[str] = frozenset({"cursor-auto", "cursor-auto-unknown"})
+CURSOR_AUTO_MODEL_TOKENS: frozenset[str] = frozenset(
+    {"auto", "unknown", "unattested-harness"}
+)
+CURSOR_AUTO_HARNESS_SEATS: frozenset[str] = frozenset(
+    {"cursor-auto", "cursor-auto-unknown", "cursor-auto-unattested-harness"}
+)
 
 UNATTESTED_MODEL_TOKENS: frozenset[str] = frozenset({"auto"})
 UNATTESTED_HARNESS_SEATS: frozenset[str] = frozenset({"cursor-auto"})

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -300,7 +300,7 @@ def test_cursor_adapter_does_not_infer_model_from_assistant_text(adapter):
     assert result.substitution is not None
     assert result.substitution["actual_model"] is None
     assert result.substitution["actual_model_known"] is False
-    assert result.substitution["source"] == "unknown"
+    assert result.substitution["source"] == "unattested-harness"
 
 
 def test_cursor_adapter_reads_concrete_model_from_session_transcript(adapter, monkeypatch):
@@ -351,7 +351,7 @@ def test_cursor_adapter_does_not_use_unrelated_existing_transcript_model(adapter
     assert result.substitution is not None
     assert result.substitution["actual_model"] is None
     assert result.substitution["actual_model_known"] is False
-    assert result.substitution["source"] == "unknown"
+    assert result.substitution["source"] == "unattested-harness"
 
 
 def test_cursor_adapter_successful_echoed_rate_limit_text_is_not_rate_limited(adapter):

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -20,7 +20,9 @@ build-invocation tests mock binary resolution and version probes only.
 from __future__ import annotations
 
 import json
+import os
 import shlex
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -233,6 +235,63 @@ def _stub_binary(
         },
     )
     return binary
+
+
+def _assert_acpx_env_overrides(env: dict, *, expected: dict[str, str]) -> None:
+    """Seat auth/config keys plus a Node-bearing PATH (#6953)."""
+    for key, value in expected.items():
+        assert env.get(key) == value
+    assert "PATH" in env
+    path_parts = env["PATH"].split(os.pathsep)
+    assert any(Path(part).joinpath("node").exists() for part in path_parts) or any(
+        "node" in part for part in path_parts
+    )
+
+
+def test_acpx_spawn_argv_pins_absolute_node_when_shebang_uses_env(tmp_path, monkeypatch):
+    """#6953: jail PATH=/usr/bin:/bin must not yield ``env: node: No such file``."""
+    script = tmp_path / "acpx"
+    script.write_text("#!/usr/bin/env node\nconsole.log('ok')\n", encoding="utf-8")
+    script.chmod(0o755)
+    node = tmp_path / "node"
+    node.write_text("#!/bin/sh\nexec /bin/echo stub-node\n", encoding="utf-8")
+    node.chmod(0o755)
+    monkeypatch.setattr(acpx_module.shutil, "which", lambda name: str(node) if name == "node" else None)
+    monkeypatch.setattr(acpx_module, "_NODE_HOST_BIN_DIRS", ())
+
+    argv = acpx_module._acpx_spawn_argv(str(script), adapter_label="test")
+    assert argv == [str(node.resolve()), str(script.resolve())]
+
+    # Ambient PATH lacks node; absolute argv still executes.
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
+    # Real host node is required to evaluate the JS shebang script; prove the
+    # probe helper survives a stripped PATH by using the runtime env override.
+    host_node = acpx_module._resolve_host_node_binary(adapter_label="test-host")
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str(host_node) if name == "node" else None,
+    )
+    monkeypatch.setattr(acpx_module, "_NODE_HOST_BIN_DIRS", (host_node.parent,))
+    # Point at the real project-local acpx when present.
+    primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/acpx")
+    if not primary.is_file():
+        pytest.skip("project-local acpx not installed")
+    jail_env = acpx_module._acpx_runtime_env_overrides()
+    jail_env["PATH"] = "/usr/bin:/bin"  # ambient stripped; argv carries node
+    spawn = acpx_module._acpx_spawn_argv(str(primary))
+    assert spawn[0].endswith("/node") or Path(spawn[0]).name == "node"
+    proc = subprocess.run(
+        [*spawn, "--version"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**jail_env, "PATH": "/usr/bin:/bin"},
+        check=False,
+    )
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    assert "env: node: No such file" not in (proc.stderr or "")
+    assert (proc.stdout or "").strip()
 
 
 def _fake_installed_claude_adapter(tmp_path: Path, *, version: str = "0.64.2") -> Path:
@@ -1696,7 +1755,7 @@ def test_grok_build_invocation_auth_env_sets_cached_token_and_scrubs_xai_keys(
     adapter = AcpxGrokShadowAdapter()
 
     plan = _build_grok(adapter, cwd=tmp_path)
-    assert plan.env_overrides == {"ACPX_AUTH_CACHED_TOKEN": "1"}
+    _assert_acpx_env_overrides(plan.env_overrides, expected={"ACPX_AUTH_CACHED_TOKEN": "1"})
     assert "XAI_API_KEY" in plan.env_unsets
     assert "GROK_API_KEY" in plan.env_unsets
     assert "ACPX_AUTH_XAI_API_KEY" in plan.env_unsets
@@ -1812,7 +1871,7 @@ def test_codex_adapter_unchanged_still_targets_codex_only(tmp_path, monkeypatch)
     assert "exec" in plan.cmd
     assert "--agent" not in plan.cmd
     assert "grok-build" not in plan.cmd
-    assert plan.env_overrides == {"ACPX_AUTH_CHAT_GPT": "1"}
+    _assert_acpx_env_overrides(plan.env_overrides, expected={"ACPX_AUTH_CHAT_GPT": "1"})
     assert build_agent_env(provider=adapter.name, overrides=plan.env_overrides)[
         "ACPX_AUTH_CHAT_GPT"
     ] == "1"
@@ -1877,7 +1936,10 @@ def test_builtin_discussion_seats_are_fixed_active_only_and_confined(
 
     assert adapter.name == f"acpx-{participant}-shadow"
     assert plan.cmd[-4:] == [acpx_agent, "exec", "-f", "-"]
-    assert plan.env_overrides == ({} if auth_env is None else {auth_env: "1"})
+    _assert_acpx_env_overrides(
+        plan.env_overrides,
+        expected=({} if auth_env is None else {auth_env: "1"}),
+    )
     sanitized_env = build_agent_env(provider=adapter.name, overrides=plan.env_overrides)
     if auth_env is not None:
         assert sanitized_env[auth_env] == "1"
@@ -2290,10 +2352,13 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
         assert ("--model", invocation_model) in zip(
             plan.cmd, plan.cmd[1:], strict=False
         )
-        assert plan.env_overrides == {
-            "ACPX_AUTH_OPENCODE_LOGIN": "1",
-            "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}'
-        }
+        _assert_acpx_env_overrides(
+            plan.env_overrides,
+            expected={
+                "ACPX_AUTH_OPENCODE_LOGIN": "1",
+                "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}',
+            },
+        )
         assert build_agent_env(provider=adapter.name, overrides=plan.env_overrides)[
             "ACPX_AUTH_OPENCODE_LOGIN"
         ] == "1"
@@ -2302,7 +2367,7 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
         ] == plan.env_overrides["OPENCODE_CONFIG_CONTENT"]
     else:
         assert "--model" not in plan.cmd
-        assert plan.env_overrides == {}
+        _assert_acpx_env_overrides(plan.env_overrides, expected={})
 
 
 def test_gemma_shadow_seat_uses_a_confined_opencode_command(tmp_path, monkeypatch):
@@ -2351,10 +2416,13 @@ def test_gemma_shadow_seat_uses_a_confined_opencode_command(tmp_path, monkeypatc
     assert plan.metadata["provider_route"] == "google-ais/gemma-4-31b-it"
     assert plan.metadata["provider_cli_compatibility"] == "native-acp-pure-v1"
     assert plan.metadata["tool_policy"] == "deny-all"
-    assert plan.env_overrides == {
-        "ACPX_AUTH_OPENCODE_LOGIN": "1",
-        "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}',
-    }
+    _assert_acpx_env_overrides(
+        plan.env_overrides,
+        expected={
+            "ACPX_AUTH_OPENCODE_LOGIN": "1",
+            "OPENCODE_CONFIG_CONTENT": '{"permission":{"*":"deny"},"tools":{"*":false}}',
+        },
+    )
     env = build_agent_env(provider=adapter.name, overrides=plan.env_overrides)
     assert env["ACPX_AUTH_OPENCODE_LOGIN"] == "1"
     assert env["OPENCODE_CONFIG_CONTENT"] == plan.env_overrides["OPENCODE_CONFIG_CONTENT"]

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -248,39 +248,121 @@ def _assert_acpx_env_overrides(env: dict, *, expected: dict[str, str]) -> None:
     )
 
 
+def _fake_node_binary(directory: Path, *, version: str) -> Path:
+    """Writable ``node`` stub that answers ``--version`` with a Node semver line."""
+    directory.mkdir(parents=True, exist_ok=True)
+    node = directory / "node"
+    node.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then printf "%s\\n" '
+        f"'{version}'; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    node.chmod(0o755)
+    return node
+
+
+def _isolate_node_fallbacks(monkeypatch, *roots: Path) -> None:
+    """Disable keg + host fallbacks except the supplied dirs (hermetic)."""
+    monkeypatch.setattr(acpx_module, "_versioned_node_keg_dirs", lambda _major: ())
+    monkeypatch.setattr(acpx_module, "_NODE_HOST_BIN_DIRS", tuple(roots))
+
+
+def test_resolve_host_node_skips_wrong_version_on_path_for_contract_fallback(
+    tmp_path, monkeypatch
+):
+    """#6953 CF: wrong-version PATH node is rejected; contract fallback wins."""
+    required = acpx_module._required_node_major(adapter_label="test")
+    wrong = _fake_node_binary(tmp_path / "wrong", version=f"v{required + 4}.0.0")
+    correct = _fake_node_binary(tmp_path / "correct", version=f"v{required}.14.0")
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str(wrong) if name == "node" else None,
+    )
+    _isolate_node_fallbacks(monkeypatch, correct.parent)
+
+    resolved = acpx_module._resolve_host_node_binary(adapter_label="test")
+    assert resolved == correct.resolve()
+
+    script = tmp_path / "acpx"
+    script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    script.chmod(0o755)
+    argv = acpx_module._acpx_spawn_argv(str(script), adapter_label="test")
+    assert argv[0] == str(correct.resolve())
+    env = acpx_module._acpx_runtime_env_overrides(adapter_label="test")
+    assert env["PATH"].split(os.pathsep)[0] == str(correct.parent.resolve())
+
+
+def test_resolve_host_node_rejects_masquerading_non_node_executable(
+    tmp_path, monkeypatch
+):
+    """#6953 CF: a shell script named ``node`` is not admitted."""
+    impostor = tmp_path / "node"
+    impostor.write_text("#!/bin/sh\nexec /bin/echo stub-node\n", encoding="utf-8")
+    impostor.chmod(0o755)
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str(impostor) if name == "node" else None,
+    )
+    _isolate_node_fallbacks(monkeypatch)
+
+    with pytest.raises(AcpxShadowRefusalError, match=r"no Node \d+\.x binary"):
+        acpx_module._resolve_host_node_binary(adapter_label="test")
+
+
+def test_resolve_host_node_fails_loudly_when_none_qualify(tmp_path, monkeypatch):
+    """#6953 CF: every candidate wrong/non-Node → loud refusal."""
+    required = acpx_module._required_node_major(adapter_label="test")
+    wrong = _fake_node_binary(tmp_path / "wrong", version=f"v{required + 1}.0.0")
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str(wrong) if name == "node" else None,
+    )
+    _isolate_node_fallbacks(monkeypatch)
+
+    with pytest.raises(
+        AcpxShadowRefusalError,
+        match=rf"no Node {required}\.x binary.*--version matching \.nvmrc",
+    ):
+        acpx_module._resolve_host_node_binary(adapter_label="test")
+
+
 def test_acpx_spawn_argv_pins_absolute_node_when_shebang_uses_env(tmp_path, monkeypatch):
     """#6953: jail PATH=/usr/bin:/bin must not yield ``env: node: No such file``."""
+    # Resolve the real contract node before hermetic PATH isolation.
+    host_node = acpx_module._resolve_host_node_binary(adapter_label="test-host")
+
+    required = acpx_module._required_node_major(adapter_label="test")
     script = tmp_path / "acpx"
     script.write_text("#!/usr/bin/env node\nconsole.log('ok')\n", encoding="utf-8")
     script.chmod(0o755)
-    node = tmp_path / "node"
-    node.write_text("#!/bin/sh\nexec /bin/echo stub-node\n", encoding="utf-8")
-    node.chmod(0o755)
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda name: str(node) if name == "node" else None)
-    monkeypatch.setattr(acpx_module, "_NODE_HOST_BIN_DIRS", ())
+    node = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
+    monkeypatch.setattr(
+        acpx_module.shutil,
+        "which",
+        lambda name: str(node) if name == "node" else None,
+    )
+    _isolate_node_fallbacks(monkeypatch)
 
     argv = acpx_module._acpx_spawn_argv(str(script), adapter_label="test")
     assert argv == [str(node.resolve()), str(script.resolve())]
 
-    # Ambient PATH lacks node; absolute argv still executes.
-    env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
-    # Real host node is required to evaluate the JS shebang script; prove the
-    # probe helper survives a stripped PATH by using the runtime env override.
-    host_node = acpx_module._resolve_host_node_binary(adapter_label="test-host")
     monkeypatch.setattr(
         acpx_module.shutil,
         "which",
         lambda name: str(host_node) if name == "node" else None,
     )
-    monkeypatch.setattr(acpx_module, "_NODE_HOST_BIN_DIRS", (host_node.parent,))
-    # Point at the real project-local acpx when present.
+    _isolate_node_fallbacks(monkeypatch, host_node.parent)
     primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/acpx")
     if not primary.is_file():
         pytest.skip("project-local acpx not installed")
-    jail_env = acpx_module._acpx_runtime_env_overrides()
-    jail_env["PATH"] = "/usr/bin:/bin"  # ambient stripped; argv carries node
-    spawn = acpx_module._acpx_spawn_argv(str(primary))
-    assert spawn[0].endswith("/node") or Path(spawn[0]).name == "node"
+    jail_env = acpx_module._acpx_runtime_env_overrides(adapter_label="test-host")
+    spawn = acpx_module._acpx_spawn_argv(str(primary), adapter_label="test-host")
+    assert Path(spawn[0]).resolve() == host_node.resolve()
     proc = subprocess.run(
         [*spawn, "--version"],
         capture_output=True,
@@ -2293,12 +2375,17 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
 ):
     _stub_binary(monkeypatch, tmp_path)
     binaries = {}
+    required = acpx_module._required_node_major(adapter_label="test")
     for name in ("node", provider_binary):
         path = tmp_path / name
-        path.write_text("#!/bin/sh\n", encoding="utf-8")
-        path.chmod(0o755)
+        if name == "node":
+            path = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
+        else:
+            path.write_text("#!/bin/sh\n", encoding="utf-8")
+            path.chmod(0o755)
         binaries[name] = str(path)
     monkeypatch.setattr(acpx_module.shutil, "which", lambda name: binaries.get(name))
+    _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(
         acpx_module,
         "_probe_participant_cli_compatibility",
@@ -2555,16 +2642,17 @@ def test_probe_participant_reachability_flags_deepseek_when_opencode_is_missing(
 
 def test_new_fleet_discussion_seat_accepts_provider_cli_version_drift(tmp_path, monkeypatch):
     _stub_binary(monkeypatch, tmp_path)
+    required = acpx_module._required_node_major(adapter_label="test")
     agy = tmp_path / "agy"
-    node = tmp_path / "node"
-    for path in (agy, node):
-        path.write_text("#!/bin/sh\n", encoding="utf-8")
-        path.chmod(0o755)
+    agy.write_text("#!/bin/sh\n", encoding="utf-8")
+    agy.chmod(0o755)
+    node = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
     monkeypatch.setattr(
         acpx_module.shutil,
         "which",
         lambda name: str({"agy": agy, "node": node}[name]),
     )
+    _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(
         acpx_module,
         "_probe_participant_cli_compatibility",
@@ -2593,16 +2681,17 @@ def test_new_fleet_discussion_seat_accepts_provider_cli_version_drift(tmp_path, 
 
 def test_new_fleet_discussion_seat_rejects_missing_provider_capability(tmp_path, monkeypatch):
     _stub_binary(monkeypatch, tmp_path)
+    required = acpx_module._required_node_major(adapter_label="test")
     agy = tmp_path / "agy"
-    node = tmp_path / "node"
-    for path in (agy, node):
-        path.write_text("#!/bin/sh\n", encoding="utf-8")
-        path.chmod(0o755)
+    agy.write_text("#!/bin/sh\n", encoding="utf-8")
+    agy.chmod(0o755)
+    node = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
     monkeypatch.setattr(
         acpx_module.shutil,
         "which",
         lambda name: str({"agy": agy, "node": node}[name]),
     )
+    _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(
         acpx_module,
         "_probe_participant_cli_compatibility",
@@ -2649,8 +2738,12 @@ def test_acpx_compatibility_probe_checks_global_and_builtin_exec_surfaces(monkey
             self.returncode = returncode
 
     root_help = " ".join((*acpx_module._ACPX_REQUIRED_GLOBAL_FLAGS, "codex participant"))
+    required = acpx_module._required_node_major(adapter_label="test")
 
     def _compatible(argv, **_kwargs):
+        # Compatibility probes build a Node-bearing child PATH (#6953).
+        if Path(argv[0]).name == "node" and argv[-1] == "--version":
+            return _Proc(f"v{required}.14.0\n")
         if argv[-1] == "--version":
             return _Proc("0.14.7\n")
         if argv[1:] == ["--help"]:
@@ -2823,8 +2916,12 @@ def test_probe_grok_cli_compatibility_checks_required_command_surface(monkeypatc
             self.returncode = returncode
 
     agent_help = " ".join(acpx_module._GROK_REQUIRED_AGENT_FLAGS)
+    required = acpx_module._required_node_major(adapter_label="test")
 
     def _compatible(argv, **_kwargs):
+        # Grok help rides ``_probe_cli_help`` → Node-bearing PATH (#6953).
+        if Path(argv[0]).name == "node" and argv[-1] == "--version":
+            return _Proc(f"v{required}.14.0\n")
         if argv[-1] == "--version":
             return _Proc("grok 0.3.7 (rolling)\n")
         if argv[1:] == ["agent", "--help"]:

--- a/tests/test_agent_runtime_acp_transport_cutover.py
+++ b/tests/test_agent_runtime_acp_transport_cutover.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib
+import os
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -140,6 +142,8 @@ def test_inter_agent_rejects_spoofed_provenance_and_unknown_source_before_spawn(
         "CLAUDE_AGENT_NAME",
         "GROK_AGENT",
         "GEMINI_SESSION",
+        "LU_RUNTIME_INITIATOR",
+        "LU_RUNTIME_INITIATOR_SOURCE",
     ):
         monkeypatch.delenv(variable, raising=False)
 
@@ -259,8 +263,20 @@ def test_adapter_transport_metadata_and_auth_selector_are_non_secret(tmp_path, m
     assert plan.metadata["via"] == "acp"
     assert plan.metadata["acpx_discussion"] is False
     assert plan.metadata["acpx_transport"] is True
-    assert plan.env_overrides == {"ACPX_AUTH_LOGIN": "1"}
+    # Auth selector + Node-bearing PATH for jail repair (#6953). PATH is
+    # operational (not a secret); it must still start with the validated
+    # host Node dir that `_acpx_runtime_env_overrides` prepends.
+    assert plan.env_overrides["ACPX_AUTH_LOGIN"] == "1"
+    assert set(plan.env_overrides) == {"ACPX_AUTH_LOGIN", "PATH"}
+    node_dir = str(
+        acpx_module._resolve_host_node_binary(
+            adapter_label="AcpxKimiShadowAdapter"
+        ).parent
+    )
+    assert plan.env_overrides["PATH"].split(os.pathsep)[0] == node_dir
+    assert Path(node_dir).joinpath("node").is_file()
     assert env["ACPX_AUTH_LOGIN"] == "1"
+    assert env["PATH"].split(os.pathsep)[0] == node_dir
     assert "KIMI_API_KEY" not in env
     assert secret not in repr(plan)
     assert secret not in repr(env)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1649,7 +1649,7 @@ def test_run_worker_persists_cursor_resolved_model_companion(tmp_tasks_dir, tmp_
     assert state["resolved_model_source"] == "cursor-stream-json"
 
 
-def test_run_worker_records_unknown_cursor_model_without_inventing_selector(
+def test_run_worker_records_unattested_harness_cursor_model_without_inventing_selector(
     tmp_tasks_dir,
     tmp_path,
 ):
@@ -1700,9 +1700,9 @@ def test_run_worker_records_unknown_cursor_model_without_inventing_selector(
     state = delegate._read_state(state_path)
     assert state is not None
     assert state["model"] == "auto"
-    assert state["resolved_model"] == "unknown"
+    assert state["resolved_model"] == "unattested-harness"
     assert state["resolved_model_known"] is False
-    assert state["resolved_model_source"] == "unknown"
+    assert state["resolved_model_source"] == "unattested-harness"
 
 
 def test_run_worker_surfaces_instant_exit_stderr_in_task_state_and_log(


### PR DESCRIPTION
## Summary

Repairs Cursor driver C0 fleet-comms transport (#6953, parent #6952):

1. **ACPX / Node jail:** Project-local `node_modules/.bin/acpx` is `#!/usr/bin/env node`. Under a jail PATH of `/usr/bin:/bin` this fails as `env: node: No such file or directory` (~8s / 0 tokens). The ACPX adapter now resolves an absolute host `node`, spawns `[node, <acpx-entry>, …]`, and prepends Node’s directory onto child `PATH`.
2. **Receipt attestation:** Unattested Cursor Auto receipts now record `resolved_model: "unattested-harness"` (with `resolved_model_known: false` / matching source), not bare `"unknown"`. Attested concrete models unchanged.
3. **Runbook:** `docs/runbooks/cursor-driver.md` §fleet-comms — verbs, venv-bridge entrypoint on the same bus, jail repair, attestation shapes.

No second bus. No deploy step outside the worktree for the jail repair. Part B four-verb driver-session proof remains post-merge / driver-run.

## Root-cause quote

```text
$ PATH=/usr/bin:/bin node_modules/.bin/acpx --version
env: node: No such file or directory

$ # after repair (absolute node argv)
argv0= /opt/homebrew/Cellar/node/…/bin/node
rc= 0 out= 0.13.0
```

## Live probe

```text
ab discuss #cursor-c0-6953-probe --with codex,grok --max-rounds 1
conversation: conversation_e8088e6a42f9478faa241f608d55089d
state: COMPLETE; rounds: 1; duration_ms: 18503; tokens: 25899
codex CALL_TERMINAL ok duration_ms=8369 token_count=25899
  message_5321bb6d6d1847d9a22362b20fd090ca
grok CALL_TERMINAL ok duration_ms=5470
  message_60a75a2c8c4f4ae1b1a4acea643bff1d
synthesis message_e4344c60a9c14a15887bef603643a8c6
```

(Red baseline was ~8s / 0 tokens with `env: node: No such file or directory`.)

## Test plan

- [x] `pytest tests/agent_runtime/test_acpx_adapter.py` (+ cursor adapter / delegate receipt tests) — 173 passed
- [x] ruff clean on touched Python
- [x] Live `ab discuss` probe above
- [ ] CI on PR
- [ ] Independent cross-family exact-head review (no auto-merge)

Fixes #6953. Parent: #6952.

Made with [Cursor](https://cursor.com)