### PR TITLE
fix(ci): comment source PR on merge-group CI Gate kick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1430,6 +1430,9 @@ jobs:
       - contracts
       - frontend
       - coverage-floor
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1460,3 +1463,28 @@ jobs:
           python scripts/ci/gate_required_results.py \
             --event "$EVENT_NAME" \
             --results "$RESULTS"
+
+      # Kicked PRs must not look CLEAN and sit (#7042): a merge_group failure
+      # dequeues the PR silently otherwise. Best-effort only — a parse/comment
+      # failure here must never change the gate's already-failed result, so
+      # this step always exits 0 and adds no required job.
+      - name: Comment merge-queue kick on source PR
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULTS: >-
+            ruff=${{ needs.ruff.result }},pytest-plan=${{ needs.pytest-plan.result }},pytest-fastlane=${{ needs.pytest-fastlane.result }},python=${{ needs.python.result }},contracts=${{ needs.contracts.result }},frontend=${{ needs.frontend.result }},coverage-floor=${{ needs.coverage-floor.result }}
+        run: |
+          set +e
+          pr_number=$(printf '%s' "$HEAD_REF" | grep -oE 'pr-[0-9]+' | grep -oE '[0-9]+' | head -n1)
+          if [[ -z "$pr_number" ]]; then
+            echo "::warning::could not parse PR number from merge_group head_ref: $HEAD_REF"
+            exit 0
+          fi
+          body=$(printf 'merge-group CI Gate failed: %s\n\nResults: %s\n\nPR-tier green is not landed; fix and re-queue the same hour.\n' "$RUN_URL" "$RESULTS")
+          if ! gh pr comment "$pr_number" --body "$body"; then
+            echo "::warning::could not comment on PR #${pr_number}"
+          fi
+          exit 0

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -358,6 +358,15 @@ another lane's PR with `needs=merge` rather than merging it.
 Skill- or docs-only landings classify as merge_group `docs_skills` (#7018):
 the four pytest shards and coverage combine are no-op **success**, not skipped.
 
+**Merge-queue kick is same-hour work (#7042).** A **kick** is `merge_group` CI Gate
+going red and GitHub dequeuing the PR — it lands back on the branch looking CLEAN,
+with no visible failure unless you go look. CI Gate now comments the source PR with
+the run URL and per-job `RESULTS` on a kick; that comment is the trigger, not a
+courtesy. On seeing it: read the failed jobs from the run, fix or rebase, re-run
+exact-head CF review if the head moved, then re-queue — same hour, never left
+overnight. Do not stand up a bot or recovery workflow for this; it is driver work
+like any other red CI.
+
 ### 7a. Post-merge cleanup is mandatory (binding — operator 2026-08-07)
 
 **A squash-merge is not done until cleanup proves free of that PR's residue.** Chat

--- a/tests/test_ci_gate_merge_kick_comment.py
+++ b/tests/test_ci_gate_merge_kick_comment.py
@@ -1,0 +1,99 @@
+"""Guard the merge-group kick comment step on CI Gate (#7042).
+
+Kicked PRs (merge_group CI Gate red, GitHub dequeues the PR) used to look
+CLEAN and just sit — nothing told the driver to look. This adds ONE
+best-effort step to the existing `ci-gate` job: on a merge_group failure it
+comments the source PR with the run URL and per-job results. No new
+workflow, no new required check, no recovery bot — see
+agents_extensions/shared/skills/drive-epic/SKILL.md §7.
+
+These tests assert the wiring statically (no GitHub Actions run required):
+the step only fires on `failure() && merge_group`, the job gained exactly
+the permissions it needs to comment, and no job was added to the workflow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_ci_gate() -> dict:
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["ci-gate"]
+
+
+def _comment_step(ci_gate: dict) -> dict:
+    for step in ci_gate["steps"]:
+        if step.get("name") == "Comment merge-queue kick on source PR":
+            return step
+    raise AssertionError("ci-gate is missing the merge-queue kick comment step")
+
+
+def test_comment_step_only_fires_on_merge_group_failure() -> None:
+    step = _comment_step(_load_ci_gate())
+    assert step["if"] == "failure() && github.event_name == 'merge_group'", (
+        "the comment step must fire only when the gate failed on a merge_group run, "
+        "never on pull_request or push"
+    )
+
+
+def test_ci_gate_job_grants_only_the_needed_write() -> None:
+    ci_gate = _load_ci_gate()
+    assert ci_gate["permissions"] == {"contents": "read", "pull-requests": "write"}, (
+        "ci-gate must scope its own permissions rather than widening workflow-level perms"
+    )
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    assert workflow["permissions"] == {"contents": "read"}, (
+        "workflow-level permissions must stay untouched by the job-level grant"
+    )
+
+
+def test_comment_step_never_overrides_the_gate_result() -> None:
+    step = _comment_step(_load_ci_gate())
+    run_lines = [line.strip() for line in step["run"].splitlines() if line.strip()]
+    assert run_lines[0] == "set +e", (
+        "a parse/comment failure inside this step must never flip an already-failed "
+        "gate to something else — the step disables -e before doing anything fallible"
+    )
+    assert run_lines[-1] == "exit 0", (
+        "the step must end by exiting 0 so its own result never changes the gate's "
+        "already-computed pass/fail"
+    )
+
+
+def test_comment_step_reads_pr_number_and_results_from_env_not_interpolation() -> None:
+    step = _comment_step(_load_ci_gate())
+    env = step["env"]
+    assert env["HEAD_REF"] == "${{ github.event.merge_group.head_ref }}"
+    assert "RESULTS" in env and "needs.ruff.result" in env["RESULTS"]
+    run = step["run"]
+    # Untrusted merge_group head_ref must be read through $HEAD_REF, never
+    # spliced into the script via ${{ }} (see check_untrusted_workflow_interpolation.py).
+    assert "${{" not in run
+    assert "$HEAD_REF" in run
+
+
+def test_no_new_job_was_added_to_ci_workflow() -> None:
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    expected_jobs = {
+        "ruff",
+        "landing-class",
+        "pytest-plan",
+        "pytest-fastlane",
+        "python",
+        "contracts",
+        "frontend",
+        "frontend-e2e",
+        "pytest-duration-publish",
+        "coverage-floor",
+        "ci-gate",
+    }
+    assert set(workflow["jobs"]) == expected_jobs, (
+        "the merge-group kick comment must be a step on ci-gate, not a new job "
+        "(brief: no new workflow, no new required check)"
+    )


### PR DESCRIPTION
## What

Merge-group kicks (merge_group CI Gate red → PR dequeued) landed back on the branch looking CLEAN, with nothing telling the driver to look. This adds ONE best-effort step to the existing `ci-gate` job — no new workflow, no new required check, no recovery bot.

## Changes

- **`.github/workflows/ci.yml`** (`ci-gate` job only):
  - Job gains `permissions: {contents: read, pull-requests: write}` — workflow-level `permissions:` untouched.
  - New step, `if: failure() && github.event_name == 'merge_group'`: parses the PR number out of `github.event.merge_group.head_ref` (`pr-([0-9]+)`) and `gh pr comment`s the run URL + per-job `$RESULTS` + "PR-tier green is not landed; fix and re-queue the same hour." A parse/comment failure always `exit 0`s so it can never flip the gate's already-computed pass/fail.
- **`agents_extensions/shared/skills/drive-epic/SKILL.md`** §7: documents the kick as same-hour driver work (read failed jobs → fix/rebase → exact-head CF if the head moved → re-queue), explicitly no bot.
- **`tests/test_ci_gate_merge_kick_comment.py`**: statically guards the step's `if:` condition, the job's scoped permissions, the exit-0 wrapping, env-based (not `${{ }}`-interpolated) handling of the untrusted `head_ref`, and that no job was added to the workflow.

## Verify

```
rg -n "merge-group CI Gate failed|same-hour" .github/workflows/ci.yml agents_extensions/shared/skills/drive-epic/SKILL.md
.venv/bin/python -m scripts.ci.slot_inventory --check   # PASS: 28 slots / ceiling 31 (unchanged)
bash scripts/audit/check_workflows.sh .github/workflows/ci.yml   # actionlint + untrusted-interpolation clean
.venv/bin/python -m pytest tests/test_ci_gate_merge_kick_comment.py tests/test_ci_gate_required_results.py tests/test_ci_slot_inventory.py -q   # 23 passed
```

Job count in `ci.yml` is unchanged (11 jobs, 14 runner slots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>