### PR TITLE
docs(rules): retarget stale harness pointers to live sources

### DIFF
--- a/.cursor/rules/cold-start.mdc
+++ b/.cursor/rules/cold-start.mdc
@@ -1,5 +1,5 @@
 ---
-description: 200k-context cold start — Monitor API live state only; skip duplicate rules
+description: 200k-context cold start — Monitor API live state plus /api/rules
 alwaysApply: true
 ---
 
@@ -11,12 +11,19 @@ alwaysApply: true
 .venv/bin/python scripts/cursor_cold_start.py
 ```
 
+The script fetches `/api/rules`. Cursor already has `AGENTS.md` + `CLAUDE.md` as workspace rules (~50k tokens); those are digests, not a substitute for `/api/rules`.
+
 ## Do not fetch at boot
 
-- `/api/rules` — `AGENTS.md` + `CLAUDE.md` already in workspace rules (~50k tokens)
 - `/api/session/current?agent=orchestrator` — wrong agent lane
 - `context_canary.py mint` — 1M orchestrator only
-- `Read` on `CLAUDE.md`, `AGENTS.md`, `memory/MEMORY.md`
+- `Read` on `CLAUDE.md`, `AGENTS.md`
+
+## Fetch at boot
+
+| Need | Call |
+| --- | --- |
+| Canonical rules | `/api/rules?format=markdown` (script hits `/api/rules?format=json`) |
 
 ## Fetch on demand
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@
 
 > **ALWAYS look for the source of the problem first.** Don't fix symptoms — trace the root cause, understand why it happens, then fix that.
 
-> **BEHAVIORAL RULES** are in `memory/MEMORY.md` — enforced every session. Key: finish the job (no tech debt), stop asking (just do it), test before shipping, use tracking docs, no quality shortcuts, investigate before coding, be honest.
+> **BEHAVIORAL RULES** are in `agents_extensions/shared/memory/MEMORY.md` — enforced every session. Key: finish the job (no tech debt), stop asking (just do it), test before shipping, use tracking docs, no quality shortcuts, investigate before coding, be honest.
 
-> **NON-NEGOTIABLE RULES** in `.claude/rules/non-negotiable-rules.md` — word count targets are MINIMUMS, all audit gates must pass, no shortcuts.
+> **NON-NEGOTIABLE RULES** in `agents_extensions/shared/rules/non-negotiable-rules.md` (served at `GET /api/rules`; offline: `agents_extensions/shared/rules/_load-via-api.md`) — word count targets are MINIMUMS, all audit gates must pass, no shortcuts.
 
 > **Status**: `curriculum/l2-uk-en/{level}/status/{slug}.json` | Update: `.venv/bin/python scripts/audit_module.py {path}`
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -180,7 +180,7 @@ data/
 ## References
 - **Commands**: `docs/SCRIPTS.md`
 - **Module manifest**: `curriculum/l2-uk-en/curriculum.yaml`
-- **Build pipeline**: `.venv/bin/python scripts/build/v6_build.py {level} {num}`
+- **Build pipeline**: `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree [--writer {claude-tools|gemini-tools|codex-tools}]`
 - **Wiki compiler**: `scripts/wiki/compile.py`
 - **Monitor API**: `docs/MONITOR-API.md`
 

--- a/agents_extensions/cursor/rules/cold-start.md
+++ b/agents_extensions/cursor/rules/cold-start.md
@@ -1,14 +1,17 @@
 # Cursor cold start (200k context)
 
 Cursor already loads `AGENTS.md` + `CLAUDE.md` as workspace rules (~40–60k tokens).
-Do **not** refetch `/api/rules` unless those files are missing from context.
+Those files are digests. When the Monitor API is up, fetch
+`GET /api/rules?format=markdown` before consequential work (AGENTS.md).
+`scripts/cursor_cold_start.py` hits `/api/rules?format=json` and prints the
+hash and source list; it does not reprint the rules blob.
 
 ## Budget
 
 | Reserve | Tokens | Purpose |
 | --- | --- | --- |
-| Workspace rules | ~50k | AGENTS + CLAUDE (Cursor-injected) |
-| Cold-start API | ~3–5k | manifest + condensed orient |
+| Workspace rules | ~50k | AGENTS + CLAUDE (Cursor-injected digests) |
+| Cold-start API | ~3–5k | manifest + rules hash/sources + condensed orient |
 | Task work | ~120–140k | reads, edits, reasoning |
 | Headroom | ~10k | tool output spikes |
 
@@ -22,15 +25,15 @@ Equivalent manual calls:
 
 ```bash
 curl -s http://localhost:8765/api/state/manifest
