### PR TITLE
ci(gate): two-tier merge-queue cutover (stage 2 of 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ name: CI
 # restores the proven pytest topology: one deterministic planner, four
 # duration-balanced file shards, and JUnit reconstruction inside CI Gate.
 #
+# Two-tier merge-queue cutover (#6943 stage 2): one workflow, two events.
+# `pull_request` keeps the historical full required set until the reduction
+# commit; `merge_group` validates the queued merged tree (event SHA) and is
+# where coverage floor is enforced. CI Gate remains the sole required context
+# and reports on both events.
+#
 # Invariant (encodes #3873 #4888 #4936 #5351 #5354): pytest must NEVER be
 # selected or skipped by changed files. Five separate incidents shipped a
 # regression to main because a data-only change skipped pytest under a
@@ -13,10 +19,12 @@ name: CI
 # early signal; it never alters the full-suite plan or its shard execution.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
+  # Event-prefixed groups so a PR push never shares a bucket with a
+  # merge_group run (and therefore cannot cancel a queued merge).
   # PRs cancel their own stale runs. `main` and `merge_group` must never
   # cancel themselves — that was why 14 of the last 30 `main` runs were
   # cancelled and 0 succeeded.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -42,6 +50,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Default checkout is the event SHA: for merge_group that is the
+      # merge-group commit (never the PR head). Do not override with
+      # pull_request.head.sha — that would test a stale tree.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -321,7 +332,9 @@ jobs:
         continue-on-error: true
         timeout-minutes: 25
         env:
-          IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Coverage collection on the trees that land: merge_group (queued
+          # merge commit) and push to main. PR heads stay coverage-free.
+          COLLECT_COVERAGE: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
           SHARD: ${{ matrix.shard }}
           PYTEST_BREADCRUMB_DIR: .pytest_breadcrumbs
         run: |
@@ -333,7 +346,7 @@ jobs:
             npm ci --ignore-scripts
           fi
           cov_args=""
-          if [ "$IS_MAIN_PUSH" = "true" ]; then
+          if [ "$COLLECT_COVERAGE" = "true" ]; then
             cov_args="--cov=scripts --cov-report="
           fi
           # shellcheck disable=SC2086  # cov_args is a deliberate word-split argument list
@@ -391,7 +404,10 @@ jobs:
       # Each matrix shard publishes its xdist-combined data. The floor stays in
       # its own job because no individual shard observes the whole suite.
       - name: Upload shard coverage data
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pytest.outcome == 'success'
+        if: >-
+          (github.event_name == 'merge_group'
+           || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+          && steps.pytest.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-shard-${{ matrix.shard }}
@@ -486,8 +502,9 @@ jobs:
           # Parenthesized: without parens, && binds tighter than || and the
           # title-tag paths yield boolean `true` (not '1'), which the
           # checker rejects — found via PR #4399.
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          # merge_group has no pull_request payload — default to empty strings.
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           MDX_PARITY_BULK_REGEN=0
           if [[ "$PR_TITLE" == *"[regen-mdx]"* || "$PR_TITLE" == *"[bulk-regen]"* \
@@ -525,8 +542,8 @@ jobs:
       - name: Check DB-free Atlas manifest freshness
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             .venv/bin/python scripts/lexicon/check_manifest_freshness.py \
@@ -571,8 +588,9 @@ jobs:
 
       - name: Validate BIO preparation capsules and active holds
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Guard merge_group: no pull_request.* / event.before — use merge_group fields.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: |
           .venv/bin/python - <<'PY'
           from pathlib import Path
@@ -994,13 +1012,13 @@ jobs:
         with:
           python-version: '3.12'
       - name: Download shard coverage data
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-shard-*
           path: coverage-artifacts
       - name: Combine and enforce
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
           python -m pip install --quiet coverage
           i=0
@@ -1016,7 +1034,7 @@ jobs:
           python -m coverage html -d coverage-html
 
       - name: Upload full coverage report
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
@@ -1027,9 +1045,9 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Not a main push — coverage is a trend floor, nothing to enforce
-        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
-        run: echo "coverage floor applies to pushes to main only; job succeeds so CI Gate can require it unconditionally"
+      - name: Not a landing event — coverage floor is merge_group/main-push only
+        if: github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: echo "coverage floor applies to merge_group and pushes to main; job succeeds so CI Gate can require it unconditionally"
 
   ci-gate:
     name: CI Gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,14 @@ name: CI
 # duration-balanced file shards, and JUnit reconstruction inside CI Gate.
 #
 # Two-tier merge-queue cutover (#6943 stage 2): one workflow, two events.
-# `pull_request` keeps the historical full required set until the reduction
-# commit; `merge_group` validates the queued merged tree (event SHA) and is
-# where coverage floor is enforced. CI Gate remains the sole required context
-# and reports on both events.
+# pull_request tier (light): ruff + fastlane + contracts + frontend.
+# merge_group / push / workflow_dispatch tier (full): light PLUS planner +
+# four shards + coverage floor. CI Gate remains the sole required context,
+# reports on both events, and fail-closes on missing/skipped required deps.
 #
-# Invariant (encodes #3873 #4888 #4936 #5351 #5354): pytest must NEVER be
-# selected or skipped by changed files. Five separate incidents shipped a
-# regression to main because a data-only change skipped pytest under a
-# path-filtered required check. Every required job below is unconditional,
-# except that pytest-fastlane uses changed files only to choose its separate
-# early signal; it never alters the full-suite plan or its shard execution.
+# Invariant (encodes #3873 #4888 #4936 #5351 #5354): on the full tier, pytest
+# must NEVER be selected or skipped by changed files. pytest-fastlane uses
+# changed files only as an early signal; it never replaces the shard plan.
 
 concurrency:
   # Event-prefixed groups so a PR push never shares a bucket with a
@@ -40,11 +37,36 @@ on:
 
 jobs:
   # ---------------------------------------------------------------------
+  # 0. ruff — light, always-on lint for both tiers (extracted from python so
+  #    the pull_request tier can require it without the four-shard suite).
+  # ---------------------------------------------------------------------
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: '.python-version'
+      - name: Install and run ruff
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff
+          python -m ruff check scripts/
+
+  # ---------------------------------------------------------------------
   # 1. pytest-plan — collect once, then produce all four LPT file plans from
   #    one duration dataset restored from a successful main run (#5744).
+  #    Full tier only (merge_group / push / workflow_dispatch).
   # ---------------------------------------------------------------------
   pytest-plan:
     name: Pytest plan
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -195,6 +217,7 @@ jobs:
   # #5776 hang investigation; one xdist session did not.
   python:
     name: Python (pytest) [${{ matrix.shard }}/4]
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -263,7 +286,6 @@ jobs:
           .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
             torch==2.13.0
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
-          .venv/bin/python -m pip install ruff
 
       - name: Save pip wheel cache
         if: steps.pip-wheel-cache.outputs.cache-hit != 'true'
@@ -313,9 +335,6 @@ jobs:
         with:
           path: ~/stanza_resources
           key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
-
-      - name: Ruff
-        run: .venv/bin/python -m ruff check scripts/
 
       - name: Download the single planner's shard plans
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -999,6 +1018,7 @@ jobs:
   # guarantee cross-family review flagged as a P1 when the reboot dropped it.
   coverage-floor:
     name: Coverage floor
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [python]
@@ -1055,6 +1075,7 @@ jobs:
     timeout-minutes: 10
     if: always()
     needs:
+      - ruff
       - pytest-plan
       - pytest-fastlane
       - python
@@ -1069,20 +1090,22 @@ jobs:
         with:
           python-version-file: '.python-version'
       - name: Download pytest plans and JUnit results
+        if: github.event_name != 'pull_request'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pytest-shard-*
           path: ci-artifacts
       - name: Verify pytest shard completeness
+        if: github.event_name != 'pull_request'
         run: python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir ci-artifacts
-      - name: Report required-job results
+      - name: Fail unless every event-required job succeeded
         env:
-          RESULTS: ${{ join(needs.*.result, ',') }}
+          EVENT_NAME: ${{ github.event_name }}
+          # Explicit pairs — join(needs.*.result) loses job ids and cannot
+          # distinguish expected PR-tier skips from unexpected ones.
+          RESULTS: >-
+            ruff=${{ needs.ruff.result }},pytest-plan=${{ needs.pytest-plan.result }},pytest-fastlane=${{ needs.pytest-fastlane.result }},python=${{ needs.python.result }},contracts=${{ needs.contracts.result }},frontend=${{ needs.frontend.result }},coverage-floor=${{ needs.coverage-floor.result }}
         run: |
-          echo "required job results: $RESULTS"
-
-      - name: Fail unless every required job succeeded
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-        run: |
-          echo "::error::A required CI job failed, was cancelled, or was unexpectedly skipped — see 'Report required-job results' for the per-job breakdown."
-          exit 1
+          python scripts/ci/gate_required_results.py \
+            --event "$EVENT_NAME" \
+            --results "$RESULTS"

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -10,78 +10,30 @@ name: Hygiene (advisory)
 #
 # #4811: the five former single-purpose jobs are one composite so a scripts/
 # touch cannot claim five concurrent runner slots while CI Gate waits.
+#
+# Merge-queue cutover (#6943 stage 2): removed from pull_request fan-out after
+# verifying branch protection required contexts == ["CI Gate"] only. Runs on
+# schedule (weekday signal), merge_group (landing tree), and workflow_dispatch.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.sha }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read
 
 on:
-  pull_request:
+  schedule:
+    # Weekdays 05:17 UTC — advisory drift signal without PR runner contention.
+    - cron: '17 5 * * 1-5'
+  merge_group:
   workflow_dispatch:
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      python: ${{ steps.filter.outputs.python }}
-      agent_config: ${{ steps.filter.outputs.agent_config }}
-      postmortems: ${{ steps.filter.outputs.postmortems }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: ./.github/actions/paths-filter-retry
-        id: filter
-        with:
-          filters: |
-            python:
-              - '.github/workflows/hygiene.yml'
-              - 'requirements*.txt'
-              - 'requirements.lock'
-              - 'pyproject.toml'
-              - 'scripts/**/*.py'
-              - 'tests/**/*.py'
-            agent_config:
-              - '.github/workflows/hygiene.yml'
-              - '.mcp.json'
-              - '.cursor/mcp.json'
-              - 'AGENTS.md'
-              - 'CLAUDE.md'
-              - 'GEMINI.md'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'start-claude.sh'
-              - 'scripts/lib/handoff_identity.sh'
-              - 'start-codex.sh'
-              - 'scripts/check_rules_deployment.sh'
-              - 'scripts/deploy_prompts.sh'
-              - 'scripts/lint/**/*.py'
-              - 'scripts/lint_prompts.py'
-              - 'agents_extensions/shared/**'
-              - 'agents_extensions/codex/**'
-              - 'gemini_extensions/**'
-              - 'scripts/build/phases/**/*.md'
-              - 'docs/l2-uk-en/template_mappings.yaml'
-              - 'docs/l2-uk-en/templates/**'
-              - 'docs/prompts/orchestrators/**'
-            postmortems:
-              - '.github/workflows/hygiene.yml'
-              - 'docs/bug-autopsies/**'
-              - 'scripts/audit/check_postmortems.py'
-
   hygiene-checks:
     name: Hygiene checks
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [changes]
-    if: >-
-      needs.changes.outputs.python == 'true'
-      || needs.changes.outputs.agent_config == 'true'
-      || needs.changes.outputs.postmortems == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -93,39 +45,26 @@ jobs:
           python-version: '3.12'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: needs.changes.outputs.agent_config == 'true'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Install radon
-        if: needs.changes.outputs.python == 'true'
+        if: github.event_name == 'merge_group'
         run: pip install radon
 
       - name: Collect changed scripts for radon
-        if: needs.changes.outputs.python == 'true'
+        if: github.event_name == 'merge_group'
         id: changed-scripts
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          PUSH_HEAD_SHA: ${{ github.sha }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            base_sha="$PR_BASE_SHA"
-            head_sha="$PR_HEAD_SHA"
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            base_sha="$PUSH_BEFORE_SHA"
-            head_sha="$PUSH_HEAD_SHA"
-          else
-            echo "ℹ️ Skipping changed-file collection on $EVENT_NAME"
-            echo "files=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$base_sha" =~ ^0+$ ]]; then
+          set -euo pipefail
+          base_sha="$MERGE_BASE_SHA"
+          head_sha="$MERGE_HEAD_SHA"
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
             base_sha="$(git merge-base origin/main "$head_sha")"
           fi
 
@@ -150,7 +89,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: No F-grade functions in changed files (CC > 40)
-        if: needs.changes.outputs.python == 'true' && steps.changed-scripts.outputs.files != ''
+        if: github.event_name == 'merge_group' && steps.changed-scripts.outputs.files != ''
         env:
           CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
         run: |
@@ -164,7 +103,7 @@ jobs:
           echo "✅ No F-grade functions in changed files"
 
       - name: No MI=C files in changed files (MI < 10)
-        if: needs.changes.outputs.python == 'true' && steps.changed-scripts.outputs.files != ''
+        if: github.event_name == 'merge_group' && steps.changed-scripts.outputs.files != ''
         env:
           CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
         run: |
@@ -178,26 +117,16 @@ jobs:
           echo "✅ No MI=C files in changed files"
 
       - name: Check for non-stub scripts in scripts/ root
-        if: needs.changes.outputs.python == 'true'
+        if: github.event_name == 'merge_group'
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          PUSH_HEAD_SHA: ${{ github.sha }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            base_sha="$PR_BASE_SHA"
-            head_sha="$PR_HEAD_SHA"
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            base_sha="$PUSH_BEFORE_SHA"
-            head_sha="$PUSH_HEAD_SHA"
-          else
-            echo "ℹ️ Skipping root-script diff on $EVENT_NAME"
-            exit 0
-          fi
+          set -euo pipefail
+          base_sha="$MERGE_BASE_SHA"
+          head_sha="$MERGE_HEAD_SHA"
 
-          if [[ "$base_sha" =~ ^0+$ ]]; then
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
             base_sha="$(git merge-base origin/main "$head_sha")"
           fi
 
@@ -236,18 +165,15 @@ jobs:
           echo "✅ No new root-level scripts"
 
       - name: Lint prompt templates
-        if: needs.changes.outputs.python == 'true' || needs.changes.outputs.agent_config == 'true'
         run: python scripts/lint/lint_prompts.py
 
       # Direct file path (NOT `-m`): the checker is stdlib-only, but `-m`
       # would import scripts.audit/__init__ which needs pyyaml (absent on
       # bare setup-python).
       - name: Validate bug-autopsy fields + INDEX freshness (#3725)
-        if: needs.changes.outputs.postmortems == 'true'
         run: python scripts/audit/check_postmortems.py --check
 
       - name: Validate agent JSON config
-        if: needs.changes.outputs.agent_config == 'true'
         run: |
           jq empty \
             .mcp.json \
@@ -258,7 +184,6 @@ jobs:
           fi
 
       - name: Validate agent shell entrypoints
-        if: needs.changes.outputs.agent_config == 'true'
         run: |
           bash -n \
             start-claude.sh \
@@ -281,20 +206,17 @@ jobs:
             scripts/check_rules_deployment.sh
 
       - name: Create local test venv
-        if: needs.changes.outputs.agent_config == 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install pytest pyyaml
 
       - name: Verify agent extension deployment
-        if: needs.changes.outputs.agent_config == 'true'
         run: |
           npm run agents:deploy --silent
           bash scripts/check_rules_deployment.sh
 
       - name: Run focused agent config tests
-        if: needs.changes.outputs.agent_config == 'true'
         run: |
           .venv/bin/python -m pytest \
             tests/test_deploy_script_idempotency.py \

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -2,27 +2,24 @@ name: Security Audit (advisory)
 
 # Report-only dependency-vulnerability visibility over the dependabot backlog.
 # This NEVER blocks a PR — it is a dashboard, not a gate. Deterministic merge
-# gating stays with `Test (pytest)` (branch protection) and code-level findings
-# stay with CodeQL. Promote a step to a hard gate (drop `continue-on-error`)
-# only once the existing backlog is drained, or branch protection would wedge.
+# gating stays with `CI Gate` (branch protection / merge queue) and code-level
+# findings stay with CodeQL. Promote a step to a hard gate (drop
+# `continue-on-error`) only once the existing backlog is drained, or branch
+# protection would wedge.
+#
+# Merge-queue cutover (#6943 stage 2): removed from pull_request after verifying
+# required contexts == ["CI Gate"] only. Weekly schedule + manual dispatch.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.sha }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 on:
-  pull_request:
-    paths:
-      - 'requirements*.txt'
-      - 'requirements.lock'
-      - 'pyproject.toml'
-      - 'site/package*.json'
-      - '.github/workflows/security-audit.yml'
   schedule:
-    # Weekly Monday 09:00 UTC — surfaces newly-disclosed advisories between PRs.
+    # Weekly Monday 09:00 UTC — surfaces newly-disclosed advisories between landings.
     - cron: '0 9 * * 1'
   workflow_dispatch: {}
 

--- a/.github/workflows/ui-policy-gate.yml
+++ b/.github/workflows/ui-policy-gate.yml
@@ -7,16 +7,19 @@ name: UI Policy Gate (advisory)
 # protection's required checks without an explicit operator/advisor decision.
 # A red run here signals a policy regression to investigate; it never blocks
 # a merge on its own.
+#
+# Merge-queue cutover (#6943 stage 2): removed from pull_request after verifying
+# required contexts == ["CI Gate"] only. `paths:` is not valid on merge_group
+# (actionlint), and a full Playwright build on every landing is too expensive
+# for an advisory signal — schedule + workflow_dispatch instead.
 
 permissions:
   contents: read
 
 on:
-  pull_request:
-    paths:
-      - 'site/**'
-      - 'scripts/practice/**'
-      - '.github/workflows/ui-policy-gate.yml'
+  schedule:
+    # Weekdays 06:40 UTC — advisory UI signal without PR / merge_group contention.
+    - cron: '40 6 * * 1-5'
   workflow_dispatch:
 
 jobs:

--- a/docs/runbooks/ci-gate.md
+++ b/docs/runbooks/ci-gate.md
@@ -7,13 +7,21 @@ an operational guard, not a change to `ci.yml`'s job graph or `CI Gate` needs.
 ## CI Gate
 
 `CI Gate` is the repository's single required check. It is the final job in
-`.github/workflows/ci.yml` and succeeds only when its unconditional required
-dependencies succeed: pytest planning, the `pytest-fastlane` result, all four
-pytest shards, contracts, frontend, and the coverage floor. The fastlane's
-changed-file selection is only an early signal: it runs directly changed test
-modules first, but never selects, skips, or replaces the full-suite shard plan.
-The workflow remains the authoritative job composition; this runbook
-deliberately does not duplicate its YAML.
+`.github/workflows/ci.yml` and succeeds only when every dependency required
+*for that event* succeeds:
+
+- **pull_request (light tier):** `ruff`, `pytest-fastlane`, `contracts`,
+  `frontend`. Planner / four shards / coverage floor are intentionally skipped.
+- **merge_group / push / workflow_dispatch (full tier):** the light set plus
+  `pytest-plan`, all four `python` shards, and `coverage-floor`. Skipped ≠
+  success on this tier.
+
+Aggregation is `scripts/ci/gate_required_results.py` (fail-closed on missing,
+failed, cancelled, or unexpectedly skipped required jobs). The fastlane's
+changed-file selection is only an early signal: it never selects, skips, or
+replaces the full-suite shard plan on the full tier. The workflow remains the
+authoritative job composition; this runbook deliberately does not duplicate
+its YAML.
 
 The contracts job's BIO preparation validation is load-bearing. In particular,
 an active BIO hold must continue to fail closed (`PREPARATION_HOLD_ACTIVE`),

--- a/scripts/ci/gate_required_results.py
+++ b/scripts/ci/gate_required_results.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Event-aware CI Gate aggregation for the two-tier merge-queue cutover.
+
+``CI Gate`` is the sole required check context. It must report on both
+``pull_request`` and ``merge_group`` and fail closed when any dependency that
+is required *for that event* is failed, cancelled, skipped, or missing.
+
+Skipped ≠ success for a required dependency. Jobs that are intentionally out
+of the pull_request tier may be skipped on PRs; the same skip on
+``merge_group`` (or push / workflow_dispatch) is a gate failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Mapping
+
+# Light PR tier: early signal without the four-shard suite.
+LIGHT_REQUIRED: tuple[str, ...] = (
+    "ruff",
+    "pytest-fastlane",
+    "contracts",
+    "frontend",
+)
+
+# Merge-queue / main / dispatch tier: strictly a superset of the light tier.
+FULL_REQUIRED: tuple[str, ...] = LIGHT_REQUIRED + (
+    "pytest-plan",
+    "python",
+    "coverage-floor",
+)
+
+FULL_TIER_EVENTS: frozenset[str] = frozenset(
+    {"merge_group", "push", "workflow_dispatch"}
+)
+
+SUCCESS = "success"
+
+
+def required_jobs(event_name: str) -> tuple[str, ...]:
+    """Return the job ids CI Gate must see as success for this event."""
+    if event_name == "pull_request":
+        return LIGHT_REQUIRED
+    if event_name in FULL_TIER_EVENTS:
+        return FULL_REQUIRED
+    # Unknown events fail closed as full tier — never treat as light.
+    return FULL_REQUIRED
+
+
+def evaluate_gate(
+    event_name: str,
+    results: Mapping[str, str],
+) -> list[str]:
+    """Return human-readable failure reasons (empty ⇒ gate green).
+
+    ``results`` maps job id → GitHub ``needs.<job>.result`` string.
+    Missing keys for required jobs are failures (not silent success).
+    """
+    failures: list[str] = []
+    required = required_jobs(event_name)
+    for job in required:
+        if job not in results:
+            failures.append(f"{job}: missing (required for {event_name})")
+            continue
+        outcome = results[job]
+        if outcome != SUCCESS:
+            failures.append(f"{job}: {outcome} (required for {event_name})")
+    return failures
+
+
+def parse_results(raw: str) -> dict[str, str]:
+    """Parse ``job=result,job=result`` from the workflow env."""
+    results: dict[str, str] = {}
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise ValueError(f"malformed result entry (expected job=result): {item!r}")
+        job, _, outcome = item.partition("=")
+        job, outcome = job.strip(), outcome.strip()
+        if not job or not outcome:
+            raise ValueError(f"malformed result entry: {item!r}")
+        results[job] = outcome
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event",
+        required=True,
+        help="github.event_name (pull_request|merge_group|push|workflow_dispatch)",
+    )
+    parser.add_argument(
+        "--results",
+        required=True,
+        help="Comma-separated job=result pairs from needs.*.result",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        results = parse_results(args.results)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    failures = evaluate_gate(args.event, results)
+    print(f"event={args.event}")
+    print(f"required={','.join(required_jobs(args.event))}")
+    print(f"results={args.results}")
+    if failures:
+        for reason in failures:
+            print(f"::error::CI Gate fail-closed: {reason}", file=sys.stderr)
+        return 1
+    print("CI Gate: every required dependency succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/gate_required_results.py
+++ b/scripts/ci/gate_required_results.py
@@ -25,7 +25,8 @@ LIGHT_REQUIRED: tuple[str, ...] = (
 )
 
 # Merge-queue / main / dispatch tier: strictly a superset of the light tier.
-FULL_REQUIRED: tuple[str, ...] = LIGHT_REQUIRED + (
+FULL_REQUIRED: tuple[str, ...] = (
+    *LIGHT_REQUIRED,
     "pytest-plan",
     "python",
     "coverage-floor",

--- a/tests/test_ci_gate_required_results.py
+++ b/tests/test_ci_gate_required_results.py
@@ -1,0 +1,93 @@
+"""Unit tests for event-aware CI Gate fail-closed aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci.gate_required_results import (
+    FULL_REQUIRED,
+    LIGHT_REQUIRED,
+    evaluate_gate,
+    main,
+    parse_results,
+    required_jobs,
+)
+
+
+def _full_success() -> dict[str, str]:
+    return {job: "success" for job in FULL_REQUIRED}
+
+
+def test_required_jobs_pull_request_is_light_tier() -> None:
+    assert required_jobs("pull_request") == LIGHT_REQUIRED
+    assert "pytest-plan" not in LIGHT_REQUIRED
+    assert "python" not in LIGHT_REQUIRED
+    assert "coverage-floor" not in LIGHT_REQUIRED
+
+
+def test_required_jobs_merge_group_is_full_superset() -> None:
+    assert required_jobs("merge_group") == FULL_REQUIRED
+    assert set(LIGHT_REQUIRED) <= set(FULL_REQUIRED)
+
+
+def test_required_jobs_push_and_dispatch_are_full() -> None:
+    assert required_jobs("push") == FULL_REQUIRED
+    assert required_jobs("workflow_dispatch") == FULL_REQUIRED
+
+
+def test_unknown_event_fails_closed_as_full_tier() -> None:
+    assert required_jobs("schedule") == FULL_REQUIRED
+
+
+def test_merge_group_green_when_all_full_deps_succeed() -> None:
+    assert evaluate_gate("merge_group", _full_success()) == []
+
+
+def test_pull_request_green_when_light_deps_succeed_and_full_skipped() -> None:
+    results = {job: "success" for job in LIGHT_REQUIRED}
+    results["pytest-plan"] = "skipped"
+    results["python"] = "skipped"
+    results["coverage-floor"] = "skipped"
+    assert evaluate_gate("pull_request", results) == []
+
+
+def test_merge_group_rejects_skipped_full_tier_dep() -> None:
+    results = _full_success()
+    results["python"] = "skipped"
+    failures = evaluate_gate("merge_group", results)
+    assert any("python: skipped" in item for item in failures)
+
+
+def test_merge_group_rejects_missing_dep() -> None:
+    results = _full_success()
+    del results["coverage-floor"]
+    failures = evaluate_gate("merge_group", results)
+    assert any("coverage-floor: missing" in item for item in failures)
+
+
+@pytest.mark.parametrize("bad", ["failure", "cancelled", "skipped"])
+def test_pull_request_rejects_bad_light_dep(bad: str) -> None:
+    results = {job: "success" for job in LIGHT_REQUIRED}
+    results["contracts"] = bad
+    failures = evaluate_gate("pull_request", results)
+    assert any(f"contracts: {bad}" in item for item in failures)
+
+
+def test_parse_results_round_trip() -> None:
+    assert parse_results("ruff=success,contracts=failure") == {
+        "ruff": "success",
+        "contracts": "failure",
+    }
+
+
+def test_main_exit_codes(capsys: pytest.CaptureFixture[str]) -> None:
+    full = ",".join(f"{job}=success" for job in FULL_REQUIRED)
+    assert main(["--event", "merge_group", "--results", full]) == 0
+    bad = full.replace("python=success", "python=skipped")
+    assert main(["--event", "merge_group", "--results", bad]) == 1
+    err = capsys.readouterr().err
+    assert "python: skipped" in err
+
+
+def test_main_malformed_results() -> None:
+    assert main(["--event", "pull_request", "--results", "not-a-pair"]) == 2

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -47,6 +47,7 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     assert "trufflesecurity/trufflehog@" in contracts_steps
     assert "lint_pr_closing_references.py" in contracts_steps
     assert set(jobs["ci-gate"]["needs"]) == {
+        "ruff",
         "pytest-plan",
         "pytest-fastlane",
         "python",
@@ -54,7 +55,15 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
         "frontend",
         "coverage-floor",
     }
-
+    assert jobs["pytest-plan"].get("if") == "github.event_name != 'pull_request'"
+    assert jobs["python"].get("if") == "github.event_name != 'pull_request'"
+    assert jobs["coverage-floor"].get("if") == "github.event_name != 'pull_request'"
+    assert "ruff" in jobs
+    gate_steps = "\n".join(
+        step.get("name", "") + "\n" + str(step.get("run", "")) for step in jobs["ci-gate"]["steps"]
+    )
+    assert "gate_required_results.py" in gate_steps
+    assert "contains(needs.*.result, 'skipped')" not in gate_steps
 
 def test_frontend_e2e_waits_for_ci_gate_success() -> None:
     e2e = _load(_CI)["jobs"]["frontend-e2e"]

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -84,6 +84,7 @@ def test_always_on_parallel_runner_slots_stay_within_budget() -> None:
 def test_hygiene_uses_one_composite_checks_job() -> None:
     jobs = _load(_HYGIENE)["jobs"]
     assert "hygiene-checks" in jobs
+    assert "changes" not in jobs, "path-filter job retired with PR fan-out trim (#6943)"
     for retired in (
         "quality-gates",
         "lint-prompts",
@@ -93,6 +94,26 @@ def test_hygiene_uses_one_composite_checks_job() -> None:
     ):
         assert retired not in jobs, f"{retired} must stay folded into hygiene-checks (#4811)"
 
+
+def test_hygiene_left_pull_request_fanout() -> None:
+    triggers = _triggers(_load(_HYGIENE))
+    assert "pull_request" not in triggers
+    assert "schedule" in triggers
+    assert "merge_group" in triggers
+    assert "workflow_dispatch" in triggers
+
+
+def test_security_and_ui_policy_left_pull_request_fanout() -> None:
+    security = _REPO_ROOT / ".github/workflows/security-audit.yml"
+    ui = _REPO_ROOT / ".github/workflows/ui-policy-gate.yml"
+    sec_triggers = _triggers(_load(security))
+    ui_triggers = _triggers(_load(ui))
+    assert "pull_request" not in sec_triggers
+    assert "schedule" in sec_triggers
+    assert "pull_request" not in ui_triggers
+    assert "schedule" in ui_triggers
+    assert "workflow_dispatch" in ui_triggers
+    # paths: is invalid on merge_group (actionlint); UI policy stays schedule-only.
 
 def test_recovery_workflow_is_schedule_dispatch_default_branch_and_write_scoped() -> None:
     workflow = _load(_RECOVERY)

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -198,16 +198,17 @@ def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
     assert "pytest_shards.py plan" in workflow
     assert workflow.count("pytest_shards.py plan") == 1
     assert "pytest_shards.py verify-artifacts" in workflow
+    assert "gate_required_results.py" in workflow
     assert "--dist=loadfile" in workflow
     assert "-m 'not atlas_release and not slow'" in workflow
     assert workflow.count("-m 'not atlas_release and not slow'") >= 2
     assert "name: CI Gate" in workflow
+    assert "name: Ruff" in workflow
     assert "pytest-slow-nightly" not in workflow
     assert "-m 'slow and not atlas_release'" in nightly
     assert "Create or update infra issue on failure" in nightly
     assert "area:infra" in nightly
     assert nightly.splitlines()[0] == "name: Pytest slow nightly"
-
 
 def test_required_markexpr_constant_matches_ci_and_addopts_boundary() -> None:
     """addopts stays atlas-only; required gate adds not slow via CLI -m everywhere."""

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -378,7 +378,10 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
     jobs = workflow["jobs"]
 
     assert "if" not in jobs["frontend"]
+    # Two-tier cutover (#6943 stage 2): CI Gate also needs `ruff` so the
+    # pull_request light tier can require lint without the four-shard suite.
     assert set(jobs["ci-gate"]["needs"]) == {
+        "ruff",
         "pytest-plan",
         "pytest-fastlane",
         "python",

--- a/tests/test_paths_filter_fail_open.py
+++ b/tests/test_paths_filter_fail_open.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _ACTION_FILE = _REPO_ROOT / ".github" / "actions" / "paths-filter-retry" / "action.yml"
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
 # ci.yml's required jobs are unconditional as of the CI reboot (#5762) — it no
-# longer has a `changes` job. The action is still consumed by the advisory
-# workflows below, where a path-filter skip is a non-event, not a silent
-# regression.
-_CONTENT_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "content-ci.yml"
-_HYGIENE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "hygiene.yml"
+# longer has a `changes` job. Hygiene dropped the action when it left the PR
+# fan-out (#6943 stage 2). Remaining consumers must still fail-open onto
+# declared outputs; a skip from a missing output is a silent regression.
+_HYGIENE_WORKFLOW = _WORKFLOWS_DIR / "hygiene.yml"
+_ACTION_USES_MARKER = "paths-filter-retry"
 
 
 def test_action_metadata_exists_and_parses() -> None:
@@ -86,31 +88,67 @@ def test_fail_open_sets_all_declared_outputs_to_true() -> None:
     )
 
 
+def _iter_uses(node: object) -> Iterator[str]:
+    if isinstance(node, dict):
+        uses = node.get("uses")
+        if isinstance(uses, str):
+            yield uses
+        for value in node.values():
+            yield from _iter_uses(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_uses(item)
+
+
+def _workflow_consumes_paths_filter(wf_data: dict) -> bool:
+    return any(_ACTION_USES_MARKER in uses for uses in _iter_uses(wf_data))
+
+
+def test_hygiene_does_not_consume_paths_filter() -> None:
+    """Advisory hygiene (#6943) is unfiltered; a `changes` job would be old shape."""
+    assert _HYGIENE_WORKFLOW.is_file(), f"Missing workflow file: {_HYGIENE_WORKFLOW}"
+    wf_data = yaml.safe_load(_HYGIENE_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(wf_data, dict)
+    assert not _workflow_consumes_paths_filter(wf_data)
+    assert "changes" not in wf_data.get("jobs", {})
+
+
 def test_workflows_only_consume_valid_action_outputs() -> None:
     action_data = yaml.safe_load(_ACTION_FILE.read_text(encoding="utf-8"))
     action_outputs = set(action_data.get("outputs", {}).keys())
 
-    for wf_path in (_CONTENT_CI_WORKFLOW, _HYGIENE_WORKFLOW):
-        assert wf_path.is_file(), f"Missing workflow file: {wf_path}"
+    consumers = sorted(
+        path
+        for path in _WORKFLOWS_DIR.glob("*.yml")
+        if _workflow_consumes_paths_filter(yaml.safe_load(path.read_text(encoding="utf-8")))
+    )
+    assert consumers, (
+        "No workflow consumes paths-filter-retry; fail-open output mapping is untested"
+    )
+
+    for wf_path in consumers:
         wf_data = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        jobs = wf_data.get("jobs", {})
+        consumer_jobs = [
+            (name, job)
+            for name, job in jobs.items()
+            if _workflow_consumes_paths_filter(job)
+        ]
+        assert consumer_jobs, f"{wf_path.name} uses the action but no job owns the step"
 
-        # Find the 'changes' job
-        changes_job = wf_data.get("jobs", {}).get("changes", {})
-        assert changes_job, f"Missing 'changes' job in {wf_path.name}"
+        for job_name, job in consumer_jobs:
+            outputs = job.get("outputs", {})
+            assert outputs, f"No outputs declared in {job_name} of {wf_path.name}"
 
-        # Find the output mappings of the 'changes' job
-        outputs = changes_job.get("outputs", {})
-        assert outputs, f"No outputs declared in changes job of {wf_path.name}"
-
-        for out_name, out_val in outputs.items():
-            # The value should look like: ${{ steps.filter.outputs.<key> }}
-            match = re.match(r"\$\{\{\s*steps\.filter\.outputs\.(\w+)\s*\}\}", out_val)
-            assert match, (
-                f"Job output '{out_name}' value '{out_val}' in {wf_path.name} "
-                f"does not match steps.filter.outputs.<key> syntax"
-            )
-            step_output_key = match.group(1)
-            assert step_output_key in action_outputs, (
-                f"Workflow {wf_path.name} references step output '{step_output_key}' "
-                f"which is not declared in action.yml"
-            )
+            for out_name, out_val in outputs.items():
+                # The value should look like: ${{ steps.filter.outputs.<key> }}
+                match = re.match(r"\$\{\{\s*steps\.filter\.outputs\.(\w+)\s*\}\}", str(out_val))
+                assert match, (
+                    f"Job output '{out_name}' value '{out_val}' in {wf_path.name} "
+                    f"does not match steps.filter.outputs.<key> syntax"
+                )
+                step_output_key = match.group(1)
+                assert step_output_key in action_outputs, (
+                    f"Workflow {wf_path.name} references step output '{step_output_key}' "
+                    f"which is not declared in action.yml"
+                )

--- a/tests/test_workflow_head_concurrency.py
+++ b/tests/test_workflow_head_concurrency.py
@@ -1,4 +1,10 @@
-"""Guard PR workflow concurrency against ref-keyed TOCTOU cancellation."""
+"""Guard workflow concurrency against ref-keyed TOCTOU cancellation.
+
+Two-tier cutover (#6943 stage 2): dual-event / advisory workflows prefix the
+group with ``github.event_name`` so a PR push cannot share a bucket with a
+queued ``merge_group`` run. PR-only workflows keep the original head-SHA
+group. ``merge_group`` must never set ``cancel-in-progress: true``.
+"""
 
 from __future__ import annotations
 
@@ -8,29 +14,63 @@ import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_HEAD_SHA_GROUP = "${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}"
+_PR_HEAD_GROUP = "${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}"
+_EVENT_PR_HEAD_GROUP = (
+    "${{ github.workflow }}-${{ github.event_name }}-"
+    "${{ github.event.pull_request.head.sha || github.ref }}"
+)
+_EVENT_SHA_GROUP = "${{ github.workflow }}-${{ github.event_name }}-${{ github.sha }}"
 _WORKFLOW_EXPECTATIONS = {
-    ".github/workflows/ci.yml": "${{ github.event_name == 'pull_request' }}",
-    ".github/workflows/content-ci.yml": True,
-    ".github/workflows/hygiene.yml": True,
-    ".github/workflows/security-audit.yml": True,
-    ".github/workflows/zizmor.yml": True,
+    ".github/workflows/ci.yml": {
+        "group": _EVENT_PR_HEAD_GROUP,
+        "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+    },
+    ".github/workflows/content-ci.yml": {
+        "group": _PR_HEAD_GROUP,
+        "cancel-in-progress": True,
+    },
+    ".github/workflows/hygiene.yml": {
+        "group": _EVENT_SHA_GROUP,
+        "cancel-in-progress": "${{ github.event_name != 'merge_group' }}",
+    },
+    ".github/workflows/security-audit.yml": {
+        "group": _EVENT_SHA_GROUP,
+        "cancel-in-progress": True,
+    },
+    ".github/workflows/zizmor.yml": {
+        "group": _PR_HEAD_GROUP,
+        "cancel-in-progress": True,
+    },
 }
 
 
 @pytest.mark.parametrize(
-    ("relative_path", "expected_cancellation"),
+    ("relative_path", "expected"),
     _WORKFLOW_EXPECTATIONS.items(),
 )
 def test_workflow_concurrency_is_head_sha_keyed_and_preserves_cancellation(
     relative_path: str,
-    expected_cancellation: bool | str,
+    expected: dict[str, str | bool],
 ) -> None:
-    """Each scoped workflow isolates PR runs by immutable head and keeps its policy."""
+    """Each scoped workflow isolates runs by immutable identity and keeps its policy."""
     workflow_path = _REPO_ROOT / relative_path
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
-    assert workflow["concurrency"] == {
-        "group": _HEAD_SHA_GROUP,
-        "cancel-in-progress": expected_cancellation,
-    }
+    assert workflow["concurrency"] == expected
+
+
+def test_merge_group_workflows_do_not_unconditionally_cancel() -> None:
+    """A queued merge_group run must not be cancelled by a later run in the same workflow."""
+    workflows_dir = _REPO_ROOT / ".github" / "workflows"
+    for path in sorted(workflows_dir.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        triggers = workflow.get("on", workflow.get(True))
+        if not isinstance(triggers, dict) or "merge_group" not in triggers:
+            continue
+        cancel = workflow.get("concurrency", {}).get("cancel-in-progress")
+        assert cancel is not True, (
+            f"{path.name} fires on merge_group but cancel-in-progress is unconditionally true"
+        )
+        assert "github.event_name" in str(cancel), (
+            f"{path.name} must gate cancel-in-progress on event_name so merge_group is kept"
+        )


### PR DESCRIPTION
## Summary

Stage 2 of the CI overhaul (#6943): PR pushes get a light required tier; the full fast suite validates the **queued merged tree** via `merge_group`. Strictly stronger than today once the merge queue is enabled — the suite tests the tree that lands, not a stale PR head.

**Required contexts inventory (implementation-time):**
```
GET .../branches/main/protection/required_status_checks
→ contexts: ["CI Gate"]   checks: [{context: "CI Gate", app_id: 15368}]
```
Only `CI Gate` is pinned — advisory fan-out trim is safe.

### Commits (ordered)

1. **`127d0cd9a9`** — dual-event hardening **without** shrinking the PR tier: event-prefixed concurrency, merge_group-safe PR-payload fallbacks, coverage floor on `merge_group`, advisory workflows off `pull_request`, fail-closed aggregator module + tests.
2. **`1d625450da`** — PR-tier reduction: light `pull_request` needs (`ruff` + fastlane + contracts + frontend); full tier on `merge_group` / push / `workflow_dispatch`; CI Gate wires `scripts/ci/gate_required_results.py`.

### Event-aware tiers

| Event | Required deps (CI Gate) |
| --- | --- |
| `pull_request` | ruff, pytest-fastlane, contracts, frontend |
| `merge_group` / `push` / `workflow_dispatch` | light **plus** pytest-plan, python×4, coverage-floor |

Skipped ≠ success for a required dep. Missing deps fail closed.

### Advisory fan-out (independence proven)

| Workflow | Before | After |
| --- | --- | --- |
| Hygiene | `pull_request` | `schedule` + `merge_group` + `workflow_dispatch` |
| Security Audit | path `pull_request` + schedule | schedule + `workflow_dispatch` |
| UI Policy | path `pull_request` | schedule + `workflow_dispatch` (`paths:` invalid on `merge_group` per actionlint) |

## Driver checklist (BINDING — do not squash past this)

Hard ordering from advisory review (Sol + grok-4.6 GO-WITH-CHANGES):

1. **[ ] Enable merge queue on `main`** (ruleset: require merge queue; required status check = `CI Gate` on both PR and merge group). Record evidence (settings screenshot / API dump).
2. **[ ] Canary PR** through the queue **green** — quote `merge_group` run URL + wall-clock; confirm CI Gate reported on `merge_group`.
3. **[ ] Measure PR-tier wall-clock** on a post-reduction PR (this PR after merge, or canary after this lands). Operator target **1–2 min**. If measured **>2 min**, report the number + largest remaining cost (likely contracts) — do **not** silently cut checks.
4. **[ ] Merge this PR via the queue** (`gh pr merge --auto` enters the queue; it is not “merged” until the queue lands it). **NO worker auto-merge.**
5. **[ ] Fail-closed red path** — optional scratch branch with a deliberate red light-tier dep; confirm CI Gate rejects (aggregator mutation-checked locally below).

⚠️ Merging commit 2 **without** an enabled merge queue leaves main with a light PR tier and no full-suite pre-land gate. Queue enable + canary **before** merge is mandatory.

## Local proof

```
pytest tests/test_ci_gate_required_results.py tests/test_ci_queue_starvation.py \
       tests/test_ci_slot_inventory.py tests/test_ci_shard_partition.py
→ 45 passed

actionlint → all workflow files valid
slot_inventory --check → PASS 27/31

# Dry dual-event aggregation
pull_request + expected full-tier skips → exit 0
merge_group + all success → exit 0
merge_group + python=skipped → exit 1 (fail-closed)
```

## Test plan

- [ ] PR CI on this branch: light tier jobs green; pytest-plan/python/coverage-floor **skipped**; CI Gate green
- [ ] After queue enable: canary `merge_group` run URL quoted (full tier + coverage)
- [ ] CI Gate red path observed (scratch deliberate failure) or local mutation proof accepted
- [ ] Cross-family exact-head review before merge
- [ ] Timing: measured PR-tier minutes reported to driver/operator

Refs #6943


Made with [Cursor](https://cursor.com)