### PR TITLE
feat(ci): CODEOWNERS + fail-closed workflow interpolation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Workflow files gate to a named human code owner: any PR touching
+# .github/workflows/** requires @krisztiankoos review (enable "Require review
+# from Code Owners" in branch protection). Agents may still *draft* workflow
+# PRs; the human review is the merge gate. No catch-all `*` rule — ordinary
+# code/docs/curriculum PRs get no extra reviewer.
+.github/workflows/**  @krisztiankoos
+.github/CODEOWNERS    @krisztiankoos

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,6 +29,11 @@ CI, security, and deploy automation for the learn-ukrainian curriculum.
 
 ## Security gates (layered, non-wedging)
 
+0. **Workflow-path gate** — `.github/CODEOWNERS` requires human code-owner
+   review for PRs touching `workflows/**`, and
+   `scripts/audit/check_untrusted_workflow_interpolation.py` (invoked by
+   `check_workflows.sh` after actionlint) fail-closes untrusted-context
+   `${{ }}` interpolation in `run:` scripts; use the `env:` + `"$VAR"` pattern.
 1. **Auto-remediate** — Dependabot covers every ecosystem (github-actions, npm,
    **pip**) with automated security fixes enabled. Security PRs land continuously.
 2. **Block-new** — CodeQL + (recommended) required-check promotion of

--- a/scripts/audit/check_untrusted_workflow_interpolation.py
+++ b/scripts/audit/check_untrusted_workflow_interpolation.py
@@ -15,9 +15,10 @@ prescribes the intermediate-``env:`` pattern instead:
 This checker scans every ``run:`` block (inline and ``|``/``>`` multiline) in
 ``.github/workflows/*.yml`` and fails on untrusted contexts. Identifiers and
 functions are matched case-insensitively (GitHub does), index syntax
-``github.event['issue']['title']`` is treated as dotted access, and
+``github.event['issue']['title']`` is treated as dotted access,
 ``toJSON(github.event)`` / ``toJSON(github)`` dumps of the event payload are
-rejected. It deliberately does NOT flag:
+rejected, and ``${{ }}`` extraction is quote-aware so ``format('}}{0}', ...)``
+cannot hide a later untrusted argument. It deliberately does NOT flag:
 
     - ``env:`` mappings (the safe pattern above),
     - SHAs and refs: ``github.sha``, ``github.ref``,
@@ -68,7 +69,43 @@ _BRACKET_IDENT = re.compile(r"""\[\s*(['"])([A-Za-z_][\w-]*)\1\s*\]""")
 # toJSON(...) are already caught by _UNTRUSTED after normalize.
 _TOJSON_WHOLE_EVENT = re.compile(r"\btojson\s*\(\s*github(?:\.event)?\s*\)", re.IGNORECASE)
 
-_EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+def iter_expressions(text: str) -> list[tuple[int, str]]:
+    """Yield ``(offset, inner)`` for each ``${{ ... }}``, quote-aware.
+
+    GitHub expressions only use single-quoted strings (``''`` escapes a quote).
+    A non-greedy ``(.*?)\\}\\}`` regex would stop at ``format('}}{0}', ...)``
+    and miss the untrusted argument after the embedded ``}}``.
+    """
+    results: list[tuple[int, str]] = []
+    i = 0
+    while True:
+        start = text.find("${{", i)
+        if start < 0:
+            return results
+        inner_start = start + 3
+        j = inner_start
+        in_string = False
+        while j < len(text):
+            if in_string:
+                if text[j] == "'":
+                    if j + 1 < len(text) and text[j + 1] == "'":
+                        j += 2
+                        continue
+                    in_string = False
+                j += 1
+                continue
+            if text[j] == "'":
+                in_string = True
+                j += 1
+                continue
+            if text.startswith("}}", j):
+                results.append((start, text[inner_start:j]))
+                i = j + 2
+                break
+            j += 1
+        else:
+            return results
+    return results
 # `run:` key, optionally after a `- ` step marker. Content indent is measured
 # from the line start so both `run: |` and `- run: |` blocks parse alike.
 _RUN_KEY = re.compile(r"^(?P<indent>\s*)(?:-\s+)?run:\s*(?P<value>.*)$")
@@ -135,15 +172,14 @@ def findings_for(path: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     findings: list[str] = []
     for start_line, body in run_blocks(text):
-        for match in _EXPRESSION.finditer(body):
-            expression = match.group(1)
+        for start, expression in iter_expressions(body):
             normalized = normalize_expression(expression)
             untrusted = _UNTRUSTED.search(normalized) or _TOJSON_WHOLE_EVENT.search(
                 normalized
             )
             if not untrusted:
                 continue
-            line_no = start_line + body[: match.start()].count("\n")
+            line_no = start_line + body[:start].count("\n")
             findings.append(
                 f"{path}:{line_no}: untrusted context `{untrusted.group(0)}` "
                 f"interpolated into a run: script — use env: + a quoted shell "

--- a/scripts/audit/check_untrusted_workflow_interpolation.py
+++ b/scripts/audit/check_untrusted_workflow_interpolation.py
@@ -105,13 +105,19 @@ def run_blocks(text: str) -> list[tuple[int, str]]:
             i += 1
             continue
         indent = len(match.group("indent"))
+        # Sibling keys (`env:`, `name:`) share the mapping indent of `run`,
+        # not the dash. For `- run: |`, dash-indent is shallower than `run`,
+        # so using dash-indent would swallow a following `env:` into the
+        # script body and false-positive the allowed env: pattern.
+        run_at = lines[i].find("run:")
+        key_indent = run_at if run_at >= 0 else indent
         value = match.group("value").strip()
         if value.startswith(("|", ">")):  # block scalar: consume deeper-indented lines
             body_lines: list[str] = []
             j = i + 1
             while j < len(lines):
                 line = lines[j]
-                if line.strip() == "" or (len(line) - len(line.lstrip())) > indent:
+                if line.strip() == "" or (len(line) - len(line.lstrip())) > key_indent:
                     body_lines.append(line)
                     j += 1
                 else:

--- a/scripts/audit/check_untrusted_workflow_interpolation.py
+++ b/scripts/audit/check_untrusted_workflow_interpolation.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Fail-closed gate: untrusted GitHub context must not reach ``run:`` scripts.
+
+Root cause this guards against (script-injection class): any ``${{ }}``
+expression expanded directly inside a ``run:`` script is substituted by the
+Actions runner *before* the shell sees it. If the expression carries
+attacker-controlled text (issue/PR titles and bodies, comment bodies, branch
+names), a crafted value injects arbitrary shell. GitHub's own hardening guide
+prescribes the intermediate-``env:`` pattern instead:
+
+    env:
+      TITLE: ${{ github.event.pull_request.title }}   # allowed: env mapping
+    run: echo "$TITLE"                                # allowed: quoted shell var
+
+This checker scans every ``run:`` block (inline and ``|``/``>`` multiline) in
+``.github/workflows/*.yml`` and fails on untrusted contexts. It deliberately
+does NOT flag:
+
+    - ``env:`` mappings (the safe pattern above),
+    - SHAs and refs: ``github.sha``, ``github.ref``,
+      ``github.event.pull_request.*.sha``, ``github.event.before/after``
+      (not attacker-controlled text),
+    - ``if:`` / ``concurrency`` / ``with:`` expressions (not shell expansion),
+    - trusted contexts such as ``github.workflow`` / ``github.event_name``.
+
+Stdlib-only on purpose: it runs from ``scripts/audit/check_workflows.sh`` in
+the always-on actionlint CI job with whatever python3 is at hand.
+
+Usage:
+    scripts/audit/check_untrusted_workflow_interpolation.py                # all workflows
+    scripts/audit/check_untrusted_workflow_interpolation.py path/to/w.yml  # specific file(s)
+
+Exit codes: 0 = clean, 1 = findings.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+# Attacker-controllable contexts (issue/PR/comment text, branch names, commit
+# messages). SHAs and github.ref are excluded: they are not attacker text.
+_UNTRUSTED = re.compile(
+    r"""
+    github\.event\.(?:
+        (?:issue|comment|review|review_comment|discussion|head_commit|commits|pages|workflow_run)\b
+        | pull_request\.(?:title|body)\b
+        | pull_request\.head\.(?:ref|label|repo)\b
+    )
+    | github\.head_ref\b
+    """,
+    re.VERBOSE,
+)
+
+_EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+# `run:` key, optionally after a `- ` step marker. Content indent is measured
+# from the line start so both `run: |` and `- run: |` blocks parse alike.
+_RUN_KEY = re.compile(r"^(?P<indent>\s*)(?:-\s+)?run:\s*(?P<value>.*)$")
+
+
+def run_blocks(text: str) -> list[tuple[int, str]]:
+    """Yield (start_line, body) for every ``run:`` script in workflow text.
+
+    ``start_line`` is the 1-based line of the first body line (inline value or
+    first block-scalar line). Only ``run:`` values are returned, so ``env:``
+    mappings and ``if:``/``with:``/``concurrency`` expressions never reach the
+    untrusted-context scan.
+    """
+    lines = text.splitlines()
+    blocks: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        match = _RUN_KEY.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        indent = len(match.group("indent"))
+        value = match.group("value").strip()
+        if value.startswith(("|", ">")):  # block scalar: consume deeper-indented lines
+            body_lines: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                line = lines[j]
+                if line.strip() == "" or (len(line) - len(line.lstrip())) > indent:
+                    body_lines.append(line)
+                    j += 1
+                else:
+                    break
+            blocks.append((i + 2, "\n".join(body_lines)))
+            i = j
+        else:
+            blocks.append((i + 1, value))
+            i += 1
+    return blocks
+
+
+def findings_for(path: Path) -> list[str]:
+    """Return human-readable findings for one workflow file (empty = clean)."""
+    text = path.read_text(encoding="utf-8")
+    findings: list[str] = []
+    for start_line, body in run_blocks(text):
+        for match in _EXPRESSION.finditer(body):
+            expression = match.group(1)
+            untrusted = _UNTRUSTED.search(expression)
+            if not untrusted:
+                continue
+            line_no = start_line + body[: match.start()].count("\n")
+            findings.append(
+                f"{path}:{line_no}: untrusted context `{untrusted.group(0)}` "
+                f"interpolated into a run: script — use env: + a quoted shell "
+                f"variable instead: {expression.strip()!r}"
+            )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="workflow files to scan (default: .github/workflows/*.yml|yaml)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.files:
+        targets = sorted(args.files)
+    else:
+        targets = sorted(
+            p for p in _WORKFLOWS_DIR.iterdir() if p.suffix in (".yml", ".yaml")
+        )
+
+    findings: list[str] = []
+    for target in targets:
+        if not target.is_file():
+            findings.append(f"{target}: file not found")
+            continue
+        findings.extend(findings_for(target))
+
+    if findings:
+        print("❌ untrusted GitHub context interpolated into run: scripts:", file=sys.stderr)
+        for finding in findings:
+            print(f"  {finding}", file=sys.stderr)
+        return 1
+    print(f"✅ no untrusted-context interpolation in {len(targets)} workflow file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/check_untrusted_workflow_interpolation.py
+++ b/scripts/audit/check_untrusted_workflow_interpolation.py
@@ -13,8 +13,11 @@ prescribes the intermediate-``env:`` pattern instead:
     run: echo "$TITLE"                                # allowed: quoted shell var
 
 This checker scans every ``run:`` block (inline and ``|``/``>`` multiline) in
-``.github/workflows/*.yml`` and fails on untrusted contexts. It deliberately
-does NOT flag:
+``.github/workflows/*.yml`` and fails on untrusted contexts. Identifiers and
+functions are matched case-insensitively (GitHub does), index syntax
+``github.event['issue']['title']`` is treated as dotted access, and
+``toJSON(github.event)`` / ``toJSON(github)`` dumps of the event payload are
+rejected. It deliberately does NOT flag:
 
     - ``env:`` mappings (the safe pattern above),
     - SHAs and refs: ``github.sha``, ``github.ref``,
@@ -44,6 +47,8 @@ _WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
 
 # Attacker-controllable contexts (issue/PR/comment text, branch names, commit
 # messages). SHAs and github.ref are excluded: they are not attacker text.
+# VERBOSE | IGNORECASE: GitHub identifiers are case-insensitive
+# (github.Event.Issue.Title == github.event.issue.title).
 _UNTRUSTED = re.compile(
     r"""
     github\.event\.(?:
@@ -53,13 +58,34 @@ _UNTRUSTED = re.compile(
     )
     | github\.head_ref\b
     """,
-    re.VERBOSE,
+    re.VERBOSE | re.IGNORECASE,
 )
+
+# github['event']['issue']['title'] is the same object as github.event.issue.title.
+_BRACKET_IDENT = re.compile(r"""\[\s*(['"])([A-Za-z_][\w-]*)\1\s*\]""")
+# toJSON(github.event) / toJSON(github) dumps the webhook payload (or the whole
+# github context, which includes it) as text. Dotted untrusted paths inside
+# toJSON(...) are already caught by _UNTRUSTED after normalize.
+_TOJSON_WHOLE_EVENT = re.compile(r"\btojson\s*\(\s*github(?:\.event)?\s*\)", re.IGNORECASE)
 
 _EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
 # `run:` key, optionally after a `- ` step marker. Content indent is measured
 # from the line start so both `run: |` and `- run: |` blocks parse alike.
 _RUN_KEY = re.compile(r"^(?P<indent>\s*)(?:-\s+)?run:\s*(?P<value>.*)$")
+
+
+def normalize_expression(expression: str) -> str:
+    """Case-fold and rewrite ``['ident']`` / ``[\"ident\"]`` to ``.ident``.
+
+    GitHub evaluates identifiers case-insensitively and treats index syntax as
+    equivalent to property dereference.
+    """
+    text = expression.casefold()
+    while True:
+        updated, count = _BRACKET_IDENT.subn(lambda m: "." + m.group(2).casefold(), text)
+        if count == 0:
+            return updated
+        text = updated
 
 
 def run_blocks(text: str) -> list[tuple[int, str]]:
@@ -105,7 +131,10 @@ def findings_for(path: Path) -> list[str]:
     for start_line, body in run_blocks(text):
         for match in _EXPRESSION.finditer(body):
             expression = match.group(1)
-            untrusted = _UNTRUSTED.search(expression)
+            normalized = normalize_expression(expression)
+            untrusted = _UNTRUSTED.search(normalized) or _TOJSON_WHOLE_EVENT.search(
+                normalized
+            )
             if not untrusted:
                 continue
             line_no = start_line + body[: match.start()].count("\n")

--- a/scripts/audit/check_workflows.sh
+++ b/scripts/audit/check_workflows.sh
@@ -23,6 +23,9 @@
 #   ACTIONLINT_FORCE_DOWNLOAD=1          ignore any actionlint on PATH and always
 #                                        fetch the pinned, checksum-verified build
 #                                        (set in CI for reproducibility)
+#   PYTHON=/path/to/python               interpreter for the untrusted-context
+#                                        interpolation checker (default:
+#                                        .venv/bin/python, else python3)
 set -euo pipefail
 
 # --- pinned release (bump VERSION + all checksums together) -------------------
@@ -143,6 +146,22 @@ main() {
   echo "→ actionlint $("$bin" --version | head -1) on ${#targets[@]} workflow file(s)" >&2
   "$bin" -color "${targets[@]}"
   echo "✅ actionlint: all workflow files valid"
+
+  # Fail-closed interpolation gate (advisor packet B+D, 2026-08-18): untrusted
+  # GitHub context (github.event.issue.*/comment.*, PR title/body, head_ref,
+  # ...) must not be ${{ }}-expanded inside run: scripts — env: + "$VAR" is
+  # the safe pattern. Runs after actionlint so this script stays the single
+  # workflow gate both CI and local devs invoke. The checker is stdlib-only;
+  # prefer the project venv interpreter, fall back to any python3.
+  local py="${PYTHON:-}"
+  if [[ -z "$py" ]]; then
+    if [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+      py="$REPO_ROOT/.venv/bin/python"
+    else
+      py="python3"
+    fi
+  fi
+  "$py" scripts/audit/check_untrusted_workflow_interpolation.py "${targets[@]}"
 }
 
 main "$@"

