### PR TITLE
fix(api): stop Monitor overview/lean orient hanging on FS and CodexBar (#6983)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -2037,6 +2037,10 @@ Query params:
 - `fresh=true` — invalidate orient-layer caches before gathering (see below).
 - `lean=true` — use the lightweight cold-start preset and omit the heavy
   `pipeline`, `issues`, and `wiki` sections. An explicit `sections` list wins.
+  `capacity` and `health` stay in the lean preset but are cache-first /
+  detached (#6983): a hung CodexBar or integrity canary returns
+  `meta.error` plus the empty/default payload and must not stall the
+  rest of the gather.
 - `sections=git,runtime` — comma-separated subset of section keys to
   collect. Valid keys: `git`, `issues`, `pipeline`, `runtime`,
   `idle_prs`, `delegate`, `bridge_pending`, `rollovers`, `wiki`, `governance`,
@@ -2095,9 +2099,10 @@ failure retries on the next call.
 | `pipeline` | 0 | `fs` | wraps `/api/state/summary`, which carries its **own** 60 s cache. Caching again at the orient layer would stack windows and label up-to-119 s-old data as fresh (#1309 reviewer BLOCKER B2). |
 | `runtime` | 60 | `fs` | agent registry + headroom + recent outcomes |
 | `delegate` | 30 | `fs` | active delegate/codex tasks |
+| `capacity` | 15 | `fs` | routing-budget lane snapshot; cache-first detached worker so CodexBar never pins `/api/orient` (#6983) |
 | `rollovers` | 15 | `fs` | compact fleet rollover counts plus actionable pending or incompletely cleaned entries |
 | `wiki` | 120 | `fs` | per-track wiki compilation coverage |
-| `health` | 15 | `probe` | API/DB/MCP port + file readability |
+| `health` | 15 | `probe` | API/DB/MCP port + integrity canaries; cache-first detached worker (#6983) |
 | `session_hints` | 60 | `fs` | recent `docs/session-state/*.md` entries |
 
 Every section is mirrored under `response.meta.<section>` with:
@@ -2860,6 +2865,13 @@ revision of this endpoint was removed per reviewer BLOCKER on
 ---
 
 ## UI Pages
+
+`GET /api/dashboard/overview` is cache-first (#6983): the request path
+never walks the curriculum tree. `meta.cache` remains the state-summary
+cache signal; `meta.track_scan` is `hit` / `stale` / `skipped`. A cold
+miss may include `meta.error=overview_warming` while a detached worker
+fills last-good. The live Monitor process does not pick up this behavior
+until restart.
 
 | Page | URL | Data source |
 |------|-----|-------------|

--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -249,6 +249,43 @@ def build_module_info(track_dir, plans_dir, track_id, slug, idx) -> dict:
     }
 
 
+def stats_from_state_summary(summary_stats: dict, *, is_seminar: bool) -> dict:
+    """Map cached ``/api/state/summary`` counts onto overview track stats.
+
+    This is the cheap request-path shape: no per-module status/orchestration
+    walk. ``fail`` / ``shippable`` / plan-review verdicts are not in the
+    summary snapshot, so they stay 0 until a background full scan fills
+    last-good. Research totals follow the same seminar-vs-core key as
+    ``overview()`` historically used.
+    """
+    total = int(summary_stats.get("total") or 0)
+    generated_md = int(summary_stats.get("generated_md") or 0)
+    audit_passing = int(summary_stats.get("audit_passing") or 0)
+    audit_stale = int(summary_stats.get("audit_stale") or 0)
+    content_done = int(summary_stats.get("content_done") or 0)
+    research_total_key = "dossier_done" if is_seminar else "research_done"
+    return {
+        "pass": audit_passing,
+        "content_complete": content_done,
+        "fail": 0,
+        "unaudited": max(0, generated_md - audit_passing - audit_stale),
+        "missing": max(0, total - generated_md),
+        "shippable": 0,
+        "reviewed": int(summary_stats.get("reviewed") or 0),
+        "final_review": int(summary_stats.get("final_review_done") or 0),
+        "plan_reviewed": int(summary_stats.get("prompt_reviewed") or 0),
+        "plan_pass": 0,
+        "plan_needs_fixes": 0,
+        "plan_fail": 0,
+        "stale_status": audit_stale,
+        "research": {
+            "total": int(summary_stats.get(research_total_key) or 0),
+            "docs": int(summary_stats.get("dossier_docs") or 0),
+            "curriculum": int(summary_stats.get("dossier_curriculum") or 0),
+        },
+    }
+
+
 def compute_track_stats(modules: list, track_id: str) -> dict:
     """Aggregate per-module data into track-level stats."""
     stats = {

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -5,8 +5,10 @@ Endpoints: overview, track detail, module deep-dive, pipeline status, activity c
 comms monitoring.
 """
 
-import asyncio
+import copy
+import logging
 import sys
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -39,9 +41,10 @@ from .dashboard_helpers import (
     scan_pipeline_queues,
     scan_track_cached,
     scan_track_summary_cached,
+    stats_from_state_summary,
 )
 from .state_coverage import compute_summary
-from .state_helpers import cache_get_with_age, cache_set, get_plan_slugs
+from .state_helpers import cache_get_with_age, cache_invalidate, cache_set, get_plan_slugs
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -54,29 +57,136 @@ except ImportError:
 from research_quality import assess_research_compat, find_research_path
 
 router = APIRouter(tags=["dashboard"])
+logger = logging.getLogger(__name__)
 DASHBOARD_STATE_SUMMARY_TTL_S = 60.0
+DASHBOARD_OVERVIEW_CACHE_KEY = "dashboard_overview"
+DASHBOARD_OVERVIEW_TTL_S = 60.0
+
+_overview_refresh_lock = threading.Lock()
+_overview_refresh_thread: threading.Thread | None = None
+_overview_last_good: dict | None = None
 
 
-async def _state_summary_for_dashboard() -> tuple[dict, str, float | None]:
-    """Reuse the state-summary cache so dashboard loads stay responsive."""
+def reset_overview_state_for_tests() -> None:
+    """Drop overview last-good + TTL cache so tests do not leak across cases."""
+    global _overview_refresh_thread, _overview_last_good
+    thread: threading.Thread | None
+    with _overview_refresh_lock:
+        thread = _overview_refresh_thread
+    if thread is not None:
+        thread.join(timeout=2.0)
+    _overview_last_good = None
+    cache_invalidate(DASHBOARD_OVERVIEW_CACHE_KEY)
+    with _overview_refresh_lock:
+        _overview_refresh_thread = None
+
+
+def _peek_state_summary() -> tuple[dict, str, float | None]:
+    """Read the state-summary TTL cache without computing on the request path."""
     cached = cache_get_with_age("summary", ttl=DASHBOARD_STATE_SUMMARY_TTL_S)
     if cached is not None:
         value, age_s = cached
         return value, "hit", age_s
-    result = await asyncio.to_thread(compute_summary)
-    cache_set("summary", result)
-    return result, "miss", 0.0
+    return {}, "miss", None
 
 
-# ==================== ENDPOINTS ====================
+def _overlay_research_from_summary(tracks: list[dict], state_tracks: dict) -> None:
+    for track_entry in tracks:
+        track_id = track_entry.get("id")
+        summary_stats = state_tracks.get(track_id, {}) if isinstance(state_tracks, dict) else {}
+        is_seminar = bool(track_entry.get("is_seminar") or summary_stats.get("is_seminar"))
+        research_total_key = "dossier_done" if is_seminar else "research_done"
+        stats = track_entry.setdefault("stats", {})
+        stats["research"] = {
+            **stats.get("research", {}),
+            "total": summary_stats.get(research_total_key, stats.get("research", {}).get("total", 0)),
+            "docs": summary_stats.get("dossier_docs", 0),
+            "curriculum": summary_stats.get("dossier_curriculum", 0),
+        }
 
 
-@router.get("/overview")
-async def overview():
-    """All tracks with module counts and pass/prose/fail stats."""
+def _build_overview_from_state_summary(
+    state_summary: dict,
+    cache_state: str,
+    age_s: float | None,
+    *,
+    track_scan: str,
+) -> dict:
+    """Assemble overview from cached summary + manifest. No per-module FS scan."""
     manifest = load_manifest()
     levels = manifest.get("levels", {})
-    state_summary, cache_state, age_s = await _state_summary_for_dashboard()
+    state_tracks = state_summary.get("tracks", {}) if isinstance(state_summary, dict) else {}
+
+    tracks = []
+    totals = {"pass": 0, "content_complete": 0, "fail": 0, "unaudited": 0, "missing": 0, "shippable": 0, "total": 0}
+
+    for level_cfg in LEVELS:
+        track_id = level_cfg["id"]
+        summary_stats = state_tracks.get(track_id, {})
+        track_modules = levels.get(track_id, {}).get("modules", []) or [
+            slug for _num, slug in get_plan_slugs(track_id)
+        ]
+        module_count = int(summary_stats.get("total") or 0) or len(track_modules)
+        if not module_count:
+            continue
+
+        is_seminar = bool(summary_stats.get("is_seminar") or track_id in SEMINAR_TRACK_IDS)
+        s = stats_from_state_summary(summary_stats, is_seminar=is_seminar)
+        pct = round(s["pass"] / module_count * 100) if module_count > 0 else 0
+        tracks.append(
+            {
+                "id": track_id,
+                "name": level_cfg["name"],
+                "module_count": module_count,
+                "stats": s,
+                "pct_complete": pct,
+                "profile": summary_stats.get("profile", "seminar" if is_seminar else "core"),
+                "is_seminar": is_seminar,
+                "module_source": summary_stats.get("module_source"),
+                "published_mdx": summary_stats.get("published_mdx", 0),
+                "generated_md": summary_stats.get("generated_md", 0),
+                "audit_stale": summary_stats.get("audit_stale", 0),
+            }
+        )
+        for key in totals:
+            if key == "total":
+                totals["total"] += module_count
+            elif key in s:
+                totals[key] += s[key]
+
+    meta = {
+        "generated_at": state_summary.get("generated_at") if isinstance(state_summary, dict) else None,
+        "source": "fs:manifest+state-summary",
+        "cache": cache_state,
+        "stale_after_s": DASHBOARD_OVERVIEW_TTL_S,
+        "stale": cache_state != "hit",
+        "track_scan": track_scan,
+    }
+    if age_s is not None:
+        meta["age_s"] = round(age_s, 3)
+    if cache_state == "miss" and track_scan == "skipped":
+        meta["error"] = "overview_warming"
+    return {
+        "tracks": tracks,
+        "totals": totals,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "meta": meta,
+    }
+
+
+def _build_overview_payload_from_scans() -> dict:
+    """Full overview including per-module status badges. Background refresh only."""
+    manifest = load_manifest()
+    levels = manifest.get("levels", {})
+    cached = cache_get_with_age("summary", ttl=DASHBOARD_STATE_SUMMARY_TTL_S)
+    if cached is not None:
+        state_summary, age_s = cached
+        cache_state = "hit"
+    else:
+        state_summary = compute_summary()
+        cache_set("summary", state_summary)
+        cache_state = "miss"
+        age_s = 0.0
     state_tracks = state_summary.get("tracks", {})
 
     tracks = []
@@ -132,11 +242,96 @@ async def overview():
             "generated_at": state_summary.get("generated_at"),
             "source": "fs:dashboard-summary+state-summary",
             "cache": cache_state,
-            "stale_after_s": DASHBOARD_STATE_SUMMARY_TTL_S,
+            "stale_after_s": DASHBOARD_OVERVIEW_TTL_S,
             "stale": False,
+            "track_scan": "hit",
             **({"age_s": round(age_s, 3)} if age_s is not None else {}),
         },
     }
+
+
+def _schedule_overview_refresh() -> None:
+    global _overview_refresh_thread
+    with _overview_refresh_lock:
+        if _overview_refresh_thread is not None and _overview_refresh_thread.is_alive():
+            return
+        _overview_refresh_thread = threading.Thread(
+            target=_run_overview_refresh,
+            daemon=True,
+            name="dashboard-overview-refresh",
+        )
+        _overview_refresh_thread.start()
+
+
+def _run_overview_refresh() -> None:
+    global _overview_last_good
+    try:
+        payload = _build_overview_payload_from_scans()
+        cache_set(DASHBOARD_OVERVIEW_CACHE_KEY, payload)
+        _overview_last_good = payload
+    except Exception:
+        logger.exception("dashboard overview background refresh failed")
+
+
+# ==================== ENDPOINTS ====================
+
+
+@router.get("/overview")
+async def overview():
+    """All tracks with module counts and pass/prose/fail stats.
+
+    The request path never walks the curriculum tree. A warm TTL cache or
+    last-good full scan is returned immediately; otherwise a cheap
+    manifest + cached-summary payload is served while a detached worker
+    fills last-good. ``meta.cache`` remains the state-summary cache
+    signal; ``meta.track_scan`` / ``meta.stale`` / ``meta.error`` stay
+    honest about whether the per-module scan has run.
+    """
+    state_summary, cache_state, age_s = _peek_state_summary()
+    state_tracks = state_summary.get("tracks", {}) if isinstance(state_summary, dict) else {}
+
+    cached = cache_get_with_age(DASHBOARD_OVERVIEW_CACHE_KEY, ttl=DASHBOARD_OVERVIEW_TTL_S)
+    if cached is not None:
+        value, overview_age_s = cached
+        payload = copy.deepcopy(value)
+        payload["timestamp"] = datetime.now(UTC).isoformat()
+        meta = dict(payload.get("meta") or {})
+        meta["cache"] = cache_state
+        meta["stale"] = False
+        meta["track_scan"] = "hit"
+        meta["stale_after_s"] = DASHBOARD_OVERVIEW_TTL_S
+        meta.pop("error", None)
+        if cache_state == "hit" and age_s is not None:
+            meta["age_s"] = round(age_s, 3)
+        elif overview_age_s is not None:
+            meta["age_s"] = round(overview_age_s, 3)
+        _overlay_research_from_summary(payload.get("tracks", []), state_tracks)
+        payload["meta"] = meta
+        return payload
+
+    if _overview_last_good is not None:
+        _schedule_overview_refresh()
+        payload = copy.deepcopy(_overview_last_good)
+        payload["timestamp"] = datetime.now(UTC).isoformat()
+        meta = dict(payload.get("meta") or {})
+        meta["cache"] = cache_state
+        meta["stale"] = True
+        meta["track_scan"] = "stale"
+        meta["refreshing"] = True
+        meta["stale_after_s"] = DASHBOARD_OVERVIEW_TTL_S
+        if age_s is not None:
+            meta["age_s"] = round(age_s, 3)
+        _overlay_research_from_summary(payload.get("tracks", []), state_tracks)
+        payload["meta"] = meta
+        return payload
+
+    _schedule_overview_refresh()
+    return _build_overview_from_state_summary(
+        state_summary,
+        cache_state,
+        age_s,
+        track_scan="skipped",
+    )
 
 
 @router.get("/research")

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -250,11 +250,13 @@ SESSION_STATE_DIR = PROJECT_ROOT / "docs" / "session-state"
 # advisory — Python threads are not cancellable once started. Real
 # protection per sync collector:
 #   - ``git``, ``issues``     — subprocess timeout 2 s (``_run_command``)
-#   - ``runtime``, ``delegate``, ``wiki``, ``health``, ``session_hints``
+#   - ``runtime``, ``delegate``, ``wiki``, ``session_hints``
 #                            — pure-Python / filesystem, no inner
 #                              timeout; they rely on being cheap.
 #   - ``idle_prs``           — cache-first detached worker; ``gh`` never runs
 #                              in the request path.
+#   - ``capacity``, ``health`` — cache-first detached worker (#6983); CodexBar
+#                              / canaries never pin the lean gather.
 # If a sync collector ever starts to block (e.g. a network FS hang), it
 # will tie up a threadpool slot past the hard timeout. See
 # MONITOR-API.md for the full breakdown.
@@ -320,7 +322,8 @@ ORIENT_SECTION_KEYS: tuple[str, ...] = tuple(ORIENT_SECTION_TTLS.keys())
 # bridge asks, blocking decisions (governance), health, and the handoff pointers / current goal
 # (session_hints). Excludes the three heavy sections — ``pipeline`` (~2k module stats),
 # ``issues`` (full gh list), ``wiki`` (per-track coverage) — which are fetched on demand via
-# ``?sections=...``. Cuts the default cold-start payload sharply (codex cold-start review; #4728).
+# ``?sections=...``. ``capacity`` and ``health`` stay in the preset but are cache-first /
+# detached so CodexBar or a hung canary cannot pin the gather at 5 s (#6983).
 LEAN_ORIENT_SECTIONS: tuple[str, ...] = (
     "git",
     "runtime",
@@ -342,6 +345,17 @@ _ORIENT_SYNC_EXECUTOR = ThreadPoolExecutor(
     max_workers=8,
     thread_name_prefix="orient-sync",
 )
+
+# Lean ``capacity`` / ``health`` are cache-first and detached: CodexBar and
+# integrity canaries must not pin ``asyncio.gather`` at the 5 s section
+# wall (#6983). A short join lets cheap (test) collectors populate the
+# same request; a live hang returns fallback immediately after this wait.
+DETACHED_ORIENT_SECTION_KEYS: frozenset[str] = frozenset({"capacity", "health"})
+DETACHED_ORIENT_INLINE_WAIT_S = 0.4
+_detached_orient_lock = threading.Lock()
+_detached_orient_threads: dict[str, threading.Thread] = {}
+_detached_orient_last_good: dict[str, tuple[Any, str]] = {}
+_detached_orient_last_error: dict[str, str] = {}
 
 # The idle-PR feed is deliberately cache-first. A live GitHub request is run by
 # one detached daemon worker, never by the ASGI request path. The last successful
@@ -737,6 +751,126 @@ def _cached_idle_pr_section(
     }
     if _idle_pr_last_error is not None:
         meta["error"] = _idle_pr_last_error
+    return fallback, meta
+
+
+def reset_detached_orient_state_for_tests() -> None:
+    """Drop capacity/health last-good so tests do not leak across cases."""
+    with _detached_orient_lock:
+        threads = list(_detached_orient_threads.values())
+    for thread in threads:
+        thread.join(timeout=2.0)
+    with _detached_orient_lock:
+        _detached_orient_threads.clear()
+    _detached_orient_last_good.clear()
+    _detached_orient_last_error.clear()
+
+
+def _schedule_detached_orient_refresh(key: str, collector: Callable[[], Any]) -> bool:
+    """Start a single-flight worker for ``key``. Return True if this call started it."""
+    with _detached_orient_lock:
+        thread = _detached_orient_threads.get(key)
+        if thread is not None and thread.is_alive():
+            return False
+        worker = threading.Thread(
+            target=_run_detached_orient_refresh,
+            args=(key, collector),
+            daemon=True,
+            name=f"orient-{key}-refresh",
+        )
+        _detached_orient_threads[key] = worker
+        worker.start()
+        return True
+
+
+def _run_detached_orient_refresh(key: str, collector: Callable[[], Any]) -> None:
+    ttl = ORIENT_SECTION_TTLS.get(key, 60.0)
+    try:
+        value = collector()
+        generated_at = _isoformat_z(datetime.now(UTC))
+        if ttl > 0:
+            cache_set(f"orient_{key}", (value, generated_at))
+        _detached_orient_last_good[key] = (value, generated_at)
+        _detached_orient_last_error.pop(key, None)
+    except Exception as exc:
+        _detached_orient_last_error[key] = str(exc)
+
+
+async def _cached_detached_orient_section(
+    key: str,
+    collector: Callable[[], Any],
+    fallback: Any,
+) -> tuple[Any, dict]:
+    """Cache-first section: never let a hung collector pin the gather.
+
+    On a miss, one detached worker runs the collector. This request waits
+    up to ``DETACHED_ORIENT_INLINE_WAIT_S`` only if *this* call started
+    that worker (so cheap test doubles still populate the same response).
+    Overlapping requests and live hangs return last-good or fallback with
+    honest ``meta.error``.
+    """
+    ttl = ORIENT_SECTION_TTLS.get(key, 60.0)
+    source = ORIENT_SECTION_SOURCES.get(key, "fs")
+    cache_key = f"orient_{key}"
+    if ttl > 0:
+        cached = cache_get(cache_key, ttl=ttl)
+        if cached is not None:
+            value, generated_at = cached  # type: ignore[misc]
+            return value, {
+                "generated_at": generated_at,
+                "stale_after_s": ttl,
+                "source": source,
+                "cache": "hit",
+            }
+
+    started = _schedule_detached_orient_refresh(key, collector)
+    thread = _detached_orient_threads.get(key)
+    if started and thread is not None and thread.is_alive():
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            _ORIENT_SYNC_EXECUTOR,
+            thread.join,
+            DETACHED_ORIENT_INLINE_WAIT_S,
+        )
+
+    if ttl > 0:
+        cached = cache_get(cache_key, ttl=ttl)
+        if cached is not None:
+            value, generated_at = cached  # type: ignore[misc]
+            return value, {
+                "generated_at": generated_at,
+                "stale_after_s": ttl,
+                "source": source,
+                "cache": "miss",
+            }
+
+    last_good = _detached_orient_last_good.get(key)
+    if last_good is not None:
+        value, generated_at = last_good
+        meta: dict[str, Any] = {
+            "generated_at": generated_at,
+            "stale_after_s": ttl,
+            "source": source,
+            "cache": "miss",
+            "stale": True,
+            "refreshing": thread is not None and thread.is_alive(),
+        }
+        last_error = _detached_orient_last_error.get(key)
+        if last_error is not None:
+            meta["error"] = last_error
+        return value, meta
+
+    short_err = _detached_orient_last_error.get(key) or "refreshing"
+    meta = {
+        "generated_at": _isoformat_z(datetime.now(UTC)),
+        "stale_after_s": ttl,
+        "source": source,
+        "cache": "miss",
+        "refreshing": thread is not None and thread.is_alive(),
+        "error": short_err,
+    }
+    if isinstance(fallback, dict):
+        return {**fallback, "error": short_err}, meta
     return fallback, meta
 
 
@@ -1183,6 +1317,8 @@ async def _cached_orient_section(
     """
     if key == "idle_prs":
         return _cached_idle_pr_section(collector, fallback)  # type: ignore[arg-type]
+    if key in DETACHED_ORIENT_SECTION_KEYS:
+        return await _cached_detached_orient_section(key, collector, fallback)  # type: ignore[arg-type]
 
     ttl = ORIENT_SECTION_TTLS.get(key, 60.0)
     source = ORIENT_SECTION_SOURCES.get(key, "fs")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -16,12 +16,17 @@ Validates:
 import asyncio
 import json
 import subprocess
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
+import scripts.api.dashboard_router as dashboard_router
+import scripts.api.state_helpers as state_helpers
 from scripts.api.main import app
+from tests.latency_budget import assert_under_budget
 
 client = TestClient(app, raise_server_exceptions=False)
 
@@ -230,6 +235,96 @@ class TestDashboardOverviewEndpoint:
         assert overview["meta"]["cache"] == "hit"
         assert tracks["a1"]["stats"]["research"]["total"] == summary["tracks"]["a1"]["research_done"]
         assert tracks["folk"]["stats"]["research"]["total"] == summary["tracks"]["folk"]["dossier_done"]
+
+    def test_overview_does_not_wait_for_curriculum_scan(self, monkeypatch):
+        """#6983: overview must not rescan every module on the request path.
+
+        Live evidence: cache-miss overview took 5.7 s with totals.missing=1932
+        and overlapped lean orient into 504s. A hung scan/summary must still
+        return 200 well under the 10 s global timeout, with honest meta.
+        """
+        dashboard_router.reset_overview_state_for_tests()
+        state_helpers.cache_invalidate("summary")
+        state_helpers.cache_invalidate(dashboard_router.DASHBOARD_OVERVIEW_CACHE_KEY)
+        release = threading.Event()
+
+        def hang_scan(*_args, **_kwargs):
+            release.wait(8)
+            return {
+                "track_id": "a1",
+                "track_path": "a1",
+                "module_count": 0,
+                "is_seminar": False,
+                "modules": [],
+            }
+
+        def hang_summary():
+            release.wait(8)
+            return {"generated_at": None, "tracks": {}, "totals": {}}
+
+        monkeypatch.setattr(dashboard_router, "scan_track_summary_cached", hang_scan)
+        monkeypatch.setattr(dashboard_router, "compute_summary", hang_summary)
+
+        start = time.perf_counter()
+        try:
+            resp = client.get("/api/dashboard/overview")
+            elapsed = time.perf_counter() - start
+            assert resp.status_code == 200
+            assert_under_budget(
+                elapsed,
+                1.5,
+                f"overview waited for curriculum scan, took {elapsed:.3f}s",
+            )
+            data = resp.json()
+            assert "tracks" in data
+            assert "totals" in data
+            meta = data["meta"]
+            assert meta["cache"] in {"hit", "miss"}
+            assert meta.get("track_scan") in {"skipped", "stale", "hit"}
+            if meta["cache"] == "miss" and meta.get("track_scan") == "skipped":
+                assert meta.get("error") == "overview_warming"
+                assert meta.get("stale") is True
+        finally:
+            release.set()
+            dashboard_router.reset_overview_state_for_tests()
+
+    def test_overview_cache_hit_stays_under_playground_budget(self, monkeypatch):
+        """Cache-hit overview must stay inside the 1.5 s in-process playground budget."""
+        dashboard_router.reset_overview_state_for_tests()
+        warm = client.get("/api/state/summary?fresh=true")
+        assert warm.status_code == 200
+        summary = warm.json()
+        seeded = dashboard_router._build_overview_from_state_summary(
+            summary, "hit", 0.0, track_scan="hit"
+        )
+        state_helpers.cache_set(dashboard_router.DASHBOARD_OVERVIEW_CACHE_KEY, seeded)
+
+        release = threading.Event()
+
+        def hang_scan(*_args, **_kwargs):
+            release.wait(8)
+            raise AssertionError("cache-hit overview must not rescan")
+
+        monkeypatch.setattr(dashboard_router, "scan_track_summary_cached", hang_scan)
+        monkeypatch.setattr(dashboard_router, "compute_summary", hang_scan)
+
+        try:
+            start = time.perf_counter()
+            resp = client.get("/api/dashboard/overview")
+            elapsed = time.perf_counter() - start
+            assert resp.status_code == 200
+            assert_under_budget(
+                elapsed,
+                1.5,
+                f"overview cache-hit took {elapsed:.3f}s",
+            )
+            data = resp.json()
+            assert data["meta"]["cache"] == "hit"
+            assert data["meta"].get("stale") is False
+            assert data["meta"].get("track_scan") == "hit"
+        finally:
+            release.set()
+            dashboard_router.reset_overview_state_for_tests()
 
 
 # ==================== Router mounting tests ====================

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1136,6 +1136,37 @@ class TestScanTrackSummaryCached:
         assert (time.time() - entry[0]) > 60  # past TTL
 
 
+class TestStatsFromStateSummary:
+    """Cheap overview stats mapping must keep research keys honest."""
+
+    def test_seminar_uses_dossier_done(self):
+        from scripts.api.dashboard_helpers import stats_from_state_summary
+
+        stats = stats_from_state_summary(
+            {
+                "total": 10,
+                "generated_md": 4,
+                "audit_passing": 2,
+                "audit_stale": 1,
+                "content_done": 3,
+                "research_done": 9,
+                "dossier_done": 5,
+                "dossier_docs": 1,
+                "dossier_curriculum": 4,
+                "reviewed": 2,
+                "final_review_done": 1,
+                "prompt_reviewed": 1,
+            },
+            is_seminar=True,
+        )
+        assert stats["pass"] == 2
+        assert stats["missing"] == 6
+        assert stats["unaudited"] == 1
+        assert stats["research"]["total"] == 5
+        assert stats["fail"] == 0
+        assert stats["shippable"] == 0
+
+
 class TestBuildModuleSummary:
     """build_module_summary returns lightweight module info."""
 

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import os
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -31,10 +32,12 @@ def _reset_orient_cache():
     keys_to_drop = [k for k in state_helpers._ttl_cache if k.startswith("orient_")]
     for key in keys_to_drop:
         state_helpers._ttl_cache.pop(key, None)
+    api_main.reset_detached_orient_state_for_tests()
     yield
     keys_to_drop = [k for k in state_helpers._ttl_cache if k.startswith("orient_")]
     for key in keys_to_drop:
         state_helpers._ttl_cache.pop(key, None)
+    api_main.reset_detached_orient_state_for_tests()
 
 
 def _patch_orient_sources(monkeypatch) -> None:
@@ -708,3 +711,49 @@ def test_orient_issues_collector_uses_five_second_subprocess_timeout(monkeypatch
         api_main._collect_issues_orient_data()
 
     assert captured["timeout"] == 5.0
+
+
+def test_lean_orient_hung_capacity_and_health_do_not_stall_other_sections(monkeypatch):
+    """#6983: a hung CodexBar/canary must not pin lean orient at the 5 s wall.
+
+    ``asyncio.gather`` waits for the slowest section. Before the detached
+    refresh, a 5 s ``section_timeout`` on ``capacity`` or ``health`` made
+    the whole lean payload take 5.0 s. Other lean sections must still
+    populate, and the request must finish well under the 10 s global
+    timeout.
+    """
+    _patch_orient_sources(monkeypatch)
+    release = threading.Event()
+
+    def hang_capacity():
+        release.wait(8)
+        return {"lanes": {"codex": {"in_flight": 0, "healthy": True}}}
+
+    def hang_health():
+        release.wait(8)
+        return {"api": True}
+
+    monkeypatch.setattr(api_main, "_collect_capacity_orient_data", hang_capacity)
+    monkeypatch.setattr(api_main, "_collect_health_orient_data", hang_health)
+
+    start = time.perf_counter()
+    try:
+        response = client.get("/api/orient?lean=true")
+        elapsed = time.perf_counter() - start
+        assert response.status_code == 200
+        assert_under_budget(
+            elapsed,
+            1.5,
+            f"lean orient stalled on capacity/health, took {elapsed:.3f}s",
+        )
+        data = response.json()
+        assert data["git"]["branch"] == "main"
+        assert data["runtime"]["agents"] == ["codex"]
+        assert data["delegate"]["active_count"] == 0
+        assert "error" in data["meta"]["capacity"]
+        assert "error" in data["meta"]["health"]
+        assert data["capacity"].get("lanes") == {}
+        assert data["health"].get("api") is True
+        assert "section_timeout" not in str(data["meta"]["capacity"].get("error", ""))
+    finally:
+        release.set()


### PR DESCRIPTION
## Summary
- `/api/dashboard/overview` no longer walks every curriculum module on the request path. It serves a TTL cache or last-good payload, or a cheap manifest + cached-summary snapshot (`meta.track_scan=skipped`, `meta.error=overview_warming` on a true cold miss) while a detached worker fills last-good. `meta.cache` stays the state-summary signal; freshness is not faked.
- Lean `/api/orient?lean=true` keeps `capacity` and `health` but runs them as cache-first detached workers (same family as idle-PRs). A hung CodexBar or integrity canary returns section `error` + empty/default payload and cannot pin `asyncio.gather` at the 5.0s `section_timeout` wall.
- Global `API_REQUEST_TIMEOUT_S=10` is unchanged. Hung overview must not take the launchpad/orient session with it.

## Test plan
- [x] `ruff check` on `scripts/api/dashboard_router.py`, `scripts/api/main.py`, `scripts/api/dashboard_helpers.py`
- [x] Regression: hung `capacity`/`health` collectors do not stall other lean sections (`test_lean_orient_hung_capacity_and_health_do_not_stall_other_sections`, 0.47s vs live 5.0s)
- [x] Regression: hung `scan_track_summary` / `compute_summary` do not block overview (`test_overview_does_not_wait_for_curriculum_scan`, 0.02s vs live 5.7s)
- [x] Overview cache-hit stays under the playground 1.5s in-process budget (`test_overview_cache_hit_stays_under_playground_budget`, 0.01s)
- [x] `pytest -q tests/test_orient_api.py tests/test_api_resilience.py tests/test_api_endpoints.py tests/test_playground_api_stability.py tests/test_dashboards.py`

**Live Monitor process will not pick up this PR until restart.** In-process tests are the merge evidence.

Do not merge or arm auto-merge from this worker (`AGENT_NO_MERGE=1`).

## Related Issues

Refs #6983

Made with [Cursor](https://cursor.com)