### PR TITLE
fix(infra): retire --agent gemini as permanent alias to agy

### DIFF
--- a/scripts/agent_runtime/agent_identity.py
+++ b/scripts/agent_runtime/agent_identity.py
@@ -13,9 +13,46 @@ Dual-READ / prefer-WRITE:
 - **Write** the canonical seat id (``grok``) for new messages and telemetry.
 - **Never rewrite** frozen history strings in attestations, audit fixtures,
   or decision docs describing past runs.
+
+This module also carries ``RETIRED_AGENT_ALIASES`` — permanent dispatch-agent
+substitutions for a provider whose CLI is gone outright (currently
+``gemini`` → ``agy``). Those are a distinct concept from the seat aliases
+above: a retired-agent alias forwards to a genuinely different adapter, so
+it is resolve-only, never dual-read.
 """
 
 from __future__ import annotations
+
+# Permanent CLI retirements: a dispatch agent whose native binary is gone for
+# good, mapped to the live adapter that now carries that provider family's
+# work. UNLIKE ``SEAT_ALIASES`` (a cosmetic rename of the SAME adapter), a
+# retired-agent alias swaps to a DIFFERENT adapter/CLI entirely — the old
+# entry is never dual-readable, it always resolves forward.
+#
+# gemini → agy (operator fact, 2026-08-18): the ``gemini`` CLI is not
+# supported and will not be installed. Live Gemini-family implementer is the
+# Antigravity CLI (``agy``). A bare CodexBar quota reading is not proof the
+# `gemini` binary exists — dispatching it fails with
+# ``FileNotFoundError: 'gemini'``. Resolve the alias BEFORE Popen,
+# unconditionally (not only when the lane is hot/near_cap/deficit).
+RETIRED_AGENT_ALIASES: dict[str, str] = {
+    "gemini": "agy",
+}
+
+
+def resolve_retired_agent_alias(name: str | None) -> str | None:
+    """Return the permanent substitute for a retired CLI seat, or None.
+
+    None means ``name`` is not a retired alias (including when ``name`` is
+    None/empty) — callers should keep the original value unchanged.
+    """
+    if name is None:
+        return None
+    key = str(name).strip().lower()
+    if not key:
+        return None
+    return RETIRED_AGENT_ALIASES.get(key)
+
 
 # Permanent backward-compat aliases: historical lane id → canonical seat.
 # Keep forever: old X-Agent trailers, inbox rows, budget usage records, and

--- a/scripts/config/agent_fallback_substitutions.yaml
+++ b/scripts/config/agent_fallback_substitutions.yaml
@@ -9,7 +9,14 @@ dispatch_fallbacks:
   # Mechanical shed when Codex is hot or in weekly deficit while free seats
   # (Cursor) sit idle — operator 2026-08-12 / stream #4707.
   codex: cursor
-  # gemini/grok/cursor/kimi/agy/glm: no automatic mapping without an explicit
+  # PERMANENT retirement, not a hot/deficit-only shed: the gemini CLI is not
+  # supported and will not be installed (operator 2026-08-18). delegate.py
+  # resolves this row UNCONDITIONALLY, before the budget guard even runs —
+  # a "gemini is cool" budget reading is not proof the binary exists.
+  # Canonical mapping lives in agent_runtime.agent_identity.RETIRED_AGENT_ALIASES;
+  # this row keeps it visible to yaml-only consumers of dispatch_fallbacks.
+  gemini: agy
+  # grok/cursor/kimi/agy/glm: no automatic mapping without an explicit
   # operator comment (refuse dispatch when hot/deficit and no row here).
 #
 # Trigger condition: when a budget bucket is at status `near_cap` or `hot`,
@@ -54,8 +61,14 @@ substitutions:
     budget_bucket: "Codex weekly → Cursor when shed"
 
   - currently_uses: "delegate.py --agent gemini"
-    fallback: "(unaffected — separate quota)"
-    budget_bucket: "Gemini"
+    fallback: |
+      PERMANENT, always-on (not a budget-status shed): gemini CLI is
+      retired and will not be reinstalled (operator 2026-08-18). Resolves
+      to `delegate.py --agent agy` before Popen, via
+      dispatch_fallbacks.gemini and agent_identity.RETIRED_AGENT_ALIASES.
+      Do not tell agents to install `gemini` — the live Gemini-family
+      implementer is agy.
+    budget_bucket: "Gemini-family quota, tracked under agy"
 
   - currently_uses: "linear_pipeline.invoke_writer(writer='claude-tools')"
     fallback: |

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -153,7 +153,7 @@ _FALLBACK_SUBS_PATH = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substi
 # dispatch a nonexistent adapter).
 _DISPATCH_AGENT_CHOICES = (
     "codex",
-    "gemini",
+    "gemini",  # permanent retired-CLI alias → agy (RETIRED_AGENT_ALIASES); gemini CLI not installed
     "claude",
     "grok",  # canonical native CLI seat
     "grok-build",  # permanent alias → grok
@@ -4508,6 +4508,7 @@ def _run_worker(
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+    from agent_runtime.agent_identity import resolve_retired_agent_alias
     from agent_runtime.attribution import resolve_invocation_attribution
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
 
@@ -4742,14 +4743,32 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"❌ {exc}", file=sys.stderr)
         return 2
 
+    # Permanent CLI retirement (e.g. gemini→agy, operator 2026-08-18): resolve
+    # BEFORE the budget guard and unconditionally — a hot/cool budget reading
+    # for a retired lane is not proof its binary still exists (CodexBar showed
+    # gemini ~99% remaining the same night `--agent gemini` failed with
+    # `FileNotFoundError: 'gemini'`). --force-agent bypasses the budget guard,
+    # not this — there is no CLI left to force.
+    agent_alias_note: str | None = None
+    retired_target = resolve_retired_agent_alias(args.agent)
+    requested_agent = args.agent
+    if retired_target:
+        agent_alias_note = f"NOTE: {requested_agent}→{retired_target} retired CLI"
+        print(
+            f"🔄 RETIRED CLI ALIAS: --agent {requested_agent} → {retired_target} "
+            f"({agent_alias_note}; the {requested_agent} CLI is not installed/supported).",
+            file=sys.stderr,
+        )
+        requested_agent = retired_target
+
     if _dispatch_check_budget_enabled(args) and not getattr(args, "force_agent", False):
         try:
-            dispatch_agent = _resolve_agent_with_budget_guard(args.agent)
+            dispatch_agent = _resolve_agent_with_budget_guard(requested_agent)
         except BudgetGuardRefuseError as exc:
             print(f"❌ {exc}", file=sys.stderr)
             return 2
     else:
-        dispatch_agent = args.agent
+        dispatch_agent = requested_agent
 
     try:
         _validate_dispatch_effort(dispatch_agent, getattr(args, "effort", None))
@@ -4937,6 +4956,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "last_error": None,
             "exit_code": None,
             "substitution": None,
+            "agent_alias_note": agent_alias_note,
         }
         if requested_harness is not None:
             dry_run_state["harness"] = requested_harness
@@ -5105,6 +5125,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "last_error": None,
         "exit_code": None,
         "substitution": None,
+        "agent_alias_note": agent_alias_note,
     }
     if requested_harness is not None:
         initial_state["harness"] = requested_harness
@@ -5608,7 +5629,16 @@ def _check_capacity_hint(dispatch_agent: str, args: argparse.Namespace | None = 
         except ImportError:
             from api.lane_health import compute_lane_health, normalize_agent_name
 
-        subscription_lanes = ("claude", "codex", "gemini", "grok", "cursor", "kimi")
+        from agent_runtime.agent_identity import RETIRED_AGENT_ALIASES
+
+        # "gemini" excluded: it is a permanent retired-CLI alias (→ agy), so
+        # it must never appear as a "idle capacity available in: gemini"
+        # suggestion — that would just point drivers back at the dead CLI.
+        subscription_lanes = tuple(
+            lane
+            for lane in ("claude", "codex", "gemini", "grok", "cursor", "kimi")
+            if lane not in RETIRED_AGENT_ALIASES
+        )
         target_norm = normalize_agent_name(dispatch_agent) or dispatch_agent.lower().strip()
 
         in_flight: dict[str, int] = {lane: 0 for lane in subscription_lanes}
@@ -5958,7 +5988,8 @@ def build_parser() -> argparse.ArgumentParser:
         # "qwen" removed from choices (banned agent): advertising it in --help
         # while the routing guard rejects it at dispatch is a UX trap. The
         # guard still catches programmatic Namespace bypass.
-        help="Agent to run for the task: codex, gemini, claude, grok "
+        help="Agent to run for the task: codex, gemini (retired CLI — permanent "
+        "alias to agy, do not install gemini), claude, grok "
         "(native CLI; grok-build=alias), grok-hermes, deepseek, agy, cursor, or kimi.",
     )
     d.add_argument(

--- a/scripts/fleet/capacity_pick.py
+++ b/scripts/fleet/capacity_pick.py
@@ -16,7 +16,15 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-# Subscription + free seats drivers may pick for code implement.
+try:
+    from scripts.agent_runtime.agent_identity import RETIRED_AGENT_ALIASES
+except ImportError:  # pragma: no cover - script path fallback
+    from agent_runtime.agent_identity import RETIRED_AGENT_ALIASES  # type: ignore
+
+# Subscription + free seats drivers may pick for code implement. "gemini" is
+# kept here for budget-row VISIBILITY (its Gemini-family quota still shows in
+# the table) but is force-AVOID via RETIRED_AGENT_ALIASES below — the gemini
+# CLI is retired (operator 2026-08-18) and must never be a `pick`.
 CODE_LANES: tuple[str, ...] = (
     "claude",
     "codex",
@@ -58,8 +66,15 @@ def will_last_to_reset(agent_info: dict[str, Any] | None) -> bool | None:
     return None
 
 
-def is_avoid_lane(agent_info: dict[str, Any] | None) -> bool:
-    """True when status is hot/near_cap or CodexBar deficit (will_last_to_reset is False)."""
+def is_avoid_lane(agent_info: dict[str, Any] | None, *, lane: str | None = None) -> bool:
+    """True when hot/near_cap, CodexBar deficit, or ``lane`` is a retired CLI alias.
+
+    A retired lane (currently just ``gemini`` → agy) is force-AVOID regardless
+    of its budget reading — a "cool" CodexBar snapshot is not proof the binary
+    is still installed.
+    """
+    if lane is not None and lane.strip().lower() in RETIRED_AGENT_ALIASES:
+        return True
     status = lane_status(agent_info)
     if status in _AVOID_STATUSES:
         return True
@@ -130,11 +145,14 @@ def build_lane_rows(
         info = agents.get(lane) if isinstance(agents.get(lane), dict) else {}
         status = lane_status(info)
         will_last = will_last_to_reset(info)
-        avoid = is_avoid_lane(info)
+        retired_target = RETIRED_AGENT_ALIASES.get(lane)
+        avoid = is_avoid_lane(info, lane=lane)
         in_flight = int(active.get(lane, budget_flight.get(lane, 0) or 0) or 0)
         notes: list[str] = []
         if avoid:
             notes.append("AVOID")
+            if retired_target:
+                notes.append(f"retired→{retired_target}")
             if will_last is False:
                 notes.append("deficit")
             if status in _AVOID_STATUSES:
@@ -248,15 +266,27 @@ def build_report(
     rows = build_lane_rows(budget, active_in_flight=active_in_flight)
     pick_order = build_pick_order(rows)
     rec = budget.get("recommendation") if isinstance(budget.get("recommendation"), dict) else {}
+    warnings = list(rec.get("warnings") or [])
+    primary = rec.get("primary_agent_for_code")
+    # The upstream recommendation (Monitor API) doesn't know gemini is
+    # retired — never surface it as a pick here, even if upstream still
+    # recommends it off a stale/uninformed CodexBar reading.
+    retired_target = RETIRED_AGENT_ALIASES.get(str(primary or "").strip().lower())
+    if retired_target:
+        warnings.append(
+            f"recommendation.primary_agent_for_code was {primary!r} (retired CLI) "
+            f"— capacity_pick substituted {retired_target!r}."
+        )
+        primary = retired_target
     return {
         "generated_at": budget.get("generated_at"),
         "rows": rows,
         "pick_order": pick_order,
         "cooler_lanes": cooler_lanes(rows),
         "recommendation": {
-            "primary_agent_for_code": rec.get("primary_agent_for_code"),
+            "primary_agent_for_code": primary,
             "rationale": rec.get("rationale"),
-            "warnings": list(rec.get("warnings") or []),
+            "warnings": warnings,
         },
         "diagnostics": budget.get("diagnostics") or {},
         "active_in_flight": dict(active_in_flight or {}),

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4727,6 +4727,62 @@ def test_dispatch_gemini_worker_env_strips_gh_token(
     assert "GITHUB_TOKEN" not in env
 
 
+def test_dispatch_gemini_resolves_to_agy_before_popen_and_never_execs_gemini(
+    tmp_tasks_dir, monkeypatch,
+):
+    """`--agent gemini` is a permanent retired-CLI alias (operator 2026-08-18):
+    the gemini CLI is not installed, so dispatch MUST resolve to agy before
+    the worker is even spawned. This is the test that proves `gemini` never
+    reaches Popen: the worker command line carries `--agent agy`, never
+    `--agent gemini` — nothing here calls out to a `gemini` binary.
+    """
+    import argparse
+
+    recorded: dict[str, object] = {}
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 13579
+        stdin = _FakeStdin()
+
+    def fake_popen(*args, **kwargs):
+        recorded["cmd"] = args[0]
+        return _FakeProc()
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+
+    args = argparse.Namespace(
+        agent="gemini",
+        task_id="gemini-retired-alias",
+        prompt="test",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=None,
+        hard_timeout=3600,
+        allow_merge=False,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    cmd = recorded["cmd"]
+    assert "gemini" not in cmd
+    assert "agy" in cmd
+    assert cmd[cmd.index("--agent") + 1] == "agy"
+
+    state = delegate._read_state(delegate._state_path("gemini-retired-alias"))
+    assert state["agent"] == "agy"
+    assert state["agent_alias_note"] == "NOTE: gemini→agy retired CLI"
+
+
 def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path, monkeypatch):
     import argparse
 
@@ -4749,7 +4805,7 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
     # is asserting. Validation returns "clean, matching, up-to-date" so
     # the reuse path succeeds.
     _, base_stub = _make_run_stub(
-        abbrev_ref="gemini/existing-worktree",
+        abbrev_ref="agy/existing-worktree",
         status_porcelain="",
         rev_list_count="0",
     )
@@ -4762,8 +4818,12 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
     monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
 
+    # Not "gemini": that's now a retired-CLI alias (→ agy) resolved before
+    # this worktree-branch validation runs, so the expected branch prefix
+    # must match the RESOLVED agent, not the requested one. Use a live lane
+    # directly — this test is about worktree reuse, not the gemini alias.
     args = argparse.Namespace(
-        agent="gemini",
+        agent="agy",
         task_id="existing-worktree",
         prompt="test",
         prompt_file=None,

--- a/tests/test_gemini_retired_agy_alias.py
+++ b/tests/test_gemini_retired_agy_alias.py
@@ -1,0 +1,97 @@
+"""Permanent gemini→agy retirement alias tests (operator 2026-08-18).
+
+The gemini CLI is not supported and will not be installed. `--agent gemini`
+must resolve to the AGY adapter unconditionally, before Popen — not only
+when the gemini budget lane happens to read hot/near_cap/deficit. Covers:
+- ``agent_identity.RETIRED_AGENT_ALIASES`` / ``resolve_retired_agent_alias``
+- ``capacity_pick`` never recommends gemini as a pick
+- the substitution is documented in the dispatch_fallbacks yaml
+
+The dispatch-level proof (worker command line never carries `--agent gemini`,
+task state records the substitution) lives in
+tests/test_delegate.py::test_dispatch_gemini_resolves_to_agy_before_popen_and_never_execs_gemini.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _scripts_on_path():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+
+
+def test_resolve_retired_agent_alias_maps_gemini_to_agy():
+    from agent_runtime.agent_identity import (
+        RETIRED_AGENT_ALIASES,
+        resolve_retired_agent_alias,
+    )
+
+    assert RETIRED_AGENT_ALIASES == {"gemini": "agy"}
+    assert resolve_retired_agent_alias("gemini") == "agy"
+    assert resolve_retired_agent_alias("GEMINI") == "agy"
+    assert resolve_retired_agent_alias("  gemini  ") == "agy"
+
+
+def test_resolve_retired_agent_alias_passthrough_for_live_agents():
+    from agent_runtime.agent_identity import resolve_retired_agent_alias
+
+    assert resolve_retired_agent_alias("agy") is None
+    assert resolve_retired_agent_alias("codex") is None
+    assert resolve_retired_agent_alias("claude") is None
+    assert resolve_retired_agent_alias(None) is None
+    assert resolve_retired_agent_alias("") is None
+
+
+def test_dispatch_fallbacks_yaml_documents_permanent_gemini_substitution():
+    """The yaml row must exist for other consumers of dispatch_fallbacks,
+    but the canonical mapping is agent_identity.RETIRED_AGENT_ALIASES."""
+    from agent_runtime.agent_identity import RETIRED_AGENT_ALIASES
+
+    path = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substitutions.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["dispatch_fallbacks"]["gemini"] == RETIRED_AGENT_ALIASES["gemini"]
+
+
+def test_capacity_pick_never_recommends_gemini_as_pick():
+    from scripts.fleet import capacity_pick
+
+    budget = {
+        "generated_at": "2026-08-18T00:00:00Z",
+        "agents": {
+            # CodexBar reads gemini as ~99% remaining / cool — the exact
+            # trap the operator flagged: a healthy quota reading is not
+            # proof the CLI binary still exists.
+            "gemini": {"status": "cool", "burn_pct_7d": 1.0, "remaining_pct": 99.0},
+            "agy": {"status": "cool", "burn_pct_7d": 15.0, "remaining_pct": 85.0},
+            "codex": {"status": "cool", "burn_pct_7d": 20.0, "remaining_pct": 80.0},
+        },
+        "in_flight": {},
+        "recommendation": {
+            "primary_agent_for_code": "gemini",
+            "rationale": "stale upstream recommendation off a cool CodexBar reading",
+            "warnings": [],
+        },
+        "diagnostics": {"records_loaded": 4, "stale": False},
+    }
+
+    report = capacity_pick.build_report(budget)
+    rows = {r["lane"]: r for r in report["rows"]}
+
+    assert rows["gemini"]["avoid"] is True
+    assert "retired→agy" in rows["gemini"]["notes"]
+    picks = report["pick_order"]
+    assert next(p for p in picks if p["lane"] == "gemini")["pick"] == "AVOID"
+
+    # Upstream still said gemini; capacity_pick must rewrite the recommendation.
+    assert report["recommendation"]["primary_agent_for_code"] == "agy"
+    assert any("retired CLI" in w for w in report["recommendation"]["warnings"])


