### PR TITLE
fix(sources): support body text matching in search_style_guide (#7028)

### DIFF
--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -1815,12 +1815,13 @@ def _dict_lookup_contains(
     word: str,
     limit: int,
 ) -> list[dict]:
-    """Case-fold + substring headword match for small multi-word tables.
+    """Case-fold + substring headword and body match for small multi-word tables.
 
     Loads the full table (e.g. `style_guide`'s ~340 rows) since headwords
     there are phrases rather than single tokens — a SQL prefix `LIKE` would
     match "Приймати" but miss "На протязі" for a "протязі" query. Exact
-    (case-folded) matches are ranked ahead of substring matches.
+    (case-folded) headword matches are ranked first, followed by substring
+    headword matches, followed by body text matches.
     """
     query_key = _fold_dict_key(word)
     if not query_key:
@@ -1833,17 +1834,22 @@ def _dict_lookup_contains(
 
     exact: list[dict] = []
     partial: list[dict] = []
+    body: list[dict] = []
     for row in rows:
         item = dict(row)
         headword_key = _fold_dict_key(str(item.get("word", "")))
-        if not headword_key:
-            continue
-        if headword_key == query_key:
-            exact.append(item)
-        elif query_key in headword_key or headword_key in query_key:
-            partial.append(item)
+        if headword_key:
+            if headword_key == query_key:
+                exact.append(item)
+                continue
+            if query_key in headword_key or headword_key in query_key:
+                partial.append(item)
+                continue
+        text_key = _fold_dict_key(str(item.get("text", "")))
+        if text_key and query_key in text_key:
+            body.append(item)
 
-    return (exact + partial)[:limit]
+    return (exact + partial + body)[:limit]
 
 
 def _dict_lookup(
@@ -2570,8 +2576,8 @@ def search_style_guide(
 
     Headwords are often multi-word phrases ("Приймати участь", "На
     протязі"), so matching is case-insensitive (Cyrillic-safe, unlike SQL
-    `COLLATE NOCASE`) and phrase-substring in either direction — see
-    :func:`_dict_lookup_contains`.
+    `COLLATE NOCASE`) and phrase-substring in headwords as well as body
+    text matches — see :func:`_dict_lookup_contains`.
     """
     rows = _dict_lookup("style_guide", word, limit, db_path=db_path, contains=True)
     for row in rows:

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -461,6 +461,18 @@ class TestSourcesDb:
         # in the canonical attribution rather than returning "".
         assert results[0]["source"] == "Антоненко-Давидович"
 
+    def test_search_style_guide_body_fallback_when_not_in_headword(
+        self, sample_data, monkeypatch
+    ):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import search_style_guide
+
+        # "протягом" is in the text of "На протязі" ("Кажіть: протягом."), but not in the headword.
+        results = search_style_guide("протягом")
+        assert len(results) >= 1
+        assert results[0]["word"] == "На протязі"
+        assert "протягом" in results[0]["text"]
+
     def test_search_style_guide_nonexistent_query_returns_empty(
         self, sample_data, monkeypatch
     ):
@@ -1087,6 +1099,30 @@ class TestHeadwordFirstRanking:
             hits = search_style_guide(query, db_path=esum_heritage_rank_db)
             assert len(hits) >= 1, f"Failed to return a row for {query!r}"
             assert hits[0]["word"] == "На протязі"
+
+    def test_search_style_guide_headword_ranks_above_body_hit(self, esum_heritage_rank_db):
+        from wiki.sources_db import search_style_guide
+
+        # Headword hit "Приймати участь" must rank ahead of any entry having "участь" in body
+        hits = search_style_guide("участь", db_path=esum_heritage_rank_db)
+        assert len(hits) >= 1
+        assert hits[0]["word"] == "Приймати участь"
+
+    def test_search_style_guide_live_db_documented_examples(self):
+        from wiki.sources_db import SOURCES_DB_PATH, search_style_guide
+
+        if not SOURCES_DB_PATH.exists() or SOURCES_DB_PATH.stat().st_size < 1000:
+            pytest.skip("sources.db not present")
+
+        # "На протязі", "протязі", "Приймати участь" must all resolve against live DB
+        for query in ("«На протязі»", "На протязі", "протязі", "«протязі»"):
+            hits = search_style_guide(query)
+            assert len(hits) >= 1, f"Failed to return a row for {query!r}"
+            assert "протязі" in (hits[0]["word"] + hits[0]["text"]).lower()
+
+        hits_uchast = search_style_guide("Приймати участь")
+        assert len(hits_uchast) >= 1
+        assert "приймати участь" in hits_uchast[0]["word"].lower()
 
     def test_search_definitions_quoted_and_case_variants(self, esum_heritage_rank_db):
         from wiki.sources_db import search_definitions


### PR DESCRIPTION
## Summary

Resolves #7028 residual where documented `search_style_guide("На протязі")` returned 0 hits against the live sources DB.

### Source Locus
Antonenko-Davydovych discusses «на протязі року» vs «протягом року» in *«Як ми говоримо»*, chapter «ЩОБ ЯСКРАВО Й ТОЧНО», section «Міфи і реальність» (p. 131):
> «Правильно не "на протязі року", а "протягом року". Замість незграбного самодовліючий треба вживати прикметника самодостатній...»

In the `style_guide` table (342 entries), this chapter was ingested under the monolithic headword `word = 'Міфи і реальність'`.

### Changes
- Updated `_dict_lookup_contains` in `scripts/wiki/sources_db.py` to rank exact headword matches first, partial headword substring matches second, and body text matches third.
- Added unit and ranking regression tests in `tests/test_sources_db.py` verifying body text fallback, headword-first ranking over body hits, and resolution of documented examples (`«На протязі»`, `На протязі`, `протязі`, `«протязі»`, `Приймати участь`).

Refs #7028

X-Agent: agy/sources-7028-style-guide