### PR TITLE
fix(api): persist overview last-good and stop bounce 0/1932

### DIFF
--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -241,8 +241,10 @@ function sumDashboardTotals(tracks) {
     acc.total += track.module_count || 0;
     acc.pass += stats.pass || 0;
     acc.content_complete += stats.content_complete || 0;
+    acc.published += track.published_mdx || stats.published_mdx || 0;
+    acc.research += (stats.research && stats.research.total) || 0;
     return acc;
-  }, { total: 0, pass: 0, content_complete: 0 });
+  }, { total: 0, pass: 0, content_complete: 0, published: 0, research: 0 });
 }
 
 function sumSummaryTotals(summary, trackIds) {
@@ -312,13 +314,14 @@ async function loadStats() {
     document.getElementById('stats-row').innerHTML = `
       <div class="stat"><div class="value">${t.total}</div><div class="label">Modules</div></div>
       <div class="stat"><div class="value" style="color:var(--green)">${t.pass}</div><div class="label">Passing</div></div>
+      <div class="stat"><div class="value" style="color:var(--cyan)">${t.published}</div><div class="label">Published</div></div>
       <div class="stat"><div class="value" style="color:var(--blue)">${t.content_complete}</div><div class="label">Prose Only</div></div>
       <div class="stat"><div class="value" style="color:var(--cyan)">${buildState.current}</div><div class="label">Current Builds</div></div>
       <div class="stat"><div class="value" style="color:var(--orange)">${buildState.backlog}</div><div class="label">Rebuild Backlog</div></div>
       <div class="stat"><div class="value" style="color:var(--purple)">${buildState.builtPct}%</div><div class="label">Built</div></div>
     `;
 
-    document.getElementById('audit-stat').textContent = `${t.pass} passing / ${t.total} total`;
+    document.getElementById('audit-stat').textContent = `${t.pass} passing · ${t.published} published / ${t.total} total`;
     document.getElementById('curriculum-stat').textContent = `${dashboardTracks.length} tracks`;
     if (pendingConsultations > 0) {
       document.getElementById('consultation-stat').textContent = `${pendingConsultations} pending proposals`;

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -2866,12 +2866,18 @@ revision of this endpoint was removed per reviewer BLOCKER on
 
 ## UI Pages
 
-`GET /api/dashboard/overview` is cache-first (#6983): the request path
+`GET /api/dashboard/overview` is cache-first (#6983 / #7024): the request path
 never walks the curriculum tree. `meta.cache` remains the state-summary
 cache signal; `meta.track_scan` is `hit` / `stale` / `skipped`. A cold
-miss may include `meta.error=overview_warming` while a detached worker
-fills last-good. The live Monitor process does not pick up this behavior
-until restart.
+miss may include `meta.error=overview_warming` and `meta.refreshing=true`
+while a detached worker fills last-good. Last-good is persisted under
+`.cache/dashboard_overview_last_good.json` so a Monitor bounce reloads it
+instead of sitting at 0/total-missing. Cheap warming and overlays treat
+`published_mdx` as presence (`totals.missing` is not `total` when
+published > 0) and never copy published onto `totals.pass`. After a
+successful scan, `track_scan=hit` and `refreshing` is absent; a stale
+last-good does not keep flipping `refreshing=true`. The live Monitor
+process does not pick up this behavior until restart.
 
 | Page | URL | Data source |
 |------|-----|-------------|

--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -249,6 +249,25 @@ def build_module_info(track_dir, plans_dir, track_id, slug, idx) -> dict:
     }
 
 
+def present_module_count(
+    *,
+    total: int,
+    generated_md: int,
+    published_mdx: int,
+    scan_present: int = 0,
+) -> int:
+    """Count modules that have some content (generated, published, or scan-found).
+
+    Published MDX is presence, not audit pass. Callers must not copy this
+    onto ``stats.pass``.
+    """
+    present = max(int(generated_md or 0), int(published_mdx or 0), int(scan_present or 0))
+    bounded_total = int(total or 0)
+    if bounded_total:
+        return min(bounded_total, present)
+    return present
+
+
 def stats_from_state_summary(summary_stats: dict, *, is_seminar: bool) -> dict:
     """Map cached ``/api/state/summary`` counts onto overview track stats.
 
@@ -257,19 +276,29 @@ def stats_from_state_summary(summary_stats: dict, *, is_seminar: bool) -> dict:
     summary snapshot, so they stay 0 until a background full scan fills
     last-good. Research totals follow the same seminar-vs-core key as
     ``overview()`` historically used.
+
+    ``missing`` subtracts published MDX as well as generated markdown so a
+    bounce where ``generated_md=0`` but ``published_mdx>0`` is not a wall of
+    zeros. ``pass`` stays ``audit_passing`` — never spoofed from published.
     """
     total = int(summary_stats.get("total") or 0)
     generated_md = int(summary_stats.get("generated_md") or 0)
+    published_mdx = int(summary_stats.get("published_mdx") or 0)
     audit_passing = int(summary_stats.get("audit_passing") or 0)
     audit_stale = int(summary_stats.get("audit_stale") or 0)
     content_done = int(summary_stats.get("content_done") or 0)
     research_total_key = "dossier_done" if is_seminar else "research_done"
+    present = present_module_count(
+        total=total,
+        generated_md=generated_md,
+        published_mdx=published_mdx,
+    )
     return {
         "pass": audit_passing,
         "content_complete": content_done,
         "fail": 0,
         "unaudited": max(0, generated_md - audit_passing - audit_stale),
-        "missing": max(0, total - generated_md),
+        "missing": max(0, total - present),
         "shippable": 0,
         "reviewed": int(summary_stats.get("reviewed") or 0),
         "final_review": int(summary_stats.get("final_review_done") or 0),
@@ -278,6 +307,7 @@ def stats_from_state_summary(summary_stats: dict, *, is_seminar: bool) -> dict:
         "plan_needs_fixes": 0,
         "plan_fail": 0,
         "stale_status": audit_stale,
+        "published_mdx": published_mdx,
         "research": {
             "total": int(summary_stats.get(research_total_key) or 0),
             "docs": int(summary_stats.get("dossier_docs") or 0),

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -5,9 +5,13 @@ Endpoints: overview, track detail, module deep-dive, pipeline status, activity c
 comms monitoring.
 """
 
+import contextlib
 import copy
+import json
 import logging
+import os
 import sys
+import tempfile
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from audit.config import ACTIVITY_COMPLEXITY, ACTIVITY_RESTRICTIONS, LEVEL_CONFIG, VALID_ACTIVITY_TYPES
 from common.thresholds import REVIEW_PASS_FLOOR
 
-from .config import CURRICULUM_ROOT, LEVELS, SEMINAR_TRACK_IDS
+from .config import CURRICULUM_ROOT, LEVELS, PROJECT_ROOT, SEMINAR_TRACK_IDS
 from .dashboard_comms import (
     collect_stuck_tasks,
     ensure_broker_cols,
@@ -37,6 +41,7 @@ from .dashboard_helpers import (
     find_active_builds,
     get_orchestration_info,
     load_manifest,
+    present_module_count,
     read_yaml_file,
     scan_pipeline_queues,
     scan_track_cached,
@@ -61,21 +66,61 @@ logger = logging.getLogger(__name__)
 DASHBOARD_STATE_SUMMARY_TTL_S = 60.0
 DASHBOARD_OVERVIEW_CACHE_KEY = "dashboard_overview"
 DASHBOARD_OVERVIEW_TTL_S = 60.0
+DASHBOARD_OVERVIEW_LAST_GOOD_ENV = "DASHBOARD_OVERVIEW_LAST_GOOD_PATH"
+_OVERVIEW_TOTAL_KEYS = (
+    "pass",
+    "content_complete",
+    "fail",
+    "unaudited",
+    "missing",
+    "shippable",
+    "total",
+    "published_mdx",
+)
 
 _overview_refresh_lock = threading.Lock()
 _overview_refresh_thread: threading.Thread | None = None
 _overview_last_good: dict | None = None
+_overview_disk_loaded = False
+
+
+def overview_last_good_path() -> Path:
+    """Durable last-good snapshot written by the background overview scan."""
+    override = os.environ.get(DASHBOARD_OVERVIEW_LAST_GOOD_ENV)
+    if override:
+        return Path(override)
+    return PROJECT_ROOT / ".cache" / "dashboard_overview_last_good.json"
 
 
 def reset_overview_state_for_tests() -> None:
-    """Drop overview last-good + TTL cache so tests do not leak across cases."""
-    global _overview_refresh_thread, _overview_last_good
+    """Drop overview last-good + TTL cache so tests do not leak across cases.
+
+    Skips reloading the host disk snapshot so pytest cannot pick up a
+    previous Monitor process's last-good file.
+    """
+    global _overview_refresh_thread, _overview_last_good, _overview_disk_loaded
     thread: threading.Thread | None
     with _overview_refresh_lock:
         thread = _overview_refresh_thread
     if thread is not None:
         thread.join(timeout=2.0)
     _overview_last_good = None
+    _overview_disk_loaded = True
+    cache_invalidate(DASHBOARD_OVERVIEW_CACHE_KEY)
+    with _overview_refresh_lock:
+        _overview_refresh_thread = None
+
+
+def simulate_overview_process_bounce_for_tests() -> None:
+    """Clear process memory only; the durable last-good file remains."""
+    global _overview_refresh_thread, _overview_last_good, _overview_disk_loaded
+    thread: threading.Thread | None
+    with _overview_refresh_lock:
+        thread = _overview_refresh_thread
+    if thread is not None:
+        thread.join(timeout=2.0)
+    _overview_last_good = None
+    _overview_disk_loaded = False
     cache_invalidate(DASHBOARD_OVERVIEW_CACHE_KEY)
     with _overview_refresh_lock:
         _overview_refresh_thread = None
@@ -88,6 +133,10 @@ def _peek_state_summary() -> tuple[dict, str, float | None]:
         value, age_s = cached
         return value, "hit", age_s
     return {}, "miss", None
+
+
+def _empty_overview_totals() -> dict[str, int]:
+    return {key: 0 for key in _OVERVIEW_TOTAL_KEYS}
 
 
 def _overlay_research_from_summary(tracks: list[dict], state_tracks: dict) -> None:
@@ -105,6 +154,116 @@ def _overlay_research_from_summary(tracks: list[dict], state_tracks: dict) -> No
         }
 
 
+def _overlay_presence_from_summary(tracks: list[dict], state_tracks: dict, totals: dict) -> None:
+    """Treat published MDX as presence so Home is not 0/total-missing after a bounce.
+
+    Does not copy published onto ``stats.pass`` — that stays audit-passing.
+    """
+    published_total = 0
+    missing_total = 0
+    research_total = 0
+    for track_entry in tracks:
+        track_id = track_entry.get("id")
+        summary_stats = state_tracks.get(track_id, {}) if isinstance(state_tracks, dict) else {}
+        published = int(summary_stats.get("published_mdx") or track_entry.get("published_mdx") or 0)
+        generated = int(summary_stats.get("generated_md") or track_entry.get("generated_md") or 0)
+        track_entry["published_mdx"] = published
+        track_entry["generated_md"] = generated
+        stats = track_entry.setdefault("stats", {})
+        stats["published_mdx"] = published
+        module_count = int(track_entry.get("module_count") or 0)
+        scan_missing = int(stats.get("missing") or 0)
+        scan_present = max(0, module_count - scan_missing) if module_count else 0
+        present = present_module_count(
+            total=module_count,
+            generated_md=generated,
+            published_mdx=published,
+            scan_present=scan_present,
+        )
+        stats["missing"] = max(0, module_count - present)
+        published_total += published
+        missing_total += stats["missing"]
+        research_total += int((stats.get("research") or {}).get("total") or 0)
+    totals["missing"] = missing_total
+    totals["published_mdx"] = published_total
+    totals["research"] = research_total
+
+
+def _apply_overview_summary_overlay(payload: dict, state_tracks: dict) -> None:
+    tracks = payload.get("tracks") or []
+    totals = payload.setdefault("totals", _empty_overview_totals())
+    _overlay_research_from_summary(tracks, state_tracks)
+    _overlay_presence_from_summary(tracks, state_tracks, totals)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _usable_overview_last_good(payload: dict | None) -> dict | None:
+    if not isinstance(payload, dict):
+        return None
+    tracks = payload.get("tracks")
+    totals = payload.get("totals")
+    if not isinstance(tracks, list) or not tracks:
+        return None
+    if not isinstance(totals, dict) or int(totals.get("total") or 0) <= 0:
+        return None
+    return payload
+
+
+def persist_overview_last_good(payload: dict) -> None:
+    """Write the full-scan overview snapshot so a Monitor bounce can reload it."""
+    if _usable_overview_last_good(payload) is None:
+        return
+    try:
+        _atomic_write_text(
+            overview_last_good_path(),
+            json.dumps(payload, ensure_ascii=False),
+        )
+    except OSError:
+        logger.exception("dashboard overview last-good persist failed")
+
+
+def read_persisted_overview_last_good() -> dict | None:
+    path = overview_last_good_path()
+    try:
+        if not path.is_file():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+    return _usable_overview_last_good(data)
+
+
+def hydrate_overview_last_good_from_disk() -> dict | None:
+    """Load durable last-good into process memory once per lifetime (or bounce)."""
+    global _overview_last_good, _overview_disk_loaded
+    if _overview_last_good is not None:
+        _overview_disk_loaded = True
+        return _overview_last_good
+    if _overview_disk_loaded:
+        return None
+    _overview_disk_loaded = True
+    payload = read_persisted_overview_last_good()
+    if payload is None:
+        return None
+    _overview_last_good = payload
+    return payload
+
+
 def _build_overview_from_state_summary(
     state_summary: dict,
     cache_state: str,
@@ -118,7 +277,7 @@ def _build_overview_from_state_summary(
     state_tracks = state_summary.get("tracks", {}) if isinstance(state_summary, dict) else {}
 
     tracks = []
-    totals = {"pass": 0, "content_complete": 0, "fail": 0, "unaudited": 0, "missing": 0, "shippable": 0, "total": 0}
+    totals = _empty_overview_totals()
 
     for level_cfg in LEVELS:
         track_id = level_cfg["id"]
@@ -166,12 +325,14 @@ def _build_overview_from_state_summary(
         meta["age_s"] = round(age_s, 3)
     if cache_state == "miss" and track_scan == "skipped":
         meta["error"] = "overview_warming"
-    return {
+    payload = {
         "tracks": tracks,
         "totals": totals,
         "timestamp": datetime.now(UTC).isoformat(),
         "meta": meta,
     }
+    _apply_overview_summary_overlay(payload, state_tracks)
+    return payload
 
 
 def _build_overview_payload_from_scans() -> dict:
@@ -190,7 +351,7 @@ def _build_overview_payload_from_scans() -> dict:
     state_tracks = state_summary.get("tracks", {})
 
     tracks = []
-    totals = {"pass": 0, "content_complete": 0, "fail": 0, "unaudited": 0, "missing": 0, "shippable": 0, "total": 0}
+    totals = _empty_overview_totals()
 
     for level_cfg in LEVELS:
         track_id = level_cfg["id"]
@@ -234,7 +395,7 @@ def _build_overview_payload_from_scans() -> dict:
             elif key in s:
                 totals[key] += s[key]
 
-    return {
+    payload = {
         "tracks": tracks,
         "totals": totals,
         "timestamp": datetime.now(UTC).isoformat(),
@@ -248,6 +409,8 @@ def _build_overview_payload_from_scans() -> dict:
             **({"age_s": round(age_s, 3)} if age_s is not None else {}),
         },
     }
+    _apply_overview_summary_overlay(payload, state_tracks)
+    return payload
 
 
 def _schedule_overview_refresh() -> None:
@@ -263,12 +426,23 @@ def _schedule_overview_refresh() -> None:
         _overview_refresh_thread.start()
 
 
+def _overview_refresh_running() -> bool:
+    with _overview_refresh_lock:
+        thread = _overview_refresh_thread
+    return thread is not None and thread.is_alive()
+
+
 def _run_overview_refresh() -> None:
-    global _overview_last_good
+    global _overview_last_good, _overview_disk_loaded
     try:
         payload = _build_overview_payload_from_scans()
+        if _usable_overview_last_good(payload) is None:
+            logger.warning("dashboard overview refresh produced no tracks; keeping last-good")
+            return
         cache_set(DASHBOARD_OVERVIEW_CACHE_KEY, payload)
         _overview_last_good = payload
+        _overview_disk_loaded = True
+        persist_overview_last_good(payload)
     except Exception:
         logger.exception("dashboard overview background refresh failed")
 
@@ -283,9 +457,11 @@ async def overview():
     The request path never walks the curriculum tree. A warm TTL cache or
     last-good full scan is returned immediately; otherwise a cheap
     manifest + cached-summary payload is served while a detached worker
-    fills last-good. ``meta.cache`` remains the state-summary cache
-    signal; ``meta.track_scan`` / ``meta.stale`` / ``meta.error`` stay
-    honest about whether the per-module scan has run.
+    fills last-good. Last-good is also persisted to disk so a process
+    bounce does not fall back to 0/total-missing. ``meta.cache`` remains
+    the state-summary cache signal; ``meta.track_scan`` / ``meta.stale``
+    / ``meta.error`` stay honest about whether the per-module scan has
+    run. ``meta.refreshing`` is only set while warming (no last-good yet).
     """
     state_summary, cache_state, age_s = _peek_state_summary()
     state_tracks = state_summary.get("tracks", {}) if isinstance(state_summary, dict) else {}
@@ -301,37 +477,43 @@ async def overview():
         meta["track_scan"] = "hit"
         meta["stale_after_s"] = DASHBOARD_OVERVIEW_TTL_S
         meta.pop("error", None)
+        meta.pop("refreshing", None)
         if cache_state == "hit" and age_s is not None:
             meta["age_s"] = round(age_s, 3)
         elif overview_age_s is not None:
             meta["age_s"] = round(overview_age_s, 3)
-        _overlay_research_from_summary(payload.get("tracks", []), state_tracks)
+        _apply_overview_summary_overlay(payload, state_tracks)
         payload["meta"] = meta
         return payload
 
-    if _overview_last_good is not None:
-        _schedule_overview_refresh()
-        payload = copy.deepcopy(_overview_last_good)
+    last_good = hydrate_overview_last_good_from_disk()
+    if last_good is not None:
+        if not _overview_refresh_running():
+            _schedule_overview_refresh()
+        payload = copy.deepcopy(last_good)
         payload["timestamp"] = datetime.now(UTC).isoformat()
         meta = dict(payload.get("meta") or {})
         meta["cache"] = cache_state
         meta["stale"] = True
         meta["track_scan"] = "stale"
-        meta["refreshing"] = True
         meta["stale_after_s"] = DASHBOARD_OVERVIEW_TTL_S
+        meta.pop("error", None)
+        meta.pop("refreshing", None)
         if age_s is not None:
             meta["age_s"] = round(age_s, 3)
-        _overlay_research_from_summary(payload.get("tracks", []), state_tracks)
+        _apply_overview_summary_overlay(payload, state_tracks)
         payload["meta"] = meta
         return payload
 
     _schedule_overview_refresh()
-    return _build_overview_from_state_summary(
+    payload = _build_overview_from_state_summary(
         state_summary,
         cache_state,
         age_s,
         track_scan="skipped",
     )
+    payload.setdefault("meta", {})["refreshing"] = True
+    return payload
 
 
 @router.get("/research")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,40 @@ def _isolate_llm_qg_runtime_stores(tmp_path, monkeypatch):
     monkeypatch their own.
     """
     monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_DB", str(tmp_path / "llm_qg.db"))
-    monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_CIRCUIT", str(tmp_path / "llm_qg_live_circuit.json"))
+@pytest.fixture(autouse=True)
+def _isolate_overview_last_good(tmp_path, monkeypatch):
+    """Keep overview last-good on a per-test tmp path (#7024).
+
+    The durable snapshot lives under ``.cache/`` in production so a Monitor
+    bounce can reload it. Tests must not read or overwrite that host file,
+    and in-memory last-good must not leak across cases.
+    """
+    import sys
+
+    monkeypatch.setenv(
+        "DASHBOARD_OVERVIEW_LAST_GOOD_PATH",
+        str(tmp_path / "dashboard_overview_last_good.json"),
+    )
+    router = sys.modules.get("scripts.api.dashboard_router")
+    if router is not None:
+        router.reset_overview_state_for_tests()
+    yield
+    router = sys.modules.get("scripts.api.dashboard_router")
+    if router is not None:
+        router.reset_overview_state_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_overview_last_good(tmp_path, monkeypatch):
+    """Keep overview last-good on a per-test tmp path (#7024).
+
+    The durable snapshot lives under ``.cache/`` in production so a Monitor
+    bounce can reload it. Tests must not read or overwrite that host file.
+    """
+    monkeypatch.setenv(
+        "DASHBOARD_OVERVIEW_LAST_GOOD_PATH",
+        str(tmp_path / "dashboard_overview_last_good.json"),
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,11 @@ def _isolate_llm_qg_runtime_stores(tmp_path, monkeypatch):
     monkeypatch their own.
     """
     monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_DB", str(tmp_path / "llm_qg.db"))
+    monkeypatch.setenv(
+        "LEARN_UKRAINIAN_LLM_QG_CIRCUIT", str(tmp_path / "llm_qg_live_circuit.json")
+    )
+
+
 @pytest.fixture(autouse=True)
 def _isolate_overview_last_good(tmp_path, monkeypatch):
     """Keep overview last-good on a per-test tmp path (#7024).
@@ -143,19 +148,6 @@ def _isolate_overview_last_good(tmp_path, monkeypatch):
     router = sys.modules.get("scripts.api.dashboard_router")
     if router is not None:
         router.reset_overview_state_for_tests()
-
-
-@pytest.fixture(autouse=True)
-def _isolate_overview_last_good(tmp_path, monkeypatch):
-    """Keep overview last-good on a per-test tmp path (#7024).
-
-    The durable snapshot lives under ``.cache/`` in production so a Monitor
-    bounce can reload it. Tests must not read or overwrite that host file.
-    """
-    monkeypatch.setenv(
-        "DASHBOARD_OVERVIEW_LAST_GOOD_PATH",
-        str(tmp_path / "dashboard_overview_last_good.json"),
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1166,6 +1166,27 @@ class TestStatsFromStateSummary:
         assert stats["fail"] == 0
         assert stats["shippable"] == 0
 
+    def test_published_mdx_is_presence_not_pass(self):
+        from scripts.api.dashboard_helpers import stats_from_state_summary
+
+        stats = stats_from_state_summary(
+            {
+                "total": 1932,
+                "generated_md": 0,
+                "published_mdx": 356,
+                "audit_passing": 0,
+                "audit_stale": 0,
+                "content_done": 0,
+                "research_done": 450,
+            },
+            is_seminar=False,
+        )
+        assert stats["pass"] == 0
+        assert stats["published_mdx"] == 356
+        assert stats["missing"] == 1932 - 356
+        assert stats["missing"] != 1932
+        assert stats["research"]["total"] == 450
+
 
 class TestBuildModuleSummary:
     """build_module_summary returns lightweight module info."""

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -217,3 +217,214 @@ class TestDashboardInventory:
         linked = sum(1 for name in self.EXPECTED_DASHBOARDS
                      if name != "index.html" and name in text)
         assert linked >= 3, f"Index links to only {linked} dashboards"
+
+
+# ── #7024 overview last-good honesty ─────────────────────────────
+
+def _published_summary(*, total: int = 80, published_mdx: int = 55, research_done: int = 40) -> dict:
+    return {
+        "generated_at": "2026-08-18T16:20:00Z",
+        "tracks": {
+            "a1": {
+                "total": total,
+                "generated_md": 0,
+                "published_mdx": published_mdx,
+                "research_done": research_done,
+                "audit_passing": 0,
+                "content_done": 0,
+                "audit_stale": 0,
+                "reviewed": 0,
+                "final_review_done": 0,
+                "prompt_reviewed": 0,
+                "is_seminar": False,
+                "module_source": "curriculum.yaml",
+            }
+        },
+    }
+
+
+class TestHomeLoadStatsPublished:
+    """Home must show the published count overview already has on each track."""
+
+    def test_index_loadstats_surfaces_published_from_overview(self):
+        text = (DASHBOARDS_DIR / "index.html").read_text(encoding="utf-8")
+        assert "track.published_mdx" in text
+        assert "t.published" in text
+        assert "passing · ${t.published} published" in text
+        assert "${t.pass} passing / ${t.total} total" not in text
+
+
+class TestOverviewLastGoodHonesty:
+    """#7024: cold last-good + published_mdx must not report missing=total."""
+
+    def setup_method(self):
+        import scripts.api.dashboard_router as dashboard_router
+
+        dashboard_router.reset_overview_state_for_tests()
+
+    def teardown_method(self):
+        import scripts.api.dashboard_router as dashboard_router
+
+        dashboard_router.reset_overview_state_for_tests()
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from scripts.api.main import app
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_cold_process_published_is_not_all_missing(self, monkeypatch, tmp_path):
+        import scripts.api.dashboard_router as dashboard_router
+
+        monkeypatch.setenv(
+            dashboard_router.DASHBOARD_OVERVIEW_LAST_GOOD_ENV,
+            str(tmp_path / "overview_last_good.json"),
+        )
+        monkeypatch.setattr(
+            dashboard_router,
+            "_peek_state_summary",
+            lambda: (_published_summary(), "hit", 0.0),
+        )
+        monkeypatch.setattr(dashboard_router, "_schedule_overview_refresh", lambda: None)
+
+        before = {
+            "pass": 0,
+            "missing": 1932,
+            "total": 1932,
+            "published_mdx": 0,
+            "generated_md": 0,
+        }
+        resp = self._client().get("/api/dashboard/overview")
+        assert resp.status_code == 200
+        data = resp.json()
+        totals = data["totals"]
+        assert before["missing"] == before["total"]
+        assert totals["pass"] == 0
+        assert totals["published_mdx"] == 55
+        assert totals["missing"] < totals["total"]
+        assert totals["missing"] != totals["total"]
+        a1 = next(track for track in data["tracks"] if track["id"] == "a1")
+        assert a1["stats"]["missing"] == 80 - 55
+        assert a1["stats"]["pass"] == 0
+        assert a1["stats"]["research"]["total"] == 40
+        assert data["meta"].get("track_scan") == "skipped"
+        assert data["meta"].get("refreshing") is True
+
+    def test_bounce_reloads_persisted_last_good(self, monkeypatch, tmp_path):
+        import scripts.api.dashboard_router as dashboard_router
+
+        last_good_path = tmp_path / "overview_last_good.json"
+        monkeypatch.setenv(
+            dashboard_router.DASHBOARD_OVERVIEW_LAST_GOOD_ENV,
+            str(last_good_path),
+        )
+        payload = {
+            "tracks": [
+                {
+                    "id": "a1",
+                    "name": "A1",
+                    "module_count": 80,
+                    "published_mdx": 55,
+                    "generated_md": 0,
+                    "stats": {
+                        "pass": 0,
+                        "missing": 80,
+                        "content_complete": 0,
+                        "fail": 0,
+                        "unaudited": 0,
+                        "shippable": 0,
+                        "research": {"total": 40},
+                    },
+                }
+            ],
+            "totals": {
+                "pass": 0,
+                "missing": 80,
+                "total": 80,
+                "published_mdx": 0,
+                "content_complete": 0,
+                "fail": 0,
+                "unaudited": 0,
+                "shippable": 0,
+            },
+            "meta": {"track_scan": "hit", "source": "fs:dashboard-summary+state-summary"},
+            "timestamp": "2026-08-18T16:21:47Z",
+        }
+        dashboard_router.persist_overview_last_good(payload)
+        dashboard_router.simulate_overview_process_bounce_for_tests()
+        monkeypatch.setattr(dashboard_router, "_schedule_overview_refresh", lambda: None)
+        monkeypatch.setattr(
+            dashboard_router,
+            "_peek_state_summary",
+            lambda: (_published_summary(), "hit", 0.0),
+        )
+
+        resp = self._client().get("/api/dashboard/overview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["pass"] == 0
+        assert data["totals"]["published_mdx"] == 55
+        assert data["totals"]["missing"] == 25
+        assert data["totals"]["missing"] != data["totals"]["total"]
+        assert data["meta"]["track_scan"] == "stale"
+        assert not data["meta"].get("refreshing")
+
+    def test_successful_refresh_settles_without_refreshing(self, monkeypatch, tmp_path):
+        import scripts.api.dashboard_router as dashboard_router
+        import scripts.api.state_helpers as state_helpers
+
+        monkeypatch.setenv(
+            dashboard_router.DASHBOARD_OVERVIEW_LAST_GOOD_ENV,
+            str(tmp_path / "overview_last_good.json"),
+        )
+        summary = _published_summary()
+        seeded = dashboard_router._build_overview_from_state_summary(
+            summary, "hit", 0.0, track_scan="hit"
+        )
+        seeded["meta"]["track_scan"] = "hit"
+        state_helpers.cache_set(dashboard_router.DASHBOARD_OVERVIEW_CACHE_KEY, seeded)
+        dashboard_router._overview_last_good = seeded
+        monkeypatch.setattr(
+            dashboard_router,
+            "_peek_state_summary",
+            lambda: (summary, "hit", 0.0),
+        )
+        monkeypatch.setattr(dashboard_router, "_schedule_overview_refresh", lambda: None)
+
+        resp = self._client().get("/api/dashboard/overview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["meta"]["track_scan"] == "hit"
+        assert "refreshing" not in data["meta"] or data["meta"].get("refreshing") is False
+        assert data["totals"]["pass"] == 0
+        assert data["totals"]["published_mdx"] == 55
+        assert data["totals"]["missing"] != data["totals"]["total"]
+
+    def test_stale_last_good_does_not_keep_refreshing(self, monkeypatch, tmp_path):
+        import scripts.api.dashboard_router as dashboard_router
+
+        monkeypatch.setenv(
+            dashboard_router.DASHBOARD_OVERVIEW_LAST_GOOD_ENV,
+            str(tmp_path / "overview_last_good.json"),
+        )
+        summary = _published_summary()
+        seeded = dashboard_router._build_overview_from_state_summary(
+            summary, "hit", 0.0, track_scan="hit"
+        )
+        dashboard_router._overview_last_good = seeded
+        dashboard_router._overview_disk_loaded = True
+        monkeypatch.setattr(
+            dashboard_router,
+            "_peek_state_summary",
+            lambda: (summary, "hit", 0.0),
+        )
+        monkeypatch.setattr(dashboard_router, "_schedule_overview_refresh", lambda: None)
+
+        resp = self._client().get("/api/dashboard/overview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["meta"]["track_scan"] == "stale"
+        assert not data["meta"].get("refreshing")
+        assert data["totals"]["published_mdx"] == 55
+        assert data["totals"]["missing"] < data["totals"]["total"]

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -308,3 +308,48 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
             f"{HEALTH_ENDPOINT} p95-of-3 took {health_p95:.3f}s after {endpoint} "
             f"(runs: {', '.join(f'{elapsed:.3f}s' for elapsed in health_timings)})",
         )
+
+
+def test_overview_cold_last_good_does_not_report_all_missing(monkeypatch, tmp_path):
+    """#7024: empty in-memory last-good + published_mdx>0 is not missing=total."""
+    import scripts.api.dashboard_router as dashboard_router
+
+    dashboard_router.reset_overview_state_for_tests()
+    monkeypatch.setenv(
+        dashboard_router.DASHBOARD_OVERVIEW_LAST_GOOD_ENV,
+        str(tmp_path / "overview_last_good.json"),
+    )
+    summary = {
+        "generated_at": "2026-08-18T16:20:00Z",
+        "tracks": {
+            "a1": {
+                "total": 80,
+                "generated_md": 0,
+                "published_mdx": 55,
+                "research_done": 40,
+                "audit_passing": 0,
+                "content_done": 0,
+                "audit_stale": 0,
+                "is_seminar": False,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        dashboard_router,
+        "_peek_state_summary",
+        lambda: (summary, "hit", 0.0),
+    )
+    monkeypatch.setattr(dashboard_router, "_schedule_overview_refresh", lambda: None)
+
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        data = client.get("/api/dashboard/overview").json()
+        totals = data["totals"]
+        assert totals["pass"] == 0
+        assert totals["published_mdx"] == 55
+        assert totals["missing"] < totals["total"]
+        assert data["meta"].get("track_scan") in {"skipped", "stale", "hit"}
+        if data["meta"].get("track_scan") == "hit":
+            assert not data["meta"].get("refreshing")
+    finally:
+        dashboard_router.reset_overview_state_for_tests()


### PR DESCRIPTION
## Summary
- Persist Monitor `/api/dashboard/overview` last-good to `.cache/` so a process bounce does not fall back to empty in-memory last-good.
- Cheap warming (and scan overlay) treats `published_mdx` as presence, not audit pass: `pass` stays `audit_passing`, `missing` is no longer `total` when published > 0, and Home `loadStats()` shows published.
- After a successful refresh, `meta.track_scan=hit` and `refreshing` is absent; stale last-good no longer keeps flipping `refreshing=true`. Empty scans are not persisted.

## Changes
- `scripts/api/dashboard_helpers.py`: `present_module_count` / honest `stats_from_state_summary`.
- `scripts/api/dashboard_router.py`: disk last-good, presence overlay, settle `refreshing`.
- `dashboards/index.html`: Home surfaces published from overview tracks.
- Tests for cold bounce, persisted last-good, and refresh settle.

## Testing
- [x] `ruff check scripts/api/dashboard_router.py scripts/api/dashboard_helpers.py`
- [x] `pytest -q tests/test_dashboards.py tests/test_playground_api_stability.py tests/test_orient_api.py` (165 passed)
- [ ] Website builds without errors (`cd site && npm run build`) — not in scope
- [ ] Ukrainian text reviewed for naturalness — not in scope

Cold last-good (empty memory, summary `published_mdx=356` / `generated_md=0` / `total=1932`):
- before: `{pass: 0, missing: 1932, total: 1932, published_mdx: 0, research: 0}`
- after: `{pass: 0, missing: 1576, total: 1932, published_mdx: 356, research: 450}`

## Related Issues
Fixes #7024
This PR leaves #6983 open.


Made with [Cursor](https://cursor.com)