### PR TITLE
docs(rules): mark formal_review_eligible projection historical, not live CF gate

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -286,6 +286,20 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
   it. Lightweight agent review + green CI + merge + worktree/temp cleanup is
   the path.
 
+  **Historical projection only — not the live CF gate (#7017).** The table
+  below mirrors `scripts/config/fleet_communications.yaml`'s endpoint
+  registry, which that file's own header marks legacy: "Sealed formal CF
+  always goes through review-pr" — the very path retired above — and "keep
+  these endpoint booleans synchronized for legacy endpoint-status consumers;
+  reviewer_resolver never reads this copy." `scripts/lint/lint_fleet_roster.py`
+  still pins this block byte-exact against that YAML for those legacy
+  consumers (`scripts/api/fleet_router.py`, `scripts/fleet_comms/endpoints.py`)
+  — keep it in sync, do not delete it — but do not read it as today's review
+  routing. For the live formal resolver use the "Code Review (PR diff)" row
+  above (`closeout_cli resolve-reviewer`, backed by `model_catalog.yaml` →
+  `review_scheduler.endpoints`); for the everyday review of record use the
+  lightweight `ask-<lane>` path just above.
+
   <!-- fleet-roster-projection:begin formal_review_eligible -->
   | endpoint | formal_review_eligible |
   | --- | --- |


### PR DESCRIPTION
Fixes #7017.

## What
The `formal_review_eligible` sealed table in `agents_extensions/shared/rules/model-assignment.md` sat right below the prose describing the current lightweight review-of-record (plain `ask-<lane>`, verdict on the PR). Read on its own it looked like the live cross-family review gate.

## Why it isn't
It's a byte-exact projection of `scripts/config/fleet_communications.yaml`'s endpoint registry. That YAML's own header says it's legacy: "Sealed formal CF always goes through review-pr" (the very path retired 2026-08-07 and fail-closed in the CLI), and "reviewer_resolver never reads this copy" — the live formal resolver (`closeout_cli resolve-reviewer`, row already in the same doc) reads `model_catalog.yaml` → `review_scheduler.endpoints` instead.

## What changed
Added prose immediately above the table:
- Marks it historical / not the live gate
- States what it's still needed for (legacy endpoint-status consumers `fleet_router.py` / `endpoints.py`, and `lint_fleet_roster.py`'s byte-exact check) — so nobody deletes it
- Points to the two live paths: `closeout_cli resolve-reviewer` (formal resolver) and plain `ask-<lane>` (everyday review of record)

No behavior change. The machine-checked `<!-- fleet-roster-projection -->` block is untouched.

## Verify
```
.venv/bin/python scripts/lint/lint_fleet_roster.py
# → Fleet roster OK (3 projection file(s); orchestrator_seats + formal_review_eligible exact match)
.venv/bin/python -m pytest tests/test_lint_fleet_roster.py -q
# → 10 passed
```

Do not merge — CF review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)