### PR TITLE
infra: Linux Type=simple loopback units + tunneled status

### DIFF
--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -1,8 +1,8 @@
 # Systemd unit templates (loopback services)
 
 Templates only — do not commit machine-specific paths. Copy a unit into
-`/etc/systemd/system/` (or `~/.config/systemd/user/`), replace `@REPO_ROOT@`
-with the checkout path, run `systemctl daemon-reload`, then enable/start.
+`~/.config/systemd/user/` (linger enabled) or `/etc/systemd/system/`, replace
+`@REPO_ROOT@` / `@PRIVATE_ROOT@`, `daemon-reload`, then enable/start.
 
 Services bind `127.0.0.1` only. Reach them from another machine with an SSH
 tunnel; set `MONITOR_INSTANCE_ID` in the environment so `/api/health`
@@ -10,4 +10,9 @@ distinguishes hosts. For `GET /api/occupancy`, set `MONITOR_OCCUPANCY_HOST_IDS`
 to comma-separated `canonical=opaque-id` pairs (opaque values only, e.g.
 `host-job`). Do not put addresses or SSH hostnames in the occupancy JSON.
 
-Units invoke `./services.sh` start/stop semantics from the repo root.
+Units are **Linux-native `Type=simple`** processes. Do not wrap
+`./services.sh start` in `Type=oneshot RemainAfterExit=yes`: that is
+launchd-shaped and does not supervise the listener on Linux. macOS still
+uses `./services.sh supervise api` / launchd.
+
+Public fixtures use opaque ids `host-job` and `host-teacher` only.

--- a/packaging/systemd/learn-ukrainian-api.service
+++ b/packaging/systemd/learn-ukrainian-api.service
@@ -4,13 +4,16 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 WorkingDirectory=@REPO_ROOT@
 Environment=MONITOR_INSTANCE_ID=%H
-ExecStart=@REPO_ROOT@/services.sh start api
-ExecStop=@REPO_ROOT@/services.sh stop api
-ExecReload=@REPO_ROOT@/services.sh restart api
+Environment=PYTHONUNBUFFERED=1
+# Optional: EnvironmentFile=-%h/.config/learn-ukrainian/monitor.env
+# (MONITOR_OCCUPANCY_HOST_IDS=canonical=opaque-id,...). Never put IPs or SSH
+# hostnames in the JSON; opaque ids in public docs are host-job / host-teacher.
+ExecStart=@REPO_ROOT@/.venv/bin/python -m uvicorn scripts.api.main:app --host 127.0.0.1 --port 8765 --log-config scripts/api/logging.json --timeout-graceful-shutdown 8
+Restart=on-failure
+RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/packaging/systemd/learn-ukrainian-astro.service
+++ b/packaging/systemd/learn-ukrainian-astro.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Learn Ukrainian Astro course UI (loopback)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@REPO_ROOT@/site
+ExecStart=/usr/bin/env npm run dev -- --host 127.0.0.1 --port 4321 --force
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/packaging/systemd/learn-ukrainian-loopback.target
+++ b/packaging/systemd/learn-ukrainian-loopback.target
@@ -1,6 +1,6 @@
 [Unit]
-Description=Learn Ukrainian loopback fleet (API + Sources)
-Requires=learn-ukrainian-api.service learn-ukrainian-sources.service
+Description=Learn Ukrainian loopback fleet (API + Sources + Work + Astro)
+Requires=learn-ukrainian-api.service learn-ukrainian-sources.service learn-ukrainian-work.service learn-ukrainian-astro.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/packaging/systemd/learn-ukrainian-sources.service
+++ b/packaging/systemd/learn-ukrainian-sources.service
@@ -4,12 +4,12 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 WorkingDirectory=@REPO_ROOT@
-ExecStart=@REPO_ROOT@/services.sh start sources
-ExecStop=@REPO_ROOT@/services.sh stop sources
-ExecReload=@REPO_ROOT@/services.sh restart sources
+Environment=PYTHONUNBUFFERED=1
+ExecStart=@REPO_ROOT@/.venv/bin/python .mcp/servers/sources/server.py --standalone --host 127.0.0.1 --port 8766
+Restart=on-failure
+RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/packaging/systemd/learn-ukrainian-work.service
+++ b/packaging/systemd/learn-ukrainian-work.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Learn Ukrainian Work projection adapter (loopback)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@PRIVATE_ROOT@
+Environment=PYTHONUNBUFFERED=1
+ExecStart=@PRIVATE_ROOT@/.venv/bin/python -m work_projection
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -26,9 +26,9 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
         "services.sh:144",
         "services.sh:163",
