### PR TITLE
fix(bridge): route ask-* --pr/--branch to the lightweight direct review path

### DIFF
--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -631,7 +631,7 @@ def _gh_pr_checkout_reason(seg: list[str], effective_cwd: Path) -> str | None:
             return None
         return (
             "gh pr checkout moves the primary checkout off main "
-            "(use a dispatch worktree or gh pr diff / review-pr instead)"
+            "(use a dispatch worktree or gh pr diff instead)"
         )
     return None
 

--- a/agents_extensions/shared/memory/MEMORY.md
+++ b/agents_extensions/shared/memory/MEMORY.md
@@ -57,8 +57,8 @@ Compound decisions = ONE table + ONE recommendation, NEVER N parallel sign-off q
 
 ## #0H — CF REVIEW MANDATORY ON EVERY PR; THEN MERGE (2026-07-27)
 **Independent cross-family (CF) formal review is ALWAYS mandatory before merge.** No exceptions for “small,” docs-only, launcher, or infra PRs. Discussion / self-review / same-family review ≠ the gate.
-- Request immediately after `gh pr create`: `.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm|grok --initiator <orchestrator/task> --author-model <model> --author-family <family>`. Omit `--reviewer` for deterministic automatic selection. **agy / kimi are NOT formal_review_eligible reviewers** — never self-seal; native Grok is eligible, while Cursor Grok is not.
-- Closeout incomplete until CF is requested (and settled). Failure encoded: 2026-07-27 Grok shipped #5875 without `review-pr`; operator had to ask.
+- Request immediately after `gh pr create` — **lightweight direct path (sealed `review-pr` RETIRED 2026-08-07):** `printf '%s\n' "Cross-family review of PR #<N> at head <SHA>: verdict + findings." | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - --task-id review-<N> --type review`, then post the verdict on the PR. Resolve the reviewer lane with `scripts.review.closeout_cli ... resolve-reviewer` (must be outside the author's model family; eligibility pins are retired with the sealed path).
+- Closeout incomplete until CF is requested (and settled). Failure encoded: 2026-07-27 Grok shipped #5875 without CF review; operator had to ask.
 - After CF pass + green blocking CI: `gh pr merge N --auto --squash --delete-branch` (action bias — don’t leave PRs limbo). Hold only for CF fail or blocking CI.
 
 ## #0G — NEVER REPORT ASYNC-TASK STATE FROM MEMORY (2026-05-08)

--- a/agents_extensions/shared/prompts/dynamic-area-epic-fleet-governor.md
+++ b/agents_extensions/shared/prompts/dynamic-area-epic-fleet-governor.md
@@ -256,9 +256,11 @@ owned paths, lifecycle, state, evidence, PR, reviewer, and disposition.
   emit fabricated StepReceipts, or automate a transition whose `blocked_on`
   dependency remains unresolved. Stop on declared STOP conditions.
 - Formal review must be outside the author family and eligible for the task
-  family under live policy. Use
-  `.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER>
-  --reviewer <eligible-lane>` and the sealed verdict publication flow.
+  family under live policy. Sealed `review-pr` is RETIRED (operator 2026-08-07)
+  — use the lightweight direct review:
+  `printf '%s\n' "Cross-family review of PR #<N> at head <SHA>: verdict + findings." |
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-<lane> - --task-id review-<N> --type review`
+  then post the verdict on the PR.
 - Resolve every material review finding, run relevant tests and repository
   gates, verify the user-visible behavior, and arm auto-merge only after the
   review gate passes. Follow RB-4 for red CI; never retry unknown failures

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -100,14 +100,16 @@ def _resolve_agy_bridge_timeout(no_timeout: bool = False) -> int:
 
 
 # Sealed formal CF isolation is not proven for AGY (project instructions, MCP,
-# hooks, nested reviewers cannot yet be suppressed). Fail closed *before*
-# provisioning a review worktree so operators get a substitute path immediately.
+# hooks, nested reviewers cannot yet be suppressed), and the sealed review-pr
+# path itself is retired (operator 2026-08-07). Fail closed *before* any send
+# on this legacy entrypoint so operators get the working path immediately.
 AGY_SEALED_REVIEW_UNSUPPORTED = (
     "agy_isolated_review_unsupported: AGY cannot yet prove native "
     "project-instruction, MCP, hook, and nested-reviewer suppression for "
-    "sealed formal CF review. "
-    "Use: `.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> "
-    "--reviewer claude|glm|codex`. "
+    "sealed formal CF review, and sealed review-pr is retired. "
+    "Use the lightweight direct review on an eligible lane: "
+    "`ask-claude|ask-codex|ask-kimi - --task-id review-<N> --type review` "
+    "(or `--pr <N>`, which routes to the same direct path). "
     "AGY remains fine for advisory ask-agy *without* --review."
 )
 

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -616,7 +616,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_claude_parser.add_argument("--from-model", dest="from_model", help="Exact sender model ID")
     ask_claude_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
     ask_claude_parser.add_argument("--effort", choices=EFFORT_CHOICES, help="Requested reasoning effort")
-    ask_claude_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_claude_parser.add_argument("--review", action="store_true", help="Review ask (same as --type review): reply must state VERDICT grounded in evidence; sealed review-pr is retired")
 
     # ask-codex
     ask_codex_parser = subparsers.add_parser(
@@ -644,7 +644,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="ISSUE",
         help="Dispatch multiple GitHub issues sequentially (e.g. 1212 #1213 issue-1214)",
     )
-    ask_codex_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_codex_parser.add_argument("--review", action="store_true", help="Review ask (same as --type review): reply must state VERDICT grounded in evidence; sealed review-pr is retired")
 
     # ask-gemini legacy compatibility shim
     ask_gemini_parser = subparsers.add_parser(
@@ -706,7 +706,7 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["auto", "subscription", "api-key", "api"],
         help="Gemini auth mode override for this invocation",
     )
-    ask_gemini_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_gemini_parser.add_argument("--review", action="store_true", help="Review ask (same as --type review): reply must state VERDICT grounded in evidence; sealed review-pr is retired")
 
     # ask-agy
     ask_agy_parser = subparsers.add_parser(
@@ -742,8 +742,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--review",
         action="store_true",
         help=(
-            "Formal sealed CF review (NOT supported on AGY — exits 2 with "
-            "substitute: review-pr --reviewer claude|glm|codex)"
+            "Review ask on the lightweight direct path "
+            "(verdict + evidence required; sealed review-pr is retired)"
         ),
     )
 
@@ -904,7 +904,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_grok_build_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
     ask_grok_build_parser.add_argument("--effort", choices=EFFORT_CHOICES, help="Requested reasoning effort")
     ask_grok_build_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
-    ask_grok_build_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_grok_build_parser.add_argument("--review", action="store_true", help="Review ask (same as --type review): reply must state VERDICT grounded in evidence; sealed review-pr is retired")
 
     ask_kimi_parser = subparsers.add_parser(
         "ask-kimi", help="Send message AND invoke native Kimi Code one-shot (use '-' to read from stdin)"
@@ -920,7 +920,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_kimi_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
     ask_kimi_parser.add_argument("--effort", choices=EFFORT_CHOICES, help="Requested reasoning effort")
     ask_kimi_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
-    ask_kimi_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_kimi_parser.add_argument("--review", action="store_true", help="Review ask (same as --type review): reply must state VERDICT grounded in evidence; sealed review-pr is retired")
 
     for review_parser in (
         ask_claude_parser,
@@ -933,12 +933,18 @@ def _build_parser() -> argparse.ArgumentParser:
         review_target = review_parser.add_mutually_exclusive_group()
         review_target.add_argument(
             "--branch",
-            help="Remote branch to review; fetched and resolved only as origin/<branch>",
+            help=(
+                "Remote branch to review via the lightweight direct path "
+                "(resolved as origin/<branch>; sealed review-pr is retired)"
+            ),
         )
         review_target.add_argument(
             "--pr",
             type=int,
-            help="PR whose head branch to fetch and review",
+            help=(
+                "PR to review via the lightweight direct path "
+                "(same as ask-LANE - --type review; sealed review-pr is retired)"
+            ),
         )
 
     for ask_parser in (
@@ -1466,14 +1472,39 @@ def _handle_acp_compat(args, target: str) -> None:
     """Route a legacy ask command through the single ACP compatibility shim."""
     if getattr(args, "background", False):
         raise SystemExit("legacy ask --background is retired; enqueue through fleet-comms")
-    if getattr(args, "branch", None) is not None or getattr(args, "pr", None) is not None:
-        raise SystemExit("formal review targets require the review-pr command")
     content = sys.stdin.read() if args.content == "-" else args.content
     data = Path(args.data).read_text(encoding="utf-8") if getattr(args, "data", None) else None
     model = getattr(args, "to_model", None) or getattr(args, "model", None)
     task_id = getattr(args, "task_id", None)
     if not task_id:
         raise SystemExit(f"ask-{target} requires --task-id")
+    # Review intent comes from either spelling: the explicit --review flag or
+    # the --type review drivers actually pass (#6805).
+    review = (
+        bool(getattr(args, "review", False))
+        or str(getattr(args, "type", "") or "").strip().casefold() == "review"
+    )
+    pr_number = getattr(args, "pr", None)
+    branch = getattr(args, "branch", None)
+    if pr_number is not None or branch is not None:
+        # #7010: sealed review-pr is retired (operator 2026-08-07). Route
+        # --pr/--branch to the same lightweight direct path as
+        # `ask-LANE - --type review`: the target is folded into the prompt and
+        # review mode is forced so the reply still needs a grounded verdict.
+        if pr_number is not None:
+            target_desc = (
+                f"PR #{pr_number} — resolve the exact head and diff with "
+                f"`gh pr view {pr_number} --json headRefOid` / `gh pr diff {pr_number}`"
+            )
+        else:
+            target_desc = f"remote branch origin/{branch}"
+        content = f"Cross-family review target: {target_desc}.\n\n{content}"
+        review = True
+        print(
+            f"ask-{target}: --pr/--branch use the lightweight direct review path "
+            "(sealed review-pr is retired); review mode forced.",
+            file=sys.stderr,
+        )
     from ._acp_compat import (
         ASK_HARD_TIMEOUT_DEFAULT_S,
         ask_hard_timeout,
@@ -1491,12 +1522,7 @@ def _handle_acp_compat(args, target: str) -> None:
             model=model,
             effort=getattr(args, "effort", None),
             data=data,
-            # Review intent comes from either spelling: the explicit --review
-            # flag or the --type review drivers actually pass (#6805).
-            review=(
-                bool(getattr(args, "review", False))
-                or str(getattr(args, "type", "") or "").strip().casefold() == "review"
-            ),
+            review=review,
             output_path=getattr(args, "output_path", None),
             stdout_only=bool(getattr(args, "stdout_only", False)),
             # None resolves the seat's per-seat timeout profile (#6877);

--- a/scripts/ai_agent_bridge/_review_safety.py
+++ b/scripts/ai_agent_bridge/_review_safety.py
@@ -262,7 +262,8 @@ def assert_formal_review_ask_payload(
         raise ReviewSafetyError(
             "review_ask_content_exceeds_cap: "
             f"bytes={content_size} limit={MAX_REVIEW_REQUEST_BYTES}. "
-            "Use review-pr <N>; it pulls PR evidence instead of accepting pasted review bodies."
+            "Point the reviewer at the PR head (e.g. `ask-LANE - --type review --pr <N>`); "
+            "do not paste full review bodies."
         )
     if attachment is not None:
         attachment_size = _attachment_bytes(attachment)
@@ -270,7 +271,8 @@ def assert_formal_review_ask_payload(
             raise ReviewSafetyError(
                 "review_ask_attachment_exceeds_cap: "
                 f"bytes={attachment_size} limit={MAX_ASK_ATTACHMENT_BYTES}. "
-                "Use review-pr <N>; it pulls PR evidence instead of accepting attachments."
+                "Point the reviewer at the PR head (e.g. `ask-LANE - --type review --pr <N>`); "
+                "do not attach oversized evidence files."
             )
     return True
 
@@ -293,16 +295,16 @@ def allow_legacy_review_ask_escape() -> bool:
 
 
 def looks_like_pr_cf_review(content: str) -> bool:
-    """Heuristic: formal CF PR review should use review-pr, not fat ask-*."""
+    """Heuristic: body reads like a formal CF PR review (target should be named)."""
     return bool(_PR_CF_REVIEW_RE.search(content[:4000]))
 
 
 def warn_missing_review_target(*, formal_review: bool, has_target: bool) -> None:
-    """Steer manual formal-review asks to the PR-targeted entrypoint."""
+    """Remind manual formal-review asks to name the PR/branch target."""
     if formal_review and not has_target:
         print(
-            "warning: formal review ask has no review target; prefer review-pr <N> "
-            "for sealed, pointer-only review.",
+            "warning: formal review ask has no review target; name the PR head "
+            "SHA (or pass --pr <N>, which routes to the lightweight direct path).",
             file=sys.stderr,
         )
 
@@ -313,11 +315,14 @@ def warn_pr_cf_review_prefer_review_pr(
     formal_review: bool,
     has_target: bool,
 ) -> None:
-    """Phase 5: steer PR CF reviews to review-pr without discarding agent work.
+    """Warn when a PR CF review ask omits its target (warn-not-reject, #5486).
 
-    Rejecting after a model already generated a formal PR review is wasteful when
-    the agent did not know to use review-pr. Emit a strong warning instead; size
-    caps still fail closed for oversized bodies/attachments.
+    Sealed review-pr is retired (operator 2026-08-07): the direct
+    `ask-LANE --type review` round IS the formal path now, so this no longer
+    steers to a separate command — it only requires the review to name its
+    exact target (PR head SHA). Rejecting after a model already generated a
+    formal PR review is wasteful; size caps still fail closed for oversized
+    bodies/attachments.
     """
     if not formal_review or has_target:
         return
@@ -325,10 +330,11 @@ def warn_pr_cf_review_prefer_review_pr(
         return
     if looks_like_pr_cf_review(content):
         print(
-            "warning: formal CF PR review via ask-* without a sealed target — "
-            "prefer `scripts/ai_agent_bridge/__main__.py review-pr <N>` (pointer-only) "
-            "then `publish-review-verdict`. This ask is allowed so work is not discarded "
-            "(fleet-comms Phase 5 / #5486; warn-not-reject). "
+            "warning: formal CF PR review via ask-* without a named target — "
+            "the direct `ask-LANE - --type review` round is the formal path "
+            "(sealed review-pr retired 2026-08-07); include the PR head SHA in "
+            "the body and post the verdict on the PR. This ask is allowed so "
+            "work is not discarded (warn-not-reject). "
             "Silence with BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1.",
             file=sys.stderr,
         )

--- a/tests/ai_agent_bridge/test_ask_pr_lightweight_route.py
+++ b/tests/ai_agent_bridge/test_ask_pr_lightweight_route.py
@@ -1,0 +1,80 @@
+"""#7010: ``ask-* --pr`` / ``--branch`` route to the lightweight direct review.
+
+Sealed ``review-pr`` is retired (operator 2026-08-07). The legacy ask flags
+must no longer bounce agents to it; they fold the target into the prompt and
+force review mode on the same path as ``ask-LANE - --type review``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ai_agent_bridge import _acp_compat, _cli
+
+
+@pytest.fixture()
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_compat(*args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return SimpleNamespace(ok=True)
+
+    monkeypatch.setattr(_acp_compat, "run_compat_ask", fake_compat)
+    return captured
+
+
+def test_ask_pr_routes_to_lightweight_review_path(captured: dict[str, object]) -> None:
+    args = _cli._build_parser().parse_args(
+        ["ask-claude", "review this change", "--task-id", "review-7010", "--pr", "7010", "--from", "test"]
+    )
+
+    _cli._handle_ask_claude(args)
+
+    assert captured["args"][0] == "claude"
+    # Target folded into the prompt; review mode forced.
+    assert "PR #7010" in captured["args"][1]
+    assert "gh pr diff 7010" in captured["args"][1]
+    assert captured["review"] is True
+
+
+def test_ask_branch_routes_to_lightweight_review_path(captured: dict[str, object]) -> None:
+    args = _cli._build_parser().parse_args(
+        ["ask-kimi", "review this change", "--task-id", "review-branch", "--branch", "feat-x", "--from", "test"]
+    )
+
+    _cli._handle_ask_kimi(args)
+
+    assert "origin/feat-x" in captured["args"][1]
+    assert captured["review"] is True
+
+
+def test_ask_pr_and_branch_remain_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit):
+        _cli._build_parser().parse_args(
+            ["ask-claude", "body", "--task-id", "t", "--pr", "1", "--branch", "b"]
+        )
+
+
+def test_ask_pr_no_longer_refuses_with_review_pr_circle(captured: dict[str, object]) -> None:
+    """The old refusal named the retired review-pr command as the next step."""
+    args = _cli._build_parser().parse_args(
+        ["ask-codex", "body", "--task-id", "review-circle", "--pr", "42", "--from", "test"]
+    )
+
+    _cli._handle_ask_codex(args)  # must not raise SystemExit
+
+    assert captured["review"] is True
+
+
+def test_ask_help_no_longer_requires_review_pr() -> None:
+    parser = _cli._build_parser()
+    help_text = parser.format_help()
+    for sub in parser._subparsers._group_actions:  # noqa: SLF001
+        for action in getattr(sub, "choices", {}).values():
+            help_text += "\n" + action.format_help()
+    assert "formal review targets require the review-pr command" not in help_text
+    assert "substitute: review-pr" not in help_text

--- a/tests/ai_agent_bridge/test_review_ask_caps.py
+++ b/tests/ai_agent_bridge/test_review_ask_caps.py
@@ -20,13 +20,15 @@ from scripts.ai_agent_bridge import _review_safety as safety
     ),
 )
 def test_named_transports_reject_fat_formal_review_body(ask, kwargs: dict[str, str]) -> None:
-    with pytest.raises(SystemExit, match=r"review-pr.*exceeds_cap|exceeds_cap.*review-pr"):
+    with pytest.raises(SystemExit, match=r"review_ask_content_exceeds_cap") as exc_info:
         ask(
             "x" * (safety.MAX_REVIEW_REQUEST_BYTES + 1),
             task_id="review-fat",
             msg_type="review",
             **kwargs,
         )
+    # #7010: the retired sealed command must not be named as the fix.
+    assert "review-pr" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -46,7 +48,7 @@ def test_named_transports_reject_fat_formal_review_attachment(
     attachment = tmp_path / "fat-evidence.txt"
     attachment.write_bytes(b"x" * (safety.MAX_ASK_ATTACHMENT_BYTES + 1))
 
-    with pytest.raises(SystemExit, match=r"review-pr.*attachment_exceeds_cap|attachment_exceeds_cap.*review-pr"):
+    with pytest.raises(SystemExit, match=r"review_ask_attachment_exceeds_cap") as exc_info:
         ask(
             "thin pointer only",
             task_id="review-attachment",
@@ -54,8 +56,12 @@ def test_named_transports_reject_fat_formal_review_attachment(
             data=str(attachment),
             **kwargs,
         )
+    assert "review-pr" not in str(exc_info.value)
 
 
 def test_formal_review_without_target_warns(capsys: pytest.CaptureFixture[str]) -> None:
     safety.warn_missing_review_target(formal_review=True, has_target=False)
-    assert "prefer review-pr <N>" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "--pr <N>" in err
+    # #7010: the retired sealed command must not be named as the next step.
+    assert "prefer review-pr" not in err

--- a/tests/ai_agent_bridge/test_review_pr_required.py
+++ b/tests/ai_agent_bridge/test_review_pr_required.py
@@ -30,7 +30,11 @@ def test_assert_pr_cf_review_warns_without_target(capsys: pytest.CaptureFixture[
         is True
     )
     err = capsys.readouterr().err
-    assert "prefer" in err and "review-pr" in err
+    # #7010: the direct ask IS the formal path now; the warning requires a
+    # named target and must not steer to the retired sealed command.
+    assert "review-pr retired" in err
+    assert "head SHA" in err
+    assert "prefer" not in err
     assert "warn-not-reject" in err or "not discarded" in err
 
 


### PR DESCRIPTION
## Summary

Fixes the circular review gate from #7010: `review-pr` fails closed pointing at `ask-LANE --type review`, while `ask-* --pr` refused with "formal review targets require the review-pr command". Per the ticket, `ask-* --pr` now **routes to the same lightweight path** (preferred option) instead of naming the retired command.

## Changes

- `scripts/ai_agent_bridge/_cli.py` — `_handle_acp_compat` folds the `--pr`/`--branch` target into the prompt (with `gh pr view/diff` resolution hints) and forces review mode, i.e. exactly the `ask-LANE - --type review` lightweight path; stderr note explains the routing. Help text for `--pr`/`--branch`/`--review` (incl. ask-agy's stale "substitute: review-pr") now describes the direct path and honest `--review` semantics (verdict+evidence outcome validation, no protocol prepend on the ACP compat path).
- `scripts/ai_agent_bridge/_agy.py` — sealed-review refusal now names the working direct command on an eligible lane instead of retired `review-pr`.
- `scripts/ai_agent_bridge/_review_safety.py` — size-cap errors and the warn-not-reject PR-CF warning no longer steer to `review-pr`/`publish-review-verdict`; the warning now requires a named target (PR head SHA) since the direct round IS the formal path.
- `agents_extensions/` (source of truth only; deployed copies via deploy script): `memory/MEMORY.md` #0H, `prompts/dynamic-area-epic-fleet-governor.md`, `hooks/guard-branch-switch-in-main.py` no longer present `review-pr` as the current gate.

Sealed `review-pr` internals are untouched (still fail closed without `LU_FORMAL_SHIELDED_CF=1`).

## Tests

- New `tests/ai_agent_bridge/test_ask_pr_lightweight_route.py`: `--pr`/`--branch` route with `review=True` and target folded into the prompt; mutual exclusion kept; help no longer names review-pr as required next step.
- Updated `test_review_ask_caps.py`, `test_review_pr_required.py` for the new messages.
- Ran: `tests/ai_agent_bridge/` (531 passed; 2 pre-existing host-env failures in `test_hermes_review_isolation.py`, fail identically on clean base — no usable Hermes runtime on this host), plus `test_guard_branch_switch_in_main.py`, `test_dynamic_fleet_governor_prompt.py`, `test_agy_sealed_review_refuse.py`, onboarding/work-contract suites (120 passed).
- `scripts/deploy_prompts.sh --dry-run`: 20 pre-existing `ORCH_TRACK_NOT_ACTIVE` errors from sparse checkout (no `curriculum/` tree); none touch the changed files.

## Out of scope (per dispatch)

`docs/runbooks/agent-seat-onboarding.md`, `docs/SCRIPTS.md`, `docs/best-practices/agent-bridge.md` still carry the stale review-pr gate text from #7010's table — dispatch limited doc edits to `agents_extensions/`.

Refs #7010

X-Agent: kimi/infra-7010-ask-pr