### PR TITLE
fix(atlas): make bs4 import lazy in source_query and propagate launcher pipefail

### DIFF
--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -210,7 +210,7 @@ run_cmd() {
     printf '%q ' "${EXTRA_ARGS[@]}"
   fi
 }
-WRAPPED="cd $(printf '%q' "$REPO") && PYTHONPATH=$(printf '%q' "$CODE_ROOT"):\$PYTHONPATH:$(printf '%q' "$REPO") exec /usr/bin/nice -n 10 /usr/bin/ionice -c3 $(run_cmd) 2>>$(printf '%q' "$LOG") | tee -a $(printf '%q' "$LOG") > $(printf '%q' "$SUMMARY_FILE")"
+WRAPPED="set -o pipefail; cd $(printf '%q' "$REPO") && PYTHONPATH=$(printf '%q' "$CODE_ROOT"):\$PYTHONPATH:$(printf '%q' "$REPO") exec /usr/bin/nice -n 10 /usr/bin/ionice -c3 $(run_cmd) 2>>$(printf '%q' "$LOG") | tee -a $(printf '%q' "$LOG") > $(printf '%q' "$SUMMARY_FILE")"
 
 if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run >/dev/null 2>&1; then
   rm -f "$PID_FILE" "$WRAPPER_PID_FILE"

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -26,14 +26,18 @@ Usage:
     result = ulif_paradigm("стіл")
 """
 
+from __future__ import annotations
+
 import re
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import requests
-from bs4 import BeautifulSoup, Tag
+
+if TYPE_CHECKING:
+    from bs4 import Tag
 
 try:
     from wiki import slovnyk_me as _slovnyk_me
@@ -478,6 +482,8 @@ def _ulif_terms(node: Tag) -> list[dict[str, str]]:
 
 def _parse_ulif_paradigm(html: str) -> dict[str, object] | None:
     """Parse a noun/adjective or verb paradigm table from a DictUA response."""
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     for table in soup.find_all("table"):
         rows: list[list[str]] = []
@@ -494,6 +500,8 @@ def _parse_ulif_paradigm(html: str) -> dict[str, object] | None:
 
 def _parse_ulif_relation_groups(html: str, kind: str) -> list[dict]:
     """Parse ordered DictUA relation groups while retaining their source HTML."""
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     panel = soup.select_one("div.p_cl")
     if panel is None:
@@ -563,6 +571,8 @@ def _parse_ulif_relation_groups(html: str, kind: str) -> list[dict]:
 
 
 def _ulif_webforms_tokens(html: str) -> dict[str, str] | None:
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     values: dict[str, str] = {}
     for name in ("__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION"):
@@ -573,11 +583,15 @@ def _ulif_webforms_tokens(html: str) -> dict[str, str] | None:
 
 
 def _ulif_has_control(html: str, control_name: str) -> bool:
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     return soup.find("input", attrs={"name": control_name}) is not None
 
 
 def _ulif_headword(html: str, requested_word: str) -> str:
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     article = soup.find(id="ContentPlaceHolder1_article")
     if article is not None:
@@ -598,6 +612,8 @@ def _ulif_search_result_matches(html: str, requested_word: str) -> bool | None:
     so a successful status plus a paradigm table is not enough evidence of a
     lookup hit.  The list is the server's only reliable match signal.
     """
+    from bs4 import BeautifulSoup
+
     soup = BeautifulSoup(html, "html.parser")
     result_list = soup.find(id="ContentPlaceHolder1_dgv")
     if result_list is None:

--- a/tests/test_launch_reenrich_venv_preflight.py
+++ b/tests/test_launch_reenrich_venv_preflight.py
@@ -159,22 +159,41 @@ def test_launcher_wrapped_command_has_pipefail() -> None:
 
 
 def test_source_query_goroh_translate_importable_without_bs4() -> None:
-    """#6876: scripts.rag.source_query and goroh_translate must be importable
-    even when bs4 / beautifulsoup4 is not installed in the environment."""
+    """#6876: goroh_translate must be importable without bs4.
+
+    Fastlane puts only the repo root on ``sys.path``, so the content trees
+    ``wiki/`` and ``audit/`` shadow ``scripts.wiki`` / ``scripts.audit``. Stub
+    a minimal ``wiki.slovnyk_me`` so this regression proves the no-bs4 contract
+    without requiring those packages (or a scripts-on-path environment).
+    """
     import sys
-    orig_bs4 = sys.modules.get("bs4")
-    orig_source_query = {k: v for k, v in sys.modules.items() if "source_query" in k}
+    import types
+
+    stub_keys = ("bs4", "wiki", "wiki.slovnyk_me")
+    saved = {key: sys.modules.get(key) for key in stub_keys}
+    saved_source_query = {k: v for k, v in sys.modules.items() if "source_query" in k}
     try:
         sys.modules["bs4"] = None  # type: ignore[assignment]
