### PR TITLE
docs(fleet): note docs_skills merge_group class (#7018 canary)

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -355,6 +355,8 @@ Never arm on a **draft** and never merge ahead of the review verdict. Blocking C
 never `--admin`-bypass. A track/infra driver **self-merges its own lane's PR** after the
 cross-family gate + green CI (lane model — there is no promoting orchestrator). Flag
 another lane's PR with `needs=merge` rather than merging it.
+Skill- or docs-only landings classify as merge_group `docs_skills` (#7018):
+the four pytest shards and coverage combine are no-op **success**, not skipped.
 
 ### 7a. Post-merge cleanup is mandatory (binding — operator 2026-08-07)
 


### PR DESCRIPTION
## Summary
One-sentence playbook note. **Also a landing-class canary:** this PR touches only `agents_extensions/shared/skills/drive-epic/SKILL.md`, so merge_group must classify `docs_skills` and take no-op success on the four pytest shards (#7018 / #7022).

Compare to #7008 (~22 min, full shards on a skill file before the classifier).

## Test plan
- [x] `printf 'agents_extensions/shared/skills/drive-epic/SKILL.md' | python -m scripts.ci.landing_class` → `docs_skills`
- [ ] merge_group Landing class job prints `docs_skills`
- [ ] pytest-plan / python shards / coverage-floor are no-op success (not skipped)

Fixes nothing except documenting #7018. Refs #7018.