### PR TITLE
perf(ci): docs/skills-only merge_group skips four-shard pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ name: CI
 # four shards + coverage floor. CI Gate remains the sole required context,
 # reports on both events, and fail-closes on missing/skipped required deps.
 #
+# Third class (#7018): docs_skills — decided by scripts/ci/landing_class.py on
+# merge_group / push / workflow_dispatch (NOT GitHub paths:/paths-ignore).
+# Allowlist-only diffs (shared skills + docs/**/*.md + repo-root *.md) take
+# no-op success on pytest-plan / python shards / coverage-floor / Gate
+# verify-artifacts so CI Gate still sees success, never skipped (#5762).
+# Any off-allowlist path or classifier error → full suite (fail closed).
+# The full tier still never path-filters pytest collection for product code.
+#
 # Invariant (encodes #3873 #4888 #4936 #5351 #5354): on the full tier, pytest
 # must NEVER be selected or skipped by changed files. pytest-fastlane uses
 # changed files only as an early signal; it never replaces the shard plan.
@@ -76,37 +84,86 @@ jobs:
           python -m ruff check scripts/
 
   # ---------------------------------------------------------------------
+  # 0b. landing-class — classify merge_group/push/dispatch diffs (#7018).
+  #     Always runs on the full tier; always succeeds; outputs class=
+  #     docs_skills|full (fail closed → full). Downstream pytest-plan /
+  #     python / coverage-floor take no-op success when docs_skills so CI
+  #     Gate can require them unconditionally (never skipped).
+  # ---------------------------------------------------------------------
+  landing-class:
+    name: Landing class
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      # Belt-and-suspenders: empty/missing step output → full (fail closed).
+      class: ${{ steps.classify.outputs.class || 'full' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Classify landing class
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # Stdlib-only classifier; system python3 matches frontend_change_scope.
+          # Script always exits 0 and always writes class= (full on any error).
+          python3 scripts/ci/landing_class.py \
+            --base "${BASE_SHA:-}" \
+            --head "${HEAD_SHA:-HEAD}" \
+            --github-output
+          if ! grep -q '^class=' "${GITHUB_OUTPUT}"; then
+            echo "class=full" >> "${GITHUB_OUTPUT}"
+          fi
+
+  # ---------------------------------------------------------------------
   # 1. pytest-plan — collect once, then produce all four LPT file plans from
   #    one duration dataset restored from a successful main run (#5744).
   #    Full tier only (merge_group / push / workflow_dispatch).
+  #    docs_skills (#7018): no-op success (job still runs; never skipped).
   # ---------------------------------------------------------------------
   pytest-plan:
     name: Pytest plan
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [landing-class]
     permissions:
       contents: read
     steps:
+      - name: Docs/skills-only — planner no-op success
+        if: needs.landing-class.outputs.class == 'docs_skills'
+        run: echo "landing-class=docs_skills; pytest-plan no-op success (#7018)"
+
       # Default checkout is the event SHA: for merge_group that is the
       # merge-group commit (never the PR head). Do not override with
       # pull_request.head.sha — that would test a stale tree.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           python-version-file: '.python-version'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Restore Atlas lexicon manifest cache
+        if: needs.landing-class.outputs.class != 'docs_skills'
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -114,10 +171,12 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Install planner dependencies
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           set -euo pipefail
           python -m venv .venv
@@ -143,6 +202,7 @@ jobs:
           exit 1
 
       - name: Restore successful-main pytest duration dataset
+        if: needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ci-artifacts/pytest-durations.json
@@ -151,12 +211,14 @@ jobs:
             pytest-shard-durations-v1-main-
 
       - name: Plan all duration-balanced pytest shards
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           .venv/bin/python scripts/ci/pytest_shards.py plan \
             --durations ci-artifacts/pytest-durations.json \
             --output-dir ci-artifacts/plans
 
       - name: Upload pytest plans
+        if: needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-plans
@@ -273,6 +335,7 @@ jobs:
   # The selection still never consults changed files: every collected test runs
   # exactly once. Four parallel jobs are the topology that completed under the
   # #5776 hang investigation; one xdist session did not.
+  # docs_skills (#7018): no-op success (job still runs; never skipped).
   python:
     name: Python (pytest) [${{ matrix.shard }}/4]
     if: github.event_name != 'pull_request'
@@ -282,28 +345,36 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
-    needs: [pytest-plan]
+    needs: [pytest-plan, landing-class]
     permissions:
       contents: read
     steps:
+      - name: Docs/skills-only — shard no-op success
+        if: needs.landing-class.outputs.class == 'docs_skills'
+        run: echo "landing-class=docs_skills; python shard ${{ matrix.shard }} no-op success (#7018)"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           python-version-file: '.python-version'
 
       # Keep the ACP protocol test's Node runtime deterministic regardless of
       # which round-robin shard owns its test file.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Restore Atlas lexicon manifest cache
+        if: needs.landing-class.outputs.class != 'docs_skills'
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -311,11 +382,12 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        if: needs.landing-class.outputs.class != 'docs_skills' && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: site/src/data/lexicon-manifest.json
@@ -326,6 +398,7 @@ jobs:
       # A restore miss or outage must not kill the shard (#7002; same posture
       # as the Stanza model-cache restore below).
       - name: Restore pip wheel cache
+        if: needs.landing-class.outputs.class != 'docs_skills'
         id: pip-wheel-cache
         continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -339,6 +412,7 @@ jobs:
       # out of this environment: the suite does not import either package.
       # Install the CPU-only torch wheel to avoid the much larger CUDA build.
       - name: Install dependencies
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           set -euo pipefail
           python -m venv .venv
@@ -365,7 +439,7 @@ jobs:
           exit 1
 
       - name: Save pip wheel cache
-        if: steps.pip-wheel-cache.outputs.cache-hit != 'true'
+        if: needs.landing-class.outputs.class != 'docs_skills' && steps.pip-wheel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
@@ -379,6 +453,7 @@ jobs:
       # Cache-service errors are recoverable: continue to the provision path.
       # A restore miss or outage must not kill the shard; provision is the gate.
       - name: Restore Stanza Ukrainian model cache
+        if: needs.landing-class.outputs.class != 'docs_skills'
         id: stanza-model-cache
         continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -391,6 +466,7 @@ jobs:
       # lazy model downloads. Bounded retry absorbs transient Hugging Face /
       # GitHub network blips (3 attempts, 10s then 30s backoff).
       - name: Provision and verify Stanza Ukrainian model
+        if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
@@ -407,13 +483,14 @@ jobs:
           exit 1
 
       - name: Save Stanza Ukrainian model cache
-        if: steps.stanza-model-cache.outputs.cache-hit != 'true'
+        if: needs.landing-class.outputs.class != 'docs_skills' && steps.stanza-model-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/stanza_resources
           key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
 
       - name: Download the single planner's shard plans
+        if: needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-plans
@@ -424,6 +501,7 @@ jobs:
       # exception, never a changed-file filter; all other collected tests run
       # through the file-grouped LPT plan exactly once.
       - name: Run planned pytest shard
+        if: needs.landing-class.outputs.class != 'docs_skills'
         id: pytest
         continue-on-error: true
         timeout-minutes: 25
@@ -473,7 +551,7 @@ jobs:
 
       - name: Playground perf probe (serial, shard 1 only)
         id: playground
-        if: matrix.shard == 1
+        if: needs.landing-class.outputs.class != 'docs_skills' && matrix.shard == 1
         continue-on-error: true
         run: |
           for attempt in 1 2 3; do
@@ -488,7 +566,7 @@ jobs:
           exit 1
 
       - name: Upload pytest shard plan and results
-        if: always()
+        if: always() && needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-shard-${{ matrix.shard }}
@@ -497,11 +575,11 @@ jobs:
           retention-days: 1
 
       - name: Fail after preserving pytest evidence
-        if: steps.pytest.outcome != 'success' || (matrix.shard == 1 && steps.playground.outcome != 'success')
+        if: needs.landing-class.outputs.class != 'docs_skills' && (steps.pytest.outcome != 'success' || (matrix.shard == 1 && steps.playground.outcome != 'success'))
         run: exit 1
 
       - name: Upload test breadcrumbs
-        if: always()
+        if: always() && needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-breadcrumbs-shard-${{ matrix.shard }}
@@ -520,7 +598,8 @@ jobs:
       # its own job because no individual shard observes the whole suite.
       - name: Upload shard coverage data
         if: >-
-          (github.event_name == 'merge_group'
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name == 'merge_group'
            || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
           && steps.pytest.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1250,29 +1329,42 @@ jobs:
   # ---------------------------------------------------------------------
   # Enforces the 35% floor ONCE, over the combined four-shard data. Restores the
   # guarantee cross-family review flagged as a P1 when the reboot dropped it.
+  # docs_skills (#7018): no-op success (do not download missing coverage).
   coverage-floor:
     name: Coverage floor
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [python]
+    needs: [python, landing-class]
     permissions:
       contents: read
     steps:
+      - name: Docs/skills-only — coverage floor no-op success
+        if: needs.landing-class.outputs.class == 'docs_skills'
+        run: echo "landing-class=docs_skills; coverage-floor no-op success (#7018)"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           python-version: '3.12'
       - name: Download shard coverage data
-        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name == 'merge_group'
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-shard-*
           path: coverage-artifacts
       - name: Combine and enforce
-        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name == 'merge_group'
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         run: |
           set -euo pipefail
           # Bounded retry absorbs transient PyPI blips (#7002; Stanza idiom).
@@ -1303,7 +1395,10 @@ jobs:
           python -m coverage html -d coverage-html
 
       - name: Upload full coverage report
-        if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name == 'merge_group'
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
@@ -1315,7 +1410,10 @@ jobs:
           retention-days: 14
 
       - name: Not a landing event — coverage floor is merge_group/main-push only
-        if: github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && github.event_name != 'merge_group'
+          && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: echo "coverage floor applies to merge_group and pushes to main; job succeeds so CI Gate can require it unconditionally"
 
   ci-gate:
@@ -1325,6 +1423,7 @@ jobs:
     if: always()
     needs:
       - ruff
+      - landing-class
       - pytest-plan
       - pytest-fastlane
       - python
@@ -1338,14 +1437,17 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: '.python-version'
+      - name: Docs/skills-only — skip shard artifact verify (no-op success)
+        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class == 'docs_skills'
+        run: echo "landing-class=docs_skills; CI Gate verify-artifacts no-op success (#7018)"
       - name: Download pytest plans and JUnit results
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pytest-shard-*
           path: ci-artifacts
       - name: Verify pytest shard completeness
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
         run: python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir ci-artifacts
       - name: Fail unless every event-required job succeeded
         env:

--- a/scripts/ci/landing_class.py
+++ b/scripts/ci/landing_class.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Classify merge-queue diffs as docs/skills-only vs full CI (#7018).
+
+Fail-closed: empty path lists, unreadable git, unexpected errors, and any
+path outside the allowlist yield ``full``. Only an exhaustive allowlist match
+yields ``docs_skills``.
+
+Allowlist (deny by omission):
+  - ``agents_extensions/shared/skills/**``
+  - ``docs/**/*.md``
+  - repo-root ``*.md``
+
+Stdlib only so GitHub runners can invoke it with system ``python3`` before
+``actions/setup-python``. The CLI always exits 0 and always emits a class
+(``full`` on any failure) so CI Gate can require downstream jobs as success
+via no-op paths, never via ``skipped`` (#5762).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+CLASS_DOCS_SKILLS = "docs_skills"
+CLASS_FULL = "full"
+
+SKILLS_PREFIX = "agents_extensions/shared/skills"
+
+
+def path_allowed(path: str) -> bool:
+    """Return True when a repo-relative POSIX path is on the docs/skills allowlist."""
+    text = PurePosixPath(path.strip()).as_posix()
+    if not text or text in {".", "/"}:
+        return False
+    if text == SKILLS_PREFIX or text.startswith(f"{SKILLS_PREFIX}/"):
+        return True
+    if text.startswith("docs/") and text.endswith(".md"):
+        return True
+    return "/" not in text and text.endswith(".md")
+
+
+def classify(paths: Iterable[str]) -> str:
+    """Return ``docs_skills`` only when every path is allowlisted; else ``full``."""
+    normalized = [p.strip() for p in paths if p and p.strip()]
+    if not normalized:
+        return CLASS_FULL
+    if all(path_allowed(path) for path in normalized):
+        return CLASS_DOCS_SKILLS
+    return CLASS_FULL
+
+
+def _parse_nul_delimited_paths(raw: bytes) -> list[str]:
+    return sorted(path.decode("utf-8", errors="surrogateescape") for path in raw.split(b"\0") if path)
+
+
+def changed_files(git_range: str, *, cwd: Path | None = None) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--no-ext-diff",
+            "--name-only",
+            "-z",
+            git_range,
+        ],
+        check=True,
+        capture_output=True,
+        cwd=cwd or Path.cwd(),
+    )
+    return _parse_nul_delimited_paths(result.stdout)
+
+
+def comparison_range(base: str, head: str = "HEAD") -> str:
+    """Three-dot merge-base range (``BASE...HEAD``) for landing classification."""
+    return base if "..." in base else f"{base}...{head}"
+
+
+def read_paths_from_stdin(stream: Iterable[str] | None = None) -> list[str]:
+    source = sys.stdin if stream is None else stream
+    return [line.strip() for line in source if line.strip()]
+
+
+def write_github_output(landing_class: str, path: Path | None = None) -> None:
+    output = path
+    if output is None:
+        raw = os.environ.get("GITHUB_OUTPUT")
+        if not raw:
+            return
+        output = Path(raw)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(f"class={landing_class}\n")
+
+
+def write_step_summary(landing_class: str, *, path_count: int, path: Path | None = None) -> None:
+    summary = path
+    if summary is None:
+        raw = os.environ.get("GITHUB_STEP_SUMMARY")
+        if not raw:
+            return
+        summary = Path(raw)
+    with summary.open("a", encoding="utf-8") as handle:
+        handle.write("## Landing class (#7018)\n\n")
+        handle.write(f"`class={landing_class}` changed_files={path_count}\n")
+
+
+def emit(landing_class: str, *, path_count: int, as_json: bool, github_output: bool) -> None:
+    if as_json:
+        print(json.dumps({"class": landing_class, "changed_files": path_count}, sort_keys=True))
+    else:
+        print(landing_class)
+    write_step_summary(landing_class, path_count=path_count)
+    if github_output:
+        write_github_output(landing_class)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="",
+        help="base SHA/ref for git diff (merge_group.base_sha / push before). "
+        "Omit to read newline-delimited paths from stdin.",
+    )
+    parser.add_argument(
+        "--head",
+        default="HEAD",
+        help="head SHA/ref (merge_group.head_sha / github.sha); default HEAD",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit {\"class\": ..., \"changed_files\": N} on stdout",
+    )
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="append class=... to $GITHUB_OUTPUT when set",
+    )
+    as_json = False
+    github_output = False
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else None)
+        as_json = bool(args.json)
+        github_output = bool(args.github_output)
+        base = (args.base or "").strip()
+        head = (args.head or "HEAD").strip() or "HEAD"
+        if base:
+            if set(base) == {"0"}:
+                emit(CLASS_FULL, path_count=-1, as_json=as_json, github_output=github_output)
+                return 0
+            paths = changed_files(comparison_range(base, head))
+        elif github_output:
+            # CI without a usable base SHA — fail closed (do not read stdin).
+            emit(CLASS_FULL, path_count=-1, as_json=as_json, github_output=github_output)
+            return 0
+        elif sys.stdin.isatty():
+            # No paths and no git range — fail closed.
+            emit(CLASS_FULL, path_count=0, as_json=as_json, github_output=github_output)
+            return 0
+        else:
+            paths = read_paths_from_stdin()
+        landing = classify(paths)
+        emit(landing, path_count=len(paths), as_json=as_json, github_output=github_output)
+        return 0
+    except Exception as exc:
+        # Fail closed to full; never crash the landing-class job.
+        print(f"landing-class: error → {CLASS_FULL} ({exc})", file=sys.stderr)
+        emit(CLASS_FULL, path_count=-1, as_json=as_json, github_output=github_output)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -48,6 +48,7 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     assert "lint_pr_closing_references.py" in contracts_steps
     assert set(jobs["ci-gate"]["needs"]) == {
         "ruff",
+        "landing-class",
         "pytest-plan",
         "pytest-fastlane",
         "python",

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -382,6 +382,7 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
     # pull_request light tier can require lint without the four-shard suite.
     assert set(jobs["ci-gate"]["needs"]) == {
         "ruff",
+        "landing-class",
         "pytest-plan",
         "pytest-fastlane",
         "python",

--- a/tests/test_landing_class.py
+++ b/tests/test_landing_class.py
@@ -1,0 +1,96 @@
+"""Unit tests for merge-group docs/skills landing-class classifier (#7018)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.landing_class import (
+    CLASS_DOCS_SKILLS,
+    CLASS_FULL,
+    classify,
+    main,
+    path_allowed,
+    write_github_output,
+)
+
+
+def test_skill_only_is_docs_skills() -> None:
+    assert (
+        classify(["agents_extensions/shared/skills/drive-epic/SKILL.md"])
+        == CLASS_DOCS_SKILLS
+    )
+
+
+def test_skill_plus_scripts_is_full() -> None:
+    assert (
+        classify(
+            [
+                "agents_extensions/shared/skills/drive-epic/SKILL.md",
+                "scripts/api/foo.py",
+            ]
+        )
+        == CLASS_FULL
+    )
+
+
+def test_empty_paths_fail_closed_to_full() -> None:
+    assert classify([]) == CLASS_FULL
+
+
+def test_docs_markdown_only_is_docs_skills() -> None:
+    assert classify(["docs/foo.md"]) == CLASS_DOCS_SKILLS
+
+
+def test_github_workflow_is_full() -> None:
+    assert classify([".github/workflows/ci.yml"]) == CLASS_FULL
+
+
+def test_repo_root_markdown_is_docs_skills() -> None:
+    assert classify(["README.md"]) == CLASS_DOCS_SKILLS
+
+
+def test_docs_non_markdown_is_full() -> None:
+    assert classify(["docs/schema.yaml"]) == CLASS_FULL
+
+
+def test_path_allowed_deny_by_omission() -> None:
+    assert not path_allowed("scripts/ci/landing_class.py")
+    assert not path_allowed("tests/test_landing_class.py")
+    assert not path_allowed("site/package.json")
+    assert path_allowed("agents_extensions/shared/skills/x/SKILL.md")
+    assert path_allowed("docs/best-practices/gitflow.md")
+    assert path_allowed("AGENTS.md")
+
+
+def test_main_no_inputs_fail_closed(capsys: pytest.CaptureFixture[str]) -> None:
+    # No --base and empty/tty stdin → fail closed to full.
+    assert main(["--json"]) == 0
+    out = capsys.readouterr().out.strip()
+    assert json.loads(out)["class"] == CLASS_FULL
+
+
+def test_main_bogus_git_range_fail_closed(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--base", "not-a-real-ref-zzz", "--head", "also-fake", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["class"] == CLASS_FULL
+    assert payload["changed_files"] == -1
+
+
+def test_write_github_output(tmp_path: Path) -> None:
+    out = tmp_path / "github_output"
+    write_github_output(CLASS_DOCS_SKILLS, path=out)
+    write_github_output(CLASS_FULL, path=out)
+    assert out.read_text(encoding="utf-8") == "class=docs_skills\nclass=full\n"
+
+
+def test_ci_gate_still_rejects_skipped_on_merge_group() -> None:
+    """Regression: docs_skills must not teach the gate to accept skipped (#5762)."""
+    from scripts.ci.gate_required_results import FULL_REQUIRED, evaluate_gate
+
+    results = {job: "success" for job in FULL_REQUIRED}
+    results["python"] = "skipped"
+    failures = evaluate_gate("merge_group", results)
+    assert any("python: skipped" in item for item in failures)


### PR DESCRIPTION
## Summary
- Add fail-closed `scripts/ci/landing_class.py` (`docs_skills` | `full`) for skills/docs-only allowlist diffs.
- Always-on `landing-class` job on the full tier; pytest-plan / python shards / coverage-floor / CI Gate verify-artifacts take **no-op success** when `docs_skills` (never `skipped` — #5762).
- Any off-allowlist path or classifier error → full suite. Fixes #7018.

## Test plan
- [x] `pytest -q tests/test_ci_gate_required_results.py tests/test_landing_class.py` (26 passed)
- [x] `ruff check scripts/ci/landing_class.py scripts/ci/gate_required_results.py`
- [x] Classifier dry-run: skill+docs → `docs_skills`; skill+`scripts/` → `full`; `.github/` → `full`; empty → `full`
- [ ] Confirm PR-tier CI still runs light jobs; merge_group on this PR runs full (touches `scripts/` + `.github/`)
- [ ] After merge, a skills-only merge_group should no-op the four shards while Gate stays green


Made with [Cursor](https://cursor.com)