### PR TITLE
fix(occupancy): local job-host load + retired Mac plane fail-closed

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -237,6 +237,8 @@ Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second p
 
 Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service`. Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
 
+When Monitor runs on the same machine as one mapped host, set `ATLAS_JOB_SELF_HOST` to that host's canonical token (the left-hand side of `MONITOR_OCCUPANCY_HOST_IDS`). Load is then collected locally — no SSH-to-self. Remote mapped hosts still use BatchMode SSH; they need a working operator SSH config on the Monitor host.
+
 Examples and fixtures use placeholders only (`host-job`, `host-teacher`). Never put addresses, SSH hostnames, or provider SKUs in this payload.
 
 ```bash

--- a/docs/runbooks/atlas-job-protocol.md
+++ b/docs/runbooks/atlas-job-protocol.md
@@ -45,7 +45,9 @@ box. Do not raise these limits for hramatka jobs without checking headroom
 against the resident services first.
 
 SSH aliases live in the operator `~/.ssh/config`. IAC: private
-`hramatka/ops/iac/` (merged #495).
+`hramatka/ops/iac/` (merged #495). Occupancy/load on the Monitor host
+itself uses `ATLAS_JOB_SELF_HOST` (local collection, no SSH-to-self).
+Remote mapped hosts still need BatchMode SSH from that Monitor host.
 
 ## Lifecycle
 

--- a/scripts/fleet_comms/paths.py
+++ b/scripts/fleet_comms/paths.py
@@ -11,11 +11,32 @@ from scripts.guardrails.worktree_containment import (
 )
 
 ENV_ROOT = "FLEET_COMMS_ROOT"
+ENV_ALLOW_LOCAL_SHADOW = "FLEET_COMMS_ALLOW_LOCAL_SHADOW"
 DEFAULT_ROOT_REL = Path("batch_state") / "fleet-comms" / "v1"
+RETIRED_LOCAL_MARKER = "READ_ME_CANONICAL_ON_JOB_HOST.txt"
 
 
 class PlaneRootAnchorError(RuntimeError):
     """Raised when the plane root cannot be anchored to the primary checkout."""
+
+
+def _refuse_retired_local_plane(root: Path) -> None:
+    """Fail closed when the notebook copy has been retired to the job host.
+
+    The marker is an ordinary file in the plane root (gitignored). Tests and
+    explicit recovery set ``FLEET_COMMS_ALLOW_LOCAL_SHADOW=1``.
+    """
+    if os.environ.get(ENV_ALLOW_LOCAL_SHADOW, "").strip() == "1":
+        return
+    marker = root / RETIRED_LOCAL_MARKER
+    sibling = root.parent / RETIRED_LOCAL_MARKER
+    if marker.is_file() or sibling.is_file():
+        raise PlaneRootAnchorError(
+            "local fleet-comms sqlite is retired; the job-host Monitor owns "
+            "the canonical plane. Do not chmod the stub directory. Observe "
+            "via the tunneled API, or set FLEET_COMMS_ALLOW_LOCAL_SHADOW=1 "
+            "only for an isolated fixture."
+        )
 
 
 def default_plane_root(
@@ -41,7 +62,9 @@ def default_plane_root(
     """
     env = os.environ.get(ENV_ROOT)
     if env:
-        return Path(env).expanduser().resolve()
+        root = Path(env).expanduser().resolve()
+        _refuse_retired_local_plane(root)
+        return root
 
     candidate = repo_root if repo_root is not None else Path.cwd()
     try:
@@ -51,10 +74,12 @@ def default_plane_root(
             raise PlaneRootAnchorError(
                 f"refusing to anchor the fleet-comms plane root at {candidate}: "
                 "not inside a git repository, so the primary checkout cannot be "
-                "verified. A silent fallback here once materialized a shadow comms "
-                "DB under a garbage cwd (#6863). Set FLEET_COMMS_ROOT for an "
+                "verified. A silent fallback here once materialized a shadow "
+                "comms DB under a garbage cwd (#6863). Set FLEET_COMMS_ROOT for an "
                 "explicit override, or pass allow_non_git=True for an isolated "
                 "non-git fixture."
             ) from exc
         base = candidate.resolve()
-    return (base / DEFAULT_ROOT_REL).resolve()
+    root = (base / DEFAULT_ROOT_REL).resolve()
+    _refuse_retired_local_plane(root)
+    return root

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -236,6 +237,126 @@ class FakeHostAdapter:
         }
 
 
+ENV_SELF_HOST = "ATLAS_JOB_SELF_HOST"
+
+
+def self_host_aliases() -> frozenset[str]:
+    """Canonical host tokens this process should probe without SSH."""
+    raw = os.environ.get(ENV_SELF_HOST, "")
+    return frozenset(
+        _canonical_host(part.strip()) for part in raw.split(",") if part.strip()
+    )
+
+
+def is_self_host(host: str) -> bool:
+    return _canonical_host(host) in self_host_aliases()
+
+
+def collect_host_load(*, run_root: Path) -> dict[str, Any]:
+    """Collect cpu/load/mem/disk/job_unit on the current machine.
+
+    Same shape as the SSH remote snippet in ``SshHostAdapter.host_load``.
+    Used when ``ATLAS_JOB_SELF_HOST`` says this process already lives on
+    the target host, so occupancy does not SSH-to-self.
+    """
+    cpu_count = os.cpu_count() or 1
+    try:
+        loadavg = [round(float(x), 2) for x in os.getloadavg()]
+    except Exception:
+        loadavg = [0.0, 0.0, 0.0]
+
+    mem_total = 0
+    mem_avail = 0
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as handle:
+            for line in handle:
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                key = parts[0].rstrip(":")
+                if key == "MemTotal":
+                    mem_total = int(parts[1]) * 1024
+                elif key == "MemAvailable":
+                    mem_avail = int(parts[1]) * 1024
+    except OSError:
+        pass
+    mem_pct = (
+        round((mem_total - mem_avail) / mem_total * 100.0, 1) if mem_total > 0 else 0.0
+    )
+
+    path = Path(run_root)
+    while not path.exists() and path != path.parent:
+        path = path.parent
+    try:
+        usage = shutil.disk_usage(str(path))
+        disk_total = usage.total
+        disk_avail = usage.free
+        disk_pct = (
+            round((usage.total - usage.free) / usage.total * 100.0, 1)
+            if usage.total > 0
+            else 0.0
+        )
+    except OSError:
+        disk_total = 0
+        disk_avail = 0
+        disk_pct = 0.0
+
+    active_count = 0
+    active_job_id = None
+    active_state = None
+    try:
+        result = subprocess.run(
+            [
+                "systemctl",
+                "--user",
+                "list-units",
+                "atlas-job-*.service",
+                "--all",
+                "--no-legend",
+                "--no-pager",
+                "--plain",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in (result.stdout or "").splitlines():
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            name, _load, active, sub = parts[0], parts[1], parts[2], parts[3]
+            if not (name.startswith("atlas-job-") and name.endswith(".service")):
+                continue
+            if active != "active":
+                continue
+            active_count += 1
+            if active_job_id is None:
+                active_job_id = name[len("atlas-job-") : -len(".service")]
+                active_state = sub or active
+    except OSError:
+        pass
+
+    return {
+        "cpu_count": cpu_count,
+        "loadavg": loadavg,
+        "mem": {
+            "available_bytes": mem_avail,
+            "total_bytes": mem_total,
+            "pct": mem_pct,
+        },
+        "disk": {
+            "available_bytes": disk_avail,
+            "total_bytes": disk_total,
+            "pct": disk_pct,
+        },
+        "job_unit": {
+            "active_count": active_count,
+            "job_id": active_job_id,
+            "state": active_state,
+        },
+    }
+
+
 class SshHostAdapter:
     """Production adapter: BatchMode SSH to the named host alias."""
 
@@ -329,7 +450,10 @@ class SshHostAdapter:
         return int(text)
 
     def host_load(self, host: str) -> dict[str, Any]:
-        target = str(_run_root(host))
+        canonical = _canonical_host(host)
+        if is_self_host(canonical):
+            return collect_host_load(run_root=_run_root(canonical))
+        target = str(_run_root(canonical))
         remote = (
             "python3 - <<'PY'\n"
             "import json, os, shutil, subprocess\n"

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -842,3 +842,62 @@ def test_mirror_dir_for_uses_primary_data(
     assert atlas_job.mirror_dir_for("job-1").resolve() == Path(
         "/tmp/primary-checkout/data/lexicon/runner-mirror/job-1"
     ).resolve()
+
+
+def test_collect_host_load_shape(tmp_path: Path) -> None:
+    payload = atlas_job.collect_host_load(run_root=tmp_path)
+    assert payload["cpu_count"] >= 1
+    assert len(payload["loadavg"]) == 3
+    assert set(payload["mem"]) == {"available_bytes", "total_bytes", "pct"}
+    assert set(payload["disk"]) == {"available_bytes", "total_bytes", "pct"}
+    assert payload["disk"]["total_bytes"] > 0
+    assert set(payload["job_unit"]) == {"active_count", "job_id", "state"}
+
+
+def test_ssh_host_load_skips_ssh_for_self_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "job-box")
+    monkeypatch.setenv("ATLAS_RUN_ROOT", str(tmp_path))
+    real_run = atlas_job.subprocess.run
+
+    def guarded(cmd: list[str], **kwargs: object) -> object:
+        if cmd and cmd[0] == "ssh":
+            raise AssertionError("ssh must not run for self-host load")
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(atlas_job.subprocess, "run", guarded)
+    payload = atlas_job.SshHostAdapter().host_load("job-box")
+    assert "cpu_count" in payload
+    assert "loadavg" in payload
+    assert "mem" in payload
+    assert "disk" in payload
+
+
+def test_ssh_host_load_uses_ssh_when_not_self(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_JOB_SELF_HOST", raising=False)
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> object:
+        seen.append(list(cmd))
+
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(atlas_job.subprocess, "run", fake_run)
+    with pytest.raises(ConnectionError, match="host_load failed"):
+        atlas_job.SshHostAdapter().host_load("job-box")
+    assert seen
+    assert seen[0][0] == "ssh"
+    assert "job-box" in seen[0]
+
+
+def test_is_self_host_uses_canonical_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "vps")
+    assert atlas_job.is_self_host("hramatka") is True
+    assert atlas_job.is_self_host("vps") is True
+    assert atlas_job.is_self_host("job-box") is False

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -80,6 +80,25 @@ def test_default_plane_root_preserves_override_and_hard_fails_outside_git(
     )
 
 
+def test_default_plane_root_refuses_retired_local_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts.fleet_comms.paths import PlaneRootAnchorError, RETIRED_LOCAL_MARKER
+
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    monkeypatch.delenv("FLEET_COMMS_ALLOW_LOCAL_SHADOW", raising=False)
+    primary = tmp_path / "primary"
+    (primary / ".git").mkdir(parents=True)
+    plane = primary / "batch_state" / "fleet-comms" / "v1"
+    plane.mkdir(parents=True)
+    (plane / RETIRED_LOCAL_MARKER).write_text("retired\n", encoding="utf-8")
+    with pytest.raises(PlaneRootAnchorError, match="retired"):
+        default_plane_root(repo_root=primary)
+
+    monkeypatch.setenv("FLEET_COMMS_ALLOW_LOCAL_SHADOW", "1")
+    assert default_plane_root(repo_root=primary) == plane.resolve()
+
+
 def test_default_plane_root_makes_relative_override_stable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Occupancy reused atlas-jobs SSH load probes. On the job host that is SSH-to-self and stays `unreachable`.
- `ATLAS_JOB_SELF_HOST` collects cpu/load/mem/disk/job_unit locally for that canonical token.
- Fleet-comms `READ_ME_CANONICAL_ON_JOB_HOST.txt` fails closed so a notebook cannot recreate a second sqlite.

Teacher occupancy still needs BatchMode SSH from the Monitor host (no `~/.ssh/config` there today). That is a separate operator install, not this PR.

## Test plan
- [x] `pytest tests/test_atlas_job_protocol.py tests/test_fleet_comms_message_plane.py tests/api/test_occupancy.py tests/api/test_atlas_jobs_router.py` (93 passed)
- [ ] After merge: set `ATLAS_JOB_SELF_HOST` on the job host, restart `learn-ukrainian-api`, `GET /api/occupancy` shows `host-job` `fresh` with opaque keys only
- [ ] Confirm `host-teacher` stays `unreachable` until job-host SSH to the teacher alias exists


Made with [Cursor](https://cursor.com)