### PR TITLE
fix(fleet_comms): preserve transaction atomicity when borrowing stores (#6987)

### DIFF
--- a/scripts/fleet_comms/authority.py
+++ b/scripts/fleet_comms/authority.py
@@ -273,7 +273,8 @@ class AuthorityService:
         self.store = store or ArtifactStore(root=root)
         self._owns_store = store is None
         self._conn = self.store.connection
-        apply_migrations(self._conn)
+        if self._owns_store:
+            apply_migrations(self._conn)
         self._require_authority_schema()
 
     def close(self) -> None:

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -126,11 +126,14 @@ class FormalReviewJobService:
         root: Path | None = None,
     ) -> None:
         self.store = store or ArtifactStore(root=root)
+        self._owns_store = store is None
         self._conn = self.store.connection
-        apply_migrations(self._conn)
+        if self._owns_store:
+            apply_migrations(self._conn)
 
     def close(self) -> None:
-        self.store.close()
+        if self._owns_store:
+            self.store.close()
 
     def __enter__(self) -> FormalReviewJobService:
         return self

--- a/scripts/fleet_comms/request_executor.py
+++ b/scripts/fleet_comms/request_executor.py
@@ -84,13 +84,16 @@ class RequestExecutor:
         default_ttl_seconds: int | None = None,
     ) -> None:
         self.store = store or ArtifactStore(root=root)
+        self._owns_store = store is None
         self.registry = registry or load_endpoint_registry()
         self.default_ttl_seconds = default_ttl_seconds
         self._conn = self.store.connection
-        apply_migrations(self._conn)
+        if self._owns_store:
+            apply_migrations(self._conn)
 
     def close(self) -> None:
-        self.store.close()
+        if self._owns_store:
+            self.store.close()
 
     def __enter__(self) -> RequestExecutor:
         return self

--- a/scripts/fleet_comms/review_publisher.py
+++ b/scripts/fleet_comms/review_publisher.py
@@ -31,7 +31,6 @@ from typing import Any
 
 from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.contracts import new_id
