### PR TITLE
test(atlas): prove ATLAS_STATIC_ROUTES SSG from atlas.db (#4385)

### DIFF
--- a/site/src/lib/lexicon/atlas-static-paths.ts
+++ b/site/src/lib/lexicon/atlas-static-paths.ts
@@ -1,0 +1,66 @@
+/**
+ * Publisher SSG path enumeration for `/lexicon/[lemma]` (GH #4385).
+ *
+ * Local `dev` / `build:shell` leave `ATLAS_STATIC_ROUTES` unset so the client
+ * shell resolves detail from committed public projections without needing
+ * `data/atlas.db`. Production `npm run build` sets `ATLAS_STATIC_ROUTES=1`,
+ * hydrates the DB, and prerenders every public route from SqliteAtlasDataSource.
+ */
+
+import { SqliteAtlasDataSource } from "./sqlite-atlas-data-source.ts";
+import type { EntryRecord } from "./atlas-data-source.ts";
+
+export type AtlasStaticPath = {
+  params: { lemma: string };
+  props: { record: EntryRecord; generatedAt: string; manifestVersion: string };
+};
+
+export function atlasStaticRoutesEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.ATLAS_STATIC_ROUTES === "1";
+}
+
+/**
+ * Enumerate lexicon article static paths from the Atlas SQLite catalog.
+ *
+ * - Env unset → `[]` (client-shell build; intentional).
+ * - Env `=1` → fail closed if the DB/catalog is missing, empty, or a catalog
+ *   slug cannot be loaded under the pinned source version.
+ */
+export async function buildAtlasStaticPaths(
+  env: NodeJS.ProcessEnv = process.env,
+  sourceFactory: () => SqliteAtlasDataSource = () => new SqliteAtlasDataSource(),
+): Promise<AtlasStaticPath[]> {
+  if (!atlasStaticRoutesEnabled(env)) return [];
+
+  const source = sourceFactory();
+  const catalog = source.getStaticCatalog();
+  if (catalog.routeSlugs.length === 0) {
+    throw new Error(
+      "Atlas static catalog is empty under ATLAS_STATIC_ROUTES=1; " +
+        "hydrate data/atlas.db (npm run hydrate / atlas:build-db) before building.",
+    );
+  }
+
+  const paths: AtlasStaticPath[] = [];
+  for (const slug of catalog.routeSlugs) {
+    const result = await source.getEntry(slug, {
+      expectedVersion: catalog.sourceVersion,
+    });
+    if (result.kind === "missing") {
+      throw new Error(
+        `Atlas static catalog slug missing under pinned version ${catalog.sourceVersion}: ${JSON.stringify(slug)}`,
+      );
+    }
+    paths.push({
+      params: { lemma: slug },
+      props: {
+        record: result.record,
+        generatedAt: catalog.generatedAt,
+        manifestVersion: catalog.manifestVersion,
+      },
+    });
+  }
+  return paths;
+}

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -15,43 +15,15 @@
 import CourseLayout from "../../layouts/CourseLayout.astro";
 import WordAtlasPageShell from "../../lexicon/WordAtlasPageShell.astro";
 import WordAtlasClientShell from "../../lexicon/WordAtlasClientShell";
