### PR TITLE
fix(delegate): fail closed on task-id reuse, archive on --force-new (#6980)

### DIFF
--- a/scripts/ai_agent_bridge/_dispatch_wrappers.py
+++ b/scripts/ai_agent_bridge/_dispatch_wrappers.py
@@ -144,6 +144,7 @@ def build_dispatch_fix_command(task_id: str, prompt_file: Path) -> list[str]:
         "origin/main",
         "--task-id",
         task_id,
+        "--force-new",
         "--effort",
         "high",
         "--prompt-file",

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4643,6 +4643,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # destroyed receipt evidence. Must run BEFORE ownership admission
     # so a rejected duplicate cannot DELETE/replace live write claims
     # (#5643 CF F001). --force-new archives first; it never clobbers.
+    # --force-new has no escape for a live running/spawning pid: archiving
+    # that record and spawning again is the duplicate-worker race the
+    # pre-#6980 guard refused with no override (#6981 F1 / #5643 CF F001).
     existing = _read_state(state_path)
     record_exists = state_path.exists()
     result_exists = _result_path(task_id).exists()
@@ -4656,6 +4659,27 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 "Dispatch refuses to reuse a task-id in any state. "
                 "Use a unique --task-id, or pass --force-new to archive "
                 "the prior record+result first.",
+                file=sys.stderr,
+            )
+            return 2
+        status = existing.get("status") if existing else None
+        pid = existing.get("pid") if existing else None
+        live_pid = False
+        if status in ("running", "spawning") and not isinstance(pid, bool):
+            try:
+                live_pid = (
+                    isinstance(pid, (int, str))
+                    and int(pid) > 0
+                    and _pid_alive(int(pid))
+                )
+            except (TypeError, ValueError):
+                live_pid = False
+        if live_pid:
+            print(
+                f"❌ task_id {task_id!r} is already {status} (pid={pid}) "
+                "and that process is still alive. --force-new has no escape "
+                "for live tasks; refusing to archive a live worker and spawn "
+                "a duplicate.",
                 file=sys.stderr,
             )
             return 2
@@ -5955,7 +5979,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Reuse an existing --task-id by first archiving the prior record "
             "and result alongside (never clobber). Required when the task "
