### PR TITLE
feat(lexicon): Goroh EN fallback after slovnyk ukreng (#6876)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -88,6 +88,7 @@ from scripts.lexicon.source_attribution import (
     CORRECTION_DICTIONARIES_LABEL,
     DAVYDOV_LABEL,
     ESUM_LABEL,
+    GOROH_LABEL,
     GRINCHENKO_LABEL,
     MPHDICT_SYNONYMS_LABEL,
     PHRASEOLOGY_LABEL,
@@ -235,6 +236,7 @@ _FORM_NOTE_MIN_BODY_CHARS = 3
 _SLOVNYK_UKRENG_SLUG = "ukreng"
 _SLOVNYK_UKRENG_LABEL = BALLA_LABEL
 _SLOVNYK_UKRENG_SOURCE = BALLA_LABEL
+_GOROH_TRANSLATION_SOURCE = GOROH_LABEL
 _SLOVNYK_BASE = "https://slovnyk.me"
 # v3 (#6524 P1): bumped because every schema_version==2 cache file on disk was
 # written by the pre-fix `" ".join(...)` article-text join (#6465's root-cause
@@ -6281,6 +6283,48 @@ def _fill_learner_english_anchor_from_slovnyk_cache(
     return True
 
 
+@functools.cache
+def query_goroh_translate(lemma: str) -> list[str]:
+    """Wrapper around rag.source_query.goroh_translate to support caching and unit test mocking."""
+    if _phase1_offline_mode():
+        return []
+
+    try:
+        from scripts.rag.source_query import goroh_translate
+
+        return goroh_translate(lemma) or []
+    except Exception:
+        return []
+
+
+def _goroh_translation(lemma: str) -> dict[str, object] | None:
+    """English translations for a Ukrainian lemma via goroh.pp.ua (#6876)."""
+    for variant in _split_lemma_variants(lemma):
+        glosses = query_goroh_translate(variant)
+        if not glosses:
+            continue
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for g in glosses:
+            g = g.strip()
+            if not g or not _is_learner_english_text(g):
+                continue
+            key = g.casefold()
+            if key not in seen:
+                seen.add(key)
+                cleaned.append(g)
+        if not cleaned:
+            continue
+        block: dict[str, object] = {
+            "en": cleaned[:6],
+            "source": _GOROH_TRANSLATION_SOURCE,
+        }
+        mirror_url = f"https://goroh.pp.ua/Переклад/{quote(variant, safe='')}"
+        attach_official_url(block, mirror_url=mirror_url, word=variant)
+        return block
+    return None
+
+
 def _translation(
     conn: sqlite3.Connection,
     lemma: str,
@@ -6297,7 +6341,9 @@ def _translation(
     back to Wiktionary/kaikki translation glosses (form-of/misspelling meta-glosses are
     stripped at build time). Балла is EN→UK only, so reverse lookup is used only when an
     exact Ukrainian token resolves to one unique English headword that matches an
-    existing learner-gloss hint from the source entry. Returns up to six glosses.
+    existing learner-gloss hint from the source entry. When slovnyk.me has a cached or
+    fetched ukreng entry, that is used next. When all previous sources miss, fall back
+    to goroh.pp.ua translation (#6876). Returns up to six glosses.
     """
     for variant in _split_lemma_variants(lemma):
         rows = _dmklinger_lookup(conn, _dmklinger_key(variant))
@@ -6333,6 +6379,9 @@ def _translation(
     slovnyk_translation = _slovnyk_ukreng_translation(lemma, slovnyk_cache)
     if slovnyk_translation:
         return slovnyk_translation
+    goroh_translation = _goroh_translation(lemma)
+    if goroh_translation:
+        return goroh_translation
 
     for variant in _split_lemma_variants(lemma):
         curated = _CURATED_LEARNER_TRANSLATIONS.get(_lookup_key(variant).casefold())

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -58,6 +58,7 @@ SYNONYM_VERDICTS_LABEL = "редакторські вердикти синоні
 ORTHOGRAPHY_LABEL = "Орфографічний словник української мови"
 HOLOSKEVYCH_LABEL = "Правописний словник Голоскевича (1929)"
 ORTHOEPY_LABEL = "Орфоепічний словник української мови"
+GOROH_LABEL = "Горох (переклад)"
 
 
 RELATION_PAIRS_PREFIX = "relation_pairs/"
@@ -92,6 +93,10 @@ LEGACY_LABEL_ALIASES: dict[str, str] = {
     SUM20_SHORT_LABEL: SUM20_ACADEMIC_LABEL,
     VTS_SHORT_LABEL: VTS_ACADEMIC_LABEL,
     "Грінченко": GRINCHENKO_LABEL,
+    "Горох": GOROH_LABEL,
+    "goroh.pp.ua": GOROH_LABEL,
+    "Горох (переклад)": GOROH_LABEL,
+    "Горох: Переклад": GOROH_LABEL,
 }
 
 KNOWN_ACADEMIC_LABELS = frozenset(
@@ -237,6 +242,8 @@ def normalize_academic_label(label: str) -> str:
         return label.strip()
     if cleaned.casefold().startswith("slovnyk.me correction"):
         return CORRECTION_DICTIONARIES_LABEL
+    if cleaned.casefold().startswith("goroh.pp.ua"):
+        return GOROH_LABEL
     if cleaned.casefold().startswith(RELATION_PAIRS_PREFIX):
         return _remap_relation_pairs_label(cleaned)
     if cleaned in LEGACY_LABEL_ALIASES:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "76b662b94b5c71919aa618d0ac1656fcdc032bf7ebd620067839d3daabd7f760"
+        "sha256": "01aada2efd85d9768050a6a56120df49c747cb0cae42560b22c594fc7cfcd3af"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -243,7 +243,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "8beea77725932b24f64a862220e6b75cab2bc2dea25844bd37ff78071e2bcb9c"
+        "sha256": "4252dbeec41754d296fc848196b1621453946b1326a227e7a5a87286e3bc469e"
       },
       {
         "path": "scripts/lexicon/sync_teacher_table_deck.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -84,6 +84,7 @@ from scripts.lexicon.enrich_manifest import (
 )
 from scripts.lexicon.source_attribution import (
     DAVYDOV_LABEL,
+    GOROH_LABEL,
     HOLOSKEVYCH_LABEL,
     MIYKLAS_LABEL,
     ORTHOEPY_LABEL,
@@ -2687,6 +2688,7 @@ def test_translation_returns_none_when_lemma_absent(monkeypatch) -> None:
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
 
     assert _translation(conn, "неіснуючеслово") is None
 
@@ -2701,6 +2703,7 @@ def test_translation_uses_unambiguous_reverse_balla_after_source_misses(monkeypa
     )
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
 
     assert _translation(conn, "помішувати", {}, entry_pos="verb") is None
@@ -2727,6 +2730,7 @@ def test_translation_skips_ambiguous_reverse_balla(monkeypatch) -> None:
     )
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
 
     assert (
@@ -2745,6 +2749,7 @@ def test_translation_prefers_kaikki_over_reverse_balla(monkeypatch) -> None:
     )
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
 
     assert _translation(conn, "помішувати", {"помішувати": {"glosses": ["to stir"]}}) == {
@@ -2763,6 +2768,7 @@ def test_translation_reverse_balla_ignores_example_sentences(monkeypatch) -> Non
     )
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     _patch_vesum_analyses(monkeypatch, {"книга": "noun"})
 
     assert _translation(conn, "книга", {}, entry_pos="noun", gloss_hints={"dash"}) is None
@@ -2778,6 +2784,7 @@ def test_translation_reverse_balla_requires_single_token_segment(monkeypatch) ->
     )
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     _patch_vesum_analyses(monkeypatch, {"базування": "noun", "дім": "noun"})
 
     assert _translation(conn, "базування", {}, entry_pos="noun", gloss_hints={"home"}) is None
@@ -2812,6 +2819,7 @@ def test_translation_uses_curated_learner_gloss_after_source_misses(monkeypatch)
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
 
     assert _translation(conn, "ого", {}) == {
         "en": ["wow", "whoa"],
@@ -2990,11 +2998,153 @@ def test_translation_prefers_kaikki_over_curated_learner_gloss(monkeypatch) -> N
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
 
     assert _translation(conn, "ого", {"ого": {"glosses": ["oh wow"]}}) == {
         "en": ["oh wow"],
         "source": KAIKKI_SOURCE,
     }
+
+
+def test_translation_uses_goroh_after_source_misses(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_goroh_translate",
+        lambda lemma: ["Albanian", "Albanians"] if lemma == "албанці" else [],
+    )
+
+    translation = _translation(conn, "албанці", {})
+    assert translation == {
+        "en": ["Albanian", "Albanians"],
+        "source": GOROH_LABEL,
+        "mirror_source_url": "https://goroh.pp.ua/Переклад/%D0%B0%D0%BB%D0%B1%D0%B0%D0%BD%D1%86%D1%96",
+    }
+    assert "source_url" not in translation
+    assert translation["source"] == "Горох (переклад)"
+
+
+def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.execute(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        ("basilica", "n базиліка", ""),
+    )
+    _patch_vesum_analyses(monkeypatch, {"базиліка": "noun"})
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+
+    goroh_calls: list[str] = []
+
+    def mock_goroh(lemma: str) -> list[str]:
+        goroh_calls.append(lemma)
+        return ["basilica", "basilicas"]
+
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", mock_goroh)
+
+    # 1. dmklinger wins over everything
+    conn.execute(
+        "INSERT INTO dmklinger_uk_en (word, pos, translations) VALUES (?, ?, ?)",
+        ("базиліка", "noun", '["basilica"]'),
+    )
+    enrich_manifest_module._DMKLINGER_INDEX = None
+    res_dmklinger = _translation(conn, "базиліка", {"базиліка": {"glosses": ["wikt-basilica"]}})
+    assert res_dmklinger is not None
+    assert res_dmklinger["source"] == enrich_manifest_module._TRANSLATION_SOURCE
+    assert not goroh_calls
+
+    # 2. Kaikki wins when dmklinger misses
+    conn.execute("DELETE FROM dmklinger_uk_en")
+    enrich_manifest_module._DMKLINGER_INDEX = None
+    res_kaikki = _translation(conn, "базиліка", {"базиліка": {"glosses": ["wikt-basilica"]}})
+    assert res_kaikki is not None
+    assert res_kaikki["source"] == KAIKKI_SOURCE
+    assert not goroh_calls
+
+    # 3. Balla reverse wins when dmklinger and Kaikki miss
+    res_balla = _translation(conn, "базиліка", {}, entry_pos="noun", gloss_hints={"basilica"})
+    assert res_balla is not None
+    assert res_balla["source"] == _BALLA_REVERSE_SOURCE
+    assert not goroh_calls
+
+    # 4. Slovnyk ukreng wins when Balla reverse misses
+    slovnyk_cache = {
+        "lookups": {
+            "ukreng": {
+                "dictionary_slug": "ukreng",
+                "text": "базиліка базиліка arch. basilica",
+                "source_url": "https://slovnyk.me/dict/ukreng/базиліка",
+            }
+        }
+    }
+    res_slovnyk = _translation(conn, "базиліка", {}, slovnyk_cache=slovnyk_cache)
+    assert res_slovnyk is not None
+    assert res_slovnyk["source"] == _SLOVNYK_UKRENG_SOURCE
+    assert not goroh_calls
+
+    # 5. Goroh wins when all previous miss
+    empty_cache = {"lookups": {"ukreng": None}}
+    res_goroh = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
+    assert res_goroh is not None
+    assert res_goroh["source"] == GOROH_LABEL
+    assert res_goroh["en"] == ["basilica", "basilicas"]
+    assert goroh_calls == ["базиліка"]
+
+
+def test_goroh_translation_filters_non_english_and_caps_at_6(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_goroh_translate",
+        lambda lemma: [
+            "one",
+            "two",
+            "три (тільки кирилиця)",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+        ],
+    )
+    translation = _translation(conn, "багатослів", {})
+    assert translation is not None
+    assert translation["en"] == ["one", "two", "three", "four", "five", "six"]
+    assert translation["source"] == GOROH_LABEL
+
+
+def test_goroh_translate_mock_html_parsing(monkeypatch) -> None:
+    from scripts.rag.source_query import goroh_translate
+
+    sample_html = """
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <div class="def">
+        <h3>Англійська</h3>
+        <p>
+          <a href="/Переклад/артикул">article</a>,
+          <a href="/Переклад/артикул">clause</a>,
+          <a href="/Переклад/артикул">item</a>
+        </p>
+      </div>
+    </body>
+    </html>
+    """
+
+    class FakeResponse:
+        status_code = 200
+        text = sample_html
+
+    monkeypatch.setattr("scripts.rag.source_query._get", lambda url, **kwargs: FakeResponse())
+    assert goroh_translate("артикул") == ["article", "clause", "item"]
 
 
 def test_wiki_reference_success(monkeypatch, tmp_path) -> None:

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -215,6 +215,7 @@ def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> 
 
     monkeypatch.setattr(enrich_manifest, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest, "query_goroh_translate", lambda lemma: [])
     monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {"lookups": {}})
     monkeypatch.setattr(enrich_manifest, "_fetch_slovnyk_entry", fail_fetch)
     monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
@@ -224,6 +225,31 @@ def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> 
         _reenrich_translation_only(conn, entry, {}, cached_slovnyk_only=True)
 
     assert "translation" not in entry["enrichment"]
+
+
+def test_reenrich_thin_manifest_entries_fills_from_goroh_fixture(monkeypatch) -> None:
+    entry = {"lemma": "анімізм", "pos": "noun", "enrichment": {}}
+
+    monkeypatch.setattr(enrich_manifest, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {"lookups": {"ukreng": None}})
+    monkeypatch.setattr(
+        enrich_manifest,
+        "query_goroh_translate",
+        lambda lemma: ["animism"] if lemma == "анімізм" else [],
+    )
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+
+    with sqlite3.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+        _reenrich_translation_only(conn, entry, {})
+
+    assert entry["enrichment"]["translation"] == {
+        "en": ["animism"],
+        "source": "Горох (переклад)",
+        "mirror_source_url": "https://goroh.pp.ua/Переклад/%D0%B0%D0%BD%D1%96%D0%BC%D1%96%D0%B7%D0%BC",
+    }
+    assert "Горох (переклад)" in entry["enrichment"]["sources"]
 
 
 def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(tmp_path, monkeypatch) -> None:

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -644,8 +644,6 @@ def test_deadjectival_adverb_fallback_fails_closed_on_vesum_error(monkeypatch) -
 
 
 def test_deadjectival_adverb_fallback_on_loaded_manifest_pair(monkeypatch) -> None:
-    from scripts.lexicon.manifest_io import load_manifest
-
     monkeypatch.setattr(
         reenrich,
         "verify_word",
@@ -657,19 +655,36 @@ def test_deadjectival_adverb_fallback_on_loaded_manifest_pair(monkeypatch) -> No
         ),
     )
 
-    manifest = load_manifest()
+    manifest = {
+        "entries": [
+            {
+                "lemma": "абстрактний",
+                "pos": "adjective",
+                "url_slug": "абстрактний",
+                "enrichment": {
+                    "translation": {
+                        "en": ["abstract"],
+                        "source": "dmklinger",
+                    },
+                    "sources": ["dmklinger"],
+                },
+            },
+            {
+                "lemma": "абстрактно",
+                "pos": "adverb",
+                "url_slug": "абстрактно",
+                "enrichment": {},
+            },
+        ]
+    }
     by_lemma = {e.get("lemma"): e for e in manifest.get("entries", []) if isinstance(e, dict) and e.get("lemma")}
 
-    if "абстрактно" in by_lemma and "абстрактний" in by_lemma:
-        abstr_adj = by_lemma["абстрактний"]
-        abstr_adv = by_lemma["абстрактно"]
-        adj_trans = abstr_adj.get("enrichment", {}).get("translation", {})
-        if adj_trans.get("en"):
-            res = reenrich._deadjectival_adverb_translation(abstr_adv, by_lemma)
-            assert res is not None
-            assert isinstance(res.get("en"), list)
-            assert "abstractly" in res["en"][0]
-            assert "base form абстрактний" in str(res.get("source"))
+    abstr_adv = by_lemma["абстрактно"]
+    res = reenrich._deadjectival_adverb_translation(abstr_adv, by_lemma)
+    assert res is not None
+    assert isinstance(res.get("en"), list)
+    assert "abstractly" in res["en"][0]
+    assert "base form абстрактний" in str(res.get("source"))
 
 
 def test_diminutive_fallback_fills_in_reenrich_thin_entries(monkeypatch) -> None:

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from scripts.lexicon.enrich_manifest import _merge_homonym_relations, _relation_source_label
 from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
+    GOROH_LABEL,
     GRAC_LABEL,
     GRINCHENKO_LABEL,
     KARAVANSKY_LABEL,
@@ -191,3 +192,33 @@ def test_learner_provenance_walker_checks_section_singular_source_url() -> None:
     }
     violations = learner_facing_mirror_violations(entry)
     assert any("sections.synonyms.source_url" in item for item in violations)
+
+
+def test_apply_entry_attribution_handles_goroh_translation() -> None:
+    entry = {
+        "lemma": "албанці",
+        "enrichment": {
+            "translation": {
+                "en": ["Albanian", "Albanians"],
+                "source": "Горох (переклад)",
+                "mirror_source_url": "https://goroh.pp.ua/Переклад/%D0%B0%D0%BB%D0%B1%D0%B0%D0%BD%D1%86%D1%96",
+            },
+            "sources": ["Горох (переклад)"],
+        },
+    }
+    assert apply_entry_attribution(entry) is False
+    assert entry["enrichment"]["translation"]["source"] == GOROH_LABEL
+    assert "source_url" not in entry["enrichment"]["translation"]
+    assert (
+        entry["enrichment"]["translation"]["mirror_source_url"]
+        == "https://goroh.pp.ua/Переклад/%D0%B0%D0%BB%D0%B1%D0%B0%D0%BD%D1%86%D1%96"
+    )
+    assert learner_facing_mirror_violations(entry) == []
+    assert learner_facing_unmapped_source_violations(entry) == []
+
+
+def test_normalize_academic_label_maps_goroh() -> None:
+    assert normalize_academic_label("goroh.pp.ua") == GOROH_LABEL
+    assert normalize_academic_label("goroh.pp.ua: Переклад") == GOROH_LABEL
+    assert normalize_academic_label("Горох") == GOROH_LABEL
+    assert normalize_academic_label("Горох (переклад)") == GOROH_LABEL


### PR DESCRIPTION
## Summary
- After dmklinger/kaikki/Balla/slovnyk `ukreng`, fill missing learner EN from goroh.pp.ua (`goroh_translate`).
- Ukrainian source, not DeepL, not e2u_reverse.
- #6876 stays open: residual EN remains.

Refs #6876

## Test plan
- [x] tests with mocked/fixture HTML (no live HTTP in CI)