-        "services.sh:724",
-        "services.sh:734",
-        "services.sh:738",
+        "services.sh:775",
+        "services.sh:785",
+        "services.sh:789",
         # Scratch-dir EXIT traps for one-shot installer scripts.
         "scripts/entire/install_kimi_external_agent.sh:18",
         "scripts/entire/install_fleet_external_agent.sh:36",

--- a/services.sh
+++ b/services.sh
@@ -240,6 +240,42 @@ _verified_port_pid() {
     return 1
 }
 
+_is_ssh_tunnel_pid() {
+    local pid="$1"
+    local comm cmdline
+
+    comm="$(command ps -p "$pid" -o comm= 2>/dev/null || true)"
+    comm="${comm##*/}"
+    comm="${comm%%$'\n'*}"
+    comm="${comm%% *}"
+    if [[ "$comm" == "ssh" || "$comm" == "ssh.exe" ]]; then
+        return 0
+    fi
+
+    cmdline="$(_cmdline_for_pid "$pid")"
+    [[ -z "$cmdline" ]] && return 1
+    case "$cmdline" in
+        ssh[\ ]*|ssh$|*/ssh[\ ]*|*/ssh)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+_ssh_tunnel_port_pid() {
+    local name="$1"
+    local port_pid
+
+    for port_pid in $(_pid_on_port "$name"); do
+        if [[ -n "$port_pid" ]] && _is_ssh_tunnel_pid "$port_pid"; then
+            printf '%s\n' "$port_pid"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 _foreign_port_pid() {
     local name="$1"
     local port_pid
@@ -420,6 +456,10 @@ _service_state() {
             fi
             return 0
         fi
+        if _ssh_tunnel_port_pid "$name" >/dev/null && _health_check "$name"; then
+            echo "tunneled"
+            return 0
+        fi
         if _foreign_port_pid "$name" >/dev/null; then
             echo "blocked"
             return 0
@@ -429,6 +469,11 @@ _service_state() {
             return 0
         fi
         echo "stopped"
+        return 0
+    fi
+
+    if _ssh_tunnel_port_pid "$name" >/dev/null && _health_check "$name"; then
+        echo "tunneled"
         return 0
     fi
 
@@ -541,7 +586,7 @@ _start_service() {
         return 1
     fi
 
-    if [[ "$name" == "api" ]]; then
+    if [[ "$name" == "api" ]] && command -v launchctl >/dev/null 2>&1; then
         _start_api_supervised
         return
     fi
@@ -615,7 +660,7 @@ _stop_service() {
     # ``launchctl disable`` happens before the listener is signalled. A
     # deliberate ``services.sh stop api`` therefore cannot be resurrected by
     # KeepAlive while the old process drains.
-    if [[ "$name" == "api" ]]; then
+    if [[ "$name" == "api" ]] && command -v launchctl >/dev/null 2>&1; then
         _disable_api_supervisor || return 1
     fi
 
@@ -802,12 +847,18 @@ _status() {
         state="$(_service_state "$name")"
         pid="$(_known_service_pid "$name" || true)"
         if [[ -z "$pid" ]]; then
+            pid="$(_ssh_tunnel_port_pid "$name" || true)"
+        fi
+        if [[ -z "$pid" ]]; then
             pid="-"
         fi
 
         case "$state" in
             running)
                 printf "%-12s \033[32m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "$detail"
+                ;;
+            tunneled)
+                printf "%-12s \033[32m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "ssh_tunnel"
                 ;;
             degraded)
                 printf "%-12s \033[33m%-11s\033[0m %-8s %-15s %s\n" "$name" "$state" "$pid" "$(_port_owner_label "$name")" "health_check_failed"

--- a/services.sh
+++ b/services.sh
@@ -498,6 +498,12 @@ _is_running() {
     return 1
 }
 
+_api_supervisor_available() {
+    # Tests inject SVC_API_SUPERVISOR_BIN. macOS has launchctl. Linux systemd
+    # units supervise uvicorn directly, so services.sh must not call launchd.
+    [[ -n "${SVC_API_SUPERVISOR_BIN:-}" ]] || command -v launchctl >/dev/null 2>&1
+}
+
 _api_supervisor() {
     if [[ -n "${SVC_API_SUPERVISOR_BIN:-}" ]]; then
         "$SVC_API_SUPERVISOR_BIN" "$@"
@@ -586,7 +592,7 @@ _start_service() {
         return 1
     fi
 
-    if [[ "$name" == "api" ]] && command -v launchctl >/dev/null 2>&1; then
+    if [[ "$name" == "api" ]] && _api_supervisor_available; then
         _start_api_supervised
         return
     fi
@@ -660,7 +666,7 @@ _stop_service() {
     # ``launchctl disable`` happens before the listener is signalled. A
     # deliberate ``services.sh stop api`` therefore cannot be resurrected by
     # KeepAlive while the old process drains.
-    if [[ "$name" == "api" ]] && command -v launchctl >/dev/null 2>&1; then
+    if [[ "$name" == "api" ]] && _api_supervisor_available; then
         _disable_api_supervisor || return 1
     fi
 

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -582,9 +582,83 @@ def test_work_status_rejects_foreign_health_listener(tmp_path, mock_lsof_env) ->
         assert "blocked" in result.stdout
         assert "foreign_listener" in result.stdout
         assert "running" not in result.stdout
+        assert "tunneled" not in result.stdout
     finally:
         proc.terminate()
         proc.wait(timeout=5)
+
+
+def test_work_status_reports_ssh_tunnel_when_health_ok(tmp_path, mock_lsof_env) -> None:
+    """An SSH LocalForward owner is tunneled, not a foreign blocker, when health is 2xx."""
+    set_pids, _, env = mock_lsof_env
+    private_root = tmp_path / "private"
+    (private_root / ".git").mkdir(parents=True)
+    (private_root / ".venv" / "bin").mkdir(parents=True)
+    (private_root / "work_projection").mkdir()
+    (private_root / ".venv" / "bin" / "python").symlink_to(VENV_PYTHON)
+    env["LEARN_UKRAINIAN_INFRA_PRIVATE_ROOT"] = str(private_root)
+
+    port = find_free_port()
+    script_path = tmp_path / "services.sh"
+    script_path.write_text(
+        SERVICES_SH.read_text(encoding="utf-8").replace("8769", str(port)),
+        encoding="utf-8",
+    )
+    script_path.chmod(0o755)
+
+    health = subprocess.Popen(
+        [
+            str(VENV_PYTHON),
+            "-c",
+            (
+                "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+                f"port = {port}\n"
+                "class H(BaseHTTPRequestHandler):\n"
+                "    def do_GET(self):\n"
+                "        body = b'ok'\n"
+                "        self.send_response(200)\n"
+                "        self.send_header('Content-Type', 'text/plain')\n"
+                "        self.send_header('Content-Length', str(len(body)))\n"
+                "        self.end_headers()\n"
+                "        self.wfile.write(body)\n"
+                "    def log_message(self, *args):\n"
+                "        return\n"
+                "HTTPServer(('127.0.0.1', port), H).serve_forever()\n"
+            ),
+        ]
+    )
+    reap_process_on_exit(health)
+
+    ssh_shim = tmp_path / "ssh"
+    ssh_shim.write_text("#!/bin/sh\nwhile true; do sleep 30; done\n", encoding="utf-8")
+    ssh_shim.chmod(0o755)
+    tunnel = subprocess.Popen([str(ssh_shim), "-N", "job-tunnel"])
+    reap_process_on_exit(tunnel)
+    set_pids([tunnel.pid])
+    try:
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if not is_port_free(port):
+                break
+            time.sleep(0.05)
+        result = subprocess.run(
+            ["bash", str(script_path), "status", "work"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "tunneled" in result.stdout
+        assert "ssh_tunnel" in result.stdout
+        assert "blocked" not in result.stdout
+        assert "foreign_listener" not in result.stdout
+    finally:
+        tunnel.terminate()
+        health.terminate()
+        tunnel.wait(timeout=5)
+        health.wait(timeout=5)
 
 
 def test_work_lifecycle_uses_sibling_checkout_and_fixed_loopback(tmp_path) -> None:

--- a/tests/packaging/test_systemd_templates.py
+++ b/tests/packaging/test_systemd_templates.py
@@ -1,0 +1,43 @@
+"""Linux-native systemd templates must supervise listeners, not oneshot services.sh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PACKAGING = Path(__file__).resolve().parents[2] / "packaging" / "systemd"
+UNITS = (
+    "learn-ukrainian-api.service",
+    "learn-ukrainian-sources.service",
+    "learn-ukrainian-work.service",
+    "learn-ukrainian-astro.service",
+)
+
+
+def test_systemd_templates_are_type_simple() -> None:
+    for name in UNITS:
+        text = (PACKAGING / name).read_text(encoding="utf-8")
+        assert "Type=simple" in text
+        assert "Type=oneshot" not in text
+        assert "RemainAfterExit" not in text
+        assert "services.sh start" not in text
+        if name != "learn-ukrainian-work.service":
+            assert "127.0.0.1" in text
+
+
+def test_api_supervisor_is_launchctl_gated() -> None:
+    text = Path(__file__).resolve().parents[2].joinpath("services.sh").read_text(
+        encoding="utf-8"
+    )
+    assert text.count("command -v launchctl >/dev/null 2>&1") >= 2
+    assert "_start_api_supervised" in text
+    assert "_disable_api_supervisor" in text
+
+
+def test_systemd_templates_have_no_host_facts() -> None:
+    forbidden = ("atlas-runner", "hramatka", "46.", "HostName")
+    for path in PACKAGING.iterdir():
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in text, f"{path.name} leaked {token!r}"

--- a/tests/packaging/test_systemd_templates.py
+++ b/tests/packaging/test_systemd_templates.py
@@ -24,13 +24,14 @@ def test_systemd_templates_are_type_simple() -> None:
             assert "127.0.0.1" in text
 
 
-def test_api_supervisor_is_launchctl_gated() -> None:
+def test_api_supervisor_is_gated_for_linux() -> None:
     text = Path(__file__).resolve().parents[2].joinpath("services.sh").read_text(
         encoding="utf-8"
     )
-    assert text.count("command -v launchctl >/dev/null 2>&1") >= 2
-    assert "_start_api_supervised" in text
-    assert "_disable_api_supervisor" in text
+    assert "_api_supervisor_available" in text
+    assert "SVC_API_SUPERVISOR_BIN" in text
+    assert "command -v launchctl >/dev/null 2>&1" in text
+    assert text.count("_api_supervisor_available") >= 3
 
 
 def test_systemd_templates_have_no_host_facts() -> None:


### PR DESCRIPTION
## Summary
- Replace launchd-shaped `Type=oneshot` systemd templates with Linux-native `Type=simple` units that exec the listeners (api, sources, work, astro).
- `services.sh status` reports an SSH LocalForward owner as `tunneled` / `ssh_tunnel` when health is 2xx, instead of `blocked` / `foreign_listener`.
- No host addresses or SSH aliases in the templates.

## Test plan
- [x] `pytest tests/packaging/test_systemd_templates.py tests/api/test_services_ops.py::test_work_status_rejects_foreign_health_listener tests/api/test_services_ops.py::test_work_status_reports_ssh_tunnel_when_health_ok`
- [ ] Independent cross-family review before merge


Made with [Cursor](https://cursor.com)