### PR TITLE
fix(routing): explain missing CodexBar host skip (#7066)

### DIFF
--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -141,17 +141,70 @@ function statusPill(status) {
   return `<span class="pill ${escapeHtml(cls)}">${escapeHtml(status || 'unknown')}</span>`;
 }
 
-function renderSummary(routing, usage, delegates) {
+const CODEXBAR_HOST_TOOLING_SKIP = {
+  warning: 'Host-tooling skip: CodexBar is not installed on this host; routing recommendation omitted.',
+  detail: 'CodexBar is not installed on this host, so the routing recommendation is omitted. This is a host-tooling skip, not an indication that routing data is empty; the lane tables remain available.'
+};
+
+function codexbarSnapshotIsMissingBinary(snapshot) {
+  const kind = String(
+    snapshot.error_kind || snapshot.failure_kind || snapshot.status || ''
+  ).toLowerCase();
+  const code = snapshot.error_code ?? snapshot.failure_code;
+  const details = [snapshot.auth_error, snapshot.failure_message, snapshot.message]
+    .filter(value => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+  return kind === 'missing_binary'
+    || Number(code) === 127
+    || /\b(?:codexbar\s+)?(?:cli\s+)?(?:binary\s+)?not found\b/.test(details);
+}
+
+function codexbarHostToolingMissing(routing) {
+  const agentRecords = Object.values(routing.agents || {})
+    .filter(agent => agent && typeof agent === 'object');
+  const snapshots = agentRecords.map(agent => agent.codexbar);
+  return snapshots.length > 0
+    && snapshots.every(snapshot => snapshot && typeof snapshot === 'object')
+    && snapshots.every(codexbarSnapshotIsMissingBinary);
+}
+
+function routingRecommendationDisplay(routing) {
   const rec = routing.recommendation || {};
-  const warnings = rec.warnings || [];
+  const hostToolingSkip = !rec.primary_agent_for_code && codexbarHostToolingMissing(routing);
+  const sourceWarnings = Array.isArray(rec.warnings) ? rec.warnings : [];
+  if (hostToolingSkip) {
+    return {
+      title: 'Routing Recommendation',
+      value: 'Skipped',
+      detail: CODEXBAR_HOST_TOOLING_SKIP.detail,
+      panelClass: 'warn',
+      warnings: [
+        CODEXBAR_HOST_TOOLING_SKIP.warning,
+        ...sourceWarnings.filter(warning => !String(warning).toLowerCase().includes('empty snapshot'))
+      ]
+    };
+  }
+  return {
+    title: 'Primary Agent',
+    value: rec.primary_agent_for_code || 'unknown',
+    detail: rec.rationale || '',
+    panelClass: 'ok',
+    warnings: sourceWarnings
+  };
+}
+
+function renderSummary(routing, usage, delegates) {
+  const recommendation = routingRecommendationDisplay(routing);
+  const warnings = recommendation.warnings;
   const active = Object.values(routing.in_flight || {}).reduce((sum, val) => sum + Number(val || 0), 0);
   const recentTasks = delegates.tasks || [];
   const recentDone = recentTasks.filter(task => task.status === 'done').length;
   document.getElementById('summary-grid').innerHTML = `
-    <div class="panel ok">
-      <h3>Primary Agent</h3>
-      <div class="value">${escapeHtml(rec.primary_agent_for_code || 'unknown')}</div>
-      <div class="sub">${escapeHtml(rec.rationale || '')}</div>
+    <div class="panel ${recommendation.panelClass}">
+      <h3>${escapeHtml(recommendation.title)}</h3>
+      <div class="value">${escapeHtml(recommendation.value)}</div>
+      <div class="sub">${escapeHtml(recommendation.detail)}</div>
     </div>
     <div class="panel info">
       <h3>In Flight</h3>

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -313,6 +313,52 @@ def test_routing_page_uses_live_monitor_sources():
     assert "Live routing budget" in html
 
 
+def test_routing_page_labels_missing_codexbar_as_host_tooling_skip():
+    html = (DASHBOARDS / "routing.html").read_text(encoding="utf-8")
+    start = html.index("const CODEXBAR_HOST_TOOLING_SKIP")
+    end = html.index("function renderSummary")
+    helpers = html[start:end]
+    script = f"""
+    {helpers}
+    const missingBinary = routingRecommendationDisplay({{
+      recommendation: {{
+        primary_agent_for_code: null,
+        rationale: 'Budget snapshot empty/absent',
+        warnings: ['empty snapshot — no recommendation emitted']
+      }},
+      agents: {{
+        codex: {{codexbar: {{error_kind: 'missing_binary', auth_error: 'CodexBar CLI binary not found'}}}}
+      }}
+    }});
+    const cliNotFound = routingRecommendationDisplay({{
+      recommendation: {{primary_agent_for_code: null, warnings: []}},
+      agents: {{
+        codex: {{codexbar: {{auth_error: 'CLI not found'}}}}
+      }}
+    }});
+    const nonBinaryFailure = routingRecommendationDisplay({{
+      recommendation: {{primary_agent_for_code: null, warnings: ['empty snapshot — no recommendation emitted']}},
+      agents: {{
+        codex: {{codexbar: {{error_kind: 'timeout', auth_error: 'CodexBar CLI timed out'}}}}
+      }}
+    }});
+    console.log(JSON.stringify({{missingBinary, cliNotFound, nonBinaryFailure}}));
+    """
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
+    output = json.loads(result.stdout)
+
+    assert output["missingBinary"]["title"] == "Routing Recommendation"
+    assert output["missingBinary"]["value"] == "Skipped"
+    assert "CodexBar is not installed on this host" in output["missingBinary"]["detail"]
+    assert "not an indication that routing data is empty" in output["missingBinary"]["detail"]
+    assert output["missingBinary"]["warnings"] == [
+        "Host-tooling skip: CodexBar is not installed on this host; routing recommendation omitted."
+    ]
+    assert output["cliNotFound"]["value"] == "Skipped"
+    assert output["nonBinaryFailure"]["value"] == "unknown"
+    assert output["nonBinaryFailure"]["warnings"] == ["empty snapshot — no recommendation emitted"]
+
+
 def test_shared_monitor_css_targets_unified_nav_classes():
     css = (DASHBOARDS / "monitor.css").read_text(encoding="utf-8")
     assert ".topbar .nav" not in css


### PR DESCRIPTION
Fixes #7066

## Summary

- Label a missing CodexBar binary as a host-tooling skip instead of an empty routing recommendation.
- Keep the budget, runtime-agent, and delegate tables visible.
- Cover `missing_binary`, equivalent CLI-not-found text, and non-binary telemetry failures.

## Verification

- `pytest tests/test_monitor_ui_contracts.py -q`
- `ruff check tests/test_monitor_ui_contracts.py`

Parent: #7061