-        for k in list(orig_source_query.keys()):
-            sys.modules.pop(k, None)
+
+        slovnyk = types.ModuleType("wiki.slovnyk_me")
+        slovnyk.SLOVNYK_ME_DICTS = {}
+        slovnyk.resolve_dict_slug = lambda slug: slug
+        wiki_pkg = types.ModuleType("wiki")
+        wiki_pkg.slovnyk_me = slovnyk
+        sys.modules["wiki"] = wiki_pkg
+        sys.modules["wiki.slovnyk_me"] = slovnyk
+
+        for key in list(saved_source_query):
+            sys.modules.pop(key, None)
 
         from scripts.rag.source_query import goroh_translate
+
         assert callable(goroh_translate)
     finally:
-        if orig_bs4 is not None:
-            sys.modules["bs4"] = orig_bs4
-        else:
-            sys.modules.pop("bs4", None)
-        sys.modules.update(orig_source_query)
+        for key, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = prior
+        sys.modules.update(saved_source_query)
 

--- a/tests/test_launch_reenrich_venv_preflight.py
+++ b/tests/test_launch_reenrich_venv_preflight.py
@@ -149,3 +149,32 @@ def test_launcher_invokes_resolved_runner_python() -> None:
     source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
     assert 'printf \'%q \' "$RUNNER_PYTHON" "$DRIVER"' in source
     assert 'import yaml, jsonschema' in source
+
+
+def test_launcher_wrapped_command_has_pipefail() -> None:
+    """#6876: WRAPPED must set pipefail so driver failures (e.g. circuit breaker 70)
+    are not masked by tee exiting 0."""
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    assert 'WRAPPED="set -o pipefail;' in source
+
+
+def test_source_query_goroh_translate_importable_without_bs4() -> None:
+    """#6876: scripts.rag.source_query and goroh_translate must be importable
+    even when bs4 / beautifulsoup4 is not installed in the environment."""
+    import sys
+    orig_bs4 = sys.modules.get("bs4")
+    orig_source_query = {k: v for k, v in sys.modules.items() if "source_query" in k}
+    try:
+        sys.modules["bs4"] = None  # type: ignore[assignment]
+        for k in list(orig_source_query.keys()):
+            sys.modules.pop(k, None)
+
+        from scripts.rag.source_query import goroh_translate
+        assert callable(goroh_translate)
+    finally:
+        if orig_bs4 is not None:
+            sys.modules["bs4"] = orig_bs4
+        else:
+            sys.modules.pop("bs4", None)
+        sys.modules.update(orig_source_query)
+


### PR DESCRIPTION
## Summary
Diagnose and fix why atlas-runner jobs filled 0/1140 EN after #6982.

### Root Cause
1. **Runner venv import failure:** `scripts/rag/source_query.py` had a top-level module import `from bs4 import BeautifulSoup, Tag`. The runner venv (`/home/ops/atlas-runner/repo/.venv`) lacked `beautifulsoup4`. When `query_goroh_translate` in `enrich_manifest.py` attempted `from scripts.rag.source_query import goroh_translate`, it threw `ModuleNotFoundError: No module named 'bs4'`.
2. **Silent catch:** The `try ... except Exception:` in `query_goroh_translate` swallowed `ModuleNotFoundError` and returned `[]` for every single lemma.
3. **Circuit breaker trip:** After 50 consecutive translation misses on the leftover batch, the driver tripped the circuit breaker and returned exit code 70.
4. **Pipeline exit status masking:** In `scripts/lexicon/runner/launch_reenrich_class_b.sh`, the wrapped command executed `... $(run_cmd) 2>>$LOG | tee -a $LOG > $SUMMARY_FILE`. Because `WRAPPED` lacked `set -o pipefail`, the pipeline exit code was determined by `tee` (which exited 0), causing systemd to record success (`exit_status: 0`, `service_result: success`).

### Fixes
- Made `BeautifulSoup` import lazy in `scripts/rag/source_query.py` so `goroh_translate` does not fail on environments without `bs4`.
- Installed `beautifulsoup4` in runner venv for defense in depth.
- Added `set -o pipefail;` to `WRAPPED` in `scripts/lexicon/runner/launch_reenrich_class_b.sh` so circuit-breaker / driver non-zero exit codes propagate to systemd / `exit-status.json`.
- Added regression tests in `tests/test_launch_reenrich_venv_preflight.py`.

X-Agent: cursor/atlas-6876-goroh-zero
Refs #6876