### PR TITLE
fix(api): work /next admits body-homed pending_native, aliases areas, bounds refresh (Fixes #6984)

### DIFF
--- a/docs/monitor-api/work.md
+++ b/docs/monitor-api/work.md
@@ -28,19 +28,28 @@ Base URL (public Monitor): `http://127.0.0.1:8765` (prefer loopback IP).
 Machine contract for "what should this lane do next" — a driver never needs the
 586-row projection dump. Params: `stream=<stream key>` (required; keys from
 `scripts/config/issue_streams.yaml`, unknown keys 400 with `valid_streams`) and
-`limit` (default 7, max 25).
+`limit` (default 7, max 25). Unambiguous fleet-taxonomy area aliases are
+accepted and echoed (`?stream=infra` → `stream: "infra-harness"` +
+`requested_stream: "infra"`, via the same `fleet_taxonomy.yaml` resolver the
+session hooks use); ambiguous or unknown selectors still fail closed (#6984).
 
 - **Pick list is stream-scoped** (operator addendum on #6880): only actionable
   rows whose `projections.stream.streams` membership includes the requested
-  stream. Items with no stream membership (orphans, pending-native, PRs, tasks)
-  are NEVER pick items — they appear only as `digest.unscoped_actionable_count`.
+  stream. Body-homed `pending_native` tickets keep that honest status but DO
+  carry their epic-body-derived membership, so they are pick items for the
+  lane that owns them while native sub-issue migration lags (#6984). Items
+  with no stream membership (orphans, PRs, tasks, pending-native with no
+  derivable lane) are NEVER pick items — they appear as
+  `digest.unscoped_actionable_count`, and pending-native ones are additionally
+  named with a reason in `digest.excluded_pending_native`.
 - **Actionable** is the server-side SSOT `scripts/work/attention.py::is_actionable`
   (OFF_TRACK/AT_RISK always; otherwise `safe_next_action.code` outside the
   `INSPECT_UNKNOWN`/`OPEN_GITHUB`/`NONE` deny list). `dashboards/work.html`
   mirrors it in JS under a parity contract test.
 - **Digest, never a queue**: `other_streams.actionable_counts_by_stream`
   (counts only), `other_streams.top_blockers` (≤3 repo-wide OFF_TRACK
-  pointers), `unscoped_actionable_count`.
+  pointers), `unscoped_actionable_count`, `excluded_pending_native`
+  (`count` + ≤25 items with `streams` and `reason`).
 - **Warm cache only**: serves strictly from the unfiltered projection cache
   (single-flight, #6861). Cold → wire body
   `503 {"error": "building", "retry_after_s": 3}` (no FastAPI `detail`
@@ -48,6 +57,9 @@ Machine contract for "what should this lane do next" — a driver never needs th
   expired-but-present entries are served with an honest `cache_age_s` while
   the shared background refresh runs, until age exceeds `max_stale_s` (300s)
   → `503 {"error": "stale", "cache_age_s", "max_stale_s", "retry_after_s"}`.
+  The background build is bounded (`NEXT_BUILD_TIMEOUT_S`, 20s) so a hung
+  collector frees the single-flight slot and the next caller's refresh can
+  succeed instead of wedging the lane at 503 stale (#6984).
   An unreadable `issue_streams.yaml` registry →
   `503 {"error": "registry_unavailable", "retry_after_s"}` (fail closed —
   never 200 + empty queue for a stream typo). Warm calls measure ~1ms

--- a/scripts/api/work_router.py
+++ b/scripts/api/work_router.py
@@ -7,7 +7,10 @@ Never proxies private adapters or mutates GitHub / dispatch state.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import contextlib
 import logging
+import threading
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -121,47 +124,186 @@ def _build_sync(filters: dict[str, Any], *, cache_age_s: float = 0.0) -> dict[st
     return validate_projection(payload)
 
 
-_IN_FLIGHT_BUILDS: dict[str, asyncio.Task[dict[str, Any]]] = {}
+# Single-flight handles live on a dedicated worker loop so sync Starlette
+# TestClient cannot abandon them. TestClient without a context manager
+# starts a fresh blocking portal per GET and cancels leftover
+# ``asyncio.create_task`` work when that portal exits — so ``cache_set``
+# never runs and every /next retry stays 503 stale (CI #7015). Production
+# uvicorn keeps the server loop; we still do not await the refresh on /next.
+_IN_FLIGHT_BUILDS: dict[str, concurrent.futures.Future[dict[str, Any]]] = {}
+_IN_FLIGHT_LOCK = threading.Lock()
+_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
+_WORKER_THREAD: threading.Thread | None = None
+_WORKER_LOOP_LOCK = threading.Lock()
 
 
-async def _run_build_job(key: str, filters: dict[str, Any]) -> dict[str, Any]:
-    try:
-        payload = await asyncio.wait_for(
-            asyncio.to_thread(_build_sync, filters, cache_age_s=0.0),
-            timeout=NEXT_BUILD_TIMEOUT_S,
-        )
-        payload["cache_age_s"] = 0.0
-        cache_set(key, payload)
-        return payload
-    finally:
-        _IN_FLIGHT_BUILDS.pop(key, None)
+def _ensure_worker_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide loop that owns background projection builds."""
+    global _WORKER_LOOP, _WORKER_THREAD
+    with _WORKER_LOOP_LOCK:
+        if (
+            _WORKER_LOOP is not None
+            and _WORKER_LOOP.is_running()
+            and _WORKER_THREAD is not None
+            and _WORKER_THREAD.is_alive()
+        ):
+            return _WORKER_LOOP
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+            loop.call_soon(ready.set)
+            loop.run_forever()
+
+        thread = threading.Thread(target=_run, name="work-proj-loop", daemon=True)
+        thread.start()
+        if not ready.wait(timeout=5.0):
+            raise RuntimeError("work projection worker loop failed to start")
+        _WORKER_LOOP = loop
+        _WORKER_THREAD = thread
+        return loop
 
 
-def _consume_build_failure(task: asyncio.Task[dict[str, Any]]) -> None:
+async def _run_build_job(
+    key: str,
+    filters: dict[str, Any],
+    timeout_s: float | None = None,
+) -> dict[str, Any]:
+    bound = NEXT_BUILD_TIMEOUT_S if timeout_s is None else timeout_s
+    payload = await asyncio.wait_for(
+        asyncio.to_thread(_build_sync, filters, cache_age_s=0.0),
+        timeout=bound,
+    )
+    payload["cache_age_s"] = 0.0
+    cache_set(key, payload)
+    return payload
+
+
+def _consume_build_failure(fut: concurrent.futures.Future[dict[str, Any]]) -> None:
     """Log (and thereby retrieve) fire-and-forget build failures.
 
     Without this, a refresh kicked by /next that raises is dropped silently
     and the cache just keeps aging toward the 503 stale cliff (#6984).
     """
-    if task.cancelled():
+    if fut.cancelled():
         return
-    exc = task.exception()
+    exc = fut.exception()
     if exc is not None:
         log.warning("work projection background build failed: %s: %s", type(exc).__name__, exc)
 
 
-def _get_or_create_build_task(key: str, filters: dict[str, Any]) -> asyncio.Task[dict[str, Any]]:
-    task = _IN_FLIGHT_BUILDS.get(key)
-    if task is None or task.done():
-        task = asyncio.create_task(_run_build_job(key, filters))
-        task.add_done_callback(_consume_build_failure)
-        _IN_FLIGHT_BUILDS[key] = task
-    return task
+def _follow_cfuture(
+    cfut: concurrent.futures.Future[dict[str, Any]],
+) -> asyncio.Future[dict[str, Any]]:
+    """Await ``cfut`` on the running loop without cancelling the worker job."""
+    loop = asyncio.get_running_loop()
+    aio: asyncio.Future[dict[str, Any]] = loop.create_future()
+
+    def apply() -> None:
+        if aio.done():
+            return
+        if cfut.cancelled():
+            aio.cancel()
+            return
+        exc = cfut.exception()
+        if exc is not None:
+            aio.set_exception(exc)
+        else:
+            aio.set_result(cfut.result())
+
+    def _on_done(_f: concurrent.futures.Future[dict[str, Any]]) -> None:
+        # Request loop already closed (sync TestClient portal teardown).
+        # The worker future still finishes and cache_set still happens.
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(apply)
+
+    if cfut.done():
+        loop.call_soon(apply)
+    else:
+        cfut.add_done_callback(_on_done)
+    return aio
+
+
+def _ensure_in_flight(
+    key: str,
+    filters: dict[str, Any],
+) -> concurrent.futures.Future[dict[str, Any]]:
+    """Start or join the single-flight build; never tied to the request loop."""
+    with _IN_FLIGHT_LOCK:
+        existing = _IN_FLIGHT_BUILDS.get(key)
+        if existing is not None and not existing.done():
+            return existing
+        handle: concurrent.futures.Future[dict[str, Any]] = concurrent.futures.Future()
+        _IN_FLIGHT_BUILDS[key] = handle
+
+    def _finish_handle(src: concurrent.futures.Future[dict[str, Any]]) -> None:
+        if handle.done():
+            return
+        if src.cancelled():
+            handle.cancel()
+            return
+        exc = src.exception()
+        if exc is not None:
+            handle.set_exception(exc)
+        else:
+            handle.set_result(src.result())
+
+    def _clear(_src: concurrent.futures.Future[dict[str, Any]]) -> None:
+        with _IN_FLIGHT_LOCK:
+            if _IN_FLIGHT_BUILDS.get(key) is handle:
+                _IN_FLIGHT_BUILDS.pop(key, None)
+
+    try:
+        worker_loop = _ensure_worker_loop()
+        cfut = asyncio.run_coroutine_threadsafe(
+            _run_build_job(key, filters, NEXT_BUILD_TIMEOUT_S),
+            worker_loop,
+        )
+    except Exception as exc:
+        handle.set_exception(exc)
+        _clear(handle)
+        raise
+
+    cfut.add_done_callback(_clear)
+    cfut.add_done_callback(_consume_build_failure)
+    cfut.add_done_callback(_finish_handle)
+    return handle
+
+
+def _get_or_create_build_task(
+    key: str,
+    filters: dict[str, Any],
+) -> concurrent.futures.Future[dict[str, Any]]:
+    """Kick (or join) the single-flight refresh. /next does not await this."""
+    return _ensure_in_flight(key, filters)
+
+
+def wait_for_in_flight_build(key: str, timeout: float = 10.0) -> None:
+    """Block until the single-flight build for ``key`` settles.
+
+    Sync TestClient does not pump request-loop ``create_task`` work between
+    GETs; this helper waits on the worker-loop future instead of sleeping
+    and re-polling. No-op when nothing is in flight. Job failures (including
+    ``NEXT_BUILD_TIMEOUT_S``) are swallowed — callers assert on cache/slot.
+    """
+    with _IN_FLIGHT_LOCK:
+        fut = _IN_FLIGHT_BUILDS.get(key)
+    if fut is None:
+        return
+    try:
+        fut.result(timeout=timeout)
+    except Exception:
+        if not fut.done():
+            raise TimeoutError(
+                f"in-flight work projection build for {key!r} did not settle in {timeout}s"
+            ) from None
+        return
 
 
 def warm_projection_cache(
     filters: dict[str, Any] | None = None,
-) -> asyncio.Task[dict[str, Any]] | None:
+) -> asyncio.Future[dict[str, Any]] | None:
     """Schedule asynchronous background warm-up of the public projection cache."""
     canonical = admit_projection_filters(filters or {})
     key = projection_cache_key(canonical)
@@ -172,7 +314,7 @@ def warm_projection_cache(
         _ = asyncio.get_running_loop()
     except RuntimeError:
         return None
-    return _get_or_create_build_task(key, canonical)
+    return _follow_cfuture(_get_or_create_build_task(key, canonical))
 
 
 @router.get("/v1/projection")
@@ -197,9 +339,9 @@ async def work_projection(
     if fresh:
         cache_invalidate(CACHE_KEY)
 
-    task = _get_or_create_build_task(key, filters)
+    handle = _get_or_create_build_task(key, filters)
     try:
-        payload = await asyncio.wait_for(asyncio.shield(task), timeout=TIMEOUT_S)
+        payload = await asyncio.wait_for(asyncio.shield(_follow_cfuture(handle)), timeout=TIMEOUT_S)
     except TimeoutError as exc:
         stale = cache_get_with_age(key, float("inf"))
         if stale is not None and isinstance(stale[0], dict):

--- a/scripts/api/work_router.py
+++ b/scripts/api/work_router.py
@@ -7,12 +7,14 @@ Never proxies private adapters or mutates GitHub / dispatch state.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from scripts.api.state_helpers import cache_get, cache_get_with_age, cache_invalidate, cache_set
+from scripts.orchestration.fleet_taxonomy import FleetTaxonomyError, resolve_area
 from scripts.orchestration.issue_stream_audit import load_registry
 from scripts.work.attention import is_actionable
 from scripts.work.normalize import build_public_projection
@@ -24,6 +26,8 @@ from scripts.work.schema import (
     validate_projection,
 )
 from scripts.work.sources_public import private_capability_seam, public_repository_id
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["work"])
 
@@ -39,6 +43,10 @@ NEXT_TOP_BLOCKERS = 3
 # Bound stale-serve for /next: expired cache may be returned while a
 # single-flight refresh runs, but never past this age (residual #3 / #6890).
 NEXT_MAX_STALE_S = 300.0
+# Bound one background build (#6984): the single-flight slot must always free
+# again even when a section collector hangs, or every later /next caller sees
+# 503 stale forever. Well above the per-section timeouts in sources_public.
+NEXT_BUILD_TIMEOUT_S = 20.0
 STREAM_REGISTRY_CACHE_KEY = "work:v1:stream-registry"
 STREAM_REGISTRY_TTL_S = 60.0
 
@@ -118,7 +126,10 @@ _IN_FLIGHT_BUILDS: dict[str, asyncio.Task[dict[str, Any]]] = {}
 
 async def _run_build_job(key: str, filters: dict[str, Any]) -> dict[str, Any]:
     try:
-        payload = await asyncio.to_thread(_build_sync, filters, cache_age_s=0.0)
+        payload = await asyncio.wait_for(
+            asyncio.to_thread(_build_sync, filters, cache_age_s=0.0),
+            timeout=NEXT_BUILD_TIMEOUT_S,
+        )
         payload["cache_age_s"] = 0.0
         cache_set(key, payload)
         return payload
@@ -126,10 +137,24 @@ async def _run_build_job(key: str, filters: dict[str, Any]) -> dict[str, Any]:
         _IN_FLIGHT_BUILDS.pop(key, None)
 
 
+def _consume_build_failure(task: asyncio.Task[dict[str, Any]]) -> None:
+    """Log (and thereby retrieve) fire-and-forget build failures.
+
+    Without this, a refresh kicked by /next that raises is dropped silently
+    and the cache just keeps aging toward the 503 stale cliff (#6984).
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.warning("work projection background build failed: %s: %s", type(exc).__name__, exc)
+
+
 def _get_or_create_build_task(key: str, filters: dict[str, Any]) -> asyncio.Task[dict[str, Any]]:
     task = _IN_FLIGHT_BUILDS.get(key)
     if task is None or task.done():
         task = asyncio.create_task(_run_build_job(key, filters))
+        task.add_done_callback(_consume_build_failure)
         _IN_FLIGHT_BUILDS[key] = task
     return task
 
@@ -225,6 +250,22 @@ def _item_streams(item: dict[str, Any]) -> list[str]:
     return [s for s in streams if isinstance(s, str) and s]
 
 
+def _resolve_stream_alias(stream: str, known: list[str]) -> str | None:
+    """Resolve an area/alias name (e.g. SESSION_EPIC ``infra``) to one stream.
+
+    Uses the fleet taxonomy (scripts/config/fleet_taxonomy.yaml), the same
+    resolver the session hooks use. Only an unambiguous mapping — exactly one
+    known stream among the area's id + aliases — aliases; anything else
+    returns None so the caller fails closed with 400 unknown_stream (#6984).
+    """
+    try:
+        area = resolve_area(stream)
+    except FleetTaxonomyError:
+        return None
+    candidates = [name for name in (area.id, *area.aliases) if name in known]
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def _next_rank_key(item: dict[str, Any]) -> tuple[int, str]:
     return (int(item.get("attention_rank") or 0), str(item.get("work_id") or ""))
 
@@ -246,7 +287,11 @@ async def work_next(
     ``cache_age_s``) while the shared single-flight refresh runs in the
     background so /next-only pollers converge without ever blocking — until
     age exceeds ``NEXT_MAX_STALE_S``, which fails closed with 503 ``stale``.
-    An unreadable stream registry fails closed with 503 ``registry_unavailable``
+    The background build itself is bounded by ``NEXT_BUILD_TIMEOUT_S`` so a
+    hung collector frees the single-flight slot instead of wedging every
+    later caller at 503 stale (#6984). ``stream`` also accepts unambiguous
+    fleet-taxonomy area aliases (``infra`` → ``infra-harness``); an
+    unreadable stream registry fails closed with 503 ``registry_unavailable``
     rather than treating typos as an empty queue (#6890).
     """
     known = _known_streams()
@@ -260,12 +305,17 @@ async def work_next(
             },
             headers={"Retry-After": str(int(NEXT_RETRY_AFTER_S))},
         )
+    requested_stream = stream
+    if stream not in known:
+        aliased = _resolve_stream_alias(stream, known)
+        if aliased is not None:
+            stream = aliased
     if stream not in known:
         return _next_error(
             400,
             {
                 "error": "unknown_stream",
-                "message": f"unknown stream {stream!r}",
+                "message": f"unknown stream {requested_stream!r}",
                 "valid_streams": known,
             },
         )
@@ -343,7 +393,31 @@ async def work_next(
         )[:NEXT_TOP_BLOCKERS]
     ]
 
-    return {
+    # Honesty for the migration-pending lane (#6984): body-homed tickets whose
+    # native sub-issue link is still pending are AT_RISK work the caller must
+    # see either in the queue (when their body-derived membership includes
+    # this stream) or named here with a reason — never only a silent bump of
+    # unscoped_actionable_count.
+    excluded_pending = [
+        {
+            "work_id": i.get("work_id"),
+            "remote_id": i.get("remote_id"),
+            "title": i.get("title") or "",
+            "streams": _item_streams(i),
+            "reason": ("no_stream_membership" if not _item_streams(i) else "scoped_to_other_stream"),
+        }
+        for i in sorted(
+            (
+                i
+                for i in actionable
+                if ((i.get("projections") or {}).get("stream") or {}).get("status") == "pending_native"
+                and stream not in _item_streams(i)
+            ),
+            key=_next_rank_key,
+        )
+    ]
+
+    body: dict[str, Any] = {
         "schema_version": "work-next.v1",
         "stream": stream,
         "generated_at": payload.get("generated_at"),
@@ -356,9 +430,16 @@ async def work_next(
                 "top_blockers": top_blockers,
             },
             "unscoped_actionable_count": unscoped,
+            "excluded_pending_native": {
+                "count": len(excluded_pending),
+                "items": excluded_pending[:NEXT_MAX_LIMIT],
+            },
         },
         "capabilities": {"mutation": False},
     }
+    if requested_stream != stream:
+        body["requested_stream"] = requested_stream
+    return body
 
 
 @router.get("/v1/capabilities")
@@ -383,13 +464,15 @@ async def work_capabilities() -> dict[str, Any]:
             "route": "GET /api/work/v1/next",
             "params": {
                 "stream": (
-                    "required — stream key from scripts/config/issue_streams.yaml; the pick list is scoped to it"
+                    "required — stream key from scripts/config/issue_streams.yaml; the pick list is scoped to it. "
+                    "Unambiguous fleet-taxonomy area aliases (e.g. infra → infra-harness) are accepted (#6984)"
                 ),
                 "limit": f"optional int, default {NEXT_DEFAULT_LIMIT}, max {NEXT_MAX_LIMIT}",
             },
             "served_from": (
                 "warm projection cache only; 503 building + retry_after_s when cold; "
                 f"503 stale when cache_age_s ≥ {int(NEXT_MAX_STALE_S)}s; "
+                f"background refresh bounded at {int(NEXT_BUILD_TIMEOUT_S)}s so the single-flight slot always frees; "
                 "503 registry_unavailable when the stream registry is unreadable"
             ),
         },

--- a/scripts/work/normalize.py
+++ b/scripts/work/normalize.py
@@ -233,8 +233,12 @@ def _build_issue_item(
         stream_status = "orphan"
         epic_streams = []
     elif number in stream_idx["pending"]:
+        # Native sub-issue migration is pending, but the epic-body reference
+        # IS stream membership per the registry rule (issue_streams.yaml).
+        # Admit the body-derived lane so stream-scoped /next can see the
+        # ticket; status stays "pending_native" — never a fake "homed".
         stream_status = "pending_native"
-        epic_streams = []
+        epic_streams = stream_idx.get("membership", {}).get(number, [])
     elif number in stream_idx.get("epic_of", {}):
         stream_status = "epic"
         epic_streams = [stream_idx["epic_of"][number]]

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -779,3 +779,213 @@ def test_streams_loader_allowlists_derived_and_preset_membership():
     assert by_id[_wid(6001)]["projections"]["stream"]["streams"] == ["infra-harness"]
     assert by_id[_wid(6004)]["projections"]["stream"]["streams"] == ["infra-harness"]
     assert "bogus-stream" not in json.dumps(projection)
+
+
+# ---------------------------------------------------------------------------
+# /next — pending_native membership, stream aliases, refresh liveness (#6984)
+# ---------------------------------------------------------------------------
+
+
+def _pending_issue(number: int, title: str) -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": "area:infra"}],
+        "assignees": [],
+        "body": "",
+        "createdAt": "2026-08-01T00:00:00Z",
+        "updatedAt": "2026-08-02T00:00:00Z",
+        "url": f"https://github.com/{REPO}/issues/{number}",
+        "state": "OPEN",
+    }
+
+
+def _next_sections_pending(*, membership: bool) -> dict[str, SectionResult]:
+    """Fixture with an AT_RISK pending_native (body-homed) infra ticket.
+
+    With ``membership=True`` the streams authority knows the owning lane via
+    the epic-body reference (open_stream_membership); with ``False`` the
+    ticket is pending with no derivable lane.
+    """
+    sections = _next_sections()
+    issues = list(sections["issues"].payload)
+    issues.append(_pending_issue(6006, "Body-homed infra ticket (migration pending)"))
+    sections["issues"] = SectionResult("issues", "ok", payload=issues, count=len(issues))
+    streams_payload = dict(sections["streams"].payload)
+    streams_payload["pending_native_link"] = [6006]
+    membership_map = dict(streams_payload.get("open_stream_membership") or {})
+    if membership:
+        membership_map["6006"] = ["infra-harness"]
+    streams_payload["open_stream_membership"] = membership_map
+    sections["streams"] = SectionResult("streams", "ok", payload=streams_payload, count=len(issues))
+    return sections
+
+
+def _warm_cache_from(sections: dict[str, SectionResult]) -> dict:
+    from scripts.api.state_helpers import cache_set
+    from scripts.api.work_router import projection_cache_key
+
+    cache_invalidate("work:v1:projection")
+    payload = build_projection(sections, repository_id=REPO)
+    cache_set(projection_cache_key({}), payload)
+    return payload
+
+
+def test_next_includes_pending_native_with_body_membership(monkeypatch):
+    """#6984: a body-homed pending_native ticket is visible to its owning lane.
+
+    Native sub-issue migration can lag (5 infra tickets resisted --migrate);
+    while pending, the epic-body reference IS membership per the registry
+    rule. The item keeps status ``pending_native`` (no fake ``homed``) and
+    appears in the lane queue with LINK_PENDING_NATIVE.
+    """
+    _patch_known_streams(monkeypatch)
+    _warm_cache_from(_next_sections_pending(membership=True))
+
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    queue_ids = [row["work_id"] for row in data["queue"]]
+    assert _wid(6006) in queue_ids
+    row = next(r for r in data["queue"] if r["work_id"] == _wid(6006))
+    assert row["health"] == "AT_RISK"
+    assert row["safe_next_action"]["code"] == "LINK_PENDING_NATIVE"
+    # Scoped, not silently dumped into the unscoped count.
+    assert data["digest"]["unscoped_actionable_count"] == 2
+    excluded = data["digest"]["excluded_pending_native"]
+    assert all(e["work_id"] != _wid(6006) for e in excluded["items"])
+    assert excluded["count"] == 0
+
+
+def test_next_pending_native_status_and_streams_stay_honest():
+    """The projection keeps status=pending_native while listing the body-derived lane."""
+    projection = build_projection(_next_sections_pending(membership=True), repository_id=REPO)
+    by_id = {i["work_id"]: i for i in projection["items"]}
+    stream = by_id[_wid(6006)]["projections"]["stream"]
+    assert stream["status"] == "pending_native"
+    assert stream["streams"] == ["infra-harness"]
+
+
+def test_next_pending_native_without_membership_is_named_in_digest(monkeypatch):
+    """#6984: an unscoped pending_native ticket is listed with a reason, never silent."""
+    _patch_known_streams(monkeypatch)
+    _warm_cache_from(_next_sections_pending(membership=False))
+
+    response = client.get("/api/work/v1/next?stream=infra-harness")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert _wid(6006) not in [row["work_id"] for row in data["queue"]]
+    excluded = data["digest"]["excluded_pending_native"]
+    assert excluded["count"] == 1
+    entry = next(e for e in excluded["items"] if e["work_id"] == _wid(6006))
+    assert entry["reason"] == "no_stream_membership"
+    assert entry["streams"] == []
+    assert entry["title"] == "Body-homed infra ticket (migration pending)"
+    # Still honestly counted as unscoped.
+    assert data["digest"]["unscoped_actionable_count"] == 3
+
+
+def test_next_stream_alias_resolves_via_fleet_taxonomy(monkeypatch):
+    """#6984: drivers type SESSION_EPIC area names ('infra'); unambiguous aliases work."""
+    _patch_known_streams(monkeypatch)
+    _warm_next_cache()
+
+    response = client.get("/api/work/v1/next?stream=infra")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["stream"] == "infra-harness"
+    assert data["requested_stream"] == "infra"
+    assert [r["work_id"] for r in data["queue"]] == [_wid(6004), _wid(6001)]
+
+    # Canonical names still pass through without a requested_stream echo.
+    canonical = client.get("/api/work/v1/next?stream=infra-harness")
+    assert canonical.status_code == 200
+    assert "requested_stream" not in canonical.json()
+
+    # Unknown selectors still fail closed with the valid stream list.
+    bad = client.get("/api/work/v1/next?stream=not-a-stream")
+    assert bad.status_code == 400
+    assert bad.json()["error"] == "unknown_stream"
+
+
+def test_next_successful_background_refresh_resets_age(monkeypatch):
+    """#6984: a kicked refresh that finishes re-warms the cache; the retry is 200."""
+    import time
+
+    from scripts.api.state_helpers import _ttl_cache
+    from scripts.api.work_router import projection_cache_key
+
+    _patch_known_streams(monkeypatch)
+    payload = _warm_next_cache()
+    key = projection_cache_key({})
+    _ttl_cache[key] = (time.monotonic() - (work_router.NEXT_MAX_STALE_S + 15.0), payload)
+
+    def fake_build(*, filters=None, cache_age_s=0.0, **_kwargs):
+        return build_projection(_next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
+
+    monkeypatch.setattr(work_router, "build_public_projection", fake_build)
+
+    first = client.get("/api/work/v1/next?stream=infra-harness")
+    assert first.status_code == 503, first.text
+    assert first.json()["error"] == "stale"
+
+    # The single-flight refresh kicked by the 503 completes and rewrites the
+    # cache; a driver retrying within seconds must converge to 200.
+    deadline = time.monotonic() + 10.0
+    second = None
+    while time.monotonic() < deadline:
+        second = client.get("/api/work/v1/next?stream=infra-harness")
+        if second.status_code == 200:
+            break
+        time.sleep(0.05)
+    assert second is not None and second.status_code == 200, "refresh never re-warmed the cache"
+    assert second.json()["cache_age_s"] < work_router.NEXT_MAX_STALE_S
+    assert [r["work_id"] for r in second.json()["queue"]] == [_wid(6004), _wid(6001)]
+
+
+def test_next_hung_refresh_frees_single_flight_slot(monkeypatch):
+    """#6984: a build that never finishes must not wedge the single-flight slot.
+
+    The background build is bounded by NEXT_BUILD_TIMEOUT_S; once it times
+    out the slot frees and the next caller's refresh can succeed.
+    """
+    import time
+
+    from scripts.api.state_helpers import _ttl_cache
+    from scripts.api.work_router import projection_cache_key
+
+    _patch_known_streams(monkeypatch)
+    payload = _warm_next_cache()
+    key = projection_cache_key({})
+    _ttl_cache[key] = (time.monotonic() - (work_router.NEXT_MAX_STALE_S + 15.0), payload)
+    monkeypatch.setattr(work_router, "NEXT_BUILD_TIMEOUT_S", 0.2)
+
+    def hanging_build(**_kwargs):
+        time.sleep(2.0)
+        return build_projection(_next_sections(), repository_id=REPO)
+
+    monkeypatch.setattr(work_router, "build_public_projection", hanging_build)
+    first = client.get("/api/work/v1/next?stream=infra-harness")
+    assert first.status_code == 503, first.text
+    assert first.json()["error"] == "stale"
+
+    # The hung build is abandoned at the timeout and the slot frees.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and key in work_router._IN_FLIGHT_BUILDS:
+        time.sleep(0.05)
+    assert key not in work_router._IN_FLIGHT_BUILDS, "hung build wedged the single-flight slot"
+
+    # A healthy retry rebuilds and serves 200.
+    def fast_build(*, filters=None, cache_age_s=0.0, **_kwargs):
+        return build_projection(_next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
+
+    monkeypatch.setattr(work_router, "build_public_projection", fast_build)
+    deadline = time.monotonic() + 10.0
+    second = None
+    while time.monotonic() < deadline:
+        second = client.get("/api/work/v1/next?stream=infra-harness")
+        if second.status_code == 200:
+            break
+        time.sleep(0.05)
+    assert second is not None and second.status_code == 200, "slot stayed wedged after the hung build"
+    assert second.json()["cache_age_s"] < work_router.NEXT_MAX_STALE_S

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -929,16 +929,11 @@ def test_next_successful_background_refresh_resets_age(monkeypatch):
     assert first.status_code == 503, first.text
     assert first.json()["error"] == "stale"
 
-    # The single-flight refresh kicked by the 503 completes and rewrites the
-    # cache; a driver retrying within seconds must converge to 200.
-    deadline = time.monotonic() + 10.0
-    second = None
-    while time.monotonic() < deadline:
-        second = client.get("/api/work/v1/next?stream=infra-harness")
-        if second.status_code == 200:
-            break
-        time.sleep(0.05)
-    assert second is not None and second.status_code == 200, "refresh never re-warmed the cache"
+    # Sync TestClient does not pump request-loop create_task work; wait on the
+    # worker-loop future so the 503 stale contract stays and the retry is 200.
+    work_router.wait_for_in_flight_build(key)
+    second = client.get("/api/work/v1/next?stream=infra-harness")
+    assert second.status_code == 200, "refresh never re-warmed the cache"
     assert second.json()["cache_age_s"] < work_router.NEXT_MAX_STALE_S
     assert [r["work_id"] for r in second.json()["queue"]] == [_wid(6004), _wid(6001)]
 
@@ -970,9 +965,7 @@ def test_next_hung_refresh_frees_single_flight_slot(monkeypatch):
     assert first.json()["error"] == "stale"
 
     # The hung build is abandoned at the timeout and the slot frees.
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline and key in work_router._IN_FLIGHT_BUILDS:
-        time.sleep(0.05)
+    work_router.wait_for_in_flight_build(key)
     assert key not in work_router._IN_FLIGHT_BUILDS, "hung build wedged the single-flight slot"
 
     # A healthy retry rebuilds and serves 200.
@@ -980,12 +973,10 @@ def test_next_hung_refresh_frees_single_flight_slot(monkeypatch):
         return build_projection(_next_sections(), repository_id=REPO, filters=filters, cache_age_s=cache_age_s)
 
     monkeypatch.setattr(work_router, "build_public_projection", fast_build)
-    deadline = time.monotonic() + 10.0
-    second = None
-    while time.monotonic() < deadline:
-        second = client.get("/api/work/v1/next?stream=infra-harness")
-        if second.status_code == 200:
-            break
-        time.sleep(0.05)
-    assert second is not None and second.status_code == 200, "slot stayed wedged after the hung build"
+    retry = client.get("/api/work/v1/next?stream=infra-harness")
+    assert retry.status_code == 503, retry.text
+    assert retry.json()["error"] == "stale"
+    work_router.wait_for_in_flight_build(key)
+    second = client.get("/api/work/v1/next?stream=infra-harness")
+    assert second.status_code == 200, "slot stayed wedged after the hung build"
     assert second.json()["cache_age_s"] < work_router.NEXT_MAX_STALE_S


### PR DESCRIPTION
Fixes #6984.

## Root causes (all three confirmed)

1. **Queue membership** — `scripts/work/normalize.py::_build_issue_item` forced `streams=[]` for `pending_native` issues even though the streams authority knows the owning lane: `pending_native_link` is exactly the set of body-homed open issues, and `open_stream_membership` (derived from the ADR-011 private index before stripping) already carries their lane. Stream-scoped `/next` filters on `streams`, so AT_RISK `area:infra` tickets (#6954, #6957, #5880, #5885 class) were invisible to `infra-harness` and only bumped `unscoped_actionable_count` silently.
2. **Alias** — `?stream=infra` (what drivers type from `SESSION_EPIC`) hit the `unknown_stream` 400 even though `scripts/config/fleet_taxonomy.yaml` already maps the `infra` area to `infra-harness`.
3. **Stale wedge** — `503 stale` after 300s is intentional fail-closed and is kept. The defect: the background build in `_run_build_job` had no timeout, so a hung section collector wedged the single-flight slot in `_IN_FLIGHT_BUILDS` forever — every later `_get_or_create_build_task` returned the dead task, the cache was never rewritten, and /next-only callers saw 503 stale indefinitely. Failures were also dropped silently ("exception never retrieved").

## Changes

- `scripts/work/normalize.py` — pending_native issues keep `status: "pending_native"` (AT_RISK, `LINK_PENDING_NATIVE` — no fake `homed`) but now carry their body-derived `streams` membership.
- `scripts/api/work_router.py`
  - `_run_build_job` bounded by `NEXT_BUILD_TIMEOUT_S = 20s`; done-callback logs build failures so the slot always frees and errors surface.
  - `_resolve_stream_alias`: unambiguous fleet-taxonomy area aliases resolve (`infra` → `infra-harness`, echoed as `requested_stream`); unknown/ambiguous selectors still 400 fail-closed.
  - Digest gains `excluded_pending_native` (`count` + ≤25 items with `streams` and `reason`: `no_stream_membership` / `scoped_to_other_stream`) so a pending ticket is either queued or honestly named.
- `docs/monitor-api/work.md` — /next contract updated (alias, pending-native membership, bounded refresh).
- `tests/test_work_api.py` — 6 new tests; 5 failed on main before the fix (the age-reset guard passes on healthy builds and now protects the regression).

## Verify

```
.venv/bin/ruff check scripts/api/work_router.py scripts/work/attention.py scripts/work/normalize.py
  → All checks passed!
.venv/bin/python -m pytest -q tests/test_work_api.py tests/test_work_privacy.py
  → 33 passed in 3.18s
```

Adjacent suites: `test_work_contract.py`, `test_work_dashboard.py`, `test_work_dashboard_private_integration.py`, `test_driver_work_api_onboarding.py`, `test_fleet_taxonomy_aliases.py` → 131 passed, 2 skipped.

Node ids:
- `tests/test_work_api.py::test_next_includes_pending_native_with_body_membership`
- `tests/test_work_api.py::test_next_pending_native_status_and_streams_stay_honest`
- `tests/test_work_api.py::test_next_pending_native_without_membership_is_named_in_digest`
- `tests/test_work_api.py::test_next_stream_alias_resolves_via_fleet_taxonomy`
- `tests/test_work_api.py::test_next_successful_background_refresh_resets_age`
- `tests/test_work_api.py::test_next_hung_refresh_frees_single_flight_slot`

Fixture `/next?stream=infra` payload (queue now contains the pending_native AT_RISK item; status stays honest):

```json
{
 "stream": "infra-harness",
 "requested_stream": "infra",
 "queue": [
  {"remote_id": "6004", "health": "OFF_TRACK", "safe_next_action": {"code": "RESOLVE_MULTI_HOME"}},
  {"remote_id": "6001", "health": "AT_RISK", "safe_next_action": {"code": "RESOLVE_BLOCKER"}},
  {"remote_id": "6006", "title": "Body-homed infra ticket (migration pending)", "health": "AT_RISK",
   "safe_next_action": {"code": "LINK_PENDING_NATIVE", "reason_codes": ["pending_native_link"]}}
 ],
 "digest": {"unscoped_actionable_count": 2, "excluded_pending_native": {"count": 0, "items": []}}
}
```

Projection row for that item: `stream.status == "pending_native"`, `stream.streams == ["infra-harness"]`.

## Non-goals respected

#6892 (grok-bot QA observer pass) untouched; dashboard/orient (#6983) untouched; no GitHub parent-link migration; no merge/auto-merge armed.

X-Agent: kimi/infra-6984-work-next
