### PR TITLE
perf(tests): eliminate wall-clock delays in required pytest suite (#6999, #7000)

### DIFF
--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
@@ -61,14 +62,17 @@ def _is_rate_limited(stderr: str) -> bool:
     return any(pat.lower() in stderr_lower for pat in _RATE_LIMIT_PATTERNS)
 
 
-def _pace_gemini_calls() -> None:
+def _pace_gemini_calls(sleep_fn: Callable[[int, str], None] | None = None) -> None:
     """Enforce minimum delay between Gemini CLI calls to avoid bursts."""
     global _last_gemini_call_time
     if _last_gemini_call_time > 0:
         elapsed = time.monotonic() - _last_gemini_call_time
         if elapsed < _GEMINI_INTER_CALL_DELAY:
             wait = _GEMINI_INTER_CALL_DELAY - elapsed
-            time.sleep(wait)
+            if sleep_fn is not None:
+                sleep_fn(int(wait) if int(wait) == wait else int(wait + 1), "gemini inter-call delay")
+            else:
+                time.sleep(wait)
     _last_gemini_call_time = time.monotonic()
 
 
@@ -412,6 +416,7 @@ def dispatch_agent(
     model: str | None = None,
     cascade_per_call_max_s: int | None = None,
     initial_response_timeout: int | None = None,
+    sleep_fn: Callable[[int, str], None] | None = None,
 ) -> tuple[bool, str]:
     """Unified dispatcher for Gemini and Claude subprocess calls.
 
@@ -428,6 +433,7 @@ def dispatch_agent(
         initial_response_timeout: Optional startup guard. When set, the runtime
             kills the subprocess if no stdout/stderr/liveness activity appears
             within this many seconds.
+        sleep_fn: Optional custom sleeper (seconds, reason) -> None for retry/pacing backoffs.
 
     Returns:
         (success, stdout_text)
@@ -474,6 +480,7 @@ def dispatch_agent(
             runtime_agent_name="gemini" if is_gemini else "codex",
             cascade_per_call_max_s=cascade_per_call_max_s,
             initial_response_timeout=initial_response_timeout,
+            sleep_fn=sleep_fn,
         )
     if is_claude:
         return _dispatch_claude_via_runtime(
@@ -623,6 +630,7 @@ def _dispatch_via_runtime(
     runtime_agent_name: str,
     cascade_per_call_max_s: int | None,
     initial_response_timeout: int | None,
+    sleep_fn: Callable[[int, str], None] | None = None,
 ) -> tuple[bool, str]:
     """Route Codex + Gemini dispatch through scripts.agent_runtime.runner.invoke().
 
@@ -798,7 +806,7 @@ def _dispatch_via_runtime(
             )
             try:
                 if not is_agy:
-                    _pace_gemini_calls()
+                    _pace_gemini_calls(sleep_fn=sleep_fn)
                 with _temporary_rate_limit_bypass():
                     result = runtime_invoke(
                         attempt_agent,
@@ -924,7 +932,7 @@ def _dispatch_via_runtime(
             min_attempt_budget_s=30,
             attempt_runner=_gemini_attempt_runner,
             logger=_log,
-            sleep_fn=lambda seconds, reason: visible_sleep(seconds, reason, logger=_log),
+            sleep_fn=sleep_fn if sleep_fn is not None else (lambda seconds, reason: visible_sleep(seconds, reason, logger=_log)),
             allowed_auth_modes=allowed_auth_modes,
         )
         if ladder_result.ok:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -258,6 +258,7 @@ class TestDispatchAgent:
         ok, raw = dispatch_agent(
             "test prompt", agent="gemini", phase="write",
             orch_dir=tmp_path, timeout=300, model="gemini-test",
+            sleep_fn=lambda _s, _r: None,
         )
         assert ok is True
         assert "Section 1" in raw
@@ -288,6 +289,7 @@ class TestDispatchAgent:
             orch_dir=tmp_path,
             timeout=300,
             model="gemini-test",
+            sleep_fn=lambda _s, _r: None,
         )
 
         assert ok is True
@@ -337,6 +339,7 @@ class TestDispatchAgent:
             timeout=300,
             model="gemini-3.1-pro-preview",
             mcp_tools=True,
+            sleep_fn=lambda _s, _r: None,
         )
 
         assert ok is True
@@ -497,9 +500,11 @@ class TestDispatchAgent:
         from agent_runtime.errors import AgentTimeoutError
         mock_invoke.side_effect = AgentTimeoutError("gemini", 300)
 
+        recorded_sleeps: list[tuple[int, str]] = []
         ok, raw = dispatch_agent(
             "test", agent="gemini", phase="skeleton",
             orch_dir=tmp_path, timeout=300, model="test",
+            sleep_fn=lambda s, r: recorded_sleeps.append((s, r)),
         )
         assert ok is False
         assert raw == ""
@@ -508,6 +513,9 @@ class TestDispatchAgent:
         for mf in meta_files:
             data = json.loads(mf.read_text())
             assert data["ok"] is False
+        # Assert retry backoff sleeps were requested between attempts without blocking wallclock (#7000)
+        retry_backoffs = [s for s, r in recorded_sleeps if "retry backoff" in r]
+        assert retry_backoffs == [10, 10]
 
     @patch("agent_runtime.runner.invoke")
     def test_gemini_dispatch_honors_custom_per_call_cap(self, mock_invoke, tmp_path):