-            "record already exists in any state (#6980)."
+            "record already exists in a non-live state (#6980). Refuses when "
+            "a running/spawning record still has a live pid (#6981 F1)."
         ),
     )
     d.add_argument(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -14,7 +14,7 @@ CLI:
     # Write-capable modes (workspace-write / danger) require a dispatch worktree.
     delegate.py dispatch --agent codex --task-id my-task \
         --prompt "do the thing" [--mode workspace-write --worktree] [--model gpt-5.6-terra]
-        [--allow-merge]
+        [--allow-merge] [--force-new]
 
     # Check status without blocking.
     delegate.py status my-task
@@ -309,6 +309,43 @@ def _state_path(task_id: str) -> Path:
     # task-ids with slashes would break paths; sanitize
     safe = task_id.replace("/", "_").replace("\\", "_")
     return _TASKS_DIR / f"{safe}.json"
+
+
+def _result_path(task_id: str) -> Path:
+    return _state_path(task_id).with_suffix(".result")
+
+
+def _archive_stamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _archived_artifact_path(path: Path, stamp: str) -> Path:
+    dest = path.with_name(f"{path.stem}.{stamp}.archived{path.suffix}")
+    if dest.exists():
+        dest = path.with_name(f"{path.stem}.{stamp}.{os.getpid()}.archived{path.suffix}")
+    return dest
+
+
+def _archive_task_artifacts(task_id: str, *, stamp: str | None = None) -> list[Path]:
+    """Move the prior record and result aside. Never overwrite an archive."""
+    stamp = stamp or _archive_stamp()
+    archived: list[Path] = []
+    for path in (_state_path(task_id), _result_path(task_id)):
+        if not path.exists():
+            continue
+        dest = _archived_artifact_path(path, stamp)
+        os.replace(path, dest)
+        archived.append(dest)
+    return archived
+
+
+def _existing_task_status(state_path: Path, existing: dict[str, Any] | None) -> str:
+    status = existing.get("status") if existing else None
+    if isinstance(status, str) and status.strip():
+        return status
+    if state_path.exists():
+        return "unreadable"
+    return "result-only"
 
 
 def _core_terminal_fields(
@@ -4599,26 +4636,39 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    # Refuse to clobber a task that's still alive — whether it's in
-    # "running" (worker up and executing) OR "spawning" (worker created
-    # but not yet past its own state-update step). Without the
-    # "spawning" check, a fast second dispatch during the tiny window
-    # between Popen and _run_worker's first state write could overwrite
-    # state and launch a duplicate worker for the same task_id.
-    # Codex 2026-04-10 review finding.
-    # Must run BEFORE ownership admission so a rejected duplicate cannot
-    # DELETE/replace the live task's write claims (#5643 CF F001).
+    # #6980: fail closed when the task record (or its .result) already
+    # exists in ANY state. The previous guard only refused live
+    # running/spawning PIDs, so a dispatch with a completed task-id
+    # silently overwrote batch_state/tasks/<id>.json + .result and
+    # destroyed receipt evidence. Must run BEFORE ownership admission
+    # so a rejected duplicate cannot DELETE/replace live write claims
+    # (#5643 CF F001). --force-new archives first; it never clobbers.
     existing = _read_state(state_path)
-    if existing and existing.get("status") in ("running", "spawning"):
-        pid = existing.get("pid")
-        if pid and _pid_alive(int(pid)):
+    record_exists = state_path.exists()
+    result_exists = _result_path(task_id).exists()
+    if record_exists or result_exists:
+        if not bool(getattr(args, "force_new", False)):
+            status = _existing_task_status(state_path, existing)
+            pid = existing.get("pid") if existing else None
+            pid_part = f" (pid={pid})" if pid not in (None, "") else ""
             print(
-                f"❌ task_id {task_id!r} is already {existing['status']} "
-                f"(pid={pid}). Use 'delegate.py status {task_id}' to check, "
-                f"or pick a different task-id.",
+                f"❌ task_id {task_id!r} is already {status}{pid_part}. "
+                "Dispatch refuses to reuse a task-id in any state. "
+                "Use a unique --task-id, or pass --force-new to archive "
+                "the prior record+result first.",
                 file=sys.stderr,
             )
             return 2
+        try:
+            archived = _archive_task_artifacts(task_id)
+        except OSError as exc:
+            print(
+                f"❌ failed to archive prior task artifacts for {task_id!r}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        for dest in archived:
+            print(f"📦 archived prior task artifact: {dest.name}", file=sys.stderr)
 
     # Resolve prompt: literal --prompt, or - for stdin, or --prompt-file.
     if args.prompt_file:
@@ -5899,6 +5949,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")
+    d.add_argument(
+        "--force-new",
+        action="store_true",
+        help=(
+            "Reuse an existing --task-id by first archiving the prior record "
+            "and result alongside (never clobber). Required when the task "
+            "record already exists in any state (#6980)."
+        ),
+    )
     d.add_argument(
         "--initiator",
         default=None,

--- a/tests/test_ab_dispatch_wrappers.py
+++ b/tests/test_ab_dispatch_wrappers.py
@@ -56,6 +56,7 @@ def test_dispatch_fix_with_explicit_brief_file_appends_checklist_and_dispatches(
     assert "--worktree" in command
     assert _option(command, "--base") == "origin/main"
     assert _option(command, "--task-id") == "1741"
+    assert "--force-new" in command
     assert _option(command, "--effort") == "high"
     assert "Existing acceptance criteria." in str(captured_prompt["text"])
     assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in str(captured_prompt["text"])
@@ -88,6 +89,7 @@ def test_dispatch_fix_with_auto_brief_uses_issue_body_and_dry_run_state(monkeypa
     assert state["model"] is None
     assert state["effort"] == "high"
     assert _option(command, "--task-id") == "1701"
+    assert "--force-new" in command
     prompt_path = Path(state["prompt_file"])
     assert prompt_path.parent == lease_root
     prompt = prompt_path.read_text(encoding="utf-8")

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1048,30 +1048,54 @@ def test_dispatch_accepts_native_grok_effort_vocabulary(agent, effort):
     """The dispatch guard admits every native Grok CLI effort level."""
     delegate._validate_dispatch_effort(agent, effort)
 
+def _minimal_dispatch_args(task_id: str, **overrides):
+    import argparse
+
+    args = {
+        "agent": "codex",
+        "task_id": task_id,
+        "prompt": "test",
+        "prompt_file": None,
+        "mode": "read-only",
+        "model": None,
+        "cwd": None,
+        "worktree": None,
+        "hard_timeout": 3600,
+    }
+    args.update(overrides)
+    return argparse.Namespace(**args)
+
+
+def _fake_worker_popen():
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 12345
+        stdin = _FakeStdin()
+
+    return _FakeProc()
+
+
 def test_dispatch_refuses_to_clobber_running_task(tmp_tasks_dir, capsys):
     """Dispatching with a task-id that's already running must fail fast."""
     path = delegate._state_path("duplicate-task")
-    delegate._write_state_atomic(path, {
+    original = {
         "task_id": "duplicate-task",
         "status": "running",
         "pid": os.getpid(),  # alive
-    })
-    import argparse
-    args = argparse.Namespace(
-        agent="codex",
-        task_id="duplicate-task",
-        prompt="test",
-        prompt_file=None,
-        mode="read-only",
-        model=None,
-        cwd=None,
-        worktree=None,
-        hard_timeout=3600,
-    )
-    rc = delegate.cmd_dispatch(args)
+        "receipt": "do-not-clobber-running",
+    }
+    delegate._write_state_atomic(path, original)
+    rc = delegate.cmd_dispatch(_minimal_dispatch_args("duplicate-task"))
     assert rc == 2
     captured = capsys.readouterr()
     assert "already running" in captured.err
+    assert delegate._read_state(path) == original
 
 
 def test_dispatch_popen_failure_marks_task_failed(tmp_tasks_dir, capsys):
@@ -1478,74 +1502,123 @@ def test_dispatch_clobber_guard_rejects_spawning_status(tmp_tasks_dir, capsys):
     duplicate worker for the same task_id.
     """
     path = delegate._state_path("spawning-clobber")
-    delegate._write_state_atomic(path, {
+    original = {
         "task_id": "spawning-clobber",
         "status": "spawning",
         "pid": os.getpid(),  # alive
-    })
-    import argparse
-    args = argparse.Namespace(
-        agent="codex",
-        task_id="spawning-clobber",
-        prompt="test",
-        prompt_file=None,
-        mode="read-only",
-        model=None,
-        cwd=None,
-        worktree=None,
-        hard_timeout=3600,
-    )
-    rc = delegate.cmd_dispatch(args)
+        "receipt": "do-not-clobber-spawning",
+    }
+    delegate._write_state_atomic(path, original)
+    rc = delegate.cmd_dispatch(_minimal_dispatch_args("spawning-clobber"))
     assert rc == 2, "must reject duplicate dispatch during spawning window"
     captured = capsys.readouterr()
-    assert "spawning" in captured.err
+    assert "already spawning" in captured.err
+    assert delegate._read_state(path) == original
 
 
-def test_dispatch_allows_new_task_when_prior_crashed(tmp_tasks_dir, capsys):
-    """If the old state is terminal, dispatching should proceed (not tested
-    end-to-end here — we just verify the guard doesn't trip). We patch
-    subprocess.Popen so no real worker is spawned."""
-    path = delegate._state_path("prior-crashed")
-    delegate._write_state_atomic(path, {
-        "task_id": "prior-crashed",
-        "status": "crashed",
-        "pid": 999_999_998,
-    })
-    import argparse
-    args = argparse.Namespace(
-        agent="codex",
-        task_id="prior-crashed",
-        prompt="test",
-        prompt_file=None,
-        mode="read-only",
-        model=None,
-        cwd=None,
-        worktree=None,
-        hard_timeout=3600,
-    )
+@pytest.mark.parametrize(
+    ("task_id", "status", "pid"),
+    [
+        ("prior-done", "done", None),
+        ("prior-failed", "failed", None),
+        ("prior-timeout", "timeout", None),
+        ("prior-crashed", "crashed", 999_999_998),
+        ("prior-rate-limited", "rate_limited", None),
+        ("prior-needs-finalize", "needs_finalize", None),
+        ("prior-no-deliverable", "no_deliverable", None),
+        ("prior-dead-running", "running", 999_999_996),
+        ("prior-dead-spawning", "spawning", 999_999_995),
+    ],
+)
+def test_dispatch_refuses_existing_task_record_in_any_state(
+    tmp_tasks_dir, capsys, monkeypatch, task_id, status, pid
+):
+    """#6980: a task-id already on disk is fail-closed, including terminal
+    receipts and dead-PID running/spawning records. The previous guard only
+    refused live running/spawning PIDs and silently clobbered everything else.
+    """
+    path = delegate._state_path(task_id)
+    result_path = path.with_suffix(".result")
+    original = {
+        "task_id": task_id,
+        "status": status,
+        "pid": pid,
+        "receipt": f"attestation-{task_id}",
+        "result_file": str(result_path),
+    }
+    delegate._write_state_atomic(path, original)
+    result_path.write_text(f"receipt body for {task_id}\n", encoding="utf-8")
 
-    # Patch Popen so we don't actually spawn a worker.
-    class _FakeStdin:
-        def write(self, _data): pass
-        def close(self): pass
+    def _unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("existing task-id must not spawn a worker")
 
-    class _FakeProc:
-        pid = 12345  # parent writes this into state for zombie detection
-        stdin = _FakeStdin()
+    monkeypatch.setattr(delegate.subprocess, "Popen", _unexpected_spawn)
 
-    with patch("delegate.subprocess.Popen", return_value=_FakeProc()):
-        rc = delegate.cmd_dispatch(args)
+    rc = delegate.cmd_dispatch(_minimal_dispatch_args(task_id))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert f"already {status}" in captured.err
+    assert "--force-new" in captured.err
+    assert delegate._read_state(path) == original
+    assert result_path.read_text(encoding="utf-8") == f"receipt body for {task_id}\n"
+    assert list(tmp_tasks_dir.glob(f"{task_id}.*.archived.json")) == []
+    assert list(tmp_tasks_dir.glob(f"{task_id}.*.archived.result")) == []
+
+
+def test_dispatch_force_new_archives_state_and_result_then_proceeds(
+    tmp_tasks_dir, capsys
+):
+    """#6980: --force-new is the only reuse escape, and it must archive both
+    the prior record and the prior result before writing a new spawn state.
+    """
+    path = delegate._state_path("force-new-task")
+    result_path = path.with_suffix(".result")
+    original = {
+        "task_id": "force-new-task",
+        "status": "done",
+        "pid": None,
+        "receipt": "keep-this-attestation",
+        "result_file": str(result_path),
+    }
+    delegate._write_state_atomic(path, original)
+    result_path.write_text("completed receipt evidence\n", encoding="utf-8")
+
+    with patch("delegate.subprocess.Popen", return_value=_fake_worker_popen()):
+        rc = delegate.cmd_dispatch(
+            _minimal_dispatch_args("force-new-task", force_new=True)
+        )
 
     assert rc == 0
-    # State file should have been rewritten with status=spawning AND
-    # the parent should have written the fake proc's PID into state
-    # immediately after Popen (Gemini fix: catches early-crash zombies).
+    archived_json = list(tmp_tasks_dir.glob("force-new-task.*.archived.json"))
+    archived_result = list(tmp_tasks_dir.glob("force-new-task.*.archived.result"))
+    assert len(archived_json) == 1
+    assert len(archived_result) == 1
+    assert json.loads(archived_json[0].read_text(encoding="utf-8")) == original
+    assert archived_result[0].read_text(encoding="utf-8") == "completed receipt evidence\n"
     state = delegate._read_state(path)
+    assert state is not None
     assert state["status"] == "spawning"
-    assert state["pid"] == 12345, (
-        "parent MUST write Popen child's PID into state file immediately "
-        "after spawn, before the worker gets a chance to run"
+    assert state["pid"] == 12345
+    assert state.get("receipt") != "keep-this-attestation"
+    captured = capsys.readouterr()
+    assert archived_json[0].name in captured.err
+    assert archived_result[0].name in captured.err
+
+
+def test_dispatch_parser_accepts_force_new_flag():
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "reuse-me",
+            "--prompt",
+            "hi",
+            "--force-new",
+        ]
     )
+    assert args.force_new is True
 
 
 def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1565,6 +1565,44 @@ def test_dispatch_refuses_existing_task_record_in_any_state(
     assert list(tmp_tasks_dir.glob(f"{task_id}.*.archived.result")) == []
 
 
+@pytest.mark.parametrize("status", ["running", "spawning"])
+def test_dispatch_force_new_refuses_live_running_or_spawning(
+    tmp_tasks_dir, capsys, monkeypatch, status
+):
+    """#6981 F1: --force-new has no escape for a live running/spawning pid.
+
+    Archiving that record and spawning again is the duplicate-worker race
+    the pre-#6980 guard refused with no override (#5643 CF F001).
+    """
+    task_id = f"live-{status}-force-new"
+    path = delegate._state_path(task_id)
+    result_path = path.with_suffix(".result")
+    original = {
+        "task_id": task_id,
+        "status": status,
+        "pid": os.getpid(),  # alive
+        "receipt": f"do-not-archive-live-{status}",
+        "result_file": str(result_path),
+    }
+    delegate._write_state_atomic(path, original)
+    result_path.write_text(f"live {status} receipt\n", encoding="utf-8")
+
+    def _unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("live task + --force-new must not spawn a worker")
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", _unexpected_spawn)
+
+    rc = delegate.cmd_dispatch(_minimal_dispatch_args(task_id, force_new=True))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert f"already {status}" in captured.err
+    assert "no escape for live tasks" in captured.err
+    assert delegate._read_state(path) == original
+    assert result_path.read_text(encoding="utf-8") == f"live {status} receipt\n"
+    assert list(tmp_tasks_dir.glob(f"{task_id}.*.archived.json")) == []
+    assert list(tmp_tasks_dir.glob(f"{task_id}.*.archived.result")) == []
+
+
 def test_dispatch_force_new_archives_state_and_result_then_proceeds(
     tmp_tasks_dir, capsys
 ):


### PR DESCRIPTION
Fixes #6980. Dispatch with an existing task-id (running OR terminal) now fails closed with the record's status named; `--force-new` archives the prior record+result before proceeding — never clobbers. Found via a live probe that silently overwrote a completed task's receipt files. 357 delegate/wrapper tests green, ruff clean.

Worker: grok; driver finalized push (grok harness cannot push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)