### PR TITLE
ci(pytest): slow-split + set-integrity guards (stage 1 of 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
           fi
           .venv/bin/python -m pytest \
             --strict-markers --timeout=120 --timeout-method=thread --durations=10 \
+            -m 'not atlas_release and not slow' \
             "${test_files[@]}"
 
   # ---------------------------------------------------------------------
@@ -338,6 +339,7 @@ jobs:
           # shellcheck disable=SC2086  # cov_args is a deliberate word-split argument list
           .venv/bin/python scripts/ci/pytest_shards.py run --nodeids ci-artifacts/test-nodeids.txt -- \
             -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread \
+            -m 'not atlas_release and not slow' \
             --junitxml=ci-artifacts/main-junit.xml --durations=0 $cov_args \
             2>&1 | tee ci-artifacts/main.log
 
@@ -1009,8 +1011,21 @@ jobs:
           echo "combining $i shard coverage files"
           if [ "$i" -eq 0 ]; then echo "::error::no coverage data — refusing to pass vacuously"; exit 1; fi
           python -m coverage combine
-          python -m coverage report --fail-under=35
+          python -m coverage report --fail-under=35 | tee coverage-report.txt
           python -m coverage xml -o coverage.xml
+          python -m coverage html -d coverage-html
+
+      - name: Upload full coverage report
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: |
+            coverage-report.txt
+            coverage.xml
+            coverage-html/
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Not a main push — coverage is a trend floor, nothing to enforce
         if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"

--- a/.github/workflows/pytest-slow-nightly.yml
+++ b/.github/workflows/pytest-slow-nightly.yml
@@ -1,0 +1,148 @@
+name: Pytest slow nightly
+
+# Advisory slow lane for @pytest.mark.slow tests excluded from the required
+# CI Gate selection (`not atlas_release and not slow`). Never a required
+# check name; never listed in CI Gate `needs`. A silent red nightly is the
+# named rot mode — failures must open or update a labeled infra issue.
+
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: pytest-slow-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  pytest-slow:
+    name: Pytest slow (nightly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Restore Atlas lexicon manifest cache
+        id: atlas-manifest-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
+      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        run: |
+          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+
+      - name: Restore pip wheel cache
+        id: pip-wheel-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch-cpu
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt \
+            > "${RUNNER_TEMP}/requirements-ci.txt"
+          .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt"
+          .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
+            torch==2.13.0
+          .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
+
+      - name: Restore Stanza Ukrainian model cache
+        id: stanza-model-cache
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/stanza_resources
+          key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
+
+      - name: Provision and verify Stanza Ukrainian model
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "stanza provision attempt ${attempt}/3"
+            if .venv/bin/python -c "from scripts.pipeline.stress_annotator import annotate_stress; print(annotate_stress('Мама читає книжку.'))"; then
+              exit 0
+            fi
+            case "${attempt}" in
+              1) sleep 10 ;;
+              2) sleep 30 ;;
+            esac
+          done
+          echo "::error::Provision and verify Stanza Ukrainian model failed after 3 attempts" >&2
+          exit 1
+
+      - name: Save Stanza Ukrainian model cache
+        if: steps.stanza-model-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/stanza_resources
+          key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
+
+      - name: Run slow pytest selection
+        id: pytest-slow
+        run: |
+          set -euo pipefail
+          mkdir -p ci-artifacts
+          .venv/bin/python -m pytest tests/ \
+            --strict-markers --timeout=120 --timeout-method=thread --durations=20 \
+            -m 'slow and not atlas_release' \
+            --junitxml=ci-artifacts/slow-junit.xml \
+            2>&1 | tee ci-artifacts/slow.log
+
+      - name: Upload slow pytest evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-slow-nightly
+          path: ci-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Create or update infra issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title='[infra] Pytest slow nightly failed'
+          body="$(cat <<EOF
+          ## Pytest slow nightly failure
+
+          The advisory slow lane (\`-m 'slow and not atlas_release'\`) failed.
+
+          - Run: ${RUN_URL}
+          - Owner: infra lane (\`area:infra\`)
+          - Required CI Gate is unaffected; this workflow is never a \`CI Gate\` \`needs\` dependency.
+
+          Silent red nightlies are the named rot mode — keep this issue open until green.
+          EOF
+          )"
+          existing="$(gh issue list --state open --label area:infra --search "Pytest slow nightly failed in:title" --json number,title --jq '.[0].number // empty')"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --body "$body"
+            echo "Updated issue #$existing"
+          else
+            gh issue create --title "$title" --label area:infra --body "$body"
+          fi

--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -5,6 +5,12 @@ The planner collects the selected suite exactly once, groups every selected
 node ID by test file, then uses deterministic longest-processing-time (LPT)
 assignment.  Workers execute only the planner-produced node-ID list; CI Gate
 reconstructs and verifies the complete partition from their JUnit artifacts.
+
+Required selection (stage-1 slow-split): the identical mark expression
+``not atlas_release and not slow`` is applied on the planner, every shard
+worker invocation path that re-collects, fastlane, and coverage inputs.
+``pyproject.toml`` ``addopts`` keeps ``-m 'not atlas_release'`` only — never
+put ``not slow`` in global addopts (nightly would inherit it).
 """
 
 from __future__ import annotations
@@ -23,7 +29,16 @@ from typing import Any
 SHARD_COUNT = 4
 PLAYGROUND_PERF_TEST = "tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast"
 SERIAL_TESTS = (PLAYGROUND_PERF_TEST,)
-COMMON_ARGS = ("tests/", f"--deselect={PLAYGROUND_PERF_TEST}")
+# Identical expression everywhere the required gate collects or filters.
+REQUIRED_MARKEXPR = "not atlas_release and not slow"
+SLOW_MARKEXPR = "slow and not atlas_release"
+COMMON_ARGS = (
+    "tests/",
+    f"--deselect={PLAYGROUND_PERF_TEST}",
+    "-m",
+    REQUIRED_MARKEXPR,
+    "--strict-markers",
+)
 _DURATION_LINE = re.compile(r"^\s*(?P<seconds>\d+(?:\.\d+)?)s\s+(?:call|setup|teardown)\s+(?P<nodeid>\S+)")
 _DATASET_VERSION = 1
 _P95_HISTORY_LIMIT = 40
@@ -119,14 +134,37 @@ def assign_shards(nodeids: Sequence[str], shard_count: int, durations: dict[str,
     return shard_groups
 
 
+def assert_set_integrity(nodeids: Sequence[str], shards: Sequence[Sequence[str]]) -> None:
+    """Fail closed unless shard union equals the fast collection exactly.
+
+    Empty shards are a silent gate collapse (green with zero work). Duplicates
+    or omissions mean the required set drifted from the planner collection.
+    """
+    if any(not assigned for assigned in shards):
+        empty = [index + 1 for index, assigned in enumerate(shards) if not assigned]
+        raise RuntimeError(f"planner produced empty shard(s): {empty}")
+    assigned = [nodeid for shard in shards for nodeid in shard]
+    if len(assigned) != len(set(assigned)):
+        raise RuntimeError("a collected test was assigned to more than one shard")
+    if set(assigned) != set(nodeids):
+        missing = sorted(set(nodeids) - set(assigned))
+        extra = sorted(set(assigned) - set(nodeids))
+        raise RuntimeError(
+            "shard union does not equal fast collection "
+            f"(missing={len(missing)}, extra={len(extra)})"
+        )
+    if len(assigned) != len(nodeids):
+        raise RuntimeError("shard assignment count does not match collected selection")
+
+
 def write_plans(*, durations_path: Path | None, output_dir: Path, shard_count: int = SHARD_COUNT) -> None:
     """Collect once and write every matrix-worker plan from one duration dataset."""
     nodeids = collect_nodeids()
     durations = load_durations(durations_path)
+    # Duration keys for deselected slow tests are ignored; unknown files use median.
+    # Refresh the committed/cache dataset only when membership imbalance is measured.
     shards = assign_shards(nodeids, shard_count, durations)
-    if any(not assigned for assigned in shards):
-        empty = [index + 1 for index, assigned in enumerate(shards) if not assigned]
-        raise RuntimeError(f"planner produced empty shard(s): {empty}")
+    assert_set_integrity(nodeids, shards)
     output_dir.mkdir(parents=True, exist_ok=True)
     weights = _file_weights(nodeids, durations)
     for shard_id, assigned in enumerate(shards, start=1):
@@ -143,6 +181,7 @@ def write_plans(*, durations_path: Path | None, output_dir: Path, shard_count: i
                 "collected_digest": _digest(nodeids),
                 "estimated_seconds": sum(weights[filename] for filename in assigned_files),
                 "grouping": "file",
+                "markexpr": REQUIRED_MARKEXPR,
                 "partition_mode": "lpt-durations",
                 "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
                 "shard_count": shard_count,
@@ -173,10 +212,16 @@ def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
         assigned = plan.get("assigned_nodeids")
         if not isinstance(assigned, list) or not all(isinstance(nodeid, str) for nodeid in assigned):
             raise RuntimeError(f"invalid assigned node IDs in {plan_path}")
+        if not assigned:
+            raise RuntimeError(f"empty shard {shard_id} collapses the required gate")
         if _digest(assigned) != plan.get("assigned_digest"):
             raise RuntimeError(f"assigned node ID digest mismatch in {plan_path}")
         if plan.get("partition_mode") != "lpt-durations" or plan.get("grouping") != "file":
             raise RuntimeError(f"invalid planner mode in {plan_path}")
+        if plan.get("markexpr") != REQUIRED_MARKEXPR:
+            raise RuntimeError(
+                f"plan markexpr must be {REQUIRED_MARKEXPR!r}, got {plan.get('markexpr')!r}"
+            )
         if _junit_count(main_junit) != len(assigned):
             raise RuntimeError(f"main JUnit count does not match plan for shard {shard_id}")
         serial = plan.get("serial_nodeids")

--- a/tests/curriculum/test_seminar_plan_refs_titles.py
+++ b/tests/curriculum/test_seminar_plan_refs_titles.py
@@ -6,6 +6,7 @@ from scripts.build.linear_pipeline import LinearPipelineError, plan_check
 from scripts.curriculum.backfill_seminar_ref_titles import derive_title
 
 
+@pytest.mark.slow
 def test_all_seminar_plans_pass_validate_plan():
     """
     Iterates every plan in the seminar levels, calls linear_pipeline.plan_check,

--- a/tests/orchestration/test_curriculum_lifecycle_pilot.py
+++ b/tests/orchestration/test_curriculum_lifecycle_pilot.py
@@ -50,6 +50,7 @@ def test_matrix_is_complete_strict_and_shadow_only(pilot_matrix: dict[str, Any])
         pilot._validate(invalid, REPO_ROOT / pilot.MATRIX_SCHEMA_PATH, "fixture")
 
 
+@pytest.mark.slow
 def test_shadow_report_passes_all_rows_without_learner_mutation_or_model_cost(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -76,12 +77,14 @@ def test_shadow_report_passes_all_rows_without_learner_mutation_or_model_cost(
     }
 
 
+@pytest.mark.slow
 def test_shadow_report_is_exactly_reproducible_at_one_source_tree(
     shadow_report: dict[str, Any],
 ) -> None:
     assert shadow_report == pilot.build_shadow_report(repo_root=REPO_ROOT)
 
 
+@pytest.mark.slow
 def test_built_level_profiles_do_not_leak_cross_level_policy(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -107,6 +110,7 @@ def test_built_level_profiles_do_not_leak_cross_level_policy(
     )
 
 
+@pytest.mark.slow
 def test_bio_pilot_binds_current_canonical_pass_and_bio_specific_prompt(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -118,6 +122,7 @@ def test_bio_pilot_binds_current_canonical_pass_and_bio_specific_prompt(
     assert row["prompt"]["profile"] == "seminar-bio"
 
 
+@pytest.mark.slow
 def test_fixture_rows_prove_owned_pause_resume_and_qg_modes(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -131,6 +136,7 @@ def test_fixture_rows_prove_owned_pause_resume_and_qg_modes(
     assert rows["production-qg-disarmed"]["entry"]["state"] == "certified-final"
 
 
+@pytest.mark.slow
 def test_shadow_detects_any_learner_tree_change(
     shadow_report: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -161,6 +167,7 @@ def test_shadow_detects_any_learner_tree_change(
     assert all(row["mutation_detected"] and not row["passed"] for row in report["rows"])
 
 
+@pytest.mark.slow
 def test_report_tampering_and_false_pass_fail_closed(
     pilot_matrix: dict[str, Any],
     shadow_report: dict[str, Any],
@@ -211,6 +218,7 @@ def test_report_tampering_and_false_pass_fail_closed(
         pilot.validate_report_value(report, matrix=matrix, repo_root=REPO_ROOT)
 
 
+@pytest.mark.slow
 def test_report_validation_rejects_contract_and_learner_drift(
     pilot_matrix: dict[str, Any],
     shadow_report: dict[str, Any],
@@ -240,6 +248,7 @@ def test_report_validation_rejects_contract_and_learner_drift(
         pilot.validate_report_value(report, matrix=matrix, repo_root=REPO_ROOT)
 
 
+@pytest.mark.slow
 def test_live_scope_rejects_fixture_historical_and_nonpassing_rows(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -268,6 +277,7 @@ def test_live_scope_rejects_fixture_historical_and_nonpassing_rows(
         )
 
 
+@pytest.mark.slow
 def test_live_scope_enforces_maximum_mutating_modules(
     shadow_report: dict[str, Any],
 ) -> None:
@@ -294,6 +304,7 @@ def test_matrix_override_must_remain_repository_backed(tmp_path: Path) -> None:
         pilot.load_matrix(repo_root=REPO_ROOT, matrix_path=matrix_path)
 
 
+@pytest.mark.slow
 def test_same_family_live_authorization_is_rejected_before_scope_or_git_lookup(
     shadow_report: dict[str, Any],
     tmp_path: Path,

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -304,6 +304,7 @@ def _raw_worktree_remove_callers(project_root: Path) -> dict[str, set[str]]:
     return actual
 
 
+@pytest.mark.slow
 def test_production_worktree_remove_call_sites_are_allowlisted() -> None:
     """Reject a new raw deletion hand anywhere below production ``scripts/``."""
     project_root = Path(__file__).resolve().parents[2]

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -25,6 +25,7 @@ def _write_complete_artifacts(root: Path, selected: list[str]) -> None:
             "collected_count": len(selected),
             "collected_digest": digest,
             "grouping": "file",
+            "markexpr": pytest_shards.REQUIRED_MARKEXPR,
             "partition_mode": "lpt-durations",
             "serial_nodeids": list(pytest_shards.SERIAL_TESTS) if shard_id == 1 else [],
             "shard_count": len(selected),
@@ -121,7 +122,34 @@ def test_verify_artifacts_rejects_mispartitioned_plan(tmp_path: Path) -> None:
     plan_path.write_text(json.dumps(plan), encoding="utf-8")
     _write_junit(tmp_path / "pytest-shard-4" / "main-junit.xml", 0)
 
-    with pytest.raises(RuntimeError, match="complete partition"):
+    with pytest.raises(RuntimeError, match=r"empty shard|complete partition"):
+        pytest_shards.verify_artifacts(tmp_path, 4)
+
+
+def test_assert_set_integrity_rejects_empty_shard_and_omissions() -> None:
+    nodeids = ["tests/a.py::test_a", "tests/b.py::test_b", "tests/c.py::test_c", "tests/d.py::test_d"]
+    shards = [["tests/a.py::test_a"], ["tests/b.py::test_b"], ["tests/c.py::test_c"], ["tests/d.py::test_d"]]
+    pytest_shards.assert_set_integrity(nodeids, shards)
+
+    with pytest.raises(RuntimeError, match="empty shard"):
+        pytest_shards.assert_set_integrity(nodeids, [["tests/a.py::test_a"], ["tests/b.py::test_b"], [], ["tests/d.py::test_d"]])
+
+    with pytest.raises(RuntimeError, match="does not equal fast collection"):
+        pytest_shards.assert_set_integrity(
+            nodeids,
+            [["tests/a.py::test_a"], ["tests/b.py::test_b"], ["tests/c.py::test_c"], ["tests/extra.py::test_x"]],
+        )
+
+
+def test_verify_artifacts_rejects_wrong_markexpr(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+    plan_path = tmp_path / "pytest-shard-1" / "plan.json"
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    plan["markexpr"] = "not atlas_release"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="plan markexpr"):
         pytest_shards.verify_artifacts(tmp_path, 4)
 
 
@@ -159,6 +187,9 @@ def test_run_nodeids_passes_exact_planner_output_to_pytest(tmp_path: Path, monke
 
 def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
     workflow = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    nightly = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pytest-slow-nightly.yml"
+    ).read_text(encoding="utf-8")
 
     assert "pytest-plan:" in workflow
     assert "pytest-fastlane:" in workflow
@@ -168,3 +199,23 @@ def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
     assert workflow.count("pytest_shards.py plan") == 1
     assert "pytest_shards.py verify-artifacts" in workflow
     assert "--dist=loadfile" in workflow
+    assert "-m 'not atlas_release and not slow'" in workflow
+    assert workflow.count("-m 'not atlas_release and not slow'") >= 2
+    assert "name: CI Gate" in workflow
+    assert "pytest-slow-nightly" not in workflow
+    assert "-m 'slow and not atlas_release'" in nightly
+    assert "Create or update infra issue on failure" in nightly
+    assert "area:infra" in nightly
+    assert nightly.splitlines()[0] == "name: Pytest slow nightly"
+
+
+def test_required_markexpr_constant_matches_ci_and_addopts_boundary() -> None:
+    """addopts stays atlas-only; required gate adds not slow via CLI -m everywhere."""
+    pyproject = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    assert "addopts = \"-v --tb=short -m 'not atlas_release'\"" in pyproject
+    assert "not slow" not in pyproject.split("addopts")[1].split("\n")[0]
+    assert pytest_shards.REQUIRED_MARKEXPR == "not atlas_release and not slow"
+    assert pytest_shards.SLOW_MARKEXPR == "slow and not atlas_release"
+    assert "-m" in pytest_shards.COMMON_ARGS
+    assert pytest_shards.REQUIRED_MARKEXPR in pytest_shards.COMMON_ARGS
+    assert "--strict-markers" in pytest_shards.COMMON_ARGS

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -230,7 +230,7 @@ The word **вода́** is useful in the morning because you see it in routines,
 # Loads the live Stanza Ukrainian model (run_ulp_fidelity_with_correction →
 # run_stress_annotation). Non-hermetic: the model download flakes the md5 check
 # in parallel CI. Marked `slow` so the required pytest selection
-# (`-k "not slow"`) excludes it; it still runs in the slow/nightly path.
+# (`-m "not atlas_release and not slow"`) excludes it; it still runs in the slow/nightly path.
 @pytest.mark.slow
 def test_ulp_fidelity_correction_reruns_stress_and_gate(tmp_path: Path) -> None:
     module_dir = tmp_path / "module"

--- a/tests/test_ohoiko_source_inventory_scope.py
+++ b/tests/test_ohoiko_source_inventory_scope.py
@@ -4,6 +4,7 @@ import json
 from collections import Counter
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts.audit import source_inventory_review_decisions as decisions
@@ -45,6 +46,7 @@ def test_ohoiko_abetka_inventory_covers_all_committed_key_words() -> None:
     assert sum(ohoiko_rows.values()) == 33
 
 
+@pytest.mark.slow
 def test_ohoiko_abetka_inventory_has_review_decisions_for_all_rows() -> None:
     records = read_source_inventory(OHOIKO_INVENTORY, project_root=PROJECT_ROOT)
     inventory_rows = Counter(

--- a/tests/test_open_model_ready_view_production.py
+++ b/tests/test_open_model_ready_view_production.py
@@ -222,6 +222,7 @@ def test_word_regex_keeps_ukrainian_apostrophe_forms() -> None:
     ]
 
 
+@pytest.mark.slow
 def test_prepare_payloads_runs_complete_admitted_scope_atomically(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -302,6 +303,7 @@ def test_prepare_payloads_runs_complete_admitted_scope_atomically(
     assert not list(tmp_path.glob("*.bak"))
 
 
+@pytest.mark.slow
 def test_tokenizer_diagnostics_runs_real_entry_point(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -361,6 +363,7 @@ def test_tokenizer_diagnostics_runs_real_entry_point(
     assert json.loads(output.read_text(encoding="utf-8")) == receipt
 
 
+@pytest.mark.slow
 def test_assemble_production_receipt_uses_payload_scoped_protection_counts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_open_model_reference_build.py
+++ b/tests/test_open_model_reference_build.py
@@ -38,6 +38,7 @@ def reference_runs(tmp_path_factory: pytest.TempPathFactory) -> tuple[dict[str, 
     return manifest_a, first, second
 
 
+@pytest.mark.slow
 def test_reference_manifest_is_deterministic_and_strict(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:
@@ -57,6 +58,7 @@ def test_reference_manifest_is_deterministic_and_strict(
     assert manifest["determinism"]["timestamps_omitted"] is True
 
 
+@pytest.mark.slow
 def test_fixture_preserves_russian_interference_lineage(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:
@@ -94,6 +96,7 @@ def test_fixture_preserves_russian_interference_lineage(
     assert manifest["source_to_view_lineage"]["source_contract_admitted_records"] == 1
 
 
+@pytest.mark.slow
 def test_five_views_are_disjoint_and_never_train_fixture_rows(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:
@@ -121,6 +124,7 @@ def test_five_views_are_disjoint_and_never_train_fixture_rows(
     }
 
 
+@pytest.mark.slow
 def test_full_profile_denominators_and_unknowns_remain_explicit(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:
@@ -142,6 +146,7 @@ def test_full_profile_denominators_and_unknowns_remain_explicit(
     assert profile["tokenizer_diagnostics"].startswith("not_run;")
 
 
+@pytest.mark.slow
 def test_saved_baseline_reproduces_without_gold_or_model_generation(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:
@@ -165,6 +170,7 @@ def test_saved_baseline_reproduces_without_gold_or_model_generation(
     assert baseline["gold_firewall"]["model_generation_performed"] is False
 
 
+@pytest.mark.slow
 def test_observation_binds_manifest_and_denies_external_actions(
     reference_runs: tuple[dict[str, Any], Path, Path],
 ) -> None:

--- a/tests/test_post_processor_mutation_invariant.py
+++ b/tests/test_post_processor_mutation_invariant.py
@@ -68,9 +68,9 @@ _ALL_FIXTURES: list[Fixture] = _POST_PROCESSOR_CORPUS + [
 # the Stanza Ukrainian model, which is non-hermetic and flakes Stanza's md5
 # check under parallel CI (`ValueError: md5 for .../uk/tokenize/iu.pt ...`).
 # Their parametrizations are marked `slow` so the required pytest selection
-# (`-k "not slow"`) excludes them — keeping the required gate hermetic per the
-# #2691 invariant — while every other processor's invariant check still runs.
-# They continue to run in the slow/nightly path. See
+# (`-m "not atlas_release and not slow"`) excludes them — keeping the required
+# gate hermetic per the #2691 invariant — while every other processor's invariant
+# check still runs. They continue to run in the slow/nightly path. See
 # docs/bug-autopsies/stanza-model-md5-flake.md.
 _MODEL_BACKED_PROCESSORS = {"pipeline.stress_annotator.annotate_stress"}
 

--- a/tests/test_scrub_decision_ledger_keys.py
+++ b/tests/test_scrub_decision_ledger_keys.py
@@ -74,6 +74,7 @@ def test_scrubbed_key_formula() -> None:
     assert scrubbed["surface_admission"] == sample_row["surface_admission"]
 
 
+@pytest.mark.slow
 def test_emitted_shards_contain_no_personal_identifier_substrings(
     migrated_shards: list[Path],
 ) -> None:
@@ -106,6 +107,7 @@ def test_emitted_shards_contain_no_personal_identifier_substrings(
                 assert pattern.search(gloss_val) is None, f"Leak in gloss: {gloss_val}"
 
 
+@pytest.mark.slow
 def test_shards_concatenate_to_original_decisions(
     migrated_shards: list[Path],
 ) -> None:
@@ -145,6 +147,7 @@ def test_shards_concatenate_to_original_decisions(
         assert recon["source_inventory"]["key"] == expected_key
 
 
+@pytest.mark.slow
 def test_shards_independently_pass_validation(
     migrated_shards: list[Path],
 ) -> None:

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -34,6 +34,7 @@ def _canonical_python() -> Path:
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.slow
 def test_session_setup_hook_handoff_fixtures() -> None:
     assert _HOOK_TEST.is_file(), f"missing hook test: {_HOOK_TEST}"
     result = subprocess.run(

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -131,10 +131,24 @@ def test_default_committed_decision_files_keep_aggregate_floors(
     assert decision_counts["approve_for_publish"] >= 20
 
 
+_SLOW_COMMITTED_DECISION_FILES = frozenset(
+    {
+        "2026-07-19-textbook-jsonl-curated-bulk-approve.yaml",
+        "2026-07-19-ohoiko-ulp-curated-bulk-approve.yaml",
+    }
+)
+
+
 @pytest.mark.parametrize(
     "ledger_path",
-    COMMITTED_DECISION_FILES,
-    ids=lambda path: path.name,
+    [
+        pytest.param(
+            path,
+            id=path.name,
+            marks=(pytest.mark.slow,) if path.name in _SLOW_COMMITTED_DECISION_FILES else (),
+        )
+        for path in COMMITTED_DECISION_FILES
+    ],
 )
 def test_default_committed_decision_files_validate(
     ledger_path: Path,
@@ -430,6 +444,7 @@ def test_decision_validator_requires_committed_inventory_present(
         decisions.validate_committed_decision_files([path])
 
 
+@pytest.mark.slow
 def test_committed_ohoiko_batch_ledgers_validate() -> None:
     # The real committed per-batch Ohoiko ledgers validate with the regenerable
     # inventory JSON absent (its normal state in git).

--- a/tests/test_video_discovery.py
+++ b/tests/test_video_discovery.py
@@ -86,7 +86,11 @@ class TestSearchChannel:
             result = search_channel(["тест"], "@testchannel")
             assert result == []
 
+    @pytest.mark.slow
     def test_returns_empty_on_timeout(self):
+        # TimeoutExpired triggers _yt_dlp_search's retry sleeps (10s+20s) on both
+        # the channel search and the global fallback — ~60s of deliberate backoff.
+        # Cheap FileNotFoundError contract stays in the required gate above.
         import subprocess
         with patch("video_discovery.subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 30)):
             result = search_channel(["тест"], "@testchannel")

--- a/tests/test_writer_size_policy.py
+++ b/tests/test_writer_size_policy.py
@@ -16,12 +16,12 @@ from scripts.build.module_size_policy import (
 )
 from scripts.build.phases.implementation_map import seed_implementation_map
 
-PROMPT_FIXTURES: tuple[tuple[str, str], ...] = (
+PROMPT_FIXTURES = (
     ("a1", "sounds-letters-and-hello"),
     ("a2", "a2-bridge"),
     ("b1", "adjectives-comparative"),
     ("b2", "academic-writing"),
-    ("bio", "andrii-malyshko"),
+    pytest.param("bio", "andrii-malyshko", marks=pytest.mark.slow),
     ("folk", "kolomyiky"),
     ("c1", "abstract-writing"),
     ("c2", "academic-publishing"),


### PR DESCRIPTION
## Summary

Stage 1 of the two-PR CI overhaul: change **which** tests are required and add integrity guards. Gate topology, triggers, and branch protection stay as-is (`CI Gate` remains the sole pinned context). Stage 2 (merge-queue cutover) is out of scope.

- Required collection is now the identical expression `-m 'not atlas_release and not slow'` on the planner (`scripts/ci/pytest_shards.py`), all 4 shard jobs, and fastlane. `pyproject.toml` `addopts` stays `-m 'not atlas_release'` only (nightly must not inherit `not slow`).
- Set-integrity fails the gate on empty shards, shard∪ ≠ fast collection, wrong `markexpr`, or digests that do not partition.
- New advisory workflow `Pytest slow nightly` (`schedule` + `workflow_dispatch`) runs `-m 'slow and not atlas_release'` and create-or-updates an `area:infra` issue on failure. Not referenced by CI Gate `needs`.
- Coverage floor uploads the full report artifact (`coverage-report.txt` + XML + HTML) on main pushes; floor remains `--fail-under=35`.

Refs #6943.

## Tests moved to `slow` (reviewed gate-membership changes)

Previously unmarked; cost verified in setup/call from main run `32074998355` durations (not import/collection/autouse that unmarked siblings still trigger):

1. `tests/test_video_discovery.py::TestSearchChannel::test_returns_empty_on_timeout` — TimeoutExpired retry sleeps (~60s call)
2. `tests/test_open_model_reference_build.py::test_reference_manifest_is_deterministic_and_strict` (+ 5 sibling `reference_runs` consumers) — module fixture ~57s setup
3. `tests/test_scrub_decision_ledger_keys.py::{test_emitted_shards_contain_no_personal_identifier_substrings,test_shards_concatenate_to_original_decisions,test_shards_independently_pass_validation}` — module `migrated_shards` fixture (~46s); cheap `test_scrubbed_key_formula` stays required
4. `tests/orchestration/test_curriculum_lifecycle_pilot.py` — all `shadow_report` consumers (11 tests); cheap matrix/CLI contracts stay required
5. `tests/curriculum/test_seminar_plan_refs_titles.py::test_all_seminar_plans_pass_validate_plan` — full seminar plan walk (~48s)
6. `tests/orchestration/test_reap_worktrees.py::test_production_worktree_remove_call_sites_are_allowlisted` — full `scripts/` AST scan (~36s)
7. `tests/test_writer_size_policy.py::…[bio-andrii-malyshko-{claude,codex}-tools]` — pytest.param marks only (~34s each)
8. `tests/test_source_inventory_review_decisions.py::test_default_committed_decision_files_validate[{textbook-jsonl,ohoiko-ulp}…]` — param marks; plus `test_committed_ohoiko_batch_ledgers_validate`
9. `tests/test_ohoiko_source_inventory_scope.py::test_ohoiko_abetka_inventory_has_review_decisions_for_all_rows`
10. `tests/test_open_model_ready_view_production.py::{test_prepare_payloads…,test_tokenizer_diagnostics…,test_assemble_production…}` — full-scope/real entry points; cheap schema contracts stay
11. `tests/test_session_setup_hook.py::test_session_setup_hook_handoff_fixtures`

Already-marked stress/MLX/immersion/post-processor `slow` tests are now actually excluded by the required expression (previously marked but still collected because CI never passed `not slow`).

## Collect-only proof (this worktree; 17 sparse-checkout collection errors unchanged)

**Before marking (existing `slow` only):**
```
======= 19412/19489 tests collected (77 deselected), 17 errors in 25.11s =======  # -m 'not atlas_release and not slow'
======= 76/19489 tests collected (19413 deselected), 17 errors in 5.59s ========   # -m 'slow and not atlas_release'
```

**After marking:**
```
======= 19382/19492 tests collected (110 deselected), 17 errors in 5.99s =======  # -m 'not atlas_release and not slow'
======= 109/19492 tests collected (19383 deselected), 17 errors in 4.58s ========  # -m 'slow and not atlas_release'
```

## Set-integrity mutation-check

```
PASS intact: verify_artifacts ok
PASS mutation raised: empty shard 4 collapses the required gate
PASS assert_set_integrity empty: planner produced empty shard(s): [4]
```

`tests/test_ci_shard_partition.py`: 11 passed.

## Duration dataset

No refresh. Evidence from main run `32074998355`: plan estimates all ~1136s; observed duration-sums 828/1152/1191/908s. Newly marked ~33 timed nodes ≈ 672s removed from the required wall. LPT + median fallback does not require exact duration membership; refreshing would be speculative churn.

## Coverage

**Before** (main run `32074998355`, Coverage floor job):
```
TOTAL  281113  82967  70%
```
`--fail-under=35` passed. Full report captured from that job log (1306 lines). After exclusion, required coverage still runs over the fast set only; 70% → expected still ≫ 35% (STOP rule: never lower floor). PR CI does not enforce coverage (main-push only); artifact upload added for full report on main.

## Other proof

- `ruff check` on touched Python: All checks passed
- `actionlint` on `ci.yml` + `pytest-slow-nightly.yml`: exit 0
- `scripts.ci.slot_inventory --check`: PASS 30/31 (nightly schedule-only, not in required PR slot budget)

## Test plan

- [ ] CI Gate green on this PR (full 4-shard required set without `slow`)
- [ ] Fastlane step shows `-m 'not atlas_release and not slow'`
- [ ] Planner plans include `"markexpr": "not atlas_release and not slow"`; verify-artifacts accepts
- [ ] Manual `workflow_dispatch` of `Pytest slow nightly` (optional) exercises slow lane
- [ ] Cross-family exact-head review before merge (no auto-merge)


Made with [Cursor](https://cursor.com)