-import { SqliteAtlasDataSource } from "../../lib/lexicon/sqlite-atlas-data-source";
+import { buildAtlasStaticPaths } from "../../lib/lexicon/atlas-static-paths";
 import type { EntryRecord } from "../../lib/lexicon/atlas-data-source";
 import type { WordAtlasPageState } from "../../lib/lexicon/word-atlas-page-state";
 
 export async function getStaticPaths() {
-  // The normal site build consumes the committed public projections and lets
-  // the Atlas client shell resolve article detail through the published runtime
-  // tree. The optional publisher-only SSG mode keeps the SQLite parity path
-  // explicit instead of making every local build depend on data/atlas.db.
-  if (process.env.ATLAS_STATIC_ROUTES !== "1") return [];
-  const source = new SqliteAtlasDataSource();
-  const catalog = source.getStaticCatalog();
-  const paths: Array<{
-    params: { lemma: string };
-    props: { record: EntryRecord; generatedAt: string; manifestVersion: string };
-  }> = [];
-
-  for (const slug of catalog.routeSlugs) {
-    const result = await source.getEntry(slug, {
-      expectedVersion: catalog.sourceVersion,
-    });
-    if (result.kind === "missing") {
-      throw new Error(
-        `Atlas static catalog slug missing under pinned version ${catalog.sourceVersion}: ${JSON.stringify(slug)}`,
-      );
-    }
-    paths.push({
-      params: { lemma: slug },
-      props: {
-        record: result.record,
-        generatedAt: catalog.generatedAt,
-        manifestVersion: catalog.manifestVersion,
-      },
-    });
-  }
-
-  return paths;
+  // Publisher builds (`npm run build`) set ATLAS_STATIC_ROUTES=1 after hydrate
+  // so Astro prerenders from data/atlas.db. Shell/dev builds leave it unset and
+  // serve the client shell from committed public projections.
+  return buildAtlasStaticPaths();
 }
 
 const { record, generatedAt, manifestVersion } = Astro.props as Partial<{

--- a/site/tests/unit/atlas-static-routes-ssg.test.ts
+++ b/site/tests/unit/atlas-static-routes-ssg.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+/**
+ * GH #4385 remainder — prove publisher SSG consumes atlas.db and fails closed
+ * when the catalog is missing/empty/wrong. Fixture DB only (no hydrate).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  atlasStaticRoutesEnabled,
+  buildAtlasStaticPaths,
+} from "@site/src/lib/lexicon/atlas-static-paths";
+import {
+  resetAtlasPayloadCacheForTests,
+} from "@site/src/lib/lexicon/atlasDb";
+import {
+  resetSqliteAtlasDataSourceCachesForTests,
+  SqliteAtlasDataSource,
+} from "@site/src/lib/lexicon/sqlite-atlas-data-source";
+
+const fixtureDb = resolve(process.cwd(), "../tests/fixtures/atlas/runtime_shards_fixture.db");
+const hasFixture = existsSync(fixtureDb);
+const packageJson = JSON.parse(
+  readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+) as { scripts: Record<string, string> };
+
+function resetCaches(): void {
+  resetAtlasPayloadCacheForTests();
+  resetSqliteAtlasDataSourceCachesForTests();
+}
+
+describe("ATLAS_STATIC_ROUTES publisher SSG contract (#4385)", () => {
+  afterEach(() => {
+    delete process.env.ATLAS_DB_PATH;
+    delete process.env.ATLAS_STATIC_ROUTES;
+    resetCaches();
+  });
+
+  test("npm run build / build:full enable ATLAS_STATIC_ROUTES; build:shell does not", () => {
+    expect(packageJson.scripts.build).toContain("ATLAS_STATIC_ROUTES=1");
+    expect(packageJson.scripts["build:full"]).toContain("ATLAS_STATIC_ROUTES=1");
+    expect(packageJson.scripts.build).toContain("hydrate");
+    expect(packageJson.scripts["build:shell"]).not.toContain("ATLAS_STATIC_ROUTES");
+    expect(atlasStaticRoutesEnabled({})).toBe(false);
+    expect(atlasStaticRoutesEnabled({ ATLAS_STATIC_ROUTES: "1" })).toBe(true);
+  });
+
+  test("without ATLAS_STATIC_ROUTES, getStaticPaths returns [] (client-shell mode)", async () => {
+    const paths = await buildAtlasStaticPaths({});
+    expect(paths).toEqual([]);
+  });
+
+  test.skipIf(!hasFixture)(
+    "ATLAS_STATIC_ROUTES=1 against fixture atlas.db emits catalog routes and fails if empty",
+    async () => {
+      process.env.ATLAS_DB_PATH = fixtureDb;
+      resetCaches();
+
+      const paths = await buildAtlasStaticPaths({ ATLAS_STATIC_ROUTES: "1" });
+      expect(paths.length).toBeGreaterThan(0);
+
+      const source = new SqliteAtlasDataSource();
+      const catalog = source.getStaticCatalog();
+      expect(paths.map((p) => p.params.lemma)).toEqual([...catalog.routeSlugs]);
+      expect(paths.every((p) => p.props.record.entry.url_slug === p.params.lemma)).toBe(true);
+      expect(paths[0]?.props.manifestVersion).toBe(catalog.manifestVersion);
+
+      await expect(
+        buildAtlasStaticPaths({ ATLAS_STATIC_ROUTES: "1" }, () => {
+          return {
+            getStaticCatalog: () => ({
+              sourceVersion: "sqlite-empty",
+              generatedAt: "1970-01-01T00:00:00Z",
+              manifestVersion: "empty",
+              routeSlugs: [],
+            }),
+            getEntry: async () => ({ kind: "missing" as const, version: "sqlite-empty", slug: "x" }),
+          } as unknown as SqliteAtlasDataSource;
+        }),
+      ).rejects.toThrow(/Atlas static catalog is empty/);
+    },
+  );
+
+  test("ATLAS_STATIC_ROUTES=1 fails closed when atlas.db is missing", async () => {
+    process.env.ATLAS_DB_PATH = resolve(process.cwd(), "../data/atlas-missing-ssg-gate.db");
+    resetCaches();
+    await expect(buildAtlasStaticPaths({ ATLAS_STATIC_ROUTES: "1" })).rejects.toThrow(
+      /Atlas DB not found/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts `/lexicon/[lemma]` publisher SSG enumeration into `buildAtlasStaticPaths` and fail-closes when `ATLAS_STATIC_ROUTES=1` and the SQLite catalog is empty/missing/wrong.
- Adds fixture-backed vitest coverage that pins `npm run build` / `build:full` to `ATLAS_STATIC_ROUTES=1` + hydrate, keeps `build:shell` opt-out, and asserts non-empty fixture routes.
- Does **not** close #4385: CI already ran publisher `npm run build` with the flag (#5815); this PR is the missing fail-closed proof that removing the flag or shipping an empty catalog cannot silently pass.

Refs #4385

## Test plan
- [x] `npx vitest run tests/unit/atlas-static-routes-ssg.test.ts` (4/4)
- [x] `npx vitest run tests/unit/atlas-static-catalog.test.ts tests/unit/atlas-static-routes-ssg.test.ts`
- [ ] CI Frontend job: build + vitest on site paths


Made with [Cursor](https://cursor.com)