### PR TITLE
fix(practice): contrast fixes and honest empty state on Practice Hub

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 17636cd8d4f6115ac1b314ca8c00bbb1f7183b544e44cb13f165d6e3158b631d
+  components_sha256: 3d13b1df624d458a7671a968d9190ca299207d63925e77c6219fc15fcaab4e3b
   config_tables_sha256: c9621b1f9b95e7fe7d7400989839ef3a1ecf338f8cec8989ae9c53bde8c9b287
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -68,11 +68,13 @@ export default function PracticeDailyDeck({
   const currentLexeme = currentLemmaId ? lexemes.get(currentLemmaId) ?? null : null;
 
   const handlePrevious = () => {
+    if (total === 0) return;
     setFlipped(false);
     setPreviewIndex((index) => (index > 0 ? index - 1 : total - 1));
   };
 
   const handleNext = () => {
+    if (total === 0) return;
     setFlipped(false);
     setPreviewIndex((index) => (index < total - 1 ? index + 1 : 0));
   };
@@ -108,12 +110,14 @@ export default function PracticeDailyDeck({
             <ChromeText k="practice.wordsTitle" />
           )}
         </h2>
-        <span className="daily-deck-position" aria-live="polite">
-          <ChromeDual
-            uk={`${previewIndex + 1} з ${total}`}
-            en={`${previewIndex + 1} / ${total}`}
-          />
-        </span>
+        {total > 0 ? (
+          <span className="daily-deck-position" aria-live="polite">
+            <ChromeDual
+              uk={`${previewIndex + 1} з ${total}`}
+              en={`${previewIndex + 1} / ${total}`}
+            />
+          </span>
+        ) : null}
         {onReRoll ? (
           <button
             type="button"
@@ -135,6 +139,7 @@ export default function PracticeDailyDeck({
           type="button"
           className="daily-deck-nav"
           aria-label={chromeString(chromeLocale, 'label.previous')}
+          disabled={total === 0}
           onClick={handlePrevious}
         >
           ‹
@@ -162,7 +167,9 @@ export default function PracticeDailyDeck({
                   {frontSubtitle && <span className="flashcard-subtitle">{frontSubtitle}</span>}
                 </>
               ) : (
-                <span className="flashcard-word">—</span>
+                <span className="flashcard-subtitle" data-testid="practice-daily-empty">
+                  <ChromeText k="practice.noCards" />
+                </span>
               )}
             </div>
             <div className="flashcard-back">
@@ -199,6 +206,7 @@ export default function PracticeDailyDeck({
           type="button"
           className="daily-deck-nav"
           aria-label={chromeString(chromeLocale, 'label.next')}
+          disabled={total === 0}
           onClick={handleNext}
         >
           ›

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -141,7 +141,10 @@ const frontmatter = {
   :global(.lexicon-practice-levels-row button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    /* --lu-on-primary-fill tracks the theme's primary fill (white on azure in
+       light, dark on the light-blue dark-theme primary); --lu-on-primary stays
+       white in both themes and fails AA on the dark theme's #5B9BD5. */
+    color: var(--lu-on-primary-fill);
   }
 
   :global(.lexicon-practice-stage) {
@@ -972,7 +975,7 @@ const frontmatter = {
   :global(.lexicon-practice-stage .matchItem.selected) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-primary-fill);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--lu-primary) 35%, transparent);
   }
 
@@ -1818,7 +1821,9 @@ const frontmatter = {
     letter-spacing: 0.03em;
   }
   :global(.daily-deck-row.state-due .row-status) {
-    color: var(--lu-yellow-dark);
+    /* --lu-yellow-dark (#E6B800) is a fill color — 1.9:1 as text on --lu-surface
+       in the light theme. The text-safe amber token keeps AA in both themes. */
+    color: var(--lu-yellow-text);
   }
   :global(.daily-deck-row.state-new .row-status) {
     color: var(--lu-blue);
@@ -2088,7 +2093,7 @@ const frontmatter = {
   :global(.stress-vowel.selected) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-primary-fill);
   }
 
   :global(.stress-vowel.correct) {
@@ -2313,7 +2318,7 @@ const frontmatter = {
   :global(.zno-practice-next) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    color: var(--lu-on-primary-fill);
   }
 
   @media (max-width: 560px) {

--- a/site/src/styles/course.css
+++ b/site/src/styles/course.css
@@ -58,6 +58,10 @@
      brand band that must stay confident azure so white text always reads; the
      footer is a dark band in both modes. Never redefine these in [data-theme]. */
   --lu-on-yellow: #1A1A1A;
+  /* Text-safe amber for "due" status TEXT on surface backgrounds. The fill
+     token --lu-yellow-dark (#E6B800) fails WCAG AA as text on --lu-surface
+     (1.9:1 — see the rule-box note below); this stays in-family at >= 4.5:1. */
+  --lu-yellow-text: #8A6D00;
   --lu-hero-grad: linear-gradient(135deg, #0057B8, #1A6FD4);
   --lu-footer-bg: #1A1F26;
 
@@ -126,6 +130,9 @@
   --lu-text: #F4F7FB;
   --lu-text-muted: #A9B2BF;
   --lu-on-primary-fill: #1A1A1A;
+  /* Dark theme: the light yellow tint already passes AA as text on dark
+     surfaces (~14:1 on --lu-surface), so the text token tracks the fill. */
+  --lu-yellow-text: #FFE58A;
   --lu-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
   --lu-shadow-lg: 0 4px 18px rgba(0, 0, 0, 0.36);
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1134,6 +1134,42 @@ describe('LexiconPractice', () => {
     expect(screen.queryByText('Context sentence for борщ')).not.toBeInTheDocument();
   });
 
+  test('renders an honest empty state for an empty daily deck — no "1 з 0", nav disabled', async () => {
+    const snapshot: DailyPracticeDeckSnapshot = {
+      version: 2,
+      date: '2026-06-23',
+      level: 'A1',
+      deckVersion: 'daily-pool-empty',
+      createdAt: NOW.getTime(),
+      items: [],
+    };
+
+    render(
+      <PracticeDailyDeck
+        snapshot={snapshot}
+        rows={{ pendingDue: [], pendingNew: [], done: [] }}
+        lexemes={new Map()}
+        atlasLemmaHref={(lemmaId) => `/lexicon/${lemmaId}/`}
+        chromeLocale="uk"
+        learnerLevel="A1"
+      />,
+    );
+
+    // Honest empty copy on the card instead of a bare dash…
+    expect(screen.getByTestId('practice-daily-empty')).toHaveTextContent(
+      'Поки що немає карток для практики.',
+    );
+    // …no "1 з 0" position counter…
+    expect(screen.queryByText(/1 з 0/)).not.toBeInTheDocument();
+    // …and no wrap-around navigation that drove the index to -1 ("0 з 0").
+    const previous = screen.getByRole('button', { name: 'Назад' });
+    const next = screen.getByRole('button', { name: 'Далі' });
+    expect(previous).toBeDisabled();
+    expect(next).toBeDisabled();
+    await userEvent.setup().click(previous);
+    expect(screen.queryByText(/з 0/)).not.toBeInTheDocument();
+  });
+
   test('renders the daily card from the pick payload when the slug is absent from the practice-lexemes map (#5852)', () => {
     const snapshot: DailyPracticeDeckSnapshot = {
       version: 2,


### PR DESCRIPTION
## What

Three concrete UI bugs on the words-of-the-day Practice Hub (`/words-of-the-day/practice/`). Pure frontend — no cloze text, lexicon JSON, or calque/VESUM logic touched.

## Bug 1 — "Due" status text fails WCAG AA in the light theme

- `site/src/pages/words-of-the-day/practice.astro` (`.daily-deck-row.state-due .row-status`) colored the 0.75rem "НА ПОВТОРЕННЯ / DUE" status with `--lu-yellow-dark` (#E6B800) on `--lu-surface` (#FFFFFF) — **1.9:1 contrast**. The repo itself documents this failure (`course.css` rule-box note: "#E6B800 fails WCAG AA on --lu-yellow-light").
- **Repro:** light theme → open the "Показати слова" word list with any due row → the amber status text is barely readable.
- **Fix:** new `--lu-yellow-text` token (`course.css`): #8A6D00 in light (4.9:1), #FFE58A in dark (~14:1, matching the existing dark fill).

## Bug 2 — White-on-light-blue selected controls in the dark theme

- Four filled selected/active states used `--lu-on-primary`, which stays **white in both themes** (`custom.css:174`), on `--lu-primary` (#5B9BD5 in dark) — **2.9:1**:
  - `.lexicon-practice-modes/levels-row button.active` (practice.astro:144)
  - `.lexicon-practice-stage [data-selected="true"]` (match tiles, :975)
  - `.stress-vowel.selected` (:2093)
  - `.zno-practice-next` (:2318)
- **Repro:** dark theme → start a session → pick a match tile / stress vowel, or look at the active mode/level pill → white text on light blue.
- **Fix:** switch all four to `--lu-on-primary-fill` — the token the #6814 fix established for exactly this case (white on azure in light, dark on the light-blue dark primary, 6.1:1).

## Bug 3 — Empty daily deck renders "1 з 0" and navigates to index −1

- `PracticeDailyDeck.tsx` rendered the position counter unconditionally: with `snapshot.items.length === 0` the header read **"1 з 0"**, and clicking ‹ wrapped `previewIndex` to `total - 1` = **−1** ("0 з 0"). The card front showed a bare "—".
- **Repro:** any state where the daily pool is empty (e.g. a custom deck with no eligible words at the current level) — `LexiconPractice.tsx:4071` mounts the deck whenever the snapshot is non-null, with no item-count guard.
- **Fix:** counter hidden at 0 items, nav buttons disabled, handlers no-op, and the card front shows the existing `practice.noCards` copy ("Поки що немає карток для практики.").

## Screenshots-in-words

- Before (light): word-list row "✦ 1 мама … ДО ПОВТОРЕННЯ" with the status in pale gold #E6B800 on white — washes out at a glance. After: same row, status in deep amber #8A6D00, clearly readable.
- Before (dark): selected stress vowel / "Далі" ZNO button = white glyph on #5B9BD5, low contrast. After: near-black #1A1A1A text on the same blue fill.
- Before (empty deck): header "Слова дня — 1 з 0", clickable ‹ › around an em-dash card; clicking ‹ flips the counter to "0 з 0". After: no counter, greyed-out disabled ‹ ›, card reads "Поки що немає карток для практики."

## Verification

- `vitest run tests/unit/LexiconPractice.test.tsx` — **178 passed**, including a new regression test: empty deck → no "1 з 0", nav disabled, `practice.noCards` copy shown, clicking prev stays empty.
- `k3-chrome-locale`, `practice-locale-purity`, `atlas-hero-contrast` — all pass (k3-chrome-locale asserts the `--lu-on-primary-fill` precedent this PR extends).
- `tsc --noEmit` — only the 16 pre-existing errors in untouched files; none in the changed files.

Refs #4700 (UX wave) — does not close it.

X-Agent: kimi/practice-frontend