--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -33,7 +33,7 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "scripts/entire/install_kimi_external_agent.sh:18",
         "scripts/entire/install_fleet_external_agent.sh:36",
         # Actionlint download cleanup (scoped under a local temp dir).
-        "scripts/audit/check_workflows.sh:50",
+        "scripts/audit/check_workflows.sh:53",
     }
 )
 

--- a/tests/test_actionlint_workflow.py
+++ b/tests/test_actionlint_workflow.py
@@ -80,6 +80,18 @@ def test_shared_script_exists_and_is_executable() -> None:
     assert mode & stat.S_IXUSR, f"{_SCRIPT} must be executable"
 
 
+def test_shared_script_invokes_interpolation_gate() -> None:
+    # The fail-closed untrusted-context gate (packet B+D) rides the always-on
+    # actionlint check: check_workflows.sh must call it after actionlint.
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "check_untrusted_workflow_interpolation.py" in text, (
+        "shared runner must invoke the untrusted-context interpolation checker"
+    )
+    assert text.index('"$bin" -color') < text.index("check_untrusted_workflow_interpolation.py"), (
+        "interpolation checker must run after actionlint succeeds"
+    )
+
+
 def test_shared_script_pins_version_and_checksums() -> None:
     text = _SCRIPT.read_text(encoding="utf-8")
     assert 'ACTIONLINT_VERSION="' in text, "script must pin an actionlint version"

