### PR TITLE
fix(cursor): merge closeout is branches + worktree only

### DIFF
--- a/.cursor/rules/merge-closeout.mdc
+++ b/.cursor/rules/merge-closeout.mdc
@@ -1,0 +1,29 @@
+---
+description: GitHub MERGED is not closeout — reap branch + worktree every merge
+alwaysApply: true
+---
+
+# Merge closeout (Cursor)
+
+`gh pr merge` / merge-queue **MERGED** is not closeout. Do not treat the PR URL as done.
+
+## Every merge (universal)
+
+Finish all three before claiming the merge closed:
+
+1. **Remote branch gone** — `git ls-remote --heads origin <branch>` empty (delete if GitHub did not).
+2. **Local branch gone** — no leftover `refs/heads/<branch>` (including worktree-linked refs).
+3. **Worktree reaped** — from the primary checkout, after every process has left the tree:
+
+```bash
+.venv/bin/python scripts/orchestration/reap_worktrees.py \
+  --repo-root "$(pwd)" --apply --merged --worktree "<exact-worktree>"
+```
+
+Canonical: `docs/runbooks/worktree-cleanup.md` § Immediate cleanup after merge. A skip is a blocker, not permission for `--force`.
+
+Do not copy the last task’s leftovers into this list.
+
+## Task-specific (not universal)
+
+Deploy, host pull, tunnel-only Mac, occupancy probes, service restarts, and similar proofs belong **only** to the task that created them. Name that remainder in the closeout, finish it for **this** task, and do not promote it into standing merge hygiene.

--- a/agents_extensions/cursor/rules/merge-closeout.md
+++ b/agents_extensions/cursor/rules/merge-closeout.md
@@ -1,0 +1,10 @@
+# Merge closeout (Cursor)
+
+Deployed digest: `.cursor/rules/merge-closeout.mdc` (`alwaysApply`).
+
+`MERGED` is not closeout. Universal git closeout: remote branch gone, local
+branch gone, worktree reaped (`reap_worktrees.py --apply --merged`). Canonical:
+`docs/runbooks/worktree-cleanup.md` § Immediate cleanup after merge.
+
+Task-specific proofs (host pull, tunnel, occupancy, restarts) stay on that
+task. Do not promote them into standing merge hygiene.

--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -124,6 +124,13 @@ The canonical PR lifecycle trail already performs worktree-first cleanup after
 merge. Other merge owners must invoke the exact command above before declaring
 closeout complete.
 
+Git closeout for **every** merge is exactly three things: worktree reaped,
+remote branch gone, local branch gone. If GitHub did not delete the remote
+head, delete it. Then delete the local branch. Host pulls, tunnels, occupancy
+probes, service restarts, and similar proofs are **task remainder**, not this
+list — name them for this task and finish them, but do not add them to standing
+merge hygiene.
+
 Do not put networked worktree deletion in Git's `post-merge` hook. GitHub merges
 do not run a local hook, and a later `git pull` is not reliable ownership
 evidence for an arbitrary dispatch worktree.


### PR DESCRIPTION
## Summary
- Standing Cursor rule: a merge is not closed until the remote branch is gone, the local branch is gone, and the worktree is reaped.
- Task leftovers (host pull, Mac tunnel, occupancy probes) stay on that task and are not copied into every merge.

## Test plan
- [ ] Confirm `.cursor/rules/merge-closeout.mdc` is `alwaysApply`
- [ ] Confirm `docs/runbooks/worktree-cleanup.md` still points at `reap_worktrees.py --apply --merged`


Made with [Cursor](https://cursor.com)