### PR TITLE
fix(api): await stale occupancy load probes

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -233,9 +233,11 @@ Standard HTTP status codes: `404` for missing resources, `500` for server errors
 
 ### `GET /api/occupancy[?host_id=x][&fresh=true]`
 
-Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board, no SSH on the request path). Host keys are opaque `host_id` values from `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Without that map the `hosts` object is empty — canonical aliases are never used as JSON keys.
+Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). Host keys are opaque `host_id` values from `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Without that map the `hosts` object is empty — canonical aliases are never used as JSON keys.
 
 Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service`. Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
+
+On a running event loop, a missing or expired cache entry and `fresh=true` wait for the shared load probe before responding. Cached metrics between 30 and 300 seconds old may still be returned as `stale` while a refresh runs.
 
 When Monitor runs on the same machine as one mapped host, set `ATLAS_JOB_SELF_HOST` to that host's canonical token (the left-hand side of `MONITOR_OCCUPANCY_HOST_IDS`). Load is then collected locally — no SSH-to-self. Remote mapped hosts still use BatchMode SSH; they need a working operator SSH config on the Monitor host.
 
@@ -3275,4 +3277,3 @@ Query params: `host` (default `atlas-runner`), `audit` (default `false`).
 ### `POST /api/atlas-jobs/{job_id}/close`
 Closes a completed or crashed job, captures exit status, pulls mirror artifacts, runs restic backup, and seals a fail-closed result receipt (`.result.json`).
 Body: `{"summary": {...}, "skip_pull": false, "skip_restic": false}`.
-

--- a/scripts/api/atlas_jobs_router.py
+++ b/scripts/api/atlas_jobs_router.py
@@ -126,12 +126,14 @@ def _probe_host_load_sync(host: str) -> tuple[dict[str, Any] | None, str]:
 
 
 async def _refresh_host_load_job(host: str) -> None:
+    task = asyncio.current_task()
     try:
         data, now_iso = await asyncio.to_thread(_probe_host_load_sync, host)
         if data is not None:
             _HOST_LOAD_CACHE[host] = (data, time.monotonic(), now_iso)
     finally:
-        _HOST_LOAD_TASKS.pop(host, None)
+        if _HOST_LOAD_TASKS.get(host) is task:
+            _HOST_LOAD_TASKS.pop(host, None)
 
 
 def _schedule_host_load_refresh(host: str) -> asyncio.Task[None] | None:
@@ -192,6 +194,22 @@ def _get_host_load_entry(host: str, *, fresh: bool = False) -> dict[str, Any]:
     }
 
 
+async def _get_host_load_entry_async(host: str, *, fresh: bool = False) -> dict[str, Any]:
+    """Read host load, awaiting the shared probe when no usable cache exists."""
+    entry = _HOST_LOAD_CACHE.get(host)
+    needs_probe_result = fresh or entry is None
+    if entry is not None:
+        _, mono_ts, _ = entry
+        needs_probe_result = needs_probe_result or time.monotonic() - mono_ts > HOST_LOAD_MAX_STALE_S
+
+    if needs_probe_result:
+        task = _schedule_host_load_refresh(host)
+        if task is not None:
+            await asyncio.shield(task)
+
+    return _get_host_load_entry(host)
+
+
 def _encode_cursor(closed_at: str | None, job_id: str) -> str:
     payload = json.dumps([closed_at or "", job_id])
     return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
@@ -238,9 +256,8 @@ async def load_jobs(
     else:
         target_hosts = all_hosts
 
-    hosts_data: dict[str, Any] = {}
-    for h in target_hosts:
-        hosts_data[h] = _get_host_load_entry(h, fresh=fresh)
+    entries = await asyncio.gather(*(_get_host_load_entry_async(h, fresh=fresh) for h in target_hosts))
+    hosts_data = dict(zip(target_hosts, entries, strict=True))
 
     now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     payload = {

--- a/scripts/api/occupancy.py
+++ b/scripts/api/occupancy.py
@@ -7,6 +7,7 @@ path. Canonical SSH aliases never appear as JSON keys. Map them with
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 from datetime import UTC, datetime
@@ -168,26 +169,31 @@ def _shape_host(host_id: str, load_entry: dict[str, Any], occupants: list[dict[s
     return shaped
 
 
-def occupancy_payload(*, host_id: str | None = None, fresh: bool = False) -> dict[str, Any]:
+def _selected_hosts(host_id: str | None) -> dict[str, str]:
     mapping = parse_host_id_map()
     if not mapping:
-        return {
-            "schema": OCCUPANCY_SCHEMA,
-            "observed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-            "hosts": {},
-        }
+        return {}
 
     reverse = {opaque: canonical for canonical, opaque in mapping.items()}
     if host_id is not None:
         if host_id not in reverse:
             raise HTTPException(status_code=400, detail="unknown host_id")
-        selected = {host_id: reverse[host_id]}
-    else:
-        selected = {opaque: canonical for canonical, opaque in mapping.items()}
+        return {host_id: reverse[host_id]}
+    return {opaque: canonical for canonical, opaque in mapping.items()}
 
+
+def _empty_payload() -> dict[str, Any]:
+    return {
+        "schema": OCCUPANCY_SCHEMA,
+        "observed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "hosts": {},
+    }
+
+
+def _payload_from_entries(selected: dict[str, str], load_entries: dict[str, dict[str, Any]]) -> dict[str, Any]:
     hosts: dict[str, Any] = {}
     for opaque, canonical in selected.items():
-        load_entry = load_mod._get_host_load_entry(canonical, fresh=fresh)
+        load_entry = load_entries[canonical]
         occupants = _merge_occupants(
             _occupants_from_registry(canonical),
             _occupants_from_job_unit(canonical, load_entry),
@@ -201,10 +207,32 @@ def occupancy_payload(*, host_id: str | None = None, fresh: bool = False) -> dic
     }
 
 
+def occupancy_payload(*, host_id: str | None = None, fresh: bool = False) -> dict[str, Any]:
+    """Build the synchronous cache-only payload for non-HTTP callers."""
+    selected = _selected_hosts(host_id)
+    if not selected:
+        return _empty_payload()
+
+    load_entries = {canonical: load_mod._get_host_load_entry(canonical, fresh=fresh) for canonical in selected.values()}
+    return _payload_from_entries(selected, load_entries)
+
+
+async def _occupancy_payload_async(*, host_id: str | None = None, fresh: bool = False) -> dict[str, Any]:
+    selected = _selected_hosts(host_id)
+    if not selected:
+        return _empty_payload()
+
+    entries = await asyncio.gather(
+        *(load_mod._get_host_load_entry_async(canonical, fresh=fresh) for canonical in selected.values())
+    )
+    load_entries = dict(zip(selected.values(), entries, strict=True))
+    return _payload_from_entries(selected, load_entries)
+
+
 @router.get("")
 async def occupancy(
     host_id: str | None = Query(default=None),
     fresh: bool = False,
 ) -> JSONResponse:
-    payload = occupancy_payload(host_id=host_id, fresh=fresh)
+    payload = await _occupancy_payload_async(host_id=host_id, fresh=fresh)
     return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
+import threading
 import time
 
 import pytest
@@ -273,20 +275,103 @@ def test_load_endpoint_ip_sanitization_and_forbidden_fields(
 
 def test_load_endpoint_dead_host_isolation(
     _isolate: atlas_job.FakeHostAdapter,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     router_mod.clear_host_load_cache()
-    # atlas-runner has fresh cache, hramatka has no cache / failed
-    router_mod.set_host_load_cache("atlas-runner", _isolate.host_load("atlas-runner"))
+    monkeypatch.setattr(router_mod, "_canonical_allowed_hosts", lambda: ["job-box", "teach-box"])
+    live_host, dead_host = "job-box", "teach-box"
+    original_host_load = _isolate.host_load
+
+    def host_load(host: str) -> dict:
+        if host == dead_host:
+            raise ConnectionError("unreachable")
+        return original_host_load(host)
+
+    monkeypatch.setattr(_isolate, "host_load", host_load)
+    router_mod.set_host_load_cache(live_host, _isolate.host_load(live_host))
 
     resp = client.get("/api/atlas-jobs/load")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["hosts"]["atlas-runner"]["status"] == "fresh"
-    assert data["hosts"]["hramatka"]["status"] == "unavailable"
-    assert data["hosts"]["hramatka"]["error"] == "unreachable"
+    assert data["hosts"][live_host]["status"] == "fresh"
+    assert data["hosts"][dead_host]["status"] == "unavailable"
+    assert data["hosts"][dead_host]["error"] == "unreachable"
     # Never zero-fill healthy metrics on unavailable host
-    assert "cpu_count" not in data["hosts"]["hramatka"]
-    assert "mem" not in data["hosts"]["hramatka"]
+    assert "cpu_count" not in data["hosts"][dead_host]
+    assert "mem" not in data["hosts"][dead_host]
+
+
+def test_load_endpoint_awaits_missing_expired_and_fresh_probes(
+    _isolate: atlas_job.FakeHostAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router_mod.clear_host_load_cache()
+    monkeypatch.setattr(router_mod, "_canonical_allowed_hosts", lambda: ["job-box", "teach-box"])
+    expired = _isolate.host_load("job-box")
+    expired["cpu_count"] = 1
+    router_mod.set_host_load_cache(
+        "job-box",
+        expired,
+        mono_ts=time.monotonic() - router_mod.HOST_LOAD_MAX_STALE_S - 1.0,
+    )
+
+    response = client.get("/api/atlas-jobs/load")
+    assert response.status_code == 200
+    hosts = response.json()["hosts"]
+    assert hosts["job-box"]["status"] == "fresh"
+    assert hosts["job-box"]["cpu_count"] == 4
+    assert hosts["teach-box"]["status"] == "fresh"
+    assert hosts["teach-box"]["cpu_count"] == 4
+
+    cached = _isolate.host_load("job-box")
+    cached["cpu_count"] = 1
+    router_mod.set_host_load_cache("job-box", cached)
+    fresh_response = client.get("/api/atlas-jobs/load?host=job-box&fresh=true")
+    assert fresh_response.status_code == 200
+    fresh_host = fresh_response.json()["hosts"]["job-box"]
+    assert fresh_host["status"] == "fresh"
+    assert fresh_host["cpu_count"] == 4
+
+
+def test_load_entry_awaits_an_inflight_probe(
+    _isolate: atlas_job.FakeHostAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router_mod.clear_host_load_cache()
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    calls = 0
+    original_host_load = _isolate.host_load
+
+    def host_load(host: str) -> dict:
+        nonlocal calls
+        calls += 1
+        probe_started.set()
+        assert release_probe.wait(timeout=1.0)
+        return original_host_load(host)
+
+    monkeypatch.setattr(_isolate, "host_load", host_load)
+
+    async def exercise() -> dict:
+        scheduled = router_mod._schedule_host_load_refresh("job-box")
+        assert scheduled is not None
+        assert await asyncio.to_thread(probe_started.wait, 1.0)
+
+        waiting_entry = asyncio.create_task(router_mod._get_host_load_entry_async("job-box"))
+        await asyncio.sleep(0)
+        assert not waiting_entry.done()
+
+        release_probe.set()
+        return await waiting_entry
+
+    try:
+        entry = asyncio.run(exercise())
+        assert calls == 1
+        assert entry["status"] == "fresh"
+        assert entry["cpu_count"] == 4
+    finally:
+        release_probe.set()
+        router_mod.clear_host_load_cache()
 
 
 def test_load_stale_while_revalidate_cache_lifecycle(

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -111,12 +111,56 @@ def test_occupancy_shape_uses_placeholders(tmp_path, monkeypatch) -> None:
         load_mod.clear_host_load_cache()
 
 
+def test_occupancy_awaits_missing_expired_and_fresh_load_probes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        load_mod.clear_host_load_cache()
+        expired = fake.host_load("job-box")
+        expired["cpu_count"] = 1
+        load_mod.set_host_load_cache(
+            "job-box",
+            expired,
+            mono_ts=time.monotonic() - load_mod.HOST_LOAD_MAX_STALE_S - 1.0,
+        )
+
+        resp = client.get("/api/occupancy")
+        assert resp.status_code == 200
+        hosts = resp.json()["hosts"]
+        assert hosts["host-job"]["status"] == "fresh"
+        assert hosts["host-job"]["cpu_count"] == 4
+        assert hosts["host-teacher"]["status"] == "fresh"
+        assert hosts["host-teacher"]["cpu_count"] == 4
+
+        cached = fake.host_load("job-box")
+        cached["cpu_count"] = 1
+        load_mod.set_host_load_cache("job-box", cached)
+        fresh_resp = client.get("/api/occupancy?host_id=host-job&fresh=true")
+        assert fresh_resp.status_code == 200
+        fresh_host = fresh_resp.json()["hosts"]["host-job"]
+        assert fresh_host["status"] == "fresh"
+        assert fresh_host["cpu_count"] == 4
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
 def test_occupancy_unavailable_has_no_metrics_or_ssh_text(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
     monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
     fake = atlas_job.FakeHostAdapter()
     atlas_job.set_host_adapter(fake)
     try:
+        original_host_load = fake.host_load
+
+        def host_load(host: str) -> dict:
+            if host == "teach-box":
+                raise ConnectionError("unreachable")
+            return original_host_load(host)
+
+        monkeypatch.setattr(fake, "host_load", host_load)
         load_mod.clear_host_load_cache()
         load_mod.set_host_load_cache("job-box", fake.host_load("job-box"))
         resp = client.get("/api/occupancy")


### PR DESCRIPTION
Fixes #7065

## Summary
- Await a shared host-load probe before responding when cache data is missing, expired, or explicitly refreshed.
- Preserve stale metrics in the allowed stale window while a refresh continues.
- Cover scheduled and in-flight probe behavior for both load and occupancy GETs.

## Verification
- Focused occupancy, load, and protocol tests: 80 passed.
- Monitor route-contract tests: 7 passed.
- Ruff check and targeted format check passed.

No merge or auto-merge has been armed. An independent cross-family exact-head review remains required before merge.