+curl -s http://localhost:8765/api/rules?format=markdown
 curl -s http://localhost:8765/api/orient   # parse git, health, delegate, governance only
 ```
 
 ## Skip (orchestrator / 1M lanes)
 
-- `/api/rules` — duplicates workspace rules
 - `/api/session/current?agent=orchestrator` — wrong agent
 - `context_canary.py mint` — 1M orchestrator sessions only
-- `Read` on `CLAUDE.md`, `AGENTS.md`, or `memory/MEMORY.md` at boot
+- `Read` on `CLAUDE.md` or `AGENTS.md` at boot
 
 ## Fetch on demand (task-scoped)
 
@@ -60,4 +63,5 @@ busy/partial behavior, and receipt-verification contract.
 ## Offline fallback
 
 If Monitor API is down: `git status --short --branch` + read
-`agents_extensions/shared/rules/operator-expectations.md` (digest only).
+`agents_extensions/shared/rules/_load-via-api.md` and its ordered local
+fallback list.

--- a/agents_extensions/shared/rules/_load-via-api.md
+++ b/agents_extensions/shared/rules/_load-via-api.md
@@ -2,9 +2,10 @@
 
 <critical>
 
-The full agent rule set (critical · non-negotiable · workflow ·
-fleet-comms-coordination · delegate-worktree · cli-help · model-assignment)
-is served at:
+The full agent rule set (operator-expectations · critical · non-negotiable ·
+workflow · fleet-comms-coordination · delegate-worktree · cli-help ·
+model-assignment · fleet-driver-routing · fleet-shared-doctrine ·
+fleet-role-scorecard) is served at:
 
     GET /api/rules?format=markdown    (Monitor API on localhost:8765)
 
@@ -12,7 +13,8 @@ Cold-start: fetch this endpoint as step 2 of the orientation sequence
 (workflow.md § "Cold-start sequence"). The endpoint supports
 `If-None-Match` for warm-cache hits.
 
-Offline fallback (API unreachable):
+Offline fallback (API unreachable) — same paths, same order as
+`scripts/api/rules_router.py` `RULE_SOURCES`:
 
     agents_extensions/shared/rules/operator-expectations.md
     agents_extensions/shared/rules/critical-rules.md
@@ -22,6 +24,9 @@ Offline fallback (API unreachable):
     agents_extensions/shared/rules/delegate-must-use-worktree.md
     agents_extensions/shared/rules/cli-help-standard.md
     agents_extensions/shared/rules/model-assignment.md
+    agents_extensions/shared/rules/fleet-driver-routing.md
+    docs/best-practices/fleet-shared-doctrine.md
+    docs/best-practices/fleet-role-scorecard.md
 
 These files no longer auto-load into the Claude Code system prompt
 (moved out of `.claude/rules/` deploy target) — read them directly

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -658,7 +658,7 @@ diffs, Codex for novel-architecture catches. (VESUM/content review = language wo
 installed" fiasco was cancelled, user 2026-06-22; Claude may be used for ANY task, incl. dispatched review, when needed.
 The cost economics above stand regardless: dispatched Claude is far pricier than inline, so route by need, not by ban.)
 
-The same table lives in `memory/MEMORY.md` rule #M0; this file is the deploy-rule mirror so it loads via `npm run agents:deploy` into `.claude/rules/`.
+The same table lives in `agents_extensions/shared/memory/MEMORY.md` rule #M0. This file is served at `GET /api/rules`; it is a Claude autoload exclude and is not deployed into `.claude/rules/`.
 
 </critical>
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -611,29 +611,29 @@ of a second server:
 
 | Document | Purpose |
 | --- | --- |
-| `.claude/rules/workflow.md` | Core workflow rules for agent sessions |
-| `.claude/rules/pipeline.md` | Build and validation workflow guidance |
-| `.claude/rules/rag-and-dictionaries.md` | MCP sources and dictionary lookup rules |
-| `.claude/rules/ukrainian-linguistics.md` | Ukrainian language quality rules |
-| `.claude/phases/gemini/README.md` | Gemini phase map |
-| `.claude/phases/gemini/v6-write.md` | Current write phase reference |
-| `.claude/phases/gemini/v6-review.md` | Current review phase reference |
-| `.claude/quick-ref/ACTIVITY-SCHEMAS.md` | Activity schema quick reference |
+| `agents_extensions/shared/rules/workflow.md` (`GET /api/rules`) | Core workflow rules for agent sessions |
+| `agents_extensions/shared/rules/pipeline.md` | Build and validation workflow guidance |
+| `agents_extensions/shared/rules/mcp-sources-and-dictionaries.md` | MCP sources and dictionary lookup rules |
+| `agents_extensions/shared/rules/ukrainian-linguistics.md` | Ukrainian language quality rules |
+| `agents_extensions/shared/phases/gemini/README.md` | Gemini phase map |
+| `agents_extensions/shared/phases/gemini/v6-write.md` | Current write phase reference |
+| `agents_extensions/shared/phases/gemini/v6-review.md` | Current review phase reference |
+| `agents_extensions/shared/quick-ref/ACTIVITY-SCHEMAS.md` | Activity schema quick reference |
 | `docs/agent-runtime-guide.md` | Agent runtime architecture |
 | `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md` | Module richness requirements |
-| `claude_extensions/consultation-queue/README.md` | Consultation queue format |
+| `agents_extensions/shared/consultation-queue/README.md` | Consultation queue format |
 
 ## Tool Inventory (Quick Reference)
 
 ### MCP sources tools
 
-Full list: [`.claude/rules/rag-and-dictionaries.md`](../.claude/rules/rag-and-dictionaries.md). Core tools used daily:
+Full list: [`agents_extensions/shared/rules/mcp-sources-and-dictionaries.md`](../agents_extensions/shared/rules/mcp-sources-and-dictionaries.md). Core tools used daily:
 
-- `mcp__rag__verify_word` - VESUM morphological check
+- `mcp__sources__verify_word` - VESUM morphological check
 - `mcp__sources__vet_vocabulary` - batched VESUM/CEFR/Russian-shadow vocabulary vetting (optional SUM-11 gloss)
-- `mcp__rag__search_text` - textbook content search
-- `mcp__rag__search_definitions` - SUM-11 explanatory dictionary
-- `mcp__rag__search_style_guide` - Antonenko-Davydovych style guidance
+- `mcp__sources__search_text` - textbook content search
+- `mcp__sources__search_definitions` - SUM-11 explanatory dictionary
+- `mcp__sources__search_style_guide` - Antonenko-Davydovych style guidance
 
 ### Deterministic audit checks
 
@@ -1266,9 +1266,9 @@ Queue locations:
 
 | Path | Purpose |
 | --- | --- |
-| `claude_extensions/consultation-queue/*.yaml` | Pending proposals |
-| `claude_extensions/consultation-queue/applied/` | Approved proposals |
-| `claude_extensions/consultation-queue/rejected/` | Rejected proposals |
+| `agents_extensions/shared/consultation-queue/*.yaml` | Pending proposals |
+| `agents_extensions/shared/consultation-queue/applied/` | Approved proposals |
+| `agents_extensions/shared/consultation-queue/rejected/` | Rejected proposals |
 
 ---
 

--- a/scripts/cursor_cold_start.py
+++ b/scripts/cursor_cold_start.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Condensed Monitor API cold start for Cursor (200k context).
 
-Skips /api/rules (AGENTS.md + CLAUDE.md already in Cursor workspace rules).
-Prints a compact markdown briefing (~3–5k tokens) for session orientation.
+Fetches /api/rules (canonical complete ruleset; AGENTS.md + CLAUDE.md are
+digests, not a substitute). Prints a compact markdown briefing (~3–5k
+tokens) for session orientation; does not reprint the rules blob.
 """
 
 from __future__ import annotations
@@ -14,6 +15,8 @@ import urllib.request
 
 DEFAULT_BASE = "http://localhost:8765"
 TIMEOUT_S = 5.0
+RULES_PATH = "/api/rules?format=json"
+OFFLINE_FALLBACK = "agents_extensions/shared/rules/_load-via-api.md"
 
 
 def _get(path: str) -> dict | list | None:
@@ -82,14 +85,34 @@ def _lines_orient(orient: dict) -> list[str]:
     return lines
 
 
+def _rules_briefing(manifest: dict | list | None, rules: dict | list | None) -> str:
+    manifest_hash = ""
+    if isinstance(manifest, dict):
+        manifest_hash = str((manifest.get("rules") or {}).get("hash", ""))[:12]
+    rules_hash = ""
+    n_sources = 0
+    if isinstance(rules, dict):
+        rules_hash = str(rules.get("hash", ""))[:12]
+        n_sources = len(rules.get("sources") or [])
+    shown = rules_hash or manifest_hash
+    if isinstance(rules, dict):
+        prefix = f"_manifest rules={shown}…" if shown else "_fetched /api/rules"
+        return f"{prefix} (fetched /api/rules; {n_sources} sources)_"
+    if shown:
+        return (
+            f"_manifest rules={shown}… "
+            f"(/api/rules unreachable — offline fallback `{OFFLINE_FALLBACK}`)_"
+        )
+    return f"_/api/rules unreachable — offline fallback `{OFFLINE_FALLBACK}`_"
+
+
 def main() -> int:
     manifest = _get("/api/state/manifest")
+    rules = _get(RULES_PATH)
     orient = _get("/api/orient")
 
     print("# Cursor cold start\n")
-    if manifest:
-        rules_hash = (manifest.get("rules") or {}).get("hash", "")[:12]
-        print(f"_manifest rules={rules_hash}… (rules skipped — already in workspace)_\n")
+    print(_rules_briefing(manifest, rules) + "\n")
 
     if orient:
         print("## Live state\n")
@@ -101,7 +124,8 @@ def main() -> int:
         print("- Monitor API down — run `git status --short --branch`\n")
 
     print("## Context budget (200k)\n")
-    print("- Workspace rules: ~50k (AGENTS + CLAUDE, do not re-read)")
+    print("- Workspace rules: ~50k (AGENTS + CLAUDE digests, do not re-read)")
+    print("- Canonical rules: GET /api/rules?format=markdown before consequential work")
     print("- This briefing: ~3–5k")
     print("- Task budget: ~140k; fetch scoped endpoints only when needed")
     print("- Full protocol: `agents_extensions/cursor/rules/cold-start.md`")

--- a/tests/test_context_audit_pointers.py
+++ b/tests/test_context_audit_pointers.py
@@ -1,0 +1,45 @@
+"""Mechanical pointer checks for the context-audit docs tickets (#7012–#7014)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_claude_md_points_at_tracked_memory_and_rules() -> None:
+    body = (REPO / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "`agents_extensions/shared/memory/MEMORY.md`" in body
+    assert "`agents_extensions/shared/rules/non-negotiable-rules.md`" in body
+    assert "GET /api/rules" in body
+    assert "`memory/MEMORY.md`" not in body
+    assert "`.claude/rules/non-negotiable-rules.md`" not in body
+
+
+def test_model_assignment_does_not_claim_claude_autoload() -> None:
+    body = (REPO / "agents_extensions/shared/rules/model-assignment.md").read_text(
+        encoding="utf-8"
+    )
+    assert "`agents_extensions/shared/memory/MEMORY.md`" in body
+    assert "GET /api/rules" in body
+    assert "loads via `npm run agents:deploy` into `.claude/rules/`" not in body
+
+
+def test_gemini_md_names_live_v7_build_command() -> None:
+    body = (REPO / "GEMINI.md").read_text(encoding="utf-8")
+    assert "scripts/build/v6_build.py" not in body
+    assert "scripts/build/v7_build.py {level} {slug}" in body
+    assert "--worktree" in body
+
+
+def test_scripts_md_indexes_live_mcp_sources() -> None:
+    body = (REPO / "docs/SCRIPTS.md").read_text(encoding="utf-8")
+    assert "rag-and-dictionaries.md" not in body
+    assert "claude_extensions/consultation-queue" not in body
+    assert "mcp__rag__" not in body
+    assert "agents_extensions/shared/rules/mcp-sources-and-dictionaries.md" in body
+    assert "agents_extensions/shared/consultation-queue/README.md" in body
+    assert "`mcp__sources__verify_word`" in body
+    assert "`mcp__sources__search_text`" in body
+    assert "`mcp__sources__search_definitions`" in body
+    assert "`mcp__sources__search_style_guide`" in body

--- a/tests/test_cursor_cold_start.py
+++ b/tests/test_cursor_cold_start.py
@@ -1,0 +1,83 @@
+"""Cursor cold-start must fetch /api/rules (#7016)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO / "scripts" / "cursor_cold_start.py"
+COLD_START_DOCS = (
+    REPO / "agents_extensions/cursor/rules/cold-start.md",
+    REPO / ".cursor/rules/cold-start.mdc",
+)
+
+spec = importlib.util.spec_from_file_location("cursor_cold_start_under_test", MODULE_PATH)
+assert spec and spec.loader
+cursor_cold_start = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cursor_cold_start)
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_cursor_cold_start_fetches_api_rules(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    seen: list[str] = []
+
+    def fake_urlopen(url: str, timeout: float | None = None) -> _FakeResp:
+        seen.append(url)
+        if url.endswith("/api/state/manifest"):
+            return _FakeResp({"rules": {"hash": "abc123def4567890"}})
+        if "/api/rules" in url:
+            assert "format=json" in url
+            return _FakeResp(
+                {
+                    "hash": "abc123def4567890",
+                    "bytes": 12,
+                    "sources": ["agents_extensions/shared/rules/operator-expectations.md"],
+                    "markdown": "# contract\n",
+                }
+            )
+        if url.endswith("/api/orient"):
+            return _FakeResp({"git": {"branch": "main", "head": "deadbeef00"}})
+        raise AssertionError(url)
+
+    monkeypatch.setattr(cursor_cold_start.urllib.request, "urlopen", fake_urlopen)
+    assert cursor_cold_start.main() == 0
+    out = capsys.readouterr().out
+    assert any("/api/rules?format=json" in url for url in seen)
+    assert "fetched /api/rules" in out
+    assert "rules skipped" not in out
+    assert "# contract" not in out
+
+
+def test_cursor_cold_start_docs_require_rules_fetch() -> None:
+    for path in COLD_START_DOCS:
+        body = path.read_text(encoding="utf-8")
+        assert "/api/rules" in body
+        assert "Do **not** refetch `/api/rules`" not in body
+        assert "/api/rules` — duplicates workspace rules" not in body
+        assert "/api/rules` — `AGENTS.md` + `CLAUDE.md` already in workspace" not in body
+        assert "`memory/MEMORY.md`" not in body
+
+
+def test_cursor_cold_start_script_does_not_skip_rules() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert "Skips /api/rules" not in source
+    assert "RULES_PATH" in source
+    assert "/api/rules?format=json" in source

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -174,6 +174,36 @@ def test_deploy_lock_step_lists_include_contract() -> None:
     assert "deploy_orphan_paths.sh" in session_setup, "session-setup hook does not source the shared lists"
 
 
+def _offline_fallback_list(body: str) -> list[str]:
+    marker = "`RULE_SOURCES`:"
+    start = body.index(marker) + len(marker)
+    paths: list[str] = []
+    for line in body[start:].splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if paths:
+                break
+            continue
+        if stripped.startswith("These files"):
+            break
+        if stripped.endswith(".md"):
+            paths.append(stripped)
+        elif paths:
+            break
+    return paths
+
+
 def test_offline_fallback_lists_contract() -> None:
     body = (REPO / "agents_extensions/shared/rules/_load-via-api.md").read_text(encoding="utf-8")
     assert CONTRACT_REL in body, "offline fallback list lost the contract"
+
+
+def test_offline_fallback_list_equals_rule_sources() -> None:
+    """#7011: a down API must not be a different ruleset than RULE_SOURCES."""
+    import sys
+
+    sys.path.insert(0, str(REPO / "scripts"))
+    from api.rules_router import RULE_SOURCES
+
+    body = (REPO / "agents_extensions/shared/rules/_load-via-api.md").read_text(encoding="utf-8")
+    assert tuple(_offline_fallback_list(body)) == RULE_SOURCES


### PR DESCRIPTION
## Summary
- Retarget always-injected `CLAUDE.md` / `model-assignment.md` from missing `memory/MEMORY.md` and excluded `.claude/rules/non-negotiable-rules.md` to tracked `agents_extensions/` sources and `GET /api/rules` (Refs #7012).
- Rewrite `docs/SCRIPTS.md` related-docs + MCP inventory to `agents_extensions/shared/rules/mcp-sources-and-dictionaries.md` and `mcp__sources__*` (Refs #7013).
- Point `GEMINI.md` at the live `v7_build.py {level} {slug} --worktree` command (Refs #7014).
- Cursor cold-start now fetches `/api/rules` (Sol REQUIRE-FETCH); offline `_load-via-api.md` list matches `RULE_SOURCES` including fleet-driver-routing + doctrine + scorecard, with a drift test (Refs #7016 #7011).

Do not merge from this worker.

## Test plan
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check` on touched Python (`scripts/cursor_cold_start.py`, three test files) — all checks passed
- [x] `.venv/bin/python -m pytest tests/test_cursor_cold_start.py tests/test_context_audit_pointers.py tests/test_operator_contract_wiring.py tests/test_fleet_comms_launcher_awareness.py::test_cursor_cold_start_points_to_same_acp_contract` — 20 passed
- [x] Live `scripts/cursor_cold_start.py` briefing: `_manifest rules=6b2d69af9ff2… (fetched /api/rules; 11 sources)_`
- [x] `git cat-file -e` + `ls`/`rg`: deleted targets gone; live pointers exist
- [ ] CI green on this PR

## Related Issues
Refs #7012 #7013 #7014 #7016 #7011

This PR leaves those issues open until each AC is independently verified on the exact head.


Made with [Cursor](https://cursor.com)