### PR TITLE
fix(fleet): demote projection_missing context health to muted notice

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -58,6 +58,7 @@ button, input, select { font: inherit; }
 .context-actions a { border: 1px solid var(--border); border-radius: 3px; color: var(--accent); font-size: 11px; font-weight: 700; padding: 5px 7px; text-decoration: none; }
 .context-actions a:hover, .context-actions a:focus-visible { border-color: var(--accent); text-decoration: underline; }
 .context-failure { background: rgba(156, 40, 40, .08); border-left: 3px solid var(--red); color: var(--red); font-size: 12px; line-height: 1.45; margin: 0 16px 14px; padding: 9px 10px; }
+.context-muted { background: rgba(138, 131, 119, .08); border-left: 3px solid var(--gray); color: var(--text2); font-size: 12px; line-height: 1.45; margin: 0 16px 14px; padding: 9px 10px; }
 .operations-grid { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0 0 18px; }
 .legacy-diagnostics { background: rgba(168, 132, 43, .06); border: 1px solid var(--border); margin: 0 0 18px; }
 .legacy-diagnostics summary { cursor: pointer; font-family: Charter, Georgia, serif; font-size: 18px; font-weight: 700; padding: 13px 16px; }
@@ -324,7 +325,12 @@ function renderContextHealth(status) {
   const recall = objectValue(status.recall);
   const projection = objectValue(recall.projection);
   if (projection.available !== true) {
-    const reason = short(projection.reason || recall.reason, 'projection unavailable').replaceAll('_', ' ');
+    const rawReason = short(projection.reason || recall.reason, 'projection unavailable');
+    if (rawReason === 'projection_missing') {
+      target.innerHTML = '<div class="context-muted">Local context projection is not configured on this host. Canonical ACP and Fleet evidence remain authoritative.</div>';
+      return;
+    }
+    const reason = rawReason.replaceAll('_', ' ');
     target.innerHTML = `<div class="context-failure">Projection unavailable · ${escapeHtml(reason)}. Canonical ACP and Fleet evidence remain authoritative.</div>`;
     return;
   }
@@ -410,7 +416,12 @@ function renderConversationContext(conversationId, payload, relatedPayload) {
     return;
   }
   if (payload.available !== true) {
-    const reason = short(payload.reason, 'projection unavailable').replaceAll('_', ' ');
+    const rawReason = short(payload.reason, 'projection unavailable');
+    if (rawReason === 'projection_missing') {
+      target.innerHTML = '<div class="context-muted">Local context projection is not configured on this host. Canonical ACP and Fleet evidence remain authoritative.</div>';
+      return;
+    }
+    const reason = rawReason.replaceAll('_', ' ');
     target.innerHTML = `<div class="context-failure">Context projection failure · ${escapeHtml(reason)}. The ACP receipt remains authoritative.</div>`;
     return;
   }

--- a/tests/test_fleet_dashboard_contract.py
+++ b/tests/test_fleet_dashboard_contract.py
@@ -76,6 +76,21 @@ def test_fleet_page_exposes_body_free_context_and_safe_acp_navigation() -> None:
     assert 'method: "POST"' not in html
 
 
+def test_fleet_page_mutes_missing_local_projection_instead_of_flagging_failure() -> None:
+    html = (DASHBOARDS / "fleet.html").read_text(encoding="utf-8")
+
+    assert ".context-muted {" in html
+    assert "projection_missing" in html
+    assert (
+        "Local context projection is not configured on this host. "
+        "Canonical ACP and Fleet evidence remain authoritative."
+    ) in html
+    # Genuine projection failures keep the red failure treatment.
+    assert "projection_request_failed" in html
+    assert '<div class="context-failure">Projection unavailable' in html
+    assert '<div class="context-failure">Context projection failure' in html
+
+
 def test_fleet_routes_are_registered_get_only_and_contracted() -> None:
     observer_app = FastAPI()
     observer_app.include_router(fleet_router, prefix="/api/fleet")


### PR DESCRIPTION
Closes #7064.

GET entire-context health returns `projection_missing` when the local sqlite projection is absent — normal on hosts without a configured projection, not a broken one. `dashboards/fleet.html` was treating any `projection.available !== true` as a red `.context-failure`.

Changes:
- Add `.context-muted` style next to `.context-failure`.
- `renderContextHealth`: raw reason `projection_missing` renders a muted notice ("Local context projection is not configured on this host. Canonical ACP and Fleet evidence remain authoritative.") and returns early; `projection_unreadable` / `projection_request_failed` / others keep the red failure.
- `renderConversationContext`: same muted branch in the `payload.available !== true` block; "no verified locator" and omission failure blocks unchanged.
- Contract test asserts `.context-muted` and the muted copy exist, and keeps the failure-copy assertions.

No changes to `scripts/api/entire_context_router.py`, occupancy, or Entire installation.

Verification: `.venv/bin/python -m pytest tests/test_fleet_dashboard_contract.py tests/test_monitor_ui_contracts.py -q` — 31 passed; ruff check/format clean.

X-Agent: kimi/fleet-panel-7064