### PR DESCRIPTION
## Operator fact (2026-08-18)
The gemini CLI is not supported and will not be installed. Dispatching `--agent gemini` failed with `FileNotFoundError: 'gemini'` even though CodexBar showed the lane ~99% remaining — a healthy quota reading is not proof the binary exists. The live Gemini-family implementer is `--agent agy`.

## Change
Same pattern as `grok-build` → `grok` (`agent_identity.py`), but cross-adapter: gemini and agy are genuinely different CLIs, so this is a permanent, resolve-only retirement, not a same-adapter seat rename.

1. **`agent_identity.RETIRED_AGENT_ALIASES`** — `{"gemini": "agy"}` + `resolve_retired_agent_alias()`.
2. **`delegate.py cmd_dispatch`** — resolves the alias unconditionally, before the budget guard and before Popen (not gated on hot/near_cap/deficit). Task state records `agent_alias_note: "NOTE: gemini→agy retired CLI"`. Also drops `gemini` from the idle-capacity hint's lane list.
3. **`agent_fallback_substitutions.yaml`** — documented `gemini: agy` row (marked permanent, not hot/deficit-only) + updated the stale `--agent gemini` substitution note.
4. **`capacity_pick.py`** — gemini lane is force-AVOID (never a `pick`); any upstream `primary_agent_for_code: gemini` recommendation is rewritten to `agy` with a warning.
5. **Help text** — `gemini` documented as a retired alias to agy; nothing tells agents to install gemini.