--- a/tests/test_untrusted_workflow_interpolation.py
+++ b/tests/test_untrusted_workflow_interpolation.py
@@ -135,6 +135,73 @@ jobs:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_mixed_case_untrusted_context_in_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.Event.Issue.Title }}"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "github.event.issue" in result.stderr.casefold()
+
+
+def test_bracket_notation_untrusted_context_in_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event['issue']['title'] }}"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "github.event.issue" in result.stderr
+
+
+def test_tojson_event_payload_in_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(github.event) }}'
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "tojson" in result.stderr.casefold()
+
+
+def test_tojson_sha_in_run_passes(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: pull_request
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(github.sha) }}'
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_current_repo_workflows_are_clean() -> None:
     result = subprocess.run(
         [sys.executable, str(_CHECKER)],

--- a/tests/test_untrusted_workflow_interpolation.py
+++ b/tests/test_untrusted_workflow_interpolation.py
@@ -1,0 +1,145 @@
+"""Fixture tests for the untrusted-context workflow interpolation gate.
+
+``scripts/audit/check_untrusted_workflow_interpolation.py`` is the fail-closed
+half of the workflow-path gate (advisor packet B+D): untrusted GitHub context
+(issue/PR text, comment bodies, branch names) must not be ``${{ }}``-expanded
+inside ``run:`` scripts, where it becomes shell injection. The safe pattern —
+an ``env:`` mapping plus a quoted ``"$VAR"`` in the script — must keep passing,
+as must SHA/ref expressions and the current repo workflows.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = _REPO_ROOT / "scripts" / "audit" / "check_untrusted_workflow_interpolation.py"
+
+
+def _run_checker(*files: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_CHECKER), *(str(f) for f in files)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_workflow(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "workflow.yml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_issue_title_in_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.issue.title }}"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "github.event.issue" in result.stderr
+
+
+def test_head_ref_in_multiline_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout attacker-named branch
+        run: |
+          echo "branch is ${{ github.head_ref }}"
+          git status
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "github.head_ref" in result.stderr
+    assert ":8:" in result.stderr  # finding points at the injected line
+
+
+def test_env_mapping_with_quoted_var_passes(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: pull_request
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo title safely
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "$TITLE"
+          echo "$BODY"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_sha_and_ref_interpolation_in_run_passes(tmp_path: Path) -> None:
+    # SHAs/refs are not attacker-controlled text; validate-yaml.yml diffs with
+    # exactly this pattern and must stay green.
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: pull_request
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          git diff "$base_sha" "$head_sha"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_untrusted_context_in_if_and_concurrency_passes(tmp_path: Path) -> None:
+    # Only run: shell expansion is exploitable; if:/concurrency are not run:
+    # interpolation.
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.title || github.ref }}
+on: pull_request
+jobs:
+  gate:
+    if: github.event.pull_request.title != ''
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_current_repo_workflows_are_clean() -> None:
+    result = subprocess.run(
+        [sys.executable, str(_CHECKER)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_untrusted_workflow_interpolation.py
+++ b/tests/test_untrusted_workflow_interpolation.py
@@ -135,6 +135,27 @@ jobs:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_env_mapping_after_dash_run_block_passes(tmp_path: Path) -> None:
+    # Compact `- run: |` measures dash-indent, which is shallower than sibling
+    # keys. env: after run: is valid YAML and must stay the allowed pattern.
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "$TITLE"
+        env:
+          TITLE: ${{ github.event.issue.title }}
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_mixed_case_untrusted_context_in_run_fails(tmp_path: Path) -> None:
     workflow = _write_workflow(
         tmp_path,

--- a/tests/test_untrusted_workflow_interpolation.py
+++ b/tests/test_untrusted_workflow_interpolation.py
@@ -24,6 +24,7 @@ def _run_checker(*files: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
 
@@ -246,5 +247,6 @@ def test_current_repo_workflows_are_clean() -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_untrusted_workflow_interpolation.py
+++ b/tests/test_untrusted_workflow_interpolation.py
@@ -156,6 +156,23 @@ jobs:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_quoted_braces_before_untrusted_context_in_run_fails(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path,
+        """\
+on: issues
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ format('}}{0}', github.event.issue.title) }}"
+""",
+    )
+    result = _run_checker(workflow)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "github.event.issue" in result.stderr
+
+
 def test_mixed_case_untrusted_context_in_run_fails(tmp_path: Path) -> None:
     workflow = _write_workflow(
         tmp_path,


### PR DESCRIPTION
## Advisor packet B+D (Fable + Sol [AGREE] 2026-08-18)

Two-layer workflow-path gate. Agents keep full drafting ability; the merge gate is human.

**B — human code-owner on workflows only**
- New `.github/CODEOWNERS`: `.github/workflows/**` and `.github/CODEOWNERS` route to `@krisztiankoos`.
- No catch-all `*` rule — ordinary code/docs/curriculum PRs get no extra reviewer.
- Agents may still **draft** workflow PRs; the code-owner review is the merge gate.
- ⚠️ Operator action needed in the console: enable **"Require review from Code Owners"** in branch protection — not done here (settings change).

**D — fail-closed untrusted-context interpolation gate**
- New `scripts/audit/check_untrusted_workflow_interpolation.py` (stdlib-only): scans every `run:` block (inline + `|`/`>` multiline) in `.github/workflows/*.yml` and fails on `${{ }}` interpolation of attacker-controlled contexts — `github.event.issue.*`, `github.event.comment.*`, `github.event.pull_request.title/body`, `github.event.pull_request.head.ref/label/repo`, `github.head_ref`, commit/review/discussion text.
- **Allowed:** the existing `env:` + `"$VAR"` pattern in `ci.yml`, SHAs (`github.sha`, `pull_request.*.sha`, `github.event.before/after`), `github.ref`, and `if:`/`concurrency`/`with:` expressions.
- Wired into `scripts/audit/check_workflows.sh` **after actionlint**, so the existing always-on `actionlint` required check gates it (single source of truth for CI + local).
- The zizmor SARIF job deliberately stays advisory (known medium backlog) — this checker is the fail-closed gate.

## Verification (raw output)

```
$ scripts/audit/check_workflows.sh
→ actionlint 1.7.12 on 16 workflow file(s)
✅ actionlint: all workflow files valid
✅ no untrusted-context interpolation in 16 workflow file(s)
```

```
$ .venv/bin/python -m pytest tests/test_untrusted_workflow_interpolation.py tests/test_actionlint_workflow.py -q
15 passed in 0.33s
```

```
$ .venv/bin/python -m ruff check scripts/audit/check_untrusted_workflow_interpolation.py
All checks passed!
```

Current main workflows stay green (16/16 clean). Fixture tests cover: bad `run: echo "${{ github.event.issue.title }}"` fails, `github.head_ref` in a multiline block fails with correct line number, good `env:` + quoted-`"$VAR"` pattern passes, SHA interpolation passes, `if:`/`concurrency` usage passes.

## Non-goals (per dispatch)

No humans-only workflow *authorship* ban, no repo-wide CODEOWNERS `*`, no branch-protection changes from the CLI, zizmor job not made fail-closed.