-from scripts.fleet_comms.migrations import apply_migrations
 from scripts.fleet_comms.review_publication import (
     DEFAULT_STATUS_CONTEXT,
     PublicationPlan,
@@ -412,7 +411,6 @@ def ensure_job_row_for_receipt(
         FormalReviewJobService,
     )
 
-    apply_migrations(store.connection)
     # Do not close the service: it shares the caller's ArtifactStore connection.
     service = FormalReviewJobService(store=store)
     existing = service.find_job(
@@ -493,7 +491,6 @@ def publish_sealed_verdict(
     already_key: str | None = None
     if store is not None:
         conn = store.connection
-        apply_migrations(conn)
         already_key = already_published_key_for_job(
             conn, sealed, status_context=status_context
         )

--- a/scripts/fleet_comms/routing_reservations.py
+++ b/scripts/fleet_comms/routing_reservations.py
@@ -282,7 +282,8 @@ class RoutingReservationLedger:
         self.store = store or ArtifactStore(root=root)
         self._owns_store = store is None
         self._conn = self.store.connection
-        apply_migrations(self._conn)
+        if self._owns_store:
+            apply_migrations(self._conn)
 
     def close(self) -> None:
         if self._owns_store:

--- a/tests/test_fleet_comms_authority_cutover.py
+++ b/tests/test_fleet_comms_authority_cutover.py
@@ -1287,3 +1287,51 @@ def test_concurrent_substitution_requests_do_not_fork_authority_or_reservation(t
         reservation = ledger.latest_for_authority_key(request.authority_key)
         assert reservation is not None and reservation.attempt == 2
         assert service.get_job(job.job_id).state == "queued"
+
+
+def test_authority_write_transaction_retains_atomicity_with_subservice_stores(
+    tmp_path: Path,
+) -> None:
+    from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
+
+    root = _root(tmp_path)
+    with AuthorityService(root=root) as service:
+        with service._write_transaction():
+            assert service._conn.in_transaction
+            RoutingReservationLedger(store=service.store)
+            assert service._conn.in_transaction
+            FormalReviewJobService(store=service.store)
+            assert service._conn.in_transaction
+
+
+def test_concurrent_substitution_requests_converge_under_high_contention(
+    tmp_path: Path,
+) -> None:
+    root = _root(tmp_path)
+    with AuthorityService(root=root) as service:
+        job, review, request, evidence = _failed_formal_substitution_fixture(service)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        outcomes = list(
+            pool.map(
+                lambda _index: _concurrent_substitution(
+                    root,
+                    job.job_id,
+                    review.review_id,
+                    str(review.snapshot_artifact_id),
+                    request,
+                    evidence,
+                ),
+                range(4),
+            )
+        )
+    reservation_ids = [value for value in outcomes if value.startswith("routing-reservation_")]
+    assert reservation_ids and len(set(reservation_ids)) == 1
+    assert all(
+        value.startswith("routing-reservation_") or value == "substitution_authority_job_not_failed"
+        for value in outcomes
+    )
+    with AuthorityService(root=root) as service, RoutingReservationLedger(store=service.store) as ledger:
+        reservation = ledger.latest_for_authority_key(request.authority_key)
+        assert reservation is not None and reservation.attempt == 2
+        assert service.get_job(job.job_id).state == "queued"
+


### PR DESCRIPTION
### Summary

Root causes and fixes issue #6987: concurrent-substitution race triggering `RoutingReservationError: substitution_idempotency_conflict`.

#### Root Cause
In `AuthorityService.authorize_formal_review_substitution`, the method opens a write transaction (`with self._write_transaction():`) and instantiates `ledger = RoutingReservationLedger(store=self.store)`.

When initialized with a shared `store`, `RoutingReservationLedger.__init__` was unconditionally invoking `apply_migrations(self._conn)`. In `scripts/fleet_comms/migrations.py`, `apply_migrations` issues `conn.commit()`, which silently terminated and committed `AuthorityService`'s outer write transaction on the shared SQLite connection.

As a direct consequence:
1. `self._conn.in_transaction` became `False`.
2. When `ledger.reserve_selection` ran, its inner transaction check (`self.nested = self.ledger._conn.in_transaction`) saw `False`, so `reserve_selection` started and committed its own standalone transaction, persisting Attempt 2 into `routing_reservations` with `prior_reservation_id = Attempt 1`.
3. Before `AuthorityService` executed `UPDATE authority_jobs SET state = 'queued'`, `authority_jobs` remained in state `'failed'`.
4. A racing concurrent worker entering `authorize_formal_review_substitution` during this window observed `job_state == 'failed'` and `ledger.latest_for_authority_key(...) == Attempt 2`.
5. The racing worker proceeded into the creation branch instead of the idempotent replay branch, constructed new substitution evidence with `prior_reservation_id = Attempt 2`, and invoked `reserve_selection`.
6. `reserve_selection` checked the active idempotent Attempt 2 against the provided evidence. Because Attempt 2's stored `authorized_substitution` decision had `prior_reservation_id = Attempt 1` while the new payload had `prior_reservation_id = Attempt 2`, `reserve_selection` raised `RoutingReservationError("substitution_idempotency_conflict")`.

#### Fix
- Guard `apply_migrations` across fleet comms sub-services (`RoutingReservationLedger`, `AuthorityService`, `FormalReviewJobService`, `RequestExecutor`) with `if self._owns_store:` so schema migrations only execute when the service instantiates its own `ArtifactStore`. (Since `ArtifactStore.__init__` already applies migrations on connection creation, borrowed stores are already migrated).
- Guard `close()` with `if self._owns_store:` in `FormalReviewJobService` and `RequestExecutor` to prevent closing shared connections prematurely.
- Add regression tests in `tests/test_fleet_comms_authority_cutover.py` verifying write transaction atomicity across subservice initializations and high-contention concurrent substitution convergence.

Fixes #6987.

X-Agent: agy/gemini-native