AGY is untouched; no gemini CLI adapter is reintroduced.

## Tests
- New `tests/test_gemini_retired_agy_alias.py`: alias resolution, yaml row, capacity_pick force-avoid + recommendation rewrite.
- New `tests/test_delegate.py::test_dispatch_gemini_resolves_to_agy_before_popen_and_never_execs_gemini` — proves the worker command line never carries `--agent gemini` (asserts `"gemini" not in cmd` and `cmd[cmd.index("--agent")+1] == "agy"`).
- Fixed an incidental `agent="gemini"` dependency in `test_dispatch_uses_existing_worktree_without_git_add` (unrelated to the alias — was just using gemini as an arbitrary agent name for a worktree-branch-reuse test).
- Existing `test_grok_seat_identity.py` (grok-build alias) stays green.

```
ruff check scripts/agent_runtime/agent_identity.py scripts/delegate.py scripts/fleet/capacity_pick.py
→ All checks passed!

pytest tests/test_delegate.py tests/test_delegate_check_budget.py tests/test_capacity_pick.py \
       tests/test_grok_seat_identity.py tests/test_gemini_retired_agy_alias.py \
       tests/test_range_worktree_force.py tests/test_agent_runtime.py
→ 531 passed
```

Not merging — leaving for review per dispatch brief (`AGENT_NO_MERGE=1`).

X-Agent: claude/infra-gemini-alias-agy

🤖 Generated with [Claude Code](https://claude.com/claude-code)