### PR TITLE
fix(mcp): unadvertise legacy SSE + hide search_images (#7026)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -14,7 +14,7 @@ The Python backing package is still `scripts/rag/` for backwards compat
 with imports; rename there is a follow-up.
 
 Tools:
-    - search_sources, search_text, search_literary, search_external, search_images, get_chunk_context
+    - search_sources, search_text, search_literary, search_external, get_chunk_context
     - verify_word, verify_words, verify_lemma, vet_vocabulary (VESUM)
     - verify_stress (stress oracle: ukrainian-word-stress trie + override layer + VESUM join)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
@@ -153,22 +153,6 @@ async def list_tools() -> list[Tool]:
                         "description": "Max results to return (default 5, max 20)",
                         "default": 5
                     }
-                },
-                "required": ["query"]
-            },
-        ),
-        Tool(
-            name="search_images",
-            description=(
-                "Image search stub (deferred; currently returns a placeholder message)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Image search query in Ukrainian (e.g., 'яблуко', 'ілюстрація букви А')"
-                    },
                 },
                 "required": ["query"]
             },
@@ -1287,7 +1271,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         _handlers = {
             "search_sources": lambda: handle_search_sources(arguments),
             "search_text": lambda: handle_search_text(arguments),
-            "search_images": lambda: handle_search_images(arguments),
             "search_literary": lambda: handle_search_literary(arguments),
             "search_external": lambda: handle_search_external(arguments),
             "get_full_text": lambda: handle_get_full_text(arguments),
@@ -1524,10 +1507,6 @@ async def handle_get_full_text(args: dict) -> list[TextContent]:
         total += len(chunk_text)
 
     return [TextContent(type="text", text="\n\n---\n\n".join(text_parts))]
-
-
-async def handle_search_images(args: dict) -> list[TextContent]:
-    return [TextContent(type="text", text="Image search deferred — will be available for l2-uk-direct track.")]
 
 
 async def handle_get_chunk_context(args: dict) -> list[TextContent]:
@@ -2450,39 +2429,18 @@ class _RejectUnsupportedStatelessMcpMethods:
 
 
 def create_http_app():
-    """Create the standalone HTTP app with SSE and Streamable HTTP transports.
+    """Create the standalone HTTP app with Streamable HTTP transport.
 
     Uses MCP 2.0's built-in ``Server.streamable_http_app`` for the
     streamable-HTTP endpoint, with ``stateless_http=True`` and
     ``json_response=True`` so each request is independent and answered with a
-    single JSON body. The legacy SSE endpoint and ``/health`` are wired as
-    custom Starlette routes. GET/DELETE on ``/mcp`` are rejected with 405 so
-    Streamable HTTP clients do not hang on an empty SSE notification stream.
+    single JSON body. Public routes are ``/mcp`` and ``/health`` only — legacy
+    SSE (``/sse``, ``/messages/``) is not advertised. GET/DELETE on ``/mcp``
+    are rejected with 405 so Streamable HTTP clients do not hang on an empty
+    SSE notification stream.
     """
-    from mcp.server.sse import SseServerTransport
     from starlette.responses import Response
-    from starlette.routing import Mount, Route
-
-    sse = SseServerTransport("/messages/")
-
-    class SseEndpoint:
-        """ASGI endpoint for the legacy SSE transport."""
-
-        async def __call__(self, scope, receive, send):
-            try:
-                async with sse.connect_sse(scope, receive, send) as (
-                    read_stream,
-                    write_stream,
-                ):
-                    await server.run(
-                        read_stream,
-                        write_stream,
-                        server.create_initialization_options(),
-                    )
-            except Exception:
-                # Client disconnected (Gemini timeout, rate limit, etc.)
-                # This is normal — don't crash the server
-                pass
+    from starlette.routing import Route
 
     def _get_git_commit() -> str:
         try:
@@ -2511,8 +2469,6 @@ def create_http_app():
 
     custom_routes = [
         Route("/health", endpoint=handle_health),
-        Route("/sse", endpoint=SseEndpoint()),
-        Mount("/messages/", app=sse.handle_post_message),
     ]
 
     app = server.streamable_http_app(
@@ -2525,7 +2481,7 @@ def create_http_app():
 
 
 async def main_sse(host: str = "127.0.0.1", port: int = 8766):
-    """Run the MCP sources server as a standalone SSE daemon."""
+    """Run the MCP sources server as a standalone Streamable HTTP daemon."""
     import uvicorn
 
     # Verify SQLite sources database exists
@@ -2540,10 +2496,9 @@ async def main_sse(host: str = "127.0.0.1", port: int = 8766):
     # (MCP 2.0's Server.run no longer accepts that parameter).
     app = create_http_app()
 
-    print(f"MCP Sources Server (SSE) running on http://{host}:{port}")
-    print(f"  SSE endpoint: http://{host}:{port}/sse")
+    print(f"MCP Sources Server running on http://{host}:{port}")
     print(f"  Streamable HTTP endpoint: http://{host}:{port}/mcp")
-    print(f"  Messages: http://{host}:{port}/messages/")
+    print(f"  Health: http://{host}:{port}/health")
     sys.stdout.flush()
 
     config = uvicorn.Config(app, host=host, port=port, log_level="warning")

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -47,7 +47,7 @@ class TestListTools:
         tool_names = {t.name for t in tools}
 
         expected = {
-            "search_sources", "search_text", "search_images", "search_literary", "search_external",
+            "search_sources", "search_text", "search_literary", "search_external",
             "get_full_text", "get_chunk_context", "collection_stats",
             "verify_word", "verify_source_attribution", "verify_words", "vet_vocabulary", "verify_lemma", "verify_quote", "check_modern_form",
             "verify_stress",
@@ -136,14 +136,11 @@ class TestUlifHandlers:
         assert "trust_tier" not in search_text.input_schema["properties"]
         assert "BGE-M3" not in search_text.description
 
-    def test_search_images_stub_schema(self, server_module):
+    def test_search_images_not_in_live_inventory(self, server_module):
+        """Image search is deferred; do not advertise a no-op stub (#7026)."""
         tools = _run(server_module.list_tools())
-        search_images = next(t for t in tools if t.name == "search_images")
-        assert "stub" in search_images.description.lower()
-        assert "SigLIP" not in search_images.description
-        assert "grade" not in search_images.input_schema["properties"]
-        assert "subject" not in search_images.input_schema["properties"]
-        assert search_images.input_schema["required"] == ["query"]
+        tool_names = {t.name for t in tools}
+        assert "search_images" not in tool_names
 
     def test_search_literary_schema(self, server_module):
         tools = _run(server_module.list_tools())
@@ -879,6 +876,10 @@ class TestHealthEndpoint:
         # #7037 wraps the ASGI app to 405 GET/DELETE on /mcp; unwrap the raw
         # Starlette app for route introspection.
         app = getattr(app, "app", app)
+        route_paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/health" in route_paths
+        assert "/sse" not in route_paths
+        assert "/messages/" not in route_paths
         routes = [r for r in app.routes if getattr(r, "path", None) == "/health"]
         assert len(routes) == 1
         health_endpoint = routes[0].endpoint

--- a/tests/test_mcp_sources_streamable_http.py
+++ b/tests/test_mcp_sources_streamable_http.py
@@ -118,6 +118,7 @@ def test_streamable_http_tools_list_contains_vocabulary_vetting_tools(sources_ht
     tool_names = {tool["name"] for tool in body["result"]["tools"]}
     assert "verify_words" in tool_names
     assert "vet_vocabulary" in tool_names
+    assert "search_images" not in tool_names
 
 
 def test_streamable_http_tool_call_returns_valid_response(sources_http_url):
@@ -185,16 +186,17 @@ def test_streamable_http_tool_call_returns_valid_response(sources_http_url):
     )
 
 
-def test_legacy_sse_endpoint_still_emits_message_endpoint(sources_http_url):
-    text = ""
+def test_legacy_sse_paths_are_not_advertised(sources_http_url):
+    """Legacy SSE must not hang as a public GET (#7026). 404/405 are fine."""
     timeout = httpx.Timeout(2.0, connect=2.0, read=2.0, write=2.0, pool=2.0)
-    with httpx.stream("GET", f"{sources_http_url}/sse", timeout=timeout) as response:
-        assert response.status_code == 200
-        assert response.headers["content-type"].startswith("text/event-stream")
-        for chunk in response.iter_text():
-            text += chunk
-            if "event: endpoint" in text and "data: /messages/?session_id=" in text:
-                break
+    sse_response = httpx.get(f"{sources_http_url}/sse", timeout=timeout)
+    assert sse_response.status_code in {404, 405}
+    assert not sse_response.headers.get("content-type", "").startswith("text/event-stream")
 
-    assert "event: endpoint" in text
-    assert "data: /messages/?session_id=" in text
+    messages_response = httpx.post(
+        f"{sources_http_url}/messages/",
+        content=b"{}",
+        headers={"content-type": "application/json"},
+        timeout=timeout,
+    )
+    assert messages_response.status_code in {404, 405}


### PR DESCRIPTION
## Summary
- Stop advertising legacy SSE: remove public `/sse` and `/messages/` mounts from the Sources MCP streamable-HTTP app. Canonical clients use `/mcp` + `/health` only.
- Omit `search_images` from the live MCP tool inventory until a real implementation exists (no more callable no-op stub).
- Update owned tests so they no longer require `/sse`/`/messages/` or list `search_images`.

Refs #7026. Does not reopen ranking / russian-shadow / quote-clip (#7028 / #7027).

## Test plan
- [x] ruff + pytest on owned paths (quoted below)
- [x] residual `rg` shows no public SSE mounts or `search_images` in `server.py`
- [ ] cross-family exact-head review before merge (AGENT_NO_MERGE=1)

## Verify (raw output)

### ruff
```bash
.venv/bin/ruff check .mcp/servers/sources/server.py tests/test_mcp_sources_server.py tests/test_mcp_sources_streamable_http.py
```
```
All checks passed!
```

### pytest
```bash
.venv/bin/python -m pytest -q tests/test_mcp_sources_server.py tests/test_mcp_sources_streamable_http.py
```
```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/cursor/sources-7026-sse-residual
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0, timeout-2.4.0, anyio-4.14.2
timeout: 120.0s
timeout method: thread
timeout func_only: False
collected 78 items

tests/test_mcp_sources_server.py ....................................... [ 50%]
...................sssss.........                                        [ 92%]
tests/test_mcp_sources_streamable_http.py ......                         [100%]

======================== 73 passed, 5 skipped in 4.21s =========================
```

### residual rg (expect no matches; exit 1)
```bash
rg -n 'Route\("/sse"|Mount\("/messages/"|search_images' .mcp/servers/sources/server.py
```
```
(no matches)
```


Made with [Cursor](https://cursor.com)