@@ -533,6 +541,7 @@ class TestDispatchAgent:
             ),
         ]
 
+        recorded_sleeps: list[tuple[int, str]] = []
         ok, raw = dispatch_agent(
             "rewrite prompt",
             agent="gemini-tools",
@@ -542,6 +551,7 @@ class TestDispatchAgent:
             model="gemini-3.1-pro-preview",
             mcp_tools=True,
             cascade_per_call_max_s=120,
+            sleep_fn=lambda s, r: recorded_sleeps.append((s, r)),
         )
 
         assert ok is True
@@ -550,6 +560,9 @@ class TestDispatchAgent:
         second_call = mock_invoke.call_args_list[1].kwargs
         assert first_call["hard_timeout"] == 120
         assert second_call["hard_timeout"] == 120
+        # Assert retry backoff sleep between attempt 1 and 2 was requested without blocking wallclock (#7000)
+        retry_backoffs = [s for s, r in recorded_sleeps if "retry backoff" in r]
+        assert retry_backoffs == [10]
 
     @patch("agent_runtime.runner.invoke")
     def test_failure_logged(self, mock_invoke, tmp_path):

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -59,13 +59,19 @@ class TestSlovnyk:
         assert _build_slovnyk(plan) == ""
 
 
-    def test_build_slovnyk_markdown_formatting(self):
+    def test_build_slovnyk_markdown_formatting(self, monkeypatch):
         """Test that build_slovnyk_markdown produces correct table output.
 
         Words with 2+ syllables get stress marks (e.g. літера -> лі́тера).
         Single-syllable words (звук) stay unchanged.
         """
         from build.vocab_gen import build_slovnyk_markdown
+
+        # Stub stress annotation to avoid loading the heavy NLP model during fast formatting tests (#6999)
+        monkeypatch.setattr(
+            "pipeline.stress_annotator.annotate_stress",
+            lambda word: ("лі\u0301тера", 1) if word == "літера" else (word, 0),
+        )
 
         entries = [
             {"word": "звук", "translation": "sound", "expression": False, "pos": "ім.", "gender": "ч."},


### PR DESCRIPTION
## Summary
Fixes hidden wall-clock bottlenecks identified during CI audits in the required fast pytest suite:

1. **#6999**: `tests/test_enrich.py::TestSlovnyk::test_build_slovnyk_markdown_formatting` reached `annotate_stress()` / `_get_stressifier()`, loading the heavy NLP model (Stanza) for formatting-only assertions. Stubbed the stress annotator dependency via `monkeypatch` in this formatting test.
2. **#7000**: `tests/test_dispatch.py` had real sleeps totaling >35s during retry ladder (`test_timeout_logged` 2x10s backoffs) and custom cap tests (`test_gemini_dispatch_honors_custom_per_call_cap` 10s backoff + 3s pacing). Made `sleep_fn` injectable in `dispatch_agent()` and `_pace_gemini_calls()`, injected no-op sleepers in tests, and asserted that retry backoff delays are requested without blocking wall-clock time.

## Durations Evidence (#M-4)

### BEFORE
```
============================= slowest 10 durations =============================
22.96s call     tests/test_dispatch.py::TestDispatchAgent::test_timeout_logged
13.00s call     tests/test_dispatch.py::TestDispatchAgent::test_gemini_dispatch_honors_custom_per_call_cap
3.82s call     tests/test_enrich.py::TestSlovnyk::test_build_slovnyk_markdown_formatting
3.00s call     tests/test_dispatch.py::TestDispatchAgent::test_gemini_dispatch_logs_auth_mode
0.11s call     tests/test_dispatch.py::TestDispatchAgent::test_gemini_dispatch
0.04s call     tests/test_enrich.py::TestResources::test_without_url
0.04s call     tests/test_enrich.py::TestResources::test_with_url
0.04s call     tests/test_enrich.py::TestEnrichIntegration::test_full_enrichment_has_tabs
0.04s call     tests/test_enrich.py::TestEnrichIntegration::test_m01_plan_enrichment
0.02s call     tests/test_enrich.py::TestEnrichIntegration::test_slovnyk_in_separate_tab
======================== 55 passed, 4 skipped in 43.71s ========================
```

### AFTER
```
============================= slowest 10 durations =============================
0.07s call     tests/test_dispatch.py::TestDispatchAgent::test_gemini_dispatch
0.05s call     tests/test_enrich.py::TestEnrichIntegration::test_full_enrichment_has_tabs
0.05s call     tests/test_enrich.py::TestResources::test_without_url
0.05s call     tests/test_enrich.py::TestResources::test_with_url
0.05s call     tests/test_enrich.py::TestEnrichIntegration::test_m01_plan_enrichment
0.03s call     tests/test_enrich.py::TestEnrichIntegration::test_slovnyk_in_separate_tab
0.03s call     tests/test_enrich.py::TestEnrichIntegration::test_workbook_placeholder
0.03s call     tests/test_enrich.py::TestResources::test_no_references
0.03s call     tests/test_enrich.py::TestEnrichIntegration::test_videos_inline_in_urok_tab
0.02s call     tests/test_enrich.py::TestMiyklasResourceIntegration::test_miyklas_alone_produces_output
======================== 55 passed, 4 skipped in 1.05s =========================
```

Fixes #6999
Fixes #7000