### PR TITLE
perf(ci): collect merge_group coverage via sysmon (Fixes #7006)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,11 @@ jobs:
           # Coverage collection on the trees that land: merge_group (queued
           # merge commit) and push to main. PR heads stay coverage-free.
           COLLECT_COVERAGE: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+          # LINE coverage only (no branch=true). sys.monitoring is near-free
+          # on coverage 7.14.1 / Python 3.12 vs the C-tracer's ~35% tax.
+          # Unused when COLLECT_COVERAGE is false (--cov is not passed).
+          # Fastlane and coverage-combine do not run pytest --cov.
+          COVERAGE_CORE: sysmon
           SHARD: ${{ matrix.shard }}
           PYTEST_BREADCRUMB_DIR: .pytest_breadcrumbs
         run: |


### PR DESCRIPTION
## Summary

Enable `COVERAGE_CORE=sysmon` on the pytest shard step so merge_group / main-push coverage collection uses the sys.monitoring backend instead of the C-tracer. #6989's pre-merge floor stays: `COLLECT_COVERAGE` conditions are unchanged.

## Changes

- Set `COVERAGE_CORE: sysmon` on `Run planned pytest shard` (the only CI step that can pass `--cov`).
- Fastlane and `coverage-floor` combine/report do **not** run pytest `--cov`, so they are left alone.
- Expected queue reclaim: full-tier back toward ~16 min (from 21.8–22.4). Real measurement is this PR's merge_group run — **do not auto-merge**.

## Testing

- [x] `actionlint .github/workflows/ci.yml` — exit 0 (empty stdout)
- [x] Workflow-contract tests: 30 passed in 1.13s
- [x] Equivalence proof (#M-4): default C-tracer vs `COVERAGE_CORE=sysmon` on an 82-test CI subset with `--cov=scripts`

```
# default (COVERAGE_CORE unset → CTracer)
664 covered / 219953 statements  (0.3018826749350998%)
wall 24.310s  (pytest 24.06s)

# COVERAGE_CORE=sysmon → SysMonitor
664 covered / 219953 statements  (0.3018826749350998%)
wall 22.912s  (pytest 22.67s)
```

Totals match exactly. Sysmon was 1.4s faster on this subset (startup-dominated; shard-scale delta lands on merge_group). Local interpreter: Python 3.12.8, coverage 7.15.4 (CI lock is coverage==7.14.1; both are LINE-only, no `branch=true`).

Workflow-contract output:

```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.3, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python
...
collected 30 items
...
============================== 30 passed in 1.13s ==============================
```

Files: `tests/test_frontend_change_scope.py tests/test_paths_filter_fail_open.py tests/test_workflow_head_concurrency.py`

## Related Issues

Fixes #7006

Made with [Cursor](https://cursor.com)