### PR TITLE
feat(fleet): settle-event idle reminder + report-only telemetry (#6976)

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -186,8 +186,21 @@ dependency/critical-path → utilization. Later items never override earlier one
    busywork (quality > utilization). Disk wins every conflict (#M-14 — `df` + `du` of
    `.worktrees` before fan-out; reap first).
 
-Mechanical enforcement (settle-event reminder + eligibility-aware idle/disposition
-telemetry) lives on #6976 — keep this prose and that tooling aligned.
+Mechanical reminder + report-only telemetry (#6976). At every dispatch/review
+settle, evaluate eligible ready items and WIP/resource caps. The reminder fires
+only when something is eligible; then dispatch or pass one of the six codes.
+Unknown codes are rejected. Missing action is recorded, not gated. Do not add a
+raw idle-time threshold. `driver_breadth_report --enforce` remains the breadth
+floor only.
+
+```bash
+.venv/bin/python -m scripts.orchestration.dispatch_settle task --task-id <id> \
+  --idle-snapshot-json <snap.json> [--dispatched | --disposition <code>]
+.venv/bin/python -m scripts.fleet.idle_settle evaluate \
+  --snapshot-json <snap.json> --kind dispatch --task-id <id> \
+  [--dispatched | --disposition <code>]
+.venv/bin/python -m scripts.fleet.idle_settle report
+```
 
 ### 3. Route by model × harness fit
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1585,4 +1585,4 @@ The original 1:1 broker (separate from channels) is still available for low-leve
 
 ### Dispatch settle (Luna handoff)
 
-`.venv/bin/python -m scripts.orchestration.dispatch_settle task --task-id <id> --push --open-pr` — heal zombie task state, release inactive write claims, optionally push/open PR. Formal CF stays orchestrator-owned.
+`.venv/bin/python -m scripts.orchestration.dispatch_settle task --task-id <id> --push --open-pr` — heal zombie task state, release inactive write claims, optionally push/open PR. Formal CF stays orchestrator-owned. After closeout it evaluates the #6976 settle reminder when `--idle-snapshot-json` is supplied (`--dispatched` or `--disposition <code>`). Standalone: `.venv/bin/python -m scripts.fleet.idle_settle evaluate|report`.

--- a/scripts/fleet/driver_breadth_report.py
+++ b/scripts/fleet/driver_breadth_report.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from scripts.fleet import idle_settle as idle_settle
+
 ROOT = Path(__file__).resolve().parents[2]
 
 # Static agent→tier fallback (not a live model_catalog.yaml load).
@@ -201,6 +203,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to a written NOTE: fleet_breadth justification (waives --enforce fail)",
     )
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON only")
+    parser.add_argument(
+        "--idle-store",
+        type=Path,
+        default=None,
+        help="Optional idle-settle events JSONL to embed (report-only; ignored by --enforce)",
+    )
     args = parser.parse_args(argv)
 
     since = datetime.now(UTC) - timedelta(hours=args.since_hours)
@@ -209,6 +217,11 @@ def main(argv: list[str] | None = None) -> int:
     report["initiator_filter"] = args.initiator
     report["since_hours"] = args.since_hours
     report["generated_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    idle_path = args.idle_store if args.idle_store is not None else idle_settle.default_store_path()
+    if idle_path.is_file():
+        report["idle_settle"] = idle_settle.build_report(idle_settle.load_events(idle_path))
+    else:
+        report["idle_settle"] = None
 
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
@@ -227,6 +240,9 @@ def main(argv: list[str] | None = None) -> int:
             f"  breadth_floor_applies={report['breadth_floor_applies']} "
             f"ok={report['breadth_floor_ok']} ({report['breadth_floor_rule']})"
         )
+        idle = report.get("idle_settle")
+        if isinstance(idle, dict):
+            print(f"  idle_settle: {idle_settle.format_report(idle)}")
 
     if args.enforce and report["breadth_floor_applies"] and not report["breadth_floor_ok"]:
         if args.note_file and args.note_file.is_file():

--- a/scripts/fleet/idle_settle.py
+++ b/scripts/fleet/idle_settle.py
@@ -1,0 +1,780 @@
+#!/usr/bin/env python3
+"""Conditional settle-event reminder + eligibility-aware idle telemetry (#6976).
+
+Report-only. This module never gates a settle on raw idle time and never
+changes ``driver_breadth_report --enforce``. Invalid disposition codes are
+rejected as vocabulary errors; a missing dispatch-or-disposition is recorded
+as telemetry, not a hard fail.
+
+Eligibility (issue #6976): healthy available lane AND compatible / ready /
+valuable / independent item AND quota/capacity AND no review / CI / disk /
+dependency constraint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.common.repo_root import main_checkout_root
+
+ROOT = Path(__file__).resolve().parents[2]
+
+EVENT_SCHEMA = "fleet-idle-settle-event.v1"
+REPORT_SCHEMA = "fleet-idle-settle.v1"
+SNAPSHOT_SCHEMA = "fleet-idle-settle-snapshot.v1"
+
+DISPOSITION_CODES: frozenset[str] = frozenset(
+    {
+        "dependency_blocked",
+        "review_wip_cap",
+        "ci_capacity",
+        "disk_capacity",
+        "human_decision",
+        "no_ready_work",
+    }
+)
+
+SETTLE_KINDS: frozenset[str] = frozenset({"dispatch", "review"})
+_HEALTHY_STATUSES: frozenset[str] = frozenset({"cool", "warm", "idle"})
+_CONSTRAINT_CODES: tuple[str, ...] = ("review_wip_cap", "ci_capacity", "disk_capacity")
+
+
+def default_store_path(repo_root: Path | None = None) -> Path:
+    root = main_checkout_root(repo_root or ROOT)
+    return root / "batch_state" / "idle_settle" / "events.jsonl"
+
+
+def infer_settle_kind(task_id: str | None) -> str:
+    ident = (task_id or "").strip().lower()
+    return "review" if ident.startswith("review-") else "dispatch"
+
+
+def normalize_disposition(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def disposition_accepted(code: str | None) -> bool:
+    return code in DISPOSITION_CODES
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def utc_now(now: datetime | None = None) -> datetime:
+    if now is None:
+        return datetime.now(UTC)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
+
+
+def format_iso(now: datetime | None = None) -> str:
+    return utc_now(now).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class ReadyItem:
+    item_id: str
+    kind: str = "issue"
+    ready: bool = True
+    valuable: bool = True
+    independent: bool = True
+    compatible_lanes: tuple[str, ...] | None = None
+    dependency_blocked: bool = False
+
+    def is_fillable(self) -> bool:
+        return (
+            self.ready
+            and self.valuable
+            and self.independent
+            and not self.dependency_blocked
+        )
+
+
+@dataclass(frozen=True)
+class LaneState:
+    lane: str
+    status: str = "unknown"
+    in_flight: int = 0
+    will_last: bool | None = None
+    quota_ok: bool | None = None
+
+    def is_healthy_available(self) -> bool:
+        if self.status not in _HEALTHY_STATUSES:
+            return False
+        if int(self.in_flight or 0) != 0:
+            return False
+        if self.quota_ok is False:
+            return False
+        return self.will_last is not False
+
+
+@dataclass(frozen=True)
+class ResourceCaps:
+    review_in_flight: int = 0
+    review_wip_limit: int | None = None
+    ci_in_flight: int = 0
+    ci_capacity_ok: bool = True
+    disk_ok: bool = True
+
+    def active_constraints(self) -> tuple[str, ...]:
+        found: list[str] = []
+        if self.review_wip_limit is not None and self.review_in_flight >= self.review_wip_limit:
+            found.append("review_wip_cap")
+        if not self.ci_capacity_ok:
+            found.append("ci_capacity")
+        if not self.disk_ok:
+            found.append("disk_capacity")
+        return tuple(found)
+
+
+@dataclass(frozen=True)
+class EligibilitySnapshot:
+    lanes: tuple[LaneState, ...] = ()
+    items: tuple[ReadyItem, ...] = ()
+    caps: ResourceCaps = field(default_factory=ResourceCaps)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SNAPSHOT_SCHEMA,
+            "lanes": [asdict(lane) for lane in self.lanes],
+            "items": [
+                {
+                    **asdict(item),
+                    "compatible_lanes": (
+                        None if item.compatible_lanes is None else list(item.compatible_lanes)
+                    ),
+                }
+                for item in self.items
+            ],
+            "caps": asdict(self.caps),
+        }
+
+
+@dataclass(frozen=True)
+class EligiblePair:
+    lane: str
+    item_id: str
+
+
+@dataclass(frozen=True)
+class SettleDecision:
+    reminder_required: bool
+    reminder_fired: bool
+    eligible: bool
+    outcome: str
+    accepted: bool
+    disposition: str | None
+    disposition_valid: bool | None
+    disposition_honest: bool | None
+    dispatched: bool
+    eligible_pairs: tuple[EligiblePair, ...]
+    eligible_lanes: tuple[str, ...]
+    eligible_item_ids: tuple[str, ...]
+    active_constraints: tuple[str, ...]
+    caps: ResourceCaps
+    settle_kind: str
+    task_id: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reminder_required": self.reminder_required,
+            "reminder_fired": self.reminder_fired,
+            "eligible": self.eligible,
+            "outcome": self.outcome,
+            "accepted": self.accepted,
+            "disposition": self.disposition,
+            "disposition_valid": self.disposition_valid,
+            "disposition_honest": self.disposition_honest,
+            "dispatched": self.dispatched,
+            "eligible_pairs": [asdict(pair) for pair in self.eligible_pairs],
+            "eligible_lanes": list(self.eligible_lanes),
+            "eligible_item_ids": list(self.eligible_item_ids),
+            "active_constraints": list(self.active_constraints),
+            "caps": asdict(self.caps),
+            "settle_kind": self.settle_kind,
+            "task_id": self.task_id,
+            "report_only": True,
+        }
+
+
+def empty_snapshot() -> EligibilitySnapshot:
+    return EligibilitySnapshot()
+
+
+def parse_snapshot(payload: dict[str, Any] | None) -> EligibilitySnapshot:
+    data = payload if isinstance(payload, dict) else {}
+    lanes_raw = data.get("lanes") or []
+    items_raw = data.get("items") or []
+    caps_raw = data.get("caps") if isinstance(data.get("caps"), dict) else {}
+
+    lanes: list[LaneState] = []
+    for row in lanes_raw:
+        if not isinstance(row, dict):
+            continue
+        lane = str(row.get("lane") or "").strip()
+        if not lane:
+            continue
+        will_last = row.get("will_last")
+        quota_ok = row.get("quota_ok")
+        lanes.append(
+            LaneState(
+                lane=lane,
+                status=str(row.get("status") or "unknown"),
+                in_flight=int(row.get("in_flight") or 0),
+                will_last=None if will_last is None else bool(will_last),
+                quota_ok=None if quota_ok is None else bool(quota_ok),
+            )
+        )
+
+    items: list[ReadyItem] = []
+    for row in items_raw:
+        if not isinstance(row, dict):
+            continue
+        item_id = str(row.get("item_id") or "").strip()
+        if not item_id:
+            continue
+        compat = row.get("compatible_lanes")
+        compatible: tuple[str, ...] | None
+        if compat is None:
+            compatible = None
+        elif isinstance(compat, (list, tuple)):
+            compatible = tuple(str(name).strip() for name in compat if str(name).strip())
+        else:
+            compatible = None
+        items.append(
+            ReadyItem(
+                item_id=item_id,
+                kind=str(row.get("kind") or "issue"),
+                ready=bool(row.get("ready", True)),
+                valuable=bool(row.get("valuable", True)),
+                independent=bool(row.get("independent", True)),
+                compatible_lanes=compatible,
+                dependency_blocked=bool(row.get("dependency_blocked", False)),
+            )
+        )
+
+    limit_raw = caps_raw.get("review_wip_limit")
+    limit = None if limit_raw is None or limit_raw == "" else int(limit_raw)
+
+    caps = ResourceCaps(
+        review_in_flight=int(caps_raw.get("review_in_flight") or 0),
+        review_wip_limit=limit,
+        ci_in_flight=int(caps_raw.get("ci_in_flight") or 0),
+        ci_capacity_ok=bool(caps_raw.get("ci_capacity_ok", True)),
+        disk_ok=bool(caps_raw.get("disk_ok", True)),
+    )
+    return EligibilitySnapshot(lanes=tuple(lanes), items=tuple(items), caps=caps)
+
+
+def lanes_from_capacity_rows(rows: list[dict[str, Any]] | None) -> tuple[LaneState, ...]:
+    lanes: list[LaneState] = []
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+        lane = str(row.get("lane") or "").strip()
+        if not lane:
+            continue
+        will_last = row.get("will_last")
+        avoid = bool(row.get("avoid"))
+        quota_ok = False if avoid else None
+        lanes.append(
+            LaneState(
+                lane=lane,
+                status=str(row.get("status") or "unknown"),
+                in_flight=int(row.get("in_flight") or 0),
+                will_last=None if will_last is None else bool(will_last),
+                quota_ok=quota_ok,
+            )
+        )
+    return tuple(lanes)
+
+
+def items_from_work_next_queue(queue: list[dict[str, Any]] | None) -> tuple[ReadyItem, ...]:
+    items: list[ReadyItem] = []
+    for row in queue or []:
+        if not isinstance(row, dict):
+            continue
+        item_id = str(row.get("work_id") or row.get("item_id") or "").strip()
+        if not item_id:
+            continue
+        action = row.get("safe_next_action") if isinstance(row.get("safe_next_action"), dict) else {}
+        code = str(action.get("code") or "")
+        reasons = action.get("reason_codes") or []
+        dep_blocked = code == "RESOLVE_BLOCKER" or "blocked_by" in reasons or "dependency_cycle" in reasons
+        items.append(
+            ReadyItem(
+                item_id=item_id,
+                kind=str(row.get("resource_kind") or row.get("kind") or "issue"),
+                ready=True,
+                valuable=True,
+                independent=True,
+                compatible_lanes=None,
+                dependency_blocked=dep_blocked,
+            )
+        )
+    return tuple(items)
+
+
+def assemble_snapshot(
+    *,
+    capacity_rows: list[dict[str, Any]] | None = None,
+    work_next_queue: list[dict[str, Any]] | None = None,
+    review_in_flight: int = 0,
+    review_wip_limit: int | None = None,
+    ci_in_flight: int = 0,
+    ci_capacity_ok: bool = True,
+    disk_ok: bool = True,
+) -> EligibilitySnapshot:
+    return EligibilitySnapshot(
+        lanes=lanes_from_capacity_rows(capacity_rows),
+        items=items_from_work_next_queue(work_next_queue),
+        caps=ResourceCaps(
+            review_in_flight=review_in_flight,
+            review_wip_limit=review_wip_limit,
+            ci_in_flight=ci_in_flight,
+            ci_capacity_ok=ci_capacity_ok,
+            disk_ok=disk_ok,
+        ),
+    )
+
+
+def eligible_pairs(snapshot: EligibilitySnapshot) -> tuple[EligiblePair, ...]:
+    constraints = snapshot.caps.active_constraints()
+    if constraints:
+        return ()
+    pairs: list[EligiblePair] = []
+    healthy = [lane for lane in snapshot.lanes if lane.is_healthy_available()]
+    for item in snapshot.items:
+        if not item.is_fillable():
+            continue
+        for lane in healthy:
+            if item.compatible_lanes is not None and lane.lane not in item.compatible_lanes:
+                continue
+            pairs.append(EligiblePair(lane=lane.lane, item_id=item.item_id))
+    return tuple(pairs)
+
+
+def disposition_is_honest(snapshot: EligibilitySnapshot, code: str | None, *, eligible: bool) -> bool | None:
+    if code is None:
+        return None
+    if code not in DISPOSITION_CODES:
+        return None
+    if code == "human_decision":
+        return True
+    constraints = set(snapshot.caps.active_constraints())
+    if code == "no_ready_work":
+        return not eligible
+    if code in _CONSTRAINT_CODES:
+        return code in constraints
+    if code == "dependency_blocked":
+        return (not eligible) and any(item.dependency_blocked for item in snapshot.items)
+    return False
+
+
+def evaluate_settle(
+    snapshot: EligibilitySnapshot,
+    *,
+    dispatched: bool = False,
+    disposition: str | None = None,
+    settle_kind: str = "dispatch",
+    task_id: str | None = None,
+) -> SettleDecision:
+    kind = settle_kind if settle_kind in SETTLE_KINDS else infer_settle_kind(task_id)
+    code = normalize_disposition(disposition)
+    pairs = eligible_pairs(snapshot)
+    eligible = bool(pairs)
+    lanes = tuple(dict.fromkeys(pair.lane for pair in pairs))
+    item_ids = tuple(dict.fromkeys(pair.item_id for pair in pairs))
+    constraints = snapshot.caps.active_constraints()
+
+    if code is not None and not disposition_accepted(code):
+        return SettleDecision(
+            reminder_required=eligible,
+            reminder_fired=eligible,
+            eligible=eligible,
+            outcome="invalid_disposition",
+            accepted=False,
+            disposition=code,
+            disposition_valid=False,
+            disposition_honest=None,
+            dispatched=bool(dispatched),
+            eligible_pairs=pairs,
+            eligible_lanes=lanes,
+            eligible_item_ids=item_ids,
+            active_constraints=constraints,
+            caps=snapshot.caps,
+            settle_kind=kind,
+            task_id=task_id,
+        )
+
+    honest = disposition_is_honest(snapshot, code, eligible=eligible)
+    if not eligible:
+        return SettleDecision(
+            reminder_required=False,
+            reminder_fired=False,
+            eligible=False,
+            outcome="silent" if code is None else "disposed",
+            accepted=True,
+            disposition=code,
+            disposition_valid=None if code is None else True,
+            disposition_honest=honest,
+            dispatched=bool(dispatched),
+            eligible_pairs=(),
+            eligible_lanes=(),
+            eligible_item_ids=(),
+            active_constraints=constraints,
+            caps=snapshot.caps,
+            settle_kind=kind,
+            task_id=task_id,
+        )
+
+    if dispatched:
+        outcome = "dispatched"
+        accepted = True
+        reminder_required = False
+        reminder_fired = False
+    elif code is not None:
+        outcome = "disposed"
+        accepted = True
+        reminder_required = False
+        reminder_fired = False
+    else:
+        outcome = "missing_action"
+        accepted = False
+        reminder_required = True
+        reminder_fired = True
+
+    return SettleDecision(
+        reminder_required=reminder_required,
+        reminder_fired=reminder_fired,
+        eligible=True,
+        outcome=outcome,
+        accepted=accepted,
+        disposition=code,
+        disposition_valid=None if code is None else True,
+        disposition_honest=honest,
+        dispatched=bool(dispatched),
+        eligible_pairs=pairs,
+        eligible_lanes=lanes,
+        eligible_item_ids=item_ids,
+        active_constraints=constraints,
+        caps=snapshot.caps,
+        settle_kind=kind,
+        task_id=task_id,
+    )
+
+
+def format_reminder(decision: SettleDecision, snapshot: EligibilitySnapshot) -> str | None:
+    if not decision.eligible:
+        return None
+    lines = [
+        "SETTLE REMINDER: eligible ready work exists.",
+        f"  kind={decision.settle_kind} task_id={decision.task_id or '-'}",
+        f"  eligible_items={len(decision.eligible_item_ids)} eligible_lanes={','.join(decision.eligible_lanes) or '-'}",
+    ]
+    by_item: dict[str, list[str]] = {}
+    for pair in decision.eligible_pairs:
+        by_item.setdefault(pair.item_id, []).append(pair.lane)
+    item_meta = {item.item_id: item for item in snapshot.items}
+    for item_id, lanes in by_item.items():
+        meta = item_meta.get(item_id)
+        kind = meta.kind if meta is not None else "item"
+        lines.append(f"  - {item_id} ({kind}) lanes={','.join(lanes)}")
+    caps = decision.caps
+    limit = "-" if caps.review_wip_limit is None else str(caps.review_wip_limit)
+    lines.append(
+        "  caps: "
+        f"review_wip={caps.review_in_flight}/{limit} "
+        f"ci_in_flight={caps.ci_in_flight} ci_ok={caps.ci_capacity_ok} "
+        f"disk_ok={caps.disk_ok}"
+    )
+    if decision.reminder_required:
+        lines.append(
+            "  ACTION REQUIRED: dispatch a compatible ready item, or pass "
+            "--disposition with one of: " + " | ".join(sorted(DISPOSITION_CODES))
+        )
+    else:
+        lines.append(f"  satisfied via {decision.outcome}")
+    return "\n".join(lines)
+
+
+def load_events(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    events: list[dict[str, Any]] = []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    for line in raw.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def opportunity_seconds_since(previous: dict[str, Any] | None, now: datetime) -> float:
+    if not previous or not previous.get("eligible"):
+        return 0.0
+    prev_at = parse_iso(str(previous.get("recorded_at") or "") or None)
+    if prev_at is None:
+        return 0.0
+    delta = (utc_now(now) - prev_at).total_seconds()
+    return max(0.0, float(delta))
+
+
+def build_event(
+    decision: SettleDecision,
+    *,
+    previous: dict[str, Any] | None = None,
+    now: datetime | None = None,
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    stamp = utc_now(now)
+    return {
+        "schema": EVENT_SCHEMA,
+        "event_id": event_id or uuid.uuid4().hex,
+        "recorded_at": format_iso(stamp),
+        "settle_kind": decision.settle_kind,
+        "task_id": decision.task_id,
+        "eligible": decision.eligible,
+        "eligible_item_ids": list(decision.eligible_item_ids),
+        "eligible_lanes": list(decision.eligible_lanes),
+        "active_constraints": list(decision.active_constraints),
+        "dispatched": decision.dispatched,
+        "disposition": decision.disposition,
+        "disposition_valid": decision.disposition_valid,
+        "disposition_honest": decision.disposition_honest,
+        "reminder_fired": decision.reminder_fired,
+        "outcome": decision.outcome,
+        "opportunity_seconds_since_prev": opportunity_seconds_since(previous, stamp),
+        "report_only": True,
+    }
+
+
+def append_event(path: Path, event: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def record_settle(
+    path: Path,
+    decision: SettleDecision,
+    *,
+    now: datetime | None = None,
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    events = load_events(path)
+    previous = events[-1] if events else None
+    event = build_event(decision, previous=previous, now=now, event_id=event_id)
+    append_event(path, event)
+    return event
+
+
+def build_report(events: list[dict[str, Any]]) -> dict[str, Any]:
+    opportunity = 0.0
+    missing = 0
+    invalid = 0
+    dishonest = 0
+    dispatched = 0
+    disposed = 0
+    silent = 0
+    reminders = 0
+    for event in events:
+        opportunity += float(event.get("opportunity_seconds_since_prev") or 0.0)
+        outcome = str(event.get("outcome") or "")
+        if outcome == "missing_action":
+            missing += 1
+        elif outcome == "invalid_disposition":
+            invalid += 1
+        elif outcome == "dispatched":
+            dispatched += 1
+        elif outcome == "disposed":
+            disposed += 1
+        elif outcome == "silent":
+            silent += 1
+        if event.get("reminder_fired"):
+            reminders += 1
+        if event.get("disposition_honest") is False:
+            dishonest += 1
+    return {
+        "schema": REPORT_SCHEMA,
+        "report_only": True,
+        "event_count": len(events),
+        "eligible_idle_opportunity_seconds": opportunity,
+        "settle_events_missing_action": missing,
+        "settle_events_invalid_disposition": invalid,
+        "settle_events_dishonest": dishonest,
+        "settle_events_dispatched": dispatched,
+        "settle_events_disposed": disposed,
+        "settle_events_silent": silent,
+        "reminder_fired_count": reminders,
+    }
+
+
+def format_report(report: dict[str, Any]) -> str:
+    return (
+        f"fleet-idle-settle report_only={report.get('report_only')} "
+        f"events={report.get('event_count')} "
+        f"eligible_idle_opportunity_seconds={report.get('eligible_idle_opportunity_seconds')} "
+        f"missing_action={report.get('settle_events_missing_action')} "
+        f"invalid_disposition={report.get('settle_events_invalid_disposition')} "
+        f"dishonest={report.get('settle_events_dishonest')}"
+    )
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON object required: {path}")
+    return payload
+
+
+def run_evaluate(
+    *,
+    snapshot: EligibilitySnapshot,
+    dispatched: bool = False,
+    disposition: str | None = None,
+    settle_kind: str = "dispatch",
+    task_id: str | None = None,
+    store: Path | None = None,
+    record: bool = True,
+    now: datetime | None = None,
+    as_json: bool = False,
+    out=None,
+    err=None,
+) -> tuple[int, SettleDecision, dict[str, Any] | None]:
+    stdout = out if out is not None else sys.stdout
+    stderr = err if err is not None else sys.stderr
+    decision = evaluate_settle(
+        snapshot,
+        dispatched=dispatched,
+        disposition=disposition,
+        settle_kind=settle_kind,
+        task_id=task_id,
+    )
+    event: dict[str, Any] | None = None
+    if record and store is not None:
+        event = record_settle(store, decision, now=now)
+    payload = decision.to_dict()
+    if event is not None:
+        payload["event"] = event
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), file=stdout)
+    else:
+        text = format_reminder(decision, snapshot)
+        if text:
+            print(text, file=stdout)
+        elif decision.outcome == "invalid_disposition":
+            print(
+                f"idle_settle: rejected disposition {decision.disposition!r}; "
+                f"accepted: {' | '.join(sorted(DISPOSITION_CODES))}",
+                file=stderr,
+            )
+    rc = 2 if decision.outcome == "invalid_disposition" else 0
+    return rc, decision, event
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    if args.snapshot_json is not None:
+        snapshot = parse_snapshot(_load_json_file(args.snapshot_json))
+    else:
+        snapshot = empty_snapshot()
+    kind = args.kind or infer_settle_kind(args.task_id)
+    store = args.store if not args.no_record else None
+    rc, _decision, _event = run_evaluate(
+        snapshot=snapshot,
+        dispatched=bool(args.dispatched),
+        disposition=args.disposition,
+        settle_kind=kind,
+        task_id=args.task_id,
+        store=store,
+        record=not args.no_record,
+        as_json=bool(args.json),
+    )
+    return rc
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    report = build_report(load_events(args.store))
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(format_report(report))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    evaluate = sub.add_parser(
+        "evaluate",
+        help="Evaluate one dispatch/review settle: reminder + optional JSONL record",
+    )
+    evaluate.add_argument("--snapshot-json", type=Path, help="Eligibility snapshot JSON")
+    evaluate.add_argument("--task-id", default=None)
+    evaluate.add_argument("--kind", choices=sorted(SETTLE_KINDS), default=None)
+    evaluate.add_argument("--dispatched", action="store_true")
+    evaluate.add_argument(
+        "--disposition",
+        default=None,
+        help="One of: " + " | ".join(sorted(DISPOSITION_CODES)),
+    )
+    evaluate.add_argument(
+        "--store",
+        type=Path,
+        default=default_store_path(),
+        help="Append-only events JSONL (default: batch_state/idle_settle/events.jsonl)",
+    )
+    evaluate.add_argument("--no-record", action="store_true")
+    evaluate.add_argument("--json", action="store_true")
+    evaluate.set_defaults(func=_cmd_evaluate)
+
+    report = sub.add_parser("report", help="Print report-only idle/disposition telemetry")
+    report.add_argument("--store", type=Path, default=default_store_path())
+    report.add_argument("--json", action="store_true")
+    report.set_defaults(func=_cmd_report)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/dispatch_settle.py
+++ b/scripts/orchestration/dispatch_settle.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.fleet import idle_settle as idle_settle
 from scripts.guardrails.delegate_ownership import OwnershipLedger, default_ledger_path
 
 
@@ -341,6 +342,61 @@ def settle_task(
     )
 
 
+def _idle_snapshot_from_args(args: argparse.Namespace) -> idle_settle.EligibilitySnapshot:
+    raw = getattr(args, "idle_snapshot_json", None)
+    if raw is None:
+        return idle_settle.empty_snapshot()
+    payload = json.loads(Path(raw).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"idle snapshot must be a JSON object: {raw}")
+    return idle_settle.parse_snapshot(payload)
+
+
+def attach_idle_reminder(
+    report: SettleReport,
+    *,
+    snapshot: idle_settle.EligibilitySnapshot | None = None,
+    dispatched: bool = False,
+    disposition: str | None = None,
+    store: Path | None = None,
+    record: bool = True,
+    settle_kind: str | None = None,
+    now: Any = None,
+) -> tuple[int, idle_settle.SettleDecision, dict[str, Any] | None]:
+    """Evaluate the #6976 settle reminder after a dispatch/review closeout.
+
+    Does not print. Invalid disposition returns 2; missing action is report-only 0.
+    """
+    kind = settle_kind or idle_settle.infer_settle_kind(report.task_id)
+    snap = snapshot or idle_settle.empty_snapshot()
+    decision = idle_settle.evaluate_settle(
+        snap,
+        dispatched=dispatched,
+        disposition=disposition,
+        settle_kind=kind,
+        task_id=report.task_id,
+    )
+    event: dict[str, Any] | None = None
+    if record and store is not None:
+        event = idle_settle.record_settle(store, decision, now=now)
+    rc = 2 if decision.outcome == "invalid_disposition" else 0
+    return rc, decision, event
+
+
+def _print_settle_report(report: SettleReport) -> None:
+    print(f"task_id={report.task_id} status={report.status} pid={report.pid} alive={report.pid_alive}")
+    print(f"worktree={report.worktree_path}")
+    print(f"branch={report.branch} ahead={report.commits_ahead} dirty={report.dirty}")
+    print(f"pr={report.pr_url or 'NONE'}")
+    if report.actions:
+        print("actions:")
+        for action in report.actions:
+            print(f"  - {action}")
+    print("CLOSEOUT")
+    for key, value in report.closeout.items():
+        print(f"{key}: {value}")
+
+
 def _cmd_task(args: argparse.Namespace) -> int:
     report = settle_task(
         args.task_id,
@@ -350,21 +406,36 @@ def _cmd_task(args: argparse.Namespace) -> int:
         push=args.push,
         release_stale=not args.no_release_stale,
     )
+    idle_payload: dict[str, Any] | None = None
+    idle_rc = 0
+    reminder_text: str | None = None
+    if not getattr(args, "no_idle_reminder", False):
+        snapshot = _idle_snapshot_from_args(args)
+        has_snapshot = args.idle_snapshot_json is not None
+        record = (not args.no_idle_record) and has_snapshot
+        store = args.idle_store if record else None
+        idle_rc, decision, event = attach_idle_reminder(
+            report,
+            snapshot=snapshot,
+            dispatched=bool(args.dispatched),
+            disposition=args.disposition,
+            store=store,
+            record=record,
+        )
+        idle_payload = decision.to_dict()
+        if event is not None:
+            idle_payload["event"] = event
+        reminder_text = idle_settle.format_reminder(decision, snapshot)
     if args.json:
-        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+        payload = report.to_dict()
+        if idle_payload is not None:
+            payload["idle_settle"] = idle_payload
+        print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print(f"task_id={report.task_id} status={report.status} pid={report.pid} alive={report.pid_alive}")
-        print(f"worktree={report.worktree_path}")
-        print(f"branch={report.branch} ahead={report.commits_ahead} dirty={report.dirty}")
-        print(f"pr={report.pr_url or 'NONE'}")
-        if report.actions:
-            print("actions:")
-            for action in report.actions:
-                print(f"  - {action}")
-        print("CLOSEOUT")
-        for key, value in report.closeout.items():
-            print(f"{key}: {value}")
-    return 0
+        _print_settle_report(report)
+        if reminder_text:
+            print(reminder_text)
+    return idle_rc
 
 
 def _cmd_release_stale(_args: argparse.Namespace) -> int:
@@ -389,6 +460,35 @@ def _build_parser() -> argparse.ArgumentParser:
     task.add_argument("--pr-body", default=None)
     task.add_argument("--no-release-stale", action="store_true")
     task.add_argument("--json", action="store_true")
+    task.add_argument(
+        "--disposition",
+        default=None,
+        help="Idle-settle disposition when no follow-up dispatch: "
+        + " | ".join(sorted(idle_settle.DISPOSITION_CODES)),
+    )
+    task.add_argument(
+        "--dispatched",
+        action="store_true",
+        help="This settle is paired with a follow-up dispatch (satisfies the reminder)",
+    )
+    task.add_argument(
+        "--idle-snapshot-json",
+        type=Path,
+        default=None,
+        help="Eligibility snapshot for the settle reminder (empty snapshot = no nag)",
+    )
+    task.add_argument(
+        "--idle-store",
+        type=Path,
+        default=idle_settle.default_store_path(),
+        help="Append-only idle-settle events JSONL",
+    )
+    task.add_argument("--no-idle-record", action="store_true")
+    task.add_argument(
+        "--no-idle-reminder",
+        action="store_true",
+        help="Skip the #6976 settle reminder (tests / explicit opt-out)",
+    )
     task.set_defaults(func=_cmd_task)
 
     stale = sub.add_parser(

--- a/tests/test_dispatch_settle.py
+++ b/tests/test_dispatch_settle.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.fleet import idle_settle
 from scripts.guardrails.delegate_ownership import OwnershipLedger
 from scripts.orchestration import dispatch_settle as ds
 
@@ -97,3 +98,156 @@ def test_settle_task_reports_closeout(tmp_path: Path, monkeypatch: pytest.Monkey
     assert report.pr_url is None
     assert report.closeout["blocker"] == "commits_without_pr"
     assert report.closeout["branch"] == "codex/t1"
+
+
+def test_attach_idle_reminder_requires_disposition_when_eligible(tmp_path: Path) -> None:
+    report = ds.SettleReport(
+        task_id="infra-6976",
+        status="done",
+        pid=None,
+        pid_alive=False,
+        worktree_path=None,
+        branch=None,
+        commits_ahead=0,
+        dirty=False,
+        pr_url=None,
+        pr_number=None,
+        actions=[],
+        closeout={},
+    )
+    snapshot = idle_settle.parse_snapshot(
+        {
+            "lanes": [{"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True}],
+            "items": [{"item_id": "issue:6976", "ready": True, "valuable": True, "independent": True}],
+            "caps": {},
+        }
+    )
+    store = tmp_path / "idle.jsonl"
+    rc, decision, event = ds.attach_idle_reminder(report, snapshot=snapshot, store=store)
+    assert rc == 0
+    assert decision.outcome == "missing_action"
+    assert decision.reminder_fired is True
+    assert event is not None
+    assert event["outcome"] == "missing_action"
+
+
+def test_attach_idle_reminder_rejects_unknown_disposition() -> None:
+    report = ds.SettleReport(
+        task_id="review-6981",
+        status="done",
+        pid=None,
+        pid_alive=False,
+        worktree_path=None,
+        branch=None,
+        commits_ahead=0,
+        dirty=False,
+        pr_url=None,
+        pr_number=None,
+        actions=[],
+        closeout={},
+    )
+    snapshot = idle_settle.parse_snapshot(
+        {
+            "lanes": [{"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True}],
+            "items": [{"item_id": "issue:6976"}],
+        }
+    )
+    rc, decision, event = ds.attach_idle_reminder(
+        report,
+        snapshot=snapshot,
+        disposition="later",
+        record=False,
+    )
+    assert rc == 2
+    assert decision.settle_kind == "review"
+    assert decision.outcome == "invalid_disposition"
+    assert event is None
+
+
+def test_cmd_task_prints_reminder_and_accepts_disposition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    canned = ds.SettleReport(
+        task_id="t-idle",
+        status="done",
+        pid=None,
+        pid_alive=False,
+        worktree_path=None,
+        branch="codex/t-idle",
+        commits_ahead=0,
+        dirty=False,
+        pr_url=None,
+        pr_number=None,
+        actions=[],
+        closeout={"branch": "codex/t-idle", "pr": "NONE", "blocker": "none"},
+    )
+    monkeypatch.setattr(ds, "settle_task", lambda *_args, **_kwargs: canned)
+
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps(
+            {
+                "lanes": [{"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True}],
+                "items": [{"item_id": "issue:6976"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = tmp_path / "idle.jsonl"
+    rc = ds.main(
+        [
+            "task",
+            "--task-id",
+            "t-idle",
+            "--no-release-stale",
+            "--idle-snapshot-json",
+            str(snap),
+            "--idle-store",
+            str(store),
+            "--disposition",
+            "human_decision",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SETTLE REMINDER" in out
+    assert "satisfied via disposed" in out
+    assert "ACTION REQUIRED" not in out
+    events = idle_settle.load_events(store)
+    assert events[0]["outcome"] == "disposed"
+    assert events[0]["disposition"] == "human_decision"
+
+
+def test_cmd_task_silent_without_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    canned = ds.SettleReport(
+        task_id="t-silent",
+        status="done",
+        pid=None,
+        pid_alive=False,
+        worktree_path=None,
+        branch="codex/t-silent",
+        commits_ahead=0,
+        dirty=False,
+        pr_url=None,
+        pr_number=None,
+        actions=[],
+        closeout={"branch": "codex/t-silent", "pr": "NONE", "blocker": "none"},
+    )
+    monkeypatch.setattr(ds, "settle_task", lambda *_args, **_kwargs: canned)
+    store = tmp_path / "idle.jsonl"
+    rc = ds.main(
+        [
+            "task",
+            "--task-id",
+            "t-silent",
+            "--no-release-stale",
+            "--idle-store",
+            str(store),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SETTLE REMINDER" not in out
+    assert not store.exists()

--- a/tests/test_driver_breadth_report.py
+++ b/tests/test_driver_breadth_report.py
@@ -197,3 +197,45 @@ def test_enforce_waived_by_note_file(tmp_path: Path) -> None:
         ]
     )
     assert code == 0
+
+
+def test_enforce_ignores_missing_idle_disposition(tmp_path: Path, capsys) -> None:
+    """#6976: --enforce stays breadth-floor-only. Missing idle action is report-only."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _task(tasks_dir / "a.json", task_id="a", agent="claude", model="claude-sonnet-5", initiator="grok-x")
+    _task(tasks_dir / "b.json", task_id="b", agent="codex", model="gpt-5.6-luna", initiator="grok-x")
+    _task(tasks_dir / "c.json", task_id="c", agent="codex", model="gpt-5.6-terra", initiator="grok-x")
+    store = tmp_path / "idle.jsonl"
+    store.write_text(
+        json.dumps(
+            {
+                "schema": "fleet-idle-settle-event.v1",
+                "outcome": "missing_action",
+                "eligible": True,
+                "reminder_fired": True,
+                "opportunity_seconds_since_prev": 12.0,
+                "disposition_honest": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    code = main(
+        [
+            "--tasks-dir",
+            str(tasks_dir),
+            "--initiator",
+            "grok",
+            "--enforce",
+            "--json",
+            "--idle-store",
+            str(store),
+        ]
+    )
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["breadth_floor_ok"] is True
+    assert payload["idle_settle"]["report_only"] is True
+    assert payload["idle_settle"]["settle_events_missing_action"] == 1
+    assert payload["idle_settle"]["eligible_idle_opportunity_seconds"] == 12.0

--- a/tests/test_idle_settle.py
+++ b/tests/test_idle_settle.py
@@ -1,0 +1,297 @@
+"""Tests for scripts.fleet.idle_settle (#6976 report-only reminder + telemetry)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet import idle_settle as idle
+
+
+def _snapshot(
+    *,
+    lanes: list[dict] | None = None,
+    items: list[dict] | None = None,
+    caps: dict | None = None,
+) -> idle.EligibilitySnapshot:
+    return idle.parse_snapshot(
+        {
+            "lanes": lanes
+            if lanes is not None
+            else [{"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True}],
+            "items": items
+            if items is not None
+            else [
+                {
+                    "item_id": "issue:6976",
+                    "kind": "issue",
+                    "ready": True,
+                    "valuable": True,
+                    "independent": True,
+                }
+            ],
+            "caps": caps or {},
+        }
+    )
+
+
+def test_disposition_codes_are_exactly_the_six() -> None:
+    assert {
+        "dependency_blocked",
+        "review_wip_cap",
+        "ci_capacity",
+        "disk_capacity",
+        "human_decision",
+        "no_ready_work",
+    } == idle.DISPOSITION_CODES
+    for code in idle.DISPOSITION_CODES:
+        assert idle.disposition_accepted(code) is True
+    assert idle.disposition_accepted("busywork") is False
+    assert idle.disposition_accepted("") is False
+    assert idle.normalize_disposition("  ") is None
+    assert idle.normalize_disposition(" human_decision ") == "human_decision"
+
+
+def test_reminder_silent_when_nothing_actionable() -> None:
+    snap = _snapshot(items=[])
+    decision = idle.evaluate_settle(snap)
+    assert decision.eligible is False
+    assert decision.reminder_fired is False
+    assert decision.reminder_required is False
+    assert decision.outcome == "silent"
+    assert idle.format_reminder(decision, snap) is None
+
+
+def test_reminder_silent_when_lane_unhealthy_or_busy() -> None:
+    hot = _snapshot(lanes=[{"lane": "codex", "status": "hot", "in_flight": 0, "will_last": True}])
+    busy = _snapshot(lanes=[{"lane": "cursor", "status": "cool", "in_flight": 1, "will_last": True}])
+    deficit = _snapshot(lanes=[{"lane": "kimi", "status": "cool", "in_flight": 0, "will_last": False}])
+    for snap in (hot, busy, deficit):
+        decision = idle.evaluate_settle(snap)
+        assert decision.eligible is False
+        assert decision.reminder_fired is False
+
+
+def test_reminder_silent_when_item_not_fillable() -> None:
+    blocked = _snapshot(items=[{"item_id": "issue:1", "dependency_blocked": True}])
+    unready = _snapshot(items=[{"item_id": "issue:2", "ready": False}])
+    cheap = _snapshot(items=[{"item_id": "issue:3", "valuable": False}])
+    colliding = _snapshot(items=[{"item_id": "issue:4", "independent": False}])
+    for snap in (blocked, unready, cheap, colliding):
+        decision = idle.evaluate_settle(snap)
+        assert decision.eligible is False
+        assert decision.reminder_fired is False
+
+
+def test_resource_caps_suppress_eligibility() -> None:
+    review_cap = _snapshot(caps={"review_in_flight": 4, "review_wip_limit": 4})
+    ci = _snapshot(caps={"ci_capacity_ok": False})
+    disk = _snapshot(caps={"disk_ok": False})
+    for snap, code in (
+        (review_cap, "review_wip_cap"),
+        (ci, "ci_capacity"),
+        (disk, "disk_capacity"),
+    ):
+        decision = idle.evaluate_settle(snap)
+        assert decision.eligible is False
+        assert decision.reminder_fired is False
+        assert code in decision.active_constraints
+
+
+def test_reminder_fires_only_when_eligible_and_no_action() -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap)
+    assert decision.eligible is True
+    assert decision.reminder_required is True
+    assert decision.reminder_fired is True
+    assert decision.outcome == "missing_action"
+    assert decision.accepted is False
+    text = idle.format_reminder(decision, snap)
+    assert text is not None
+    assert "issue:6976" in text
+    assert "ACTION REQUIRED" in text
+    assert "review_wip=" in text
+    assert "cursor" in text
+
+
+def test_dispatch_satisfies_and_does_not_nag() -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap, dispatched=True)
+    assert decision.outcome == "dispatched"
+    assert decision.accepted is True
+    assert decision.reminder_required is False
+    assert decision.reminder_fired is False
+    text = idle.format_reminder(decision, snap)
+    assert text is not None
+    assert "satisfied via dispatched" in text
+    assert "ACTION REQUIRED" not in text
+
+
+@pytest.mark.parametrize("code", sorted(idle.DISPOSITION_CODES))
+def test_six_disposition_codes_accepted(code: str) -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap, disposition=code)
+    assert decision.outcome == "disposed"
+    assert decision.accepted is True
+    assert decision.disposition_valid is True
+    assert decision.reminder_fired is False
+    assert decision.disposition == code
+
+
+def test_unknown_disposition_rejected() -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap, disposition="taking_a_break")
+    assert decision.outcome == "invalid_disposition"
+    assert decision.accepted is False
+    assert decision.disposition_valid is False
+    assert decision.reminder_fired is True
+
+
+def test_compatible_lanes_must_intersect() -> None:
+    snap = _snapshot(
+        lanes=[
+            {"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True},
+            {"lane": "codex", "status": "hot", "in_flight": 0, "will_last": True},
+        ],
+        items=[{"item_id": "issue:1", "compatible_lanes": ["codex"]}],
+    )
+    decision = idle.evaluate_settle(snap)
+    assert decision.eligible is False
+    snap2 = _snapshot(
+        items=[{"item_id": "issue:1", "compatible_lanes": ["cursor"]}],
+    )
+    decision2 = idle.evaluate_settle(snap2)
+    assert decision2.eligible is True
+    assert decision2.eligible_pairs == (idle.EligiblePair(lane="cursor", item_id="issue:1"),)
+
+
+def test_no_ready_work_is_dishonest_when_eligible() -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap, disposition="no_ready_work")
+    assert decision.disposition_honest is False
+    empty = _snapshot(items=[])
+    honest = idle.evaluate_settle(empty, disposition="no_ready_work")
+    assert honest.disposition_honest is True
+    assert honest.reminder_fired is False
+
+
+def test_human_decision_is_always_honest() -> None:
+    snap = _snapshot()
+    decision = idle.evaluate_settle(snap, disposition="human_decision")
+    assert decision.disposition_honest is True
+
+
+def test_opportunity_seconds_only_when_previous_was_eligible() -> None:
+    t0 = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    t1 = t0 + timedelta(seconds=45)
+    prev_eligible = {"eligible": True, "recorded_at": idle.format_iso(t0)}
+    prev_silent = {"eligible": False, "recorded_at": idle.format_iso(t0)}
+    assert idle.opportunity_seconds_since(prev_eligible, t1) == 45.0
+    assert idle.opportunity_seconds_since(prev_silent, t1) == 0.0
+    assert idle.opportunity_seconds_since(None, t1) == 0.0
+
+
+def test_record_and_report_counts_missing_and_opportunity(tmp_path: Path) -> None:
+    store = tmp_path / "events.jsonl"
+    snap = _snapshot()
+    t0 = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    t1 = t0 + timedelta(seconds=30)
+    first = idle.evaluate_settle(snap)
+    idle.record_settle(store, first, now=t0, event_id="e1")
+    second = idle.evaluate_settle(snap, dispatched=True)
+    idle.record_settle(store, second, now=t1, event_id="e2")
+    report = idle.build_report(idle.load_events(store))
+    assert report["schema"] == idle.REPORT_SCHEMA
+    assert report["report_only"] is True
+    assert report["event_count"] == 2
+    assert report["settle_events_missing_action"] == 1
+    assert report["settle_events_dispatched"] == 1
+    assert report["eligible_idle_opportunity_seconds"] == 30.0
+    assert "pass" not in report
+    assert "threshold" not in report
+
+
+def test_cli_evaluate_rejects_unknown_disposition(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    snap_path = tmp_path / "snap.json"
+    snap_path.write_text(json.dumps(_snapshot().to_dict()), encoding="utf-8")
+    store = tmp_path / "events.jsonl"
+    rc = idle.main(
+        [
+            "evaluate",
+            "--snapshot-json",
+            str(snap_path),
+            "--store",
+            str(store),
+            "--disposition",
+            "taking_a_break",
+            "--json",
+        ]
+    )
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "invalid_disposition"
+
+
+def test_cli_evaluate_missing_action_is_report_only_zero(tmp_path: Path) -> None:
+    snap_path = tmp_path / "snap.json"
+    snap_path.write_text(json.dumps(_snapshot().to_dict()), encoding="utf-8")
+    store = tmp_path / "events.jsonl"
+    rc = idle.main(
+        [
+            "evaluate",
+            "--snapshot-json",
+            str(snap_path),
+            "--store",
+            str(store),
+            "--task-id",
+            "infra-6976",
+        ]
+    )
+    assert rc == 0
+    report = idle.build_report(idle.load_events(store))
+    assert report["settle_events_missing_action"] == 1
+
+
+def test_cli_report_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    store = tmp_path / "events.jsonl"
+    idle.record_settle(store, idle.evaluate_settle(_snapshot()), now=datetime(2026, 8, 17, tzinfo=UTC))
+    rc = idle.main(["report", "--store", str(store), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_only"] is True
+    assert payload["settle_events_missing_action"] == 1
+
+
+def test_infer_review_kind() -> None:
+    assert idle.infer_settle_kind("review-6981") == "review"
+    assert idle.infer_settle_kind("infra-6976") == "dispatch"
+
+
+def test_items_from_work_next_marks_blockers() -> None:
+    items = idle.items_from_work_next_queue(
+        [
+            {
+                "work_id": "issue:1",
+                "resource_kind": "issue",
+                "safe_next_action": {"code": "RESOLVE_BLOCKER", "reason_codes": ["blocked_by"]},
+            },
+            {"work_id": "issue:2", "resource_kind": "pr", "safe_next_action": {"code": "REQUEST_CF_REVIEW"}},
+        ]
+    )
+    assert items[0].dependency_blocked is True
+    assert items[1].dependency_blocked is False
+    assert items[1].is_fillable() is True
+
+
+def test_lanes_from_capacity_rows_mark_avoid_as_quota_fail() -> None:
+    lanes = idle.lanes_from_capacity_rows(
+        [
+            {"lane": "codex", "status": "hot", "in_flight": 0, "will_last": False, "avoid": True},
+            {"lane": "cursor", "status": "cool", "in_flight": 0, "will_last": True, "avoid": False},
+        ]
+    )
+    assert lanes[0].is_healthy_available() is False
+    assert lanes[1].is_healthy_available() is True


### PR DESCRIPTION
Implements #6976 build-order items 1+2 per the cross-family-agreed spec (codex+kimi discussion on the issue): conditional settle-event reminder (dispatch-or-disposition, six codes) + eligibility-aware idle opportunity-seconds telemetry, report-only. Six guard mutation-checks quoted in the task result (batch_state/tasks/infra-6976-no-idle-r2.result). Residual by spec: snapshot fetch is caller-supplied (--idle-snapshot-json); items 3+4 out of scope. Worker: grok (cannot push — driver finalized; worktree was reaped pre-push, branch ref recovered from shared object store). Refs #6943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)