### PR TITLE
feat(dispatch): forward notebook workers to VPS with notebook fallback

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4541,34 +4541,35 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"❌ invalid --initiator: {exc}", file=sys.stderr)
         return 2
 
-    placement, reason, host_id = decide_dispatch_placement(repo_root=_REPO_ROOT)
-    if placement == "vps" and host_id:
-        print(f"→ forwarding dispatch to {host_id}", file=sys.stderr)
-        forward_error: BaseException | None = None
-        forward_rc: int | None = None
-        try:
-            forward_rc = forward_dispatch(
-                host_id=host_id,
-                argv=sys.argv,
-                initiator=attribution.initiator,
-                initiator_source=attribution.source,
+    if not bool(getattr(args, "dry_run", False)):
+        placement, reason, host_id = decide_dispatch_placement(repo_root=_REPO_ROOT)
+        if placement == "vps" and host_id:
+            print(f"→ forwarding dispatch to {host_id}", file=sys.stderr)
+            forward_error: BaseException | None = None
+            forward_rc: int | None = None
+            try:
+                forward_rc = forward_dispatch(
+                    host_id=host_id,
+                    argv=sys.argv,
+                    initiator=attribution.initiator,
+                    initiator_source=attribution.source,
+                )
+            except SshTransportError as exc:
+                forward_error = exc
+            except (ValueError, FileNotFoundError, OSError) as exc:
+                forward_error = exc
+            if not notebook_fallback_after_forward(forward_rc, error=forward_error):
+                if forward_error is not None:
+                    print(f"❌ VPS forward failed: {forward_error}", file=sys.stderr)
+                    return 2
+                return int(forward_rc or 0)
+            why = str(forward_error) if forward_error is not None else f"ssh rc {forward_rc}"
+            print(
+                f"⚠️  VPS forward failed ({why}); spawning on notebook",
+                file=sys.stderr,
             )
-        except SshTransportError as exc:
-            forward_error = exc
-        except (ValueError, FileNotFoundError, OSError) as exc:
-            forward_error = exc
-        if not notebook_fallback_after_forward(forward_rc, error=forward_error):
-            if forward_error is not None:
-                print(f"❌ VPS forward failed: {forward_error}", file=sys.stderr)
-                return 2
-            return int(forward_rc or 0)
-        why = str(forward_error) if forward_error is not None else f"ssh rc {forward_rc}"
-        print(
-            f"⚠️  VPS forward failed ({why}); spawning on notebook",
-            file=sys.stderr,
-        )
-    elif reason in {"unavailable", "full"}:
-        print(f"⚠️  every VPS worker host is {reason}; spawning on notebook", file=sys.stderr)
+        elif reason in {"unavailable", "full"}:
+            print(f"⚠️  every VPS worker host is {reason}; spawning on notebook", file=sys.stderr)
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     from agent_runtime.agent_identity import resolve_retired_agent_alias
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4540,6 +4540,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         except (ValueError, FileNotFoundError, OSError) as exc:
             forward_error = exc
         if not notebook_fallback_after_forward(forward_rc, error=forward_error):
+            if forward_error is not None:
+                print(f"❌ VPS forward failed: {forward_error}", file=sys.stderr)
+                return 2
             return int(forward_rc or 0)
         why = str(forward_error) if forward_error is not None else f"ssh rc {forward_rc}"
         print(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4524,6 +4524,30 @@ def _run_worker(
 
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
+    from scripts.orchestration.job_host_exec import (
+        decide_dispatch_placement,
+        forward_dispatch,
+        notebook_fallback_after_forward,
+    )
+
+    placement, reason, host_id = decide_dispatch_placement(repo_root=_REPO_ROOT)
+    if placement == "vps" and host_id:
+        print(f"→ forwarding dispatch to {host_id}", file=sys.stderr)
+        forward_error: BaseException | None = None
+        forward_rc: int | None = None
+        try:
+            forward_rc = forward_dispatch(host_id=host_id, argv=sys.argv)
+        except (ValueError, FileNotFoundError, OSError) as exc:
+            forward_error = exc
+        if not notebook_fallback_after_forward(forward_rc, error=forward_error):
+            return int(forward_rc or 0)
+        why = str(forward_error) if forward_error is not None else f"ssh rc {forward_rc}"
+        print(
+            f"⚠️  VPS forward failed ({why}); spawning on notebook",
+            file=sys.stderr,
+        )
+    elif reason in {"unavailable", "full"}:
+        print(f"⚠️  every VPS worker host is {reason}; spawning on notebook", file=sys.stderr)
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     from agent_runtime.agent_identity import resolve_retired_agent_alias
     from agent_runtime.attribution import resolve_invocation_attribution

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4525,6 +4525,7 @@ def _run_worker(
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
     from scripts.orchestration.job_host_exec import (
+        SshTransportError,
         decide_dispatch_placement,
         forward_dispatch,
         notebook_fallback_after_forward,
@@ -4537,6 +4538,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         forward_rc: int | None = None
         try:
             forward_rc = forward_dispatch(host_id=host_id, argv=sys.argv)
+        except SshTransportError as exc:
+            forward_error = exc
         except (ValueError, FileNotFoundError, OSError) as exc:
             forward_error = exc
         if not notebook_fallback_after_forward(forward_rc, error=forward_error):

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -4524,6 +4524,7 @@ def _run_worker(
 
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
+    from scripts.agent_runtime.attribution import resolve_invocation_attribution
     from scripts.orchestration.job_host_exec import (
         SshTransportError,
         decide_dispatch_placement,
@@ -4531,13 +4532,27 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         notebook_fallback_after_forward,
     )
 
+    try:
+        attribution = resolve_invocation_attribution(
+            explicit=getattr(args, "initiator", None),
+            task_id=args.task_id,
+        )
+    except ValueError as exc:
+        print(f"❌ invalid --initiator: {exc}", file=sys.stderr)
+        return 2
+
     placement, reason, host_id = decide_dispatch_placement(repo_root=_REPO_ROOT)
     if placement == "vps" and host_id:
         print(f"→ forwarding dispatch to {host_id}", file=sys.stderr)
         forward_error: BaseException | None = None
         forward_rc: int | None = None
         try:
-            forward_rc = forward_dispatch(host_id=host_id, argv=sys.argv)
+            forward_rc = forward_dispatch(
+                host_id=host_id,
+                argv=sys.argv,
+                initiator=attribution.initiator,
+                initiator_source=attribution.source,
+            )
         except SshTransportError as exc:
             forward_error = exc
         except (ValueError, FileNotFoundError, OSError) as exc:
@@ -4556,7 +4571,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"⚠️  every VPS worker host is {reason}; spawning on notebook", file=sys.stderr)
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     from agent_runtime.agent_identity import resolve_retired_agent_alias
-    from agent_runtime.attribution import resolve_invocation_attribution
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
 
     task_id = args.task_id
@@ -4564,14 +4578,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         _validate_dispatch_effort(args.agent, getattr(args, "effort", None))
     except ValueError as exc:
         print(f"❌ {exc}", file=sys.stderr)
-        return 2
-    try:
-        attribution = resolve_invocation_attribution(
-            explicit=getattr(args, "initiator", None),
-            task_id=task_id,
-        )
-    except ValueError as exc:
-        print(f"❌ invalid --initiator: {exc}", file=sys.stderr)
         return 2
     try:
         requested_harness = _resolve_dispatch_harness(args.agent, getattr(args, "harness", None))

--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -106,3 +106,21 @@ fleet_comms_print_banner_line() {
       ;;
   esac
 }
+
+# Prefer the tunneled job-host Monitor. If it is down, warn and continue on the
+# notebook — never start a second Mac Monitor, never lift the retired sqlite.
+fleet_comms_warn_if_plane_unreachable() {
+  local root="${PROJECT_DIR:-${LC_ROOT:-.}}"
+  local py=""
+  if [ "${LU_SKIP_PLANE_TUNNEL_CHECK:-}" = "1" ]; then
+    return 0
+  fi
+  if ! py="$(fleet_comms_resolve_python "$root")"; then
+    echo "⚠️  plane fallback: no project interpreter; starting on notebook." >&2
+    return 0
+  fi
+  (
+    cd "$root" || exit 0
+    "$py" -m scripts.orchestration.plane_tunnel_gate
+  ) || true
+}

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -564,6 +564,12 @@ launcher_main() {
   launcher_adapter_validate
   launcher_adapter_preflight
 
+  if [ "$LC_DRY_RUN" != "1" ]; then
+    if declare -F fleet_comms_warn_if_plane_unreachable >/dev/null 2>&1; then
+      fleet_comms_warn_if_plane_unreachable
+    fi
+  fi
+
   # Agent-extensions staleness gate (restored from the pre-cutover
   # start-claude.sh, now for EVERY provider): a session launched against stale
   # deployed hooks/rules runs retired definitions — refuse rather than launch.

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -70,6 +70,7 @@ PlacementReason = Literal[
     "available",
 ]
 _COPY_FILE_FLAGS = {
+    "--prompt-file": "prompt",
     "--lifecycle-file": "lifecycle",
     "--output-schema": "output-schema",
 }
@@ -335,18 +336,24 @@ def _remote_payload_preamble(kind: str, contents: bytes) -> tuple[str, str]:
     return preamble, remote_path
 
 
-def materialize_local_dispatch_argv(argv: list[str]) -> tuple[list[str], bytes | None, str | None]:
+def materialize_local_dispatch_argv(
+    argv: list[str],
+    *,
+    stdin_body: bytes | None = None,
+) -> tuple[list[str], bytes | None, str | None]:
     """Rewrite notebook-only paths so SSH does not send Darwin paths.
 
-    ``--prompt-file`` becomes ``--prompt -`` with the body on SSH stdin.
-    File payloads (``--lifecycle-file``, ``--output-schema``) are written to
-    content-addressed ``/tmp`` files on the remote host via a base64 preamble.
+    File payloads (``--prompt-file``, ``--lifecycle-file``, ``--output-schema``)
+    are written to content-addressed ``/tmp`` files on the remote host via a
+    base64 preamble so remote argparse still sees a real file (sparse-checkout
+    inference reads ``--prompt-file`` before stdin).
+    ``--prompt -`` is rewritten to a remote ``--prompt-file`` after the notebook
+    stdin body is captured.
     ``--cwd`` is rejected: a Darwin working directory is not a VPS checkout.
     A notebook ``--worktree PATH`` is rewritten to bare ``--worktree`` so the
     remote checkout creates its own isolation.
     """
     out: list[str] = []
-    stdin: bytes | None = None
     preambles: list[str] = []
     i = 0
     while i < len(argv):
@@ -357,10 +364,19 @@ def materialize_local_dispatch_argv(argv: list[str]) -> tuple[list[str], bytes |
                 "to a VPS worker; omit --cwd or pass --worktree so the remote "
                 "checkout isolates itself"
             )
-        prompt_path, next_i = _flag_value(argv, i, "--prompt-file")
-        if prompt_path is not None:
-            stdin = Path(prompt_path).read_text(encoding="utf-8").encode("utf-8")
-            out.extend(["--prompt", "-"])
+        prompt_val, next_i = _flag_value(argv, i, "--prompt")
+        if prompt_val is not None:
+            if prompt_val == "-":
+                if stdin_body is None:
+                    raise ValueError(
+                        "--prompt - cannot be forwarded without the prompt body; "
+                        "pass --prompt-file"
+                    )
+                preamble, remote_path = _remote_payload_preamble("prompt", stdin_body)
+                preambles.append(preamble)
+                out.extend(["--prompt-file", remote_path])
+            else:
+                out.extend(["--prompt", prompt_val])
             i = next_i
             continue
         copied = False
@@ -387,7 +403,7 @@ def materialize_local_dispatch_argv(argv: list[str]) -> tuple[list[str], bytes |
             continue
         out.append(argv[i])
         i += 1
-    return out, stdin, ("; ".join(preambles) if preambles else None)
+    return out, None, ("; ".join(preambles) if preambles else None)
 
 
 def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
@@ -422,7 +438,16 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
         raise ValueError("dispatch argv is empty")
     alias = ssh_alias_for_host_id(host_id)
     repo = repo_for_host_id(host_id)
-    rest, stdin, preamble = materialize_local_dispatch_argv(list(argv[1:]))
+    payload = list(argv[1:])
+    stdin_body: bytes | None = None
+    idx = 0
+    while idx < len(payload):
+        prompt_val, next_idx = _flag_value(payload, idx, "--prompt")
+        if prompt_val == "-":
+            stdin_body = sys.stdin.buffer.read()
+            break
+        idx = next_idx if prompt_val is not None else idx + 1
+    rest, _stdin, preamble = materialize_local_dispatch_argv(payload, stdin_body=stdin_body)
     extra_exports = [f"export {ENV_ALLOW_NOTEBOOK}=1"]
     if preamble:
         extra_exports.append(preamble)
@@ -435,7 +460,6 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
         completed = subprocess.run(
             build_ssh_argv(alias, remote),
             check=False,
-            input=stdin,
         )
     except (FileNotFoundError, PermissionError) as exc:
         raise SshTransportError(str(exc)) from exc

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -34,6 +34,10 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Literal
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from scripts.fleet_comms.paths import RETIRED_LOCAL_MARKER
 from scripts.guardrails.worktree_containment import resolve_main_root
 

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -297,14 +297,6 @@ def decide_dispatch_placement(
     return "notebook", capacity, None
 
 
-def notebook_dispatch_blocked(*, repo_root: Path | None = None, occupancy: Any = _MISSING) -> str | None:
-    """Return an error when this checkout must not spawn Darwin workers."""
-    placement, _reason, host_id = decide_dispatch_placement(repo_root=repo_root, occupancy=occupancy)
-    if placement == "vps":
-        return notebook_block_message(host_id=host_id)
-    return None
-
-
 def build_remote_command(
     argv: list[str],
     *,
@@ -339,28 +331,24 @@ def _flag_value(argv: list[str], index: int, flag: str) -> tuple[str | None, int
     return None, index
 
 
-def _remote_payload_preamble(kind: str, contents: bytes, *, seq: int) -> tuple[str, str]:
+def _remote_payload_binding(kind: str, *, seq: int) -> tuple[str, str]:
+    """Return the remote variable and argv token for one private payload."""
     ident = kind.replace("-", "_")
     var = f"LU_DISPATCH_{ident.upper()}_{seq}"
-    encoded = base64.b64encode(contents).decode("ascii")
-    preamble = (
-        f"umask 077 && {var}=$(mktemp /tmp/lu-dispatch-{kind}.XXXXXX) && "
-        f"printf '%s' {shlex.quote(encoded)} | base64 -d > \"${var}\""
-    )
-    return preamble, f"{_REMOTE_VAR_PREFIX}{var}"
+    return var, f"{_REMOTE_VAR_PREFIX}{var}"
 
 
 def materialize_local_dispatch_argv(
     argv: list[str],
     *,
     stdin_body: bytes | None = None,
-) -> tuple[list[str], bytes | None, str | None]:
+) -> tuple[list[str], list[tuple[str, str, bytes]]]:
     """Rewrite notebook-only paths so SSH does not send Darwin paths.
 
     File payloads (``--prompt-file``, ``--lifecycle-file``, ``--output-schema``)
-    are written to unique private ``mktemp`` files on the remote host via a
-    fail-closed base64 preamble so remote argparse still sees a real file
-    (sparse-checkout inference reads ``--prompt-file`` before stdin).
+    are written to unique private ``mktemp`` files by a remote stdin script,
+    so remote argparse still sees a real file (sparse-checkout inference reads
+    ``--prompt-file`` before stdin). The script has EXIT/signal cleanup traps.
     ``--prompt -`` is rewritten to a remote ``--prompt-file`` after the notebook
     stdin body is captured.
     ``--cwd`` is rejected: a Darwin working directory is not a VPS checkout.
@@ -368,7 +356,7 @@ def materialize_local_dispatch_argv(
     remote checkout creates its own isolation.
     """
     out: list[str] = []
-    preambles: list[str] = []
+    payloads: list[tuple[str, str, bytes]] = []
     seq = 0
     i = 0
     while i < len(argv):
@@ -387,9 +375,9 @@ def materialize_local_dispatch_argv(
                         "--prompt - cannot be forwarded without the prompt body; "
                         "pass --prompt-file"
                     )
-                preamble, remote_path = _remote_payload_preamble("prompt", stdin_body, seq=seq)
+                var, remote_path = _remote_payload_binding("prompt", seq=seq)
                 seq += 1
-                preambles.append(preamble)
+                payloads.append((var, "prompt", stdin_body))
                 out.extend(["--prompt-file", remote_path])
             else:
                 out.extend(["--prompt", prompt_val])
@@ -401,9 +389,9 @@ def materialize_local_dispatch_argv(
             if file_path is None:
                 continue
             body = Path(file_path).read_bytes()
-            preamble, remote_path = _remote_payload_preamble(kind, body, seq=seq)
+            var, remote_path = _remote_payload_binding(kind, seq=seq)
             seq += 1
-            preambles.append(preamble)
+            payloads.append((var, kind, body))
             out.extend([flag, remote_path])
             i = next_i
             copied = True
@@ -420,13 +408,68 @@ def materialize_local_dispatch_argv(
             continue
         out.append(argv[i])
         i += 1
-    return out, None, (" && ".join(preambles) if preambles else None)
+    return out, payloads
 
 
-def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
-    """Rewrite local ``--prompt-file`` to ``--prompt -`` so SSH can carry the body."""
-    rest, stdin, _preamble = materialize_local_dispatch_argv(argv)
-    return rest, stdin
+def _build_remote_dispatch_script(
+    *,
+    argv: list[str],
+    remote_repo: str,
+    payloads: list[tuple[str, str, bytes]],
+    extra_exports: list[str],
+) -> bytes:
+    """Build the SSH-stdin bash program for a forwarded dispatch.
+
+    Private content intentionally appears only in this stdin body, never in
+    the local ``ssh`` argv. Remote files are 0600 under ``umask 077`` and an
+    EXIT/signal cleanup trap covers normal completion, failure, HUP, INT, and
+    TERM. Cleanup failure turns a successful dispatch into failure so residue
+    is never silently accepted.
+    """
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "payload_paths=()",
+        "_cleanup() {",
+        "  local status=$1",
+        '  if ((${#payload_paths[@]})) && ! rm -f -- "${payload_paths[@]}"; then',
+        '    [ "$status" -eq 0 ] && status=1',
+        "  fi",
+        '  exit "$status"',
+        "}",
+        "_on_exit() {",
+        "  local status=$?",
+        "  trap - EXIT HUP INT TERM",
+        '  _cleanup "$status"',
+        "}",
+        "_on_signal() {",
+        "  local signal=$1",
+        "  trap - EXIT HUP INT TERM",
+        '  _cleanup "$((128 + signal))"',
+        "}",
+        "trap _on_exit EXIT",
+        "trap '_on_signal 1' HUP",
+        "trap '_on_signal 2' INT",
+        "trap '_on_signal 15' TERM",
+        "umask 077",
+    ]
+    for var, kind, contents in payloads:
+        encoded = base64.b64encode(contents).decode("ascii")
+        lines.extend(
+            [
+                f"{var}=$(mktemp /tmp/lu-dispatch-{kind}.XXXXXX)",
+                f'payload_paths+=("${var}")',
+                f"printf '%s' {shlex.quote(encoded)} | base64 -d > \"${var}\"",
+            ]
+        )
+    lines.append(
+        build_remote_command(
+            [".venv/bin/python", "scripts/delegate.py", *argv],
+            remote_repo=remote_repo,
+            extra_exports=extra_exports,
+        )
+    )
+    return ("\n".join(lines) + "\n").encode("utf-8")
 
 
 def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | None = None) -> bool:
@@ -471,7 +514,7 @@ def forward_dispatch(
             stdin_body = sys.stdin.buffer.read()
             break
         idx = next_idx if prompt_val is not None else idx + 1
-    rest, _stdin, preamble = materialize_local_dispatch_argv(payload, stdin_body=stdin_body)
+    rest, payloads = materialize_local_dispatch_argv(payload, stdin_body=stdin_body)
     has_initiator = False
     scan = 0
     while scan < len(rest):
@@ -486,17 +529,17 @@ def forward_dispatch(
     if initiator and initiator_source and initiator_source != "unknown":
         extra_exports.append(f"export {ENV_RUNTIME_INITIATOR}={shlex.quote(initiator)}")
         extra_exports.append(f"export {ENV_RUNTIME_INITIATOR_SOURCE}={shlex.quote(initiator_source)}")
-    if preamble:
-        extra_exports.append(preamble)
-    remote = build_remote_command(
-        [".venv/bin/python", "scripts/delegate.py", *rest],
+    remote_script = _build_remote_dispatch_script(
+        argv=rest,
         remote_repo=repo,
         extra_exports=extra_exports,
+        payloads=payloads,
     )
     try:
         completed = subprocess.run(
-            build_ssh_argv(alias, remote),
+            build_ssh_argv(alias, "bash -s"),
             check=False,
+            input=remote_script,
         )
     except (FileNotFoundError, PermissionError) as exc:
         raise SshTransportError(str(exc)) from exc

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -69,6 +69,14 @@ PlacementReason = Literal[
     "full",
     "available",
 ]
+_COPY_FILE_FLAGS = {
+    "--lifecycle-file": "lifecycle",
+    "--output-schema": "output-schema",
+}
+
+
+class SshTransportError(OSError):
+    """Raised when the local ssh client cannot be started."""
 
 
 def notebook_block_message(*, host_id: str | None = None) -> str:
@@ -331,27 +339,51 @@ def materialize_local_dispatch_argv(argv: list[str]) -> tuple[list[str], bytes |
     """Rewrite notebook-only paths so SSH does not send Darwin paths.
 
     ``--prompt-file`` becomes ``--prompt -`` with the body on SSH stdin.
-    ``--lifecycle-file`` is written to a content-addressed ``/tmp`` file on
-    the remote host via a base64 preamble.
+    File payloads (``--lifecycle-file``, ``--output-schema``) are written to
+    content-addressed ``/tmp`` files on the remote host via a base64 preamble.
+    ``--cwd`` is rejected: a Darwin working directory is not a VPS checkout.
+    A notebook ``--worktree PATH`` is rewritten to bare ``--worktree`` so the
+    remote checkout creates its own isolation.
     """
     out: list[str] = []
     stdin: bytes | None = None
     preambles: list[str] = []
     i = 0
     while i < len(argv):
+        cwd_path, next_i = _flag_value(argv, i, "--cwd")
+        if cwd_path is not None:
+            raise ValueError(
+                f"--cwd {cwd_path!r} is a notebook path and cannot be forwarded "
+                "to a VPS worker; omit --cwd or pass --worktree so the remote "
+                "checkout isolates itself"
+            )
         prompt_path, next_i = _flag_value(argv, i, "--prompt-file")
         if prompt_path is not None:
             stdin = Path(prompt_path).read_text(encoding="utf-8").encode("utf-8")
             out.extend(["--prompt", "-"])
             i = next_i
             continue
-        lifecycle_path, next_i = _flag_value(argv, i, "--lifecycle-file")
-        if lifecycle_path is not None:
-            body = Path(lifecycle_path).read_bytes()
-            preamble, remote_path = _remote_payload_preamble("lifecycle", body)
+        copied = False
+        for flag, kind in _COPY_FILE_FLAGS.items():
+            file_path, next_i = _flag_value(argv, i, flag)
+            if file_path is None:
+                continue
+            body = Path(file_path).read_bytes()
+            preamble, remote_path = _remote_payload_preamble(kind, body)
             preambles.append(preamble)
-            out.extend(["--lifecycle-file", remote_path])
+            out.extend([flag, remote_path])
             i = next_i
+            copied = True
+            break
+        if copied:
+            continue
+        if argv[i] == "--worktree" and i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+            out.append("--worktree")
+            i += 2
+            continue
+        if argv[i].startswith("--worktree="):
+            out.append("--worktree")
+            i += 1
             continue
         out.append(argv[i])
         i += 1
@@ -368,22 +400,15 @@ def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | No
     """True only for SSH transport failure, so the notebook may spawn.
 
     Occupancy miss/full is decided before forward. Payload errors
-    (missing ``--prompt-file`` / ``--lifecycle-file``, bad host config)
-    must fail closed — they are not a reason to spawn on Darwin.
+    (missing local files, ``--cwd``, bad host config) must fail closed —
+    they are not a reason to spawn on Darwin. Missing ``ssh`` is classified
+    by ``SshTransportError`` from the exec site, not by filename basename.
     """
-    if error is None:
-        return rc == 255
-    if isinstance(error, FileNotFoundError):
-        names = []
-        if error.filename:
-            names.append(os.fsdecode(error.filename))
-        for arg in error.args:
-            if isinstance(arg, bytes):
-                names.append(os.fsdecode(arg))
-            elif isinstance(arg, str):
-                names.append(arg)
-        return any(Path(name).name == "ssh" for name in names if name)
-    return False
+    if isinstance(error, SshTransportError):
+        return True
+    if error is not None:
+        return False
+    return rc == 255
 
 
 def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
@@ -405,11 +430,14 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
         remote_repo=repo,
         extra_exports=extra_exports,
     )
-    completed = subprocess.run(
-        build_ssh_argv(alias, remote),
-        check=False,
-        input=stdin,
-    )
+    try:
+        completed = subprocess.run(
+            build_ssh_argv(alias, remote),
+            check=False,
+            input=stdin,
+        )
+    except FileNotFoundError as exc:
+        raise SshTransportError(str(exc)) from exc
     return int(completed.returncode)
 
 

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -44,6 +44,8 @@ ENV_DISPATCH_SSH = "LU_DISPATCH_SSH"
 ENV_REPO = "LU_JOB_REPO"
 ENV_TEACHER_REPO = "LU_TEACHER_REPO"
 ENV_ALLOW_NOTEBOOK = "LU_ALLOW_NOTEBOOK_DISPATCH"
+ENV_RUNTIME_INITIATOR = "LU_RUNTIME_INITIATOR"
+ENV_RUNTIME_INITIATOR_SOURCE = "LU_RUNTIME_INITIATOR_SOURCE"
 ENV_OCCUPANCY_HOST = "LU_JOB_OCCUPANCY_HOST_ID"
 ENV_MEM_FULL = "LU_JOB_MEM_FULL_PCT"
 ENV_DISK_FULL = "LU_JOB_DISK_FULL_PCT"
@@ -443,11 +445,18 @@ def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | No
     return rc == 255
 
 
-def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
+def forward_dispatch(
+    *,
+    host_id: str,
+    argv: list[str],
+    initiator: str | None = None,
+    initiator_source: str | None = None,
+) -> int:
     """SSH a notebook ``delegate.py dispatch`` onto the chosen VPS and spawn there.
 
     Remote spawn sets ``LU_ALLOW_NOTEBOOK_DISPATCH=1`` so the worker checkout
-    does not try to forward again.
+    does not try to forward again. Session-derived initiator identity is
+    exported so the remote worker does not record ``unknown``.
     """
     if len(argv) < 2:
         raise ValueError("dispatch argv is empty")
@@ -463,7 +472,20 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
             break
         idx = next_idx if prompt_val is not None else idx + 1
     rest, _stdin, preamble = materialize_local_dispatch_argv(payload, stdin_body=stdin_body)
+    has_initiator = False
+    scan = 0
+    while scan < len(rest):
+        value, next_scan = _flag_value(rest, scan, "--initiator")
+        if value is not None:
+            has_initiator = True
+            break
+        scan = next_scan if value is not None else scan + 1
+    if initiator and not has_initiator:
+        rest.extend(["--initiator", initiator])
     extra_exports = [f"export {ENV_ALLOW_NOTEBOOK}=1"]
+    if initiator and initiator_source and initiator_source != "unknown":
+        extra_exports.append(f"export {ENV_RUNTIME_INITIATOR}={shlex.quote(initiator)}")
+        extra_exports.append(f"export {ENV_RUNTIME_INITIATOR_SOURCE}={shlex.quote(initiator_source)}")
     if preamble:
         extra_exports.append(preamble)
     remote = build_remote_command(

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -82,18 +82,6 @@ class SshTransportError(OSError):
     """Raised when the local ssh client cannot be started."""
 
 
-def notebook_block_message(*, host_id: str | None = None) -> str:
-    where = f" ({host_id})" if host_id else ""
-    return (
-        f"a VPS worker host{where} is available; spawn workers there. "
-        f"Run: {ENV_DISPATCH_SSH}=<opaque=alias,...> {ENV_REPO}=<remote-checkout> "
-        ".venv/bin/python scripts/orchestration/job_host_exec.py -- "
-        ".venv/bin/python scripts/delegate.py dispatch ... "
-        "Notebook spawn is allowed only when every VPS worker host is "
-        f"unavailable or full (or {ENV_ALLOW_NOTEBOOK}=1)."
-    )
-
-
 def job_dispatch_host() -> str:
     return (
         os.environ.get(ENV_HOST, "").strip()
@@ -257,19 +245,6 @@ def pick_worker_host(payload: dict[str, Any] | None) -> tuple[str | None, Litera
     if saw_full:
         return None, "full"
     return None, "unavailable"
-
-
-def classify_worker_host(payload: dict[str, Any] | None, *, host_id: str | None = None) -> Literal["available", "unavailable", "full"]:
-    """Classify one occupancy host, or the picked pool host when ``host_id`` is omitted."""
-    if host_id is not None:
-        if not isinstance(payload, dict):
-            return "unavailable"
-        hosts = payload.get("hosts")
-        if not isinstance(hosts, dict):
-            return "unavailable"
-        return classify_host_entry(hosts.get(host_id) if isinstance(hosts.get(host_id), dict) else None)
-    _picked, state = pick_worker_host(payload)
-    return state
 
 
 def decide_dispatch_placement(

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -633,8 +633,31 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
         dispatch_argv = _delegate_dispatch_argv(remote_argv)
         if dispatch_argv is not None:
+            from scripts.agent_runtime.attribution import resolve_invocation_attribution
+
+            explicit = None
+            task_id = None
+            idx = 0
+            while idx < len(dispatch_argv):
+                value, nxt = _flag_value(dispatch_argv, idx, "--initiator")
+                if value is not None:
+                    explicit = value
+                    idx = nxt
+                    continue
+                value, nxt = _flag_value(dispatch_argv, idx, "--task-id")
+                if value is not None:
+                    task_id = value
+                    idx = nxt
+                    continue
+                idx += 1
+            attribution = resolve_invocation_attribution(explicit=explicit, task_id=task_id)
             try:
-                return forward_dispatch(host_id=host_id, argv=dispatch_argv)
+                return forward_dispatch(
+                    host_id=host_id,
+                    argv=dispatch_argv,
+                    initiator=attribution.initiator,
+                    initiator_source=attribution.source,
+                )
             except SshTransportError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 255

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -478,9 +478,47 @@ def build_ssh_argv(host: str, remote_command: str) -> list[str]:
     ]
 
 
-def main(argv: list[str] | None = None) -> int:
+def _delegate_dispatch_argv(remote_argv: list[str]) -> list[str] | None:
+    """Return ``[scripts/delegate.py, dispatch, ...]`` when this is a dispatch."""
+    try:
+        idx = remote_argv.index("scripts/delegate.py")
+    except ValueError:
+        return None
+    rest = remote_argv[idx:]
+    if len(rest) < 2 or rest[1] != "dispatch":
+        return None
+    return rest
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Execute a command on a VPS worker checkout (BatchMode SSH)."
+        prog="job_host_exec.py",
+        description=(
+            "Execute a command on a VPS worker checkout over BatchMode SSH.\n"
+            "Use it to place long Python jobs and agent dispatches on occupancy "
+            "hosts; do not use it to start a second Monitor or reopen retired Mac sqlite."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/orchestration/job_host_exec.py -- "
+            ".venv/bin/python scripts/delegate.py dispatch --agent codex "
+            "--task-id review-123 --prompt-file brief.md --mode read-only\n"
+            "  .venv/bin/python scripts/orchestration/job_host_exec.py "
+            "--host-id host-job -- .venv/bin/python -m pytest tests/orchestration/test_job_host_exec.py\n\n"
+            "Outputs:\n"
+            "  Runs the remote command in the occupancy checkout. Dispatch argv "
+            "is rewritten so notebook --prompt-file/--lifecycle-file/--output-schema "
+            "bodies land in remote /tmp and LU_ALLOW_NOTEBOOK_DISPATCH=1 prevents "
+            "a second forward hop.\n\n"
+            "Exit codes:\n"
+            "  0 on successful remote completion; 2 on CLI misuse or missing host; "
+            "255 on SSH transport failure; other codes are the remote command.\n\n"
+            "Related:\n"
+            "  Occupancy: GET /api/occupancy\n"
+            "  Dispatch: scripts/delegate.py\n"
+            "  Issue: #7062\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--host-id",
@@ -492,6 +530,11 @@ def main(argv: list[str] | None = None) -> int:
         nargs=argparse.REMAINDER,
         help="Command to run after -- on the remote checkout",
     )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
     args = parser.parse_args(argv)
     remote_argv = list(args.remote_argv)
     if remote_argv and remote_argv[0] == "--":
@@ -506,10 +549,13 @@ def main(argv: list[str] | None = None) -> int:
             if capacity != "available" or not host_id:
                 print(f"error: no VPS worker host available ({capacity})", file=sys.stderr)
                 return 2
+        dispatch_argv = _delegate_dispatch_argv(remote_argv)
+        if dispatch_argv is not None:
+            return forward_dispatch(host_id=host_id, argv=dispatch_argv)
         alias = ssh_alias_for_host_id(host_id)
         repo = repo_for_host_id(host_id)
         ssh_argv = build_ssh_argv(alias, build_remote_command(remote_argv, remote_repo=repo))
-    except ValueError as exc:
+    except (ValueError, FileNotFoundError, PermissionError, SshTransportError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     completed = subprocess.run(ssh_argv, check=False)

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Run a command on a VPS worker checkout over BatchMode SSH.
+
+Notebook orchestrators keep talking to tunneled ``127.0.0.1`` APIs. Both
+occupancy hosts are the worker pool: agent CLIs and long Python jobs run
+on either box. The job host also holds Monitor and fleet-comms. The
+teacher host also holds the teacher product — workers stay out of
+``/opt/hramatka`` and ``/srv``, and occupancy headroom decides who takes
+the next job. Notebook ``delegate.py dispatch`` is the fallback only when
+**every** VPS worker host is unavailable or full. This helper never prints
+host aliases, IPs, or occupancy env.
+
+SSH aliases stay in operator env (not git):
+
+- ``LU_DISPATCH_SSH`` — ``opaque-id=ssh-alias,...``
+- ``LU_JOB_DISPATCH_HOST`` / ``ATLAS_RUNNER_HOST`` — job-host fallback
+- ``LU_TEACHER_DISPATCH_HOST`` — teacher-host fallback
+- ``LU_JOB_REPO`` / ``LU_TEACHER_REPO`` — absolute remote checkouts
+
+Remote PATH always includes ``$HOME/.local/bin`` and ``$HOME/.opencode/bin``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Literal
+
+from scripts.fleet_comms.paths import RETIRED_LOCAL_MARKER
+from scripts.guardrails.worktree_containment import resolve_main_root
+
+ENV_HOST = "LU_JOB_DISPATCH_HOST"
+ENV_HOST_FALLBACK = "ATLAS_RUNNER_HOST"
+ENV_TEACHER_HOST = "LU_TEACHER_DISPATCH_HOST"
+ENV_DISPATCH_SSH = "LU_DISPATCH_SSH"
+ENV_REPO = "LU_JOB_REPO"
+ENV_TEACHER_REPO = "LU_TEACHER_REPO"
+ENV_ALLOW_NOTEBOOK = "LU_ALLOW_NOTEBOOK_DISPATCH"
+ENV_OCCUPANCY_HOST = "LU_JOB_OCCUPANCY_HOST_ID"
+ENV_MEM_FULL = "LU_JOB_MEM_FULL_PCT"
+ENV_DISK_FULL = "LU_JOB_DISK_FULL_PCT"
+REMOTE_PATH_EXPORT = 'export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"'
+# Canonical SSH Host names already used by atlas_job (public repo contract).
+DEFAULT_JOB_SSH = "atlas-runner"
+DEFAULT_TEACHER_SSH = "hramatka"
+DEFAULT_JOB_REPO = "/home/ops/services/learn-ukrainian"
+DEFAULT_TEACHER_REPO = "/home/ops/learn-ukrainian"
+DEFAULT_MEM_FULL_PCT = 85.0
+DEFAULT_DISK_FULL_PCT = 85.0
+_MONITOR_DEFAULT = "http://127.0.0.1:8765"
+_MISSING = object()
+TEACHER_HOST_ID = "host-teacher"
+JOB_HOST_ID = "host-job"
+
+Placement = Literal["notebook", "vps"]
+PlacementReason = Literal[
+    "no_retire_marker",
+    "allow_env",
+    "unavailable",
+    "full",
+    "available",
+]
+
+
+def notebook_block_message(*, host_id: str | None = None) -> str:
+    where = f" ({host_id})" if host_id else ""
+    return (
+        f"a VPS worker host{where} is available; spawn workers there. "
+        f"Run: {ENV_DISPATCH_SSH}=<opaque=alias,...> {ENV_REPO}=<remote-checkout> "
+        ".venv/bin/python scripts/orchestration/job_host_exec.py -- "
+        ".venv/bin/python scripts/delegate.py dispatch ... "
+        "Notebook spawn is allowed only when every VPS worker host is "
+        f"unavailable or full (or {ENV_ALLOW_NOTEBOOK}=1)."
+    )
+
+
+def job_dispatch_host() -> str:
+    return (
+        os.environ.get(ENV_HOST, "").strip()
+        or os.environ.get(ENV_HOST_FALLBACK, "").strip()
+        or DEFAULT_JOB_SSH
+    )
+
+
+def job_dispatch_repo() -> str:
+    repo = os.environ.get(ENV_REPO, "").strip() or DEFAULT_JOB_REPO
+    if not repo.startswith("/"):
+        raise ValueError(f"{ENV_REPO} must be an absolute remote path")
+    return repo
+
+
+def _parse_opaque_map(raw: str) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for part in raw.split(","):
+        item = part.strip()
+        if not item or "=" not in item:
+            continue
+        opaque, alias = item.split("=", 1)
+        opaque = opaque.strip()
+        alias = alias.strip()
+        if opaque and alias:
+            mapping[opaque] = alias
+    return mapping
+
+
+def ssh_alias_for_host_id(host_id: str) -> str:
+    mapped = _parse_opaque_map(os.environ.get(ENV_DISPATCH_SSH, ""))
+    if host_id in mapped:
+        return mapped[host_id]
+    if host_id == TEACHER_HOST_ID:
+        return os.environ.get(ENV_TEACHER_HOST, "").strip() or DEFAULT_TEACHER_SSH
+    if host_id == JOB_HOST_ID:
+        return job_dispatch_host()
+    raise ValueError(f"no SSH alias configured for occupancy host {host_id}")
+
+
+def repo_for_host_id(host_id: str) -> str:
+    if host_id == TEACHER_HOST_ID:
+        teacher_repo = os.environ.get(ENV_TEACHER_REPO, "").strip() or DEFAULT_TEACHER_REPO
+        if not teacher_repo.startswith("/"):
+            raise ValueError(f"{ENV_TEACHER_REPO} must be an absolute remote path")
+        return teacher_repo
+    return job_dispatch_repo()
+
+
+def _monitor_base() -> str:
+    return os.environ.get("DELEGATE_MONITOR_API", _MONITOR_DEFAULT).rstrip("/")
+
+
+def _threshold(env_name: str, default: float) -> float:
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if value <= 0 or value > 100:
+        return default
+    return value
+
+
+def fetch_occupancy(*, timeout: float = 2.0) -> dict[str, Any] | None:
+    """Read tunneled occupancy. None means the board is not available."""
+    url = f"{_monitor_base()}/api/occupancy?fresh=true"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        OSError,
+        TimeoutError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+        ValueError,
+        UnicodeDecodeError,
+    ):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _pool_host_ids(hosts: dict[str, Any]) -> list[str]:
+    restricted = os.environ.get(ENV_OCCUPANCY_HOST, "").strip()
+    if restricted:
+        return [restricted]
+    return [key for key in hosts if isinstance(hosts.get(key), dict)]
+
+
+def classify_host_entry(host: dict[str, Any] | None) -> Literal["available", "unavailable", "full"]:
+    if not isinstance(host, dict):
+        return "unavailable"
+    status = str(host.get("status") or "unavailable")
+    if status == "unavailable":
+        return "unavailable"
+    if status not in {"fresh", "stale"}:
+        return "unavailable"
+    mem = host.get("mem") if isinstance(host.get("mem"), dict) else {}
+    disk = host.get("disk") if isinstance(host.get("disk"), dict) else {}
+    mem_pct = mem.get("pct")
+    disk_pct = disk.get("pct")
+    cpu_count = host.get("cpu_count") or 1
+    loadavg = host.get("loadavg") if isinstance(host.get("loadavg"), list) else []
+    load1 = loadavg[0] if loadavg else 0.0
+    if isinstance(mem_pct, (int, float)) and float(mem_pct) >= _threshold(ENV_MEM_FULL, DEFAULT_MEM_FULL_PCT):
+        return "full"
+    if isinstance(disk_pct, (int, float)) and float(disk_pct) >= _threshold(ENV_DISK_FULL, DEFAULT_DISK_FULL_PCT):
+        return "full"
+    try:
+        cores = float(cpu_count)
+        load = float(load1)
+    except (TypeError, ValueError):
+        cores, load = 1.0, 0.0
+    if cores > 0 and load >= cores:
+        return "full"
+    if status == "stale" and mem_pct is None and disk_pct is None:
+        return "unavailable"
+    return "available"
+
+
+def _pressure(host: dict[str, Any]) -> float:
+    mem = host.get("mem") if isinstance(host.get("mem"), dict) else {}
+    disk = host.get("disk") if isinstance(host.get("disk"), dict) else {}
+    mem_pct = float(mem.get("pct") or 0.0)
+    disk_pct = float(disk.get("pct") or 0.0)
+    cpu_count = host.get("cpu_count") or 1
+    loadavg = host.get("loadavg") if isinstance(host.get("loadavg"), list) else []
+    try:
+        load1 = float(loadavg[0]) if loadavg else 0.0
+        cores = max(float(cpu_count), 1.0)
+    except (TypeError, ValueError, IndexError):
+        load1, cores = 0.0, 1.0
+    return mem_pct + disk_pct + (load1 / cores) * 100.0
+
+
+def pick_worker_host(payload: dict[str, Any] | None) -> tuple[str | None, Literal["available", "unavailable", "full"]]:
+    """Choose the least-loaded available VPS. Notebook only if none qualify."""
+    if not isinstance(payload, dict):
+        return None, "unavailable"
+    hosts = payload.get("hosts")
+    if not isinstance(hosts, dict) or not hosts:
+        return None, "unavailable"
+    saw_full = False
+    available: list[tuple[str, dict[str, Any]]] = []
+    for host_id in _pool_host_ids(hosts):
+        entry = hosts.get(host_id)
+        if not isinstance(entry, dict):
+            continue
+        state = classify_host_entry(entry)
+        if state == "available":
+            available.append((host_id, entry))
+        elif state == "full":
+            saw_full = True
+    if available:
+        available.sort(key=lambda item: (_pressure(item[1]), item[0]))
+        return available[0][0], "available"
+    if saw_full:
+        return None, "full"
+    return None, "unavailable"
+
+
+def classify_worker_host(payload: dict[str, Any] | None, *, host_id: str | None = None) -> Literal["available", "unavailable", "full"]:
+    """Classify one occupancy host, or the picked pool host when ``host_id`` is omitted."""
+    if host_id is not None:
+        if not isinstance(payload, dict):
+            return "unavailable"
+        hosts = payload.get("hosts")
+        if not isinstance(hosts, dict):
+            return "unavailable"
+        return classify_host_entry(hosts.get(host_id) if isinstance(hosts.get(host_id), dict) else None)
+    _picked, state = pick_worker_host(payload)
+    return state
+
+
+def decide_dispatch_placement(
+    *,
+    repo_root: Path | None = None,
+    occupancy: Any = _MISSING,
+) -> tuple[Placement, PlacementReason, str | None]:
+    """Where a notebook ``delegate.py dispatch`` may spawn.
+
+    ``vps`` means refuse Darwin spawn and name the opaque occupancy host.
+    ``notebook`` is allowed when the retire marker is absent, the operator
+    opted in, or every VPS worker host is unavailable or full.
+    """
+    if os.environ.get(ENV_ALLOW_NOTEBOOK, "").strip() == "1":
+        return "notebook", "allow_env", None
+    root = Path(repo_root) if repo_root is not None else resolve_main_root(Path.cwd())
+    marker = root / "batch_state" / "fleet-comms" / "v1" / RETIRED_LOCAL_MARKER
+    sibling = root / "batch_state" / "fleet-comms" / RETIRED_LOCAL_MARKER
+    if not marker.is_file() and not sibling.is_file():
+        return "notebook", "no_retire_marker", None
+    payload = fetch_occupancy() if occupancy is _MISSING else occupancy
+    host_id, capacity = pick_worker_host(payload if isinstance(payload, dict) else None)
+    if capacity == "available" and host_id:
+        return "vps", "available", host_id
+    return "notebook", capacity, None
+
+
+def notebook_dispatch_blocked(*, repo_root: Path | None = None, occupancy: Any = _MISSING) -> str | None:
+    """Return an error when this checkout must not spawn Darwin workers."""
+    placement, _reason, host_id = decide_dispatch_placement(repo_root=repo_root, occupancy=occupancy)
+    if placement == "vps":
+        return notebook_block_message(host_id=host_id)
+    return None
+
+
+def build_remote_command(
+    argv: list[str],
+    *,
+    remote_repo: str,
+    extra_exports: list[str] | None = None,
+) -> str:
+    if not argv:
+        raise ValueError("remote command is empty")
+    quoted = " ".join(shlex.quote(part) for part in argv)
+    prefix = REMOTE_PATH_EXPORT
+    for item in extra_exports or []:
+        prefix = f"{prefix}; {item}"
+    return f"{prefix}; cd {shlex.quote(remote_repo)} && {quoted}"
+
+
+def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | None = None) -> bool:
+    """True when VPS forward failed in transport, so the notebook may spawn."""
+    if error is not None:
+        return True
+    return rc == 255
+
+
+def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
+    """SSH a notebook ``delegate.py dispatch`` onto the chosen VPS and spawn there.
+
+    Remote spawn sets ``LU_ALLOW_NOTEBOOK_DISPATCH=1`` so the worker checkout
+    does not try to forward again.
+    """
+    if len(argv) < 2:
+        raise ValueError("dispatch argv is empty")
+    alias = ssh_alias_for_host_id(host_id)
+    repo = repo_for_host_id(host_id)
+    remote = build_remote_command(
+        [".venv/bin/python", "scripts/delegate.py", *argv[1:]],
+        remote_repo=repo,
+        extra_exports=[f"export {ENV_ALLOW_NOTEBOOK}=1"],
+    )
+    completed = subprocess.run(build_ssh_argv(alias, remote), check=False)
+    return int(completed.returncode)
+
+
+def build_ssh_argv(host: str, remote_command: str) -> list[str]:
+    return [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=12",
+        host,
+        remote_command,
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute a command on a VPS worker checkout (BatchMode SSH)."
+    )
+    parser.add_argument(
+        "--host-id",
+        default=None,
+        help="Opaque occupancy host_id (default: pick least-loaded available VPS)",
+    )
+    parser.add_argument(
+        "remote_argv",
+        nargs=argparse.REMAINDER,
+        help="Command to run after -- on the remote checkout",
+    )
+    args = parser.parse_args(argv)
+    remote_argv = list(args.remote_argv)
+    if remote_argv and remote_argv[0] == "--":
+        remote_argv = remote_argv[1:]
+    if not remote_argv:
+        parser.error("pass a remote command after --")
+    host_id = args.host_id
+    try:
+        if not host_id:
+            payload = fetch_occupancy()
+            host_id, capacity = pick_worker_host(payload)
+            if capacity != "available" or not host_id:
+                print(f"error: no VPS worker host available ({capacity})", file=sys.stderr)
+                return 2
+        alias = ssh_alias_for_host_id(host_id)
+        repo = repo_for_host_id(host_id)
+        ssh_argv = build_ssh_argv(alias, build_remote_command(remote_argv, remote_repo=repo))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    completed = subprocess.run(ssh_argv, check=False)
+    return int(completed.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -401,8 +401,9 @@ def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | No
 
     Occupancy miss/full is decided before forward. Payload errors
     (missing local files, ``--cwd``, bad host config) must fail closed —
-    they are not a reason to spawn on Darwin. Missing ``ssh`` is classified
-    by ``SshTransportError`` from the exec site, not by filename basename.
+    they are not a reason to spawn on Darwin. Missing or unexecutable ``ssh``
+    is classified by ``SshTransportError`` from the exec site
+    (``FileNotFoundError`` / ``PermissionError``), not by filename basename.
     """
     if isinstance(error, SshTransportError):
         return True
@@ -436,7 +437,7 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
             check=False,
             input=stdin,
         )
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, PermissionError) as exc:
         raise SshTransportError(str(exc)) from exc
     return int(completed.returncode)
 

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -23,6 +23,8 @@ Remote PATH always includes ``$HOME/.local/bin`` and ``$HOME/.opencode/bin``.
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
 import os
 import shlex
@@ -307,33 +309,81 @@ def build_remote_command(
     return f"{prefix}; cd {shlex.quote(remote_repo)} && {quoted}"
 
 
-def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
-    """Rewrite local ``--prompt-file`` to ``--prompt -`` so SSH can carry the body."""
+def _flag_value(argv: list[str], index: int, flag: str) -> tuple[str | None, int]:
+    item = argv[index]
+    if item == flag and index + 1 < len(argv):
+        return argv[index + 1], index + 2
+    prefix = f"{flag}="
+    if item.startswith(prefix):
+        return item.split("=", 1)[1], index + 1
+    return None, index
+
+
+def _remote_payload_preamble(kind: str, contents: bytes) -> tuple[str, str]:
+    digest = hashlib.sha256(contents).hexdigest()[:16]
+    remote_path = f"/tmp/lu-dispatch-{kind}-{digest}"
+    encoded = base64.b64encode(contents).decode("ascii")
+    preamble = f"printf '%s' {shlex.quote(encoded)} | base64 -d > {shlex.quote(remote_path)}"
+    return preamble, remote_path
+
+
+def materialize_local_dispatch_argv(argv: list[str]) -> tuple[list[str], bytes | None, str | None]:
+    """Rewrite notebook-only paths so SSH does not send Darwin paths.
+
+    ``--prompt-file`` becomes ``--prompt -`` with the body on SSH stdin.
+    ``--lifecycle-file`` is written to a content-addressed ``/tmp`` file on
+    the remote host via a base64 preamble.
+    """
     out: list[str] = []
     stdin: bytes | None = None
+    preambles: list[str] = []
     i = 0
     while i < len(argv):
-        item = argv[i]
-        if item == "--prompt-file" and i + 1 < len(argv):
-            stdin = Path(argv[i + 1]).read_text(encoding="utf-8").encode("utf-8")
+        prompt_path, next_i = _flag_value(argv, i, "--prompt-file")
+        if prompt_path is not None:
+            stdin = Path(prompt_path).read_text(encoding="utf-8").encode("utf-8")
             out.extend(["--prompt", "-"])
-            i += 2
+            i = next_i
             continue
-        if item.startswith("--prompt-file="):
-            stdin = Path(item.split("=", 1)[1]).read_text(encoding="utf-8").encode("utf-8")
-            out.extend(["--prompt", "-"])
-            i += 1
+        lifecycle_path, next_i = _flag_value(argv, i, "--lifecycle-file")
+        if lifecycle_path is not None:
+            body = Path(lifecycle_path).read_bytes()
+            preamble, remote_path = _remote_payload_preamble("lifecycle", body)
+            preambles.append(preamble)
+            out.extend(["--lifecycle-file", remote_path])
+            i = next_i
             continue
-        out.append(item)
+        out.append(argv[i])
         i += 1
-    return out, stdin
+    return out, stdin, ("; ".join(preambles) if preambles else None)
+
+
+def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
+    """Rewrite local ``--prompt-file`` to ``--prompt -`` so SSH can carry the body."""
+    rest, stdin, _preamble = materialize_local_dispatch_argv(argv)
+    return rest, stdin
 
 
 def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | None = None) -> bool:
-    """True when VPS forward failed in transport, so the notebook may spawn."""
-    if error is not None:
-        return True
-    return rc == 255
+    """True only for SSH transport failure, so the notebook may spawn.
+
+    Occupancy miss/full is decided before forward. Payload errors
+    (missing ``--prompt-file`` / ``--lifecycle-file``, bad host config)
+    must fail closed — they are not a reason to spawn on Darwin.
+    """
+    if error is None:
+        return rc == 255
+    if isinstance(error, FileNotFoundError):
+        names = []
+        if error.filename:
+            names.append(os.fsdecode(error.filename))
+        for arg in error.args:
+            if isinstance(arg, bytes):
+                names.append(os.fsdecode(arg))
+            elif isinstance(arg, str):
+                names.append(arg)
+        return any(Path(name).name == "ssh" for name in names if name)
+    return False
 
 
 def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
@@ -346,11 +396,14 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
         raise ValueError("dispatch argv is empty")
     alias = ssh_alias_for_host_id(host_id)
     repo = repo_for_host_id(host_id)
-    rest, stdin = materialize_local_prompt_argv(list(argv[1:]))
+    rest, stdin, preamble = materialize_local_dispatch_argv(list(argv[1:]))
+    extra_exports = [f"export {ENV_ALLOW_NOTEBOOK}=1"]
+    if preamble:
+        extra_exports.append(preamble)
     remote = build_remote_command(
         [".venv/bin/python", "scripts/delegate.py", *rest],
         remote_repo=repo,
-        extra_exports=[f"export {ENV_ALLOW_NOTEBOOK}=1"],
+        extra_exports=extra_exports,
     )
     completed = subprocess.run(
         build_ssh_argv(alias, remote),

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import argparse
 import base64
-import hashlib
 import json
 import os
 import shlex
@@ -49,6 +48,7 @@ ENV_OCCUPANCY_HOST = "LU_JOB_OCCUPANCY_HOST_ID"
 ENV_MEM_FULL = "LU_JOB_MEM_FULL_PCT"
 ENV_DISK_FULL = "LU_JOB_DISK_FULL_PCT"
 REMOTE_PATH_EXPORT = 'export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"'
+_REMOTE_VAR_PREFIX = "__LU_REMOTE_VAR:"
 # Canonical SSH Host names already used by atlas_job (public repo contract).
 DEFAULT_JOB_SSH = "atlas-runner"
 DEFAULT_TEACHER_SSH = "hramatka"
@@ -311,11 +311,20 @@ def build_remote_command(
 ) -> str:
     if not argv:
         raise ValueError("remote command is empty")
-    quoted = " ".join(shlex.quote(part) for part in argv)
+    parts: list[str] = []
+    for part in argv:
+        if part.startswith(_REMOTE_VAR_PREFIX):
+            var = part[len(_REMOTE_VAR_PREFIX) :]
+            if not var.isidentifier():
+                raise ValueError(f"invalid remote payload variable {var!r}")
+            parts.append(f'"${var}"')
+        else:
+            parts.append(shlex.quote(part))
+    quoted = " ".join(parts)
     prefix = REMOTE_PATH_EXPORT
     for item in extra_exports or []:
-        prefix = f"{prefix}; {item}"
-    return f"{prefix}; cd {shlex.quote(remote_repo)} && {quoted}"
+        prefix = f"{prefix} && {item}"
+    return f"{prefix} && cd {shlex.quote(remote_repo)} && {quoted}"
 
 
 def _flag_value(argv: list[str], index: int, flag: str) -> tuple[str | None, int]:
@@ -328,12 +337,15 @@ def _flag_value(argv: list[str], index: int, flag: str) -> tuple[str | None, int
     return None, index
 
 
-def _remote_payload_preamble(kind: str, contents: bytes) -> tuple[str, str]:
-    digest = hashlib.sha256(contents).hexdigest()[:16]
-    remote_path = f"/tmp/lu-dispatch-{kind}-{digest}"
+def _remote_payload_preamble(kind: str, contents: bytes, *, seq: int) -> tuple[str, str]:
+    ident = kind.replace("-", "_")
+    var = f"LU_DISPATCH_{ident.upper()}_{seq}"
     encoded = base64.b64encode(contents).decode("ascii")
-    preamble = f"printf '%s' {shlex.quote(encoded)} | base64 -d > {shlex.quote(remote_path)}"
-    return preamble, remote_path
+    preamble = (
+        f"umask 077 && {var}=$(mktemp /tmp/lu-dispatch-{kind}.XXXXXX) && "
+        f"printf '%s' {shlex.quote(encoded)} | base64 -d > \"${var}\""
+    )
+    return preamble, f"{_REMOTE_VAR_PREFIX}{var}"
 
 
 def materialize_local_dispatch_argv(
@@ -344,9 +356,9 @@ def materialize_local_dispatch_argv(
     """Rewrite notebook-only paths so SSH does not send Darwin paths.
 
     File payloads (``--prompt-file``, ``--lifecycle-file``, ``--output-schema``)
-    are written to content-addressed ``/tmp`` files on the remote host via a
-    base64 preamble so remote argparse still sees a real file (sparse-checkout
-    inference reads ``--prompt-file`` before stdin).
+    are written to unique private ``mktemp`` files on the remote host via a
+    fail-closed base64 preamble so remote argparse still sees a real file
+    (sparse-checkout inference reads ``--prompt-file`` before stdin).
     ``--prompt -`` is rewritten to a remote ``--prompt-file`` after the notebook
     stdin body is captured.
     ``--cwd`` is rejected: a Darwin working directory is not a VPS checkout.
@@ -355,6 +367,7 @@ def materialize_local_dispatch_argv(
     """
     out: list[str] = []
     preambles: list[str] = []
+    seq = 0
     i = 0
     while i < len(argv):
         cwd_path, next_i = _flag_value(argv, i, "--cwd")
@@ -372,7 +385,8 @@ def materialize_local_dispatch_argv(
                         "--prompt - cannot be forwarded without the prompt body; "
                         "pass --prompt-file"
                     )
-                preamble, remote_path = _remote_payload_preamble("prompt", stdin_body)
+                preamble, remote_path = _remote_payload_preamble("prompt", stdin_body, seq=seq)
+                seq += 1
                 preambles.append(preamble)
                 out.extend(["--prompt-file", remote_path])
             else:
@@ -385,7 +399,8 @@ def materialize_local_dispatch_argv(
             if file_path is None:
                 continue
             body = Path(file_path).read_bytes()
-            preamble, remote_path = _remote_payload_preamble(kind, body)
+            preamble, remote_path = _remote_payload_preamble(kind, body, seq=seq)
+            seq += 1
             preambles.append(preamble)
             out.extend([flag, remote_path])
             i = next_i
@@ -403,7 +418,7 @@ def materialize_local_dispatch_argv(
             continue
         out.append(argv[i])
         i += 1
-    return out, None, ("; ".join(preambles) if preambles else None)
+    return out, None, (" && ".join(preambles) if preambles else None)
 
 
 def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
@@ -511,8 +526,10 @@ def build_parser() -> argparse.ArgumentParser:
             "bodies land in remote /tmp and LU_ALLOW_NOTEBOOK_DISPATCH=1 prevents "
             "a second forward hop.\n\n"
             "Exit codes:\n"
-            "  0 on successful remote completion; 2 on CLI misuse or missing host; "
-            "255 on SSH transport failure; other codes are the remote command.\n\n"
+            "  0 on successful remote completion; 2 on CLI misuse, missing host, "
+            "or notebook payload errors; 255 on SSH transport failure "
+            "(missing/unexecutable ssh, or ssh rc 255); other codes are the "
+            "remote command.\n\n"
             "Related:\n"
             "  Occupancy: GET /api/occupancy\n"
             "  Dispatch: scripts/delegate.py\n"
@@ -551,14 +568,25 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
         dispatch_argv = _delegate_dispatch_argv(remote_argv)
         if dispatch_argv is not None:
-            return forward_dispatch(host_id=host_id, argv=dispatch_argv)
+            try:
+                return forward_dispatch(host_id=host_id, argv=dispatch_argv)
+            except SshTransportError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 255
+            except (ValueError, FileNotFoundError, PermissionError) as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
         alias = ssh_alias_for_host_id(host_id)
         repo = repo_for_host_id(host_id)
         ssh_argv = build_ssh_argv(alias, build_remote_command(remote_argv, remote_repo=repo))
-    except (ValueError, FileNotFoundError, PermissionError, SshTransportError) as exc:
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    completed = subprocess.run(ssh_argv, check=False)
+    try:
+        completed = subprocess.run(ssh_argv, check=False)
+    except (FileNotFoundError, PermissionError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 255
     return int(completed.returncode)
 
 

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -307,6 +307,28 @@ def build_remote_command(
     return f"{prefix}; cd {shlex.quote(remote_repo)} && {quoted}"
 
 
+def materialize_local_prompt_argv(argv: list[str]) -> tuple[list[str], bytes | None]:
+    """Rewrite local ``--prompt-file`` to ``--prompt -`` so SSH can carry the body."""
+    out: list[str] = []
+    stdin: bytes | None = None
+    i = 0
+    while i < len(argv):
+        item = argv[i]
+        if item == "--prompt-file" and i + 1 < len(argv):
+            stdin = Path(argv[i + 1]).read_text(encoding="utf-8").encode("utf-8")
+            out.extend(["--prompt", "-"])
+            i += 2
+            continue
+        if item.startswith("--prompt-file="):
+            stdin = Path(item.split("=", 1)[1]).read_text(encoding="utf-8").encode("utf-8")
+            out.extend(["--prompt", "-"])
+            i += 1
+            continue
+        out.append(item)
+        i += 1
+    return out, stdin
+
+
 def notebook_fallback_after_forward(rc: int | None, *, error: BaseException | None = None) -> bool:
     """True when VPS forward failed in transport, so the notebook may spawn."""
     if error is not None:
@@ -324,12 +346,17 @@ def forward_dispatch(*, host_id: str, argv: list[str]) -> int:
         raise ValueError("dispatch argv is empty")
     alias = ssh_alias_for_host_id(host_id)
     repo = repo_for_host_id(host_id)
+    rest, stdin = materialize_local_prompt_argv(list(argv[1:]))
     remote = build_remote_command(
-        [".venv/bin/python", "scripts/delegate.py", *argv[1:]],
+        [".venv/bin/python", "scripts/delegate.py", *rest],
         remote_repo=repo,
         extra_exports=[f"export {ENV_ALLOW_NOTEBOOK}=1"],
     )
-    completed = subprocess.run(build_ssh_argv(alias, remote), check=False)
+    completed = subprocess.run(
+        build_ssh_argv(alias, remote),
+        check=False,
+        input=stdin,
+    )
     return int(completed.returncode)
 
 

--- a/scripts/orchestration/plane_tunnel_gate.py
+++ b/scripts/orchestration/plane_tunnel_gate.py
@@ -9,6 +9,7 @@ occupancy env.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -84,8 +85,35 @@ def format_launcher_line(status: PlaneStatus, reason: str) -> str:
     return f"⚠️  plane fallback: {reason}"
 
 
+def build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        prog="plane_tunnel_gate.py",
+        description=(
+            "Probe the tunneled job-host Monitor before notebook driver launch.\n"
+            "Use it to warn when the plane is down; do not use it to start a "
+            "second Monitor or reopen retired Mac sqlite."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/orchestration/plane_tunnel_gate.py\n"
+            "  LU_SKIP_PLANE_TUNNEL_CHECK=1 .venv/bin/python scripts/orchestration/plane_tunnel_gate.py\n\n"
+            "Outputs:\n"
+            "  Prints a one-line plane status. Degraded probes still exit 0 so "
+            "drivers start on the notebook; they never reopen retired sqlite.\n\n"
+            "Exit codes:\n"
+            "  0 after a probe (ok, degraded, or skipped); 2 on CLI misuse.\n\n"
+            "Related:\n"
+            "  Dispatch: scripts/orchestration/job_host_exec.py\n"
+            "  Fleet: scripts/lib/fleet_comms_cold_start.sh\n"
+            "  Issue: #7062\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
-    del argv
+    parser = build_parser()
+    parser.parse_args(argv)
     status, reason = check_driver_plane()
     print(format_launcher_line(status, reason), file=sys.stderr if status == "degraded" else sys.stdout)
     return 0

--- a/scripts/orchestration/plane_tunnel_gate.py
+++ b/scripts/orchestration/plane_tunnel_gate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Probe the tunneled job-host Monitor for notebook driver launchers.
+
+Drivers prefer the job-host plane at loopback (the persistent tunnel). If that
+Monitor is down, launchers must still start on the notebook — they must not
+enable the retired local sqlite. This module never prints host aliases or
+occupancy env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Literal
+
+ENV_SKIP = "LU_SKIP_PLANE_TUNNEL_CHECK"
+_MONITOR_DEFAULT = "http://127.0.0.1:8765"
+
+PlaneStatus = Literal["ok", "degraded", "skipped"]
+
+
+def _monitor_base() -> str:
+    return os.environ.get("DELEGATE_MONITOR_API", _MONITOR_DEFAULT).rstrip("/")
+
+
+def _get_json(path: str, *, timeout: float) -> dict[str, Any]:
+    url = f"{_monitor_base()}{path}"
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("monitor payload is not an object")
+    return payload
+
+
+def check_driver_plane(*, timeout: float = 2.0) -> tuple[PlaneStatus, str]:
+    """Return launcher posture for the job-host plane.
+
+    ``ok`` — loopback Monitor is the job-host observer.
+    ``degraded`` — VPS/tunnel unreachable; start on the notebook anyway.
+    ``skipped`` — hermetic tests opted out.
+    """
+    if os.environ.get(ENV_SKIP, "").strip() == "1":
+        return "skipped", "plane probe skipped"
+    try:
+        health = _get_json("/api/health", timeout=timeout)
+        fleet = _get_json("/api/fleet/health", timeout=timeout)
+    except (
+        OSError,
+        TimeoutError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+        ValueError,
+        UnicodeDecodeError,
+    ):
+        return (
+            "degraded",
+            "job-host Monitor unreachable on loopback; starting on notebook. "
+            "Fleet sqlite stays retired until the tunnel is back.",
+        )
+    if str(health.get("status") or "") != "ok":
+        return (
+            "degraded",
+            "job-host Monitor health is not ok; starting on notebook. "
+            "Fleet sqlite stays retired until the tunnel is back.",
+        )
+    schema = fleet.get("schema") if isinstance(fleet.get("schema"), dict) else {}
+    if schema.get("db_exists") is not True:
+        return (
+            "degraded",
+            "job-host fleet db is not visible; starting on notebook. "
+            "Fleet sqlite stays retired until the tunnel is back.",
+        )
+    return "ok", "job-host plane reachable on loopback"
+
+
+def format_launcher_line(status: PlaneStatus, reason: str) -> str:
+    if status == "ok":
+        return f"plane: {reason}"
+    if status == "skipped":
+        return f"plane: {reason}"
+    return f"⚠️  plane fallback: {reason}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv
+    status, reason = check_driver_plane()
+    print(format_launcher_line(status, reason), file=sys.stderr if status == "degraded" else sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -32,6 +32,7 @@ def test_cli_help_runs_without_pythonpath(tmp_path: Path) -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode == 0, proc.stderr
     assert "Examples:" in proc.stdout
@@ -712,7 +713,13 @@ def test_remote_payload_script_cleans_private_files_on_exit_failure_and_signal(
     assert "trap _on_exit EXIT" in rendered
     assert "trap '_on_signal 15' TERM" in rendered
     assert "private body" not in rendered
-    completed = subprocess.run(["bash", "-s"], input=script, check=False, capture_output=True)
+    completed = subprocess.run(
+        ["bash", "-s"],
+        input=script,
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
     assert completed.returncode == expected_rc, completed.stderr.decode("utf-8")
     payload_name, payload_mode = observed_path.read_text(encoding="utf-8").splitlines()
     payload_path = Path(payload_name)

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import io
 from pathlib import Path
 
 import pytest
@@ -229,18 +231,16 @@ def test_forward_dispatch_inlines_prompt_file(
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     args_file = tmp_path / "ssh.args"
-    stdin_file = tmp_path / "ssh.stdin"
     fake_ssh = fake_bin / "ssh"
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
-        f"cat > {stdin_file}\n"
         "exit 0\n",
         encoding="utf-8",
     )
     fake_ssh.chmod(0o755)
     prompt = tmp_path / "brief.md"
-    prompt.write_text("review PR 7070 exact head\n", encoding="utf-8")
+    prompt.write_text("keep curriculum/l2-uk-en in the worktree\n", encoding="utf-8")
     monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
     monkeypatch.setenv(jh.ENV_HOST, "job-alias")
     monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
@@ -259,9 +259,53 @@ def test_forward_dispatch_inlines_prompt_file(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
-    assert "--prompt-file" not in recorded
-    assert "--prompt" in recorded
-    assert stdin_file.read_text(encoding="utf-8") == "review PR 7070 exact head\n"
+    assert str(prompt) not in recorded
+    assert "--prompt-file" in recorded
+    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert "\n--prompt\n-\n" not in recorded
+    assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
+
+
+def test_forward_dispatch_rewrites_prompt_dash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    class _Stdin:
+        buffer = io.BytesIO(b"touch wiki/pages.md\n")
+
+    monkeypatch.setattr(jh.sys, "stdin", _Stdin())
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=[
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--prompt",
+            "-",
+        ],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert "--prompt-file" in recorded
+    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert "\n--prompt\n-\n" not in recorded
+    assert base64.b64encode(b"touch wiki/pages.md\n").decode("ascii") in recorded.replace("\n", "")
 
 
 def test_forward_dispatch_copies_lifecycle_file(

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -10,6 +10,11 @@ from scripts.fleet_comms.paths import RETIRED_LOCAL_MARKER
 from scripts.orchestration import job_host_exec as jh
 
 
+@pytest.fixture(autouse=True)
+def _clear_occupancy_pin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_OCCUPANCY_HOST, raising=False)
+
+
 def _marker_root(tmp_path: Path) -> Path:
     plane = tmp_path / "batch_state" / "fleet-comms" / "v1"
     plane.mkdir(parents=True)
@@ -259,8 +264,50 @@ def test_forward_dispatch_inlines_prompt_file(
     assert stdin_file.read_text(encoding="utf-8") == "review PR 7070 exact head\n"
 
 
+def test_forward_dispatch_copies_lifecycle_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    ledger = tmp_path / "task-lifecycle.json"
+    ledger.write_text('{"schema":"task-lifecycle.v1","task_id":"cf"}\n', encoding="utf-8")
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=[
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--lifecycle-file",
+            str(ledger),
+        ],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert str(ledger) not in recorded
+    assert "--lifecycle-file" in recorded
+    assert "/tmp/lu-dispatch-lifecycle-" in recorded
+    assert "base64 -d >" in recorded
+
+
 def test_notebook_fallback_only_on_transport_failure() -> None:
-    assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is True
+    assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is False
+    assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("/tmp/local.json")) is False
+    assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("ssh")) is True
     assert jh.notebook_fallback_after_forward(255) is True
     assert jh.notebook_fallback_after_forward(0) is False
     assert jh.notebook_fallback_after_forward(2) is False

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -197,6 +197,47 @@ def test_main_uses_ssh_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in script
 
 
+def test_main_dispatch_preserves_session_initiator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        f"cat > {args_file}.stdin\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    monkeypatch.setenv("SESSION_HANDOFF_AGENT", "cursor")
+    rc = jh.main(
+        [
+            "--host-id",
+            "host-job",
+            "--",
+            ".venv/bin/python",
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+        ]
+    )
+    assert rc == 0
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
+    assert "--initiator" in script
+    assert "cursor" in script
+    assert f"export {jh.ENV_RUNTIME_INITIATOR}=" in script
+    assert f"export {jh.ENV_RUNTIME_INITIATOR_SOURCE}=" in script
+
+
 def test_main_dispatch_copies_local_prompt_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -218,6 +218,47 @@ def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytes
     assert "--agent" in recorded
 
 
+def test_forward_dispatch_inlines_prompt_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    stdin_file = tmp_path / "ssh.stdin"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        f"cat > {stdin_file}\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    prompt = tmp_path / "brief.md"
+    prompt.write_text("review PR 7070 exact head\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=[
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--prompt-file",
+            str(prompt),
+        ],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert "--prompt-file" not in recorded
+    assert "--prompt" in recorded
+    assert stdin_file.read_text(encoding="utf-8") == "review PR 7070 exact head\n"
+
+
 def test_notebook_fallback_only_on_transport_failure() -> None:
     assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is True
     assert jh.notebook_fallback_after_forward(255) is True

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -304,10 +304,126 @@ def test_forward_dispatch_copies_lifecycle_file(
     assert "base64 -d >" in recorded
 
 
+def test_forward_dispatch_copies_output_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    schema = tmp_path / "review.schema.json"
+    schema.write_text('{"type":"object"}\n', encoding="utf-8")
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=[
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--output-schema",
+            str(schema),
+        ],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert str(schema) not in recorded
+    assert "--output-schema" in recorded
+    assert "/tmp/lu-dispatch-output-schema-" in recorded
+    assert "base64 -d >" in recorded
+
+
+def test_forward_dispatch_rejects_notebook_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    with pytest.raises(ValueError, match="--cwd"):
+        jh.forward_dispatch(
+            host_id="host-job",
+            argv=[
+                "scripts/delegate.py",
+                "dispatch",
+                "--agent",
+                "codex",
+                "--task-id",
+                "cf",
+                "--cwd",
+                str(tmp_path),
+            ],
+        )
+
+
+def test_forward_dispatch_strips_notebook_worktree_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    local_wt = tmp_path / "wt"
+    local_wt.mkdir()
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=[
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--worktree",
+            str(local_wt),
+        ],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert str(local_wt) not in recorded
+    assert "--worktree" in recorded
+
+
+def test_forward_dispatch_missing_ssh_is_transport_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", str(empty))
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    with pytest.raises(jh.SshTransportError):
+        jh.forward_dispatch(
+            host_id="host-job",
+            argv=["scripts/delegate.py", "dispatch", "--agent", "codex", "--task-id", "cf"],
+        )
+
+
 def test_notebook_fallback_only_on_transport_failure() -> None:
     assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is False
     assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("/tmp/local.json")) is False
-    assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("ssh")) is True
+    assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("/tmp/ssh")) is False
+    assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("ssh")) is False
+    assert jh.notebook_fallback_after_forward(None, error=jh.SshTransportError("ssh missing")) is True
     assert jh.notebook_fallback_after_forward(255) is True
     assert jh.notebook_fallback_after_forward(0) is False
     assert jh.notebook_fallback_after_forward(2) is False

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -195,6 +195,63 @@ def test_main_uses_ssh_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert "teacher-alias" in recorded
     assert "cd /remote/repo" in recorded
     assert "scripts/delegate.py" in recorded
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
+
+
+def test_main_dispatch_copies_local_prompt_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    prompt = tmp_path / "brief.md"
+    prompt.write_text("keep curriculum/l2-uk-en in the worktree\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.main(
+        [
+            "--host-id",
+            "host-job",
+            "--",
+            ".venv/bin/python",
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+            "--prompt-file",
+            str(prompt),
+        ]
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert str(prompt) not in recorded
+    assert "--prompt-file" in recorded
+    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
+    assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
+
+
+def test_main_help_contract() -> None:
+    help_text = jh.build_parser().format_help()
+    assert "Execute a command on a VPS worker checkout over BatchMode SSH." in help_text
+    assert "do not use it to start a second Monitor" in help_text
+    assert "Examples:" in help_text
+    assert "Outputs:" in help_text
+    assert "Exit codes:" in help_text
+    assert "Related:" in help_text
+    assert "--prompt-file" in help_text
+    assert "Issue: #7062" in help_text
 
 
 def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import base64
 import io
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -564,8 +566,20 @@ def test_remote_payload_preamble_is_private_unique_and_fail_closed() -> None:
     assert token_a != token_b
     var_a = token_a.split(":", 1)[1]
     var_b = token_b.split(":", 1)[1]
+    mode_check = shlex.join(
+        [
+            sys.executable,
+            "-c",
+            "import os,stat,sys; p=sys.argv[1]; m=stat.S_IMODE(os.stat(p).st_mode); "
+            "raise SystemExit(0 if m & 0o077 == 0 else 1)",
+        ]
+    )
     created = subprocess.run(
-        ["bash", "-c", f"{first} && {second} && test \"${var_a}\" != \"${var_b}\" && python3 -c 'import os,stat,sys; p=sys.argv[1]; m=stat.S_IMODE(os.stat(p).st_mode); raise SystemExit(0 if m & 0o077 == 0 else 1)' \"${var_a}\""],
+        [
+            "bash",
+            "-c",
+            f"{first} && {second} && test \"${var_a}\" != \"${var_b}\" && {mode_check} \"${var_a}\"",
+        ],
         check=False,
         capture_output=True,
         text=True,

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -17,6 +17,8 @@ from scripts.orchestration import job_host_exec as jh
 @pytest.fixture(autouse=True)
 def _clear_occupancy_pin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(jh.ENV_OCCUPANCY_HOST, raising=False)
+    monkeypatch.delenv(jh.ENV_RUNTIME_INITIATOR, raising=False)
+    monkeypatch.delenv(jh.ENV_RUNTIME_INITIATOR_SOURCE, raising=False)
 
 
 def test_cli_help_runs_without_pythonpath(tmp_path: Path) -> None:

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import base64
 import io
-import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -94,10 +92,6 @@ def test_picks_teacher_when_it_has_more_headroom(tmp_path: Path, monkeypatch: py
     )
     placement, reason, host_id = jh.decide_dispatch_placement(repo_root=root, occupancy=occupancy)
     assert (placement, reason, host_id) == ("vps", "available", "host-teacher")
-    blocked = jh.notebook_dispatch_blocked(repo_root=root, occupancy=occupancy)
-    assert blocked is not None
-    assert "host-teacher" in blocked
-    assert "every VPS worker host" in blocked
 
 
 def test_job_full_uses_teacher(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -149,7 +143,6 @@ def test_both_full_or_down_falls_back_to_notebook(tmp_path: Path, monkeypatch: p
         None,
     )
     assert jh.decide_dispatch_placement(repo_root=root, occupancy=None) == ("notebook", "unavailable", None)
-    assert jh.notebook_dispatch_blocked(repo_root=root, occupancy=None) is None
 
 
 def test_allow_env_bypasses_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -182,6 +175,7 @@ def test_main_uses_ssh_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -194,11 +188,13 @@ def test_main_uses_ssh_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert "BatchMode=yes" in recorded
     assert "teacher-alias" in recorded
-    assert "cd /remote/repo" in recorded
-    assert "scripts/delegate.py" in recorded
-    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
+    assert "bash -s" in recorded
+    assert "cd /remote/repo" in script
+    assert "scripts/delegate.py" in script
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in script
 
 
 def test_main_dispatch_copies_local_prompt_file(
@@ -211,6 +207,7 @@ def test_main_dispatch_copies_local_prompt_file(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -238,12 +235,13 @@ def test_main_dispatch_copies_local_prompt_file(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert str(prompt) not in recorded
-    assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
-    assert "$LU_DISPATCH_PROMPT_0" in recorded
-    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
-    assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
+    assert "keep curriculum/l2-uk-en in the worktree" not in recorded
+    assert "--prompt-file" in script
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in script
+    assert "$LU_DISPATCH_PROMPT_0" in script
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in script
 
 
 def test_main_help_contract() -> None:
@@ -266,6 +264,7 @@ def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytes
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -279,11 +278,13 @@ def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytes
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert "BatchMode=yes" in recorded
     assert "job-alias" in recorded
-    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
-    assert "dispatch" in recorded
-    assert "--agent" in recorded
+    assert "bash -s" in recorded
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in script
+    assert "dispatch" in script
+    assert "--agent" in script
 
 
 def test_forward_dispatch_preserves_initiator(
@@ -296,6 +297,7 @@ def test_forward_dispatch_preserves_initiator(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -311,10 +313,12 @@ def test_forward_dispatch_preserves_initiator(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
-    assert "--initiator" in recorded
-    assert "cursor/job-host-dispatch" in recorded
-    assert f"export {jh.ENV_RUNTIME_INITIATOR}=" in recorded
-    assert f"export {jh.ENV_RUNTIME_INITIATOR_SOURCE}=" in recorded
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
+    assert "--initiator" in script
+    assert "cursor/job-host-dispatch" in script
+    assert f"export {jh.ENV_RUNTIME_INITIATOR}=" in script
+    assert f"export {jh.ENV_RUNTIME_INITIATOR_SOURCE}=" in script
+    assert "cursor/job-host-dispatch" not in recorded
 
 
 def test_forward_dispatch_inlines_prompt_file(
@@ -327,6 +331,7 @@ def test_forward_dispatch_inlines_prompt_file(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -351,12 +356,14 @@ def test_forward_dispatch_inlines_prompt_file(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert str(prompt) not in recorded
-    assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
-    assert "$LU_DISPATCH_PROMPT_0" in recorded
-    assert "\n--prompt\n-\n" not in recorded
-    assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
+    assert "keep curriculum/l2-uk-en in the worktree" not in recorded
+    assert "--prompt-file" in script
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in script
+    assert "$LU_DISPATCH_PROMPT_0" in script
+    assert "\n--prompt\n-\n" not in script
+    assert "keep curriculum/l2-uk-en in the worktree" not in script
 
 
 def test_forward_dispatch_rewrites_prompt_dash(
@@ -369,6 +376,7 @@ def test_forward_dispatch_rewrites_prompt_dash(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -395,11 +403,12 @@ def test_forward_dispatch_rewrites_prompt_dash(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
-    assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
-    assert "$LU_DISPATCH_PROMPT_0" in recorded
-    assert "\n--prompt\n-\n" not in recorded
-    assert base64.b64encode(b"touch wiki/pages.md\n").decode("ascii") in recorded.replace("\n", "")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
+    assert "--prompt-file" in script
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in script
+    assert "$LU_DISPATCH_PROMPT_0" in script
+    assert "\n--prompt\n-\n" not in script
+    assert "touch wiki/pages.md" not in recorded
 
 
 def test_forward_dispatch_copies_lifecycle_file(
@@ -412,6 +421,7 @@ def test_forward_dispatch_copies_lifecycle_file(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -436,11 +446,12 @@ def test_forward_dispatch_copies_lifecycle_file(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert str(ledger) not in recorded
-    assert "--lifecycle-file" in recorded
-    assert "/tmp/lu-dispatch-lifecycle.XXXXXX" in recorded
-    assert "$LU_DISPATCH_LIFECYCLE_0" in recorded
-    assert "base64 -d >" in recorded
+    assert "--lifecycle-file" in script
+    assert "/tmp/lu-dispatch-lifecycle.XXXXXX" in script
+    assert "$LU_DISPATCH_LIFECYCLE_0" in script
+    assert "base64 -d >" in script
 
 
 def test_forward_dispatch_copies_output_schema(
@@ -453,6 +464,7 @@ def test_forward_dispatch_copies_output_schema(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -477,11 +489,12 @@ def test_forward_dispatch_copies_output_schema(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert str(schema) not in recorded
-    assert "--output-schema" in recorded
-    assert "/tmp/lu-dispatch-output-schema.XXXXXX" in recorded
-    assert "$LU_DISPATCH_OUTPUT_SCHEMA_0" in recorded
-    assert "base64 -d >" in recorded
+    assert "--output-schema" in script
+    assert "/tmp/lu-dispatch-output-schema.XXXXXX" in script
+    assert "$LU_DISPATCH_OUTPUT_SCHEMA_0" in script
+    assert "base64 -d >" in script
 
 
 def test_forward_dispatch_rejects_notebook_cwd(
@@ -515,6 +528,7 @@ def test_forward_dispatch_strips_notebook_worktree_path(
     fake_ssh.write_text(
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$@" > {args_file}\n'
+        f'cat > {args_file}.stdin\n'
         "exit 0\n",
         encoding="utf-8",
     )
@@ -539,8 +553,9 @@ def test_forward_dispatch_strips_notebook_worktree_path(
     )
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
+    script = (tmp_path / "ssh.args.stdin").read_text(encoding="utf-8")
     assert str(local_wt) not in recorded
-    assert "--worktree" in recorded
+    assert "--worktree" in script
 
 
 def test_forward_dispatch_missing_ssh_is_transport_error(
@@ -588,42 +603,60 @@ def test_notebook_fallback_only_on_transport_failure() -> None:
     assert jh.notebook_fallback_after_forward(2) is False
 
 
-def test_remote_payload_preamble_is_private_unique_and_fail_closed() -> None:
-    first, token_a = jh._remote_payload_preamble("prompt", b"same\n", seq=0)
-    second, token_b = jh._remote_payload_preamble("prompt", b"same\n", seq=1)
-    assert "umask 077" in first
-    assert "mktemp /tmp/lu-dispatch-prompt.XXXXXX" in first
-    assert "base64 -d >" in first
-    assert token_a != token_b
-    var_a = token_a.split(":", 1)[1]
-    var_b = token_b.split(":", 1)[1]
-    mode_check = shlex.join(
-        [
-            sys.executable,
-            "-c",
-            "import os,stat,sys; p=sys.argv[1]; m=stat.S_IMODE(os.stat(p).st_mode); "
-            "raise SystemExit(0 if m & 0o077 == 0 else 1)",
-        ]
+@pytest.mark.parametrize(
+    ("mode", "expected_rc"),
+    [("success", 0), ("failure", 7), ("signal", 143)],
+)
+def test_remote_payload_script_cleans_private_files_on_exit_failure_and_signal(
+    tmp_path: Path, mode: str, expected_rc: int
+) -> None:
+    """The remote trap must remove each 0600 payload file in every exit path."""
+    remote_python = tmp_path / ".venv" / "bin" / "python"
+    remote_python.parent.mkdir(parents=True)
+    remote_python.symlink_to(sys.executable)
+    remote_delegate = tmp_path / "scripts" / "delegate.py"
+    remote_delegate.parent.mkdir()
+    observed_path = tmp_path / "payload-path"
+    remote_delegate.write_text(
+        "import os\n"
+        "import signal\n"
+        "import stat\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "payload = Path(sys.argv[sys.argv.index('--prompt-file') + 1])\n"
+        "mode = stat.S_IMODE(payload.stat().st_mode)\n"
+        "Path(os.environ['LU_TEST_PAYLOAD_PATH']).write_text(f'{payload}\\n{mode:o}', encoding='utf-8')\n"
+        "if os.environ['LU_TEST_PAYLOAD_MODE'] == 'signal':\n"
+        "    os.kill(os.getppid(), signal.SIGTERM)\n"
+        "sys.exit(7 if os.environ['LU_TEST_PAYLOAD_MODE'] == 'failure' else 0)\n",
+        encoding="utf-8",
     )
-    created = subprocess.run(
-        [
-            "bash",
-            "-c",
-            f"{first} && {second} && test \"${var_a}\" != \"${var_b}\" && {mode_check} \"${var_a}\"",
+    prompt = tmp_path / "brief.md"
+    prompt.write_text("private body\n", encoding="utf-8")
+    rest, payloads = jh.materialize_local_dispatch_argv(
+        ["dispatch", "--prompt-file", str(prompt)]
+    )
+    script = jh._build_remote_dispatch_script(
+        argv=rest,
+        remote_repo=str(tmp_path),
+        payloads=payloads,
+        extra_exports=[
+            f"export LU_TEST_PAYLOAD_PATH={observed_path}",
+            f"export LU_TEST_PAYLOAD_MODE={mode}",
         ],
-        check=False,
-        capture_output=True,
-        text=True,
     )
-    assert created.returncode == 0, created.stderr
-    failed = subprocess.run(
-        ["bash", "-c", "umask 077 && f=$(mktemp /tmp/lu-dispatch-prompt.XXXXXX) && printf '%s' '!!!!' | base64 -d > \"$f\" && echo reached"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    assert failed.returncode != 0
-    assert "reached" not in failed.stdout
+    rendered = script.decode("utf-8")
+    assert "umask 077" in rendered
+    assert "mktemp /tmp/lu-dispatch-prompt.XXXXXX" in rendered
+    assert "trap _on_exit EXIT" in rendered
+    assert "trap '_on_signal 15' TERM" in rendered
+    assert "private body" not in rendered
+    completed = subprocess.run(["bash", "-s"], input=script, check=False, capture_output=True)
+    assert completed.returncode == expected_rc, completed.stderr.decode("utf-8")
+    payload_name, payload_mode = observed_path.read_text(encoding="utf-8").splitlines()
+    payload_path = Path(payload_name)
+    assert int(payload_mode, 8) & 0o077 == 0
+    assert not payload_path.exists()
 
 
 def test_main_missing_ssh_dispatch_returns_255(

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -418,12 +418,31 @@ def test_forward_dispatch_missing_ssh_is_transport_error(
         )
 
 
+def test_forward_dispatch_unexecutable_ssh_is_transport_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_ssh.chmod(0o644)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    with pytest.raises(jh.SshTransportError):
+        jh.forward_dispatch(
+            host_id="host-job",
+            argv=["scripts/delegate.py", "dispatch", "--agent", "codex", "--task-id", "cf"],
+        )
+
+
 def test_notebook_fallback_only_on_transport_failure() -> None:
     assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is False
     assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("/tmp/local.json")) is False
     assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("/tmp/ssh")) is False
     assert jh.notebook_fallback_after_forward(None, error=FileNotFoundError("ssh")) is False
     assert jh.notebook_fallback_after_forward(None, error=jh.SshTransportError("ssh missing")) is True
+    assert jh.notebook_fallback_after_forward(None, error=jh.SshTransportError("Permission denied")) is True
     assert jh.notebook_fallback_after_forward(255) is True
     assert jh.notebook_fallback_after_forward(0) is False
     assert jh.notebook_fallback_after_forward(2) is False

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,23 @@ from scripts.orchestration import job_host_exec as jh
 @pytest.fixture(autouse=True)
 def _clear_occupancy_pin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(jh.ENV_OCCUPANCY_HOST, raising=False)
+
+
+def test_cli_help_runs_without_pythonpath(tmp_path: Path) -> None:
+    script = Path(jh.__file__).resolve()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = ""
+    proc = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Examples:" in proc.stdout
+    assert "Exit codes:" in proc.stdout
 
 
 def _marker_root(tmp_path: Path) -> Path:

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -286,6 +286,37 @@ def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytes
     assert "--agent" in recorded
 
 
+def test_forward_dispatch_preserves_initiator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=["scripts/delegate.py", "dispatch", "--agent", "codex", "--task-id", "cf"],
+        initiator="cursor/job-host-dispatch",
+        initiator_source="session_env",
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert "--initiator" in recorded
+    assert "cursor/job-host-dispatch" in recorded
+    assert f"export {jh.ENV_RUNTIME_INITIATOR}=" in recorded
+    assert f"export {jh.ENV_RUNTIME_INITIATOR_SOURCE}=" in recorded
+
+
 def test_forward_dispatch_inlines_prompt_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -237,7 +238,8 @@ def test_main_dispatch_copies_local_prompt_file(
     recorded = args_file.read_text(encoding="utf-8")
     assert str(prompt) not in recorded
     assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
+    assert "$LU_DISPATCH_PROMPT_0" in recorded
     assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
     assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
 
@@ -318,7 +320,8 @@ def test_forward_dispatch_inlines_prompt_file(
     recorded = args_file.read_text(encoding="utf-8")
     assert str(prompt) not in recorded
     assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
+    assert "$LU_DISPATCH_PROMPT_0" in recorded
     assert "\n--prompt\n-\n" not in recorded
     assert base64.b64encode(b"keep curriculum/l2-uk-en in the worktree\n").decode("ascii") in recorded.replace("\n", "")
 
@@ -360,7 +363,8 @@ def test_forward_dispatch_rewrites_prompt_dash(
     assert rc == 0
     recorded = args_file.read_text(encoding="utf-8")
     assert "--prompt-file" in recorded
-    assert "/tmp/lu-dispatch-prompt-" in recorded
+    assert "/tmp/lu-dispatch-prompt.XXXXXX" in recorded
+    assert "$LU_DISPATCH_PROMPT_0" in recorded
     assert "\n--prompt\n-\n" not in recorded
     assert base64.b64encode(b"touch wiki/pages.md\n").decode("ascii") in recorded.replace("\n", "")
 
@@ -401,7 +405,8 @@ def test_forward_dispatch_copies_lifecycle_file(
     recorded = args_file.read_text(encoding="utf-8")
     assert str(ledger) not in recorded
     assert "--lifecycle-file" in recorded
-    assert "/tmp/lu-dispatch-lifecycle-" in recorded
+    assert "/tmp/lu-dispatch-lifecycle.XXXXXX" in recorded
+    assert "$LU_DISPATCH_LIFECYCLE_0" in recorded
     assert "base64 -d >" in recorded
 
 
@@ -441,7 +446,8 @@ def test_forward_dispatch_copies_output_schema(
     recorded = args_file.read_text(encoding="utf-8")
     assert str(schema) not in recorded
     assert "--output-schema" in recorded
-    assert "/tmp/lu-dispatch-output-schema-" in recorded
+    assert "/tmp/lu-dispatch-output-schema.XXXXXX" in recorded
+    assert "$LU_DISPATCH_OUTPUT_SCHEMA_0" in recorded
     assert "base64 -d >" in recorded
 
 
@@ -547,3 +553,66 @@ def test_notebook_fallback_only_on_transport_failure() -> None:
     assert jh.notebook_fallback_after_forward(255) is True
     assert jh.notebook_fallback_after_forward(0) is False
     assert jh.notebook_fallback_after_forward(2) is False
+
+
+def test_remote_payload_preamble_is_private_unique_and_fail_closed() -> None:
+    first, token_a = jh._remote_payload_preamble("prompt", b"same\n", seq=0)
+    second, token_b = jh._remote_payload_preamble("prompt", b"same\n", seq=1)
+    assert "umask 077" in first
+    assert "mktemp /tmp/lu-dispatch-prompt.XXXXXX" in first
+    assert "base64 -d >" in first
+    assert token_a != token_b
+    var_a = token_a.split(":", 1)[1]
+    var_b = token_b.split(":", 1)[1]
+    created = subprocess.run(
+        ["bash", "-c", f"{first} && {second} && test \"${var_a}\" != \"${var_b}\" && python3 -c 'import os,stat,sys; p=sys.argv[1]; m=stat.S_IMODE(os.stat(p).st_mode); raise SystemExit(0 if m & 0o077 == 0 else 1)' \"${var_a}\""],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert created.returncode == 0, created.stderr
+    failed = subprocess.run(
+        ["bash", "-c", "umask 077 && f=$(mktemp /tmp/lu-dispatch-prompt.XXXXXX) && printf '%s' '!!!!' | base64 -d > \"$f\" && echo reached"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert failed.returncode != 0
+    assert "reached" not in failed.stdout
+
+
+def test_main_missing_ssh_dispatch_returns_255(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", str(empty))
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.main(
+        [
+            "--host-id",
+            "host-job",
+            "--",
+            ".venv/bin/python",
+            "scripts/delegate.py",
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "cf",
+        ]
+    )
+    assert rc == 255
+
+
+def test_main_missing_ssh_plain_command_returns_255(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", str(empty))
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.main(["--host-id", "host-job", "--", "true"])
+    assert rc == 255

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -1,0 +1,225 @@
+"""VPS worker exec + dual-host occupancy placement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.paths import RETIRED_LOCAL_MARKER
+from scripts.orchestration import job_host_exec as jh
+
+
+def _marker_root(tmp_path: Path) -> Path:
+    plane = tmp_path / "batch_state" / "fleet-comms" / "v1"
+    plane.mkdir(parents=True)
+    (plane / RETIRED_LOCAL_MARKER).write_text("retired\n", encoding="utf-8")
+    return tmp_path
+
+
+def _entry(*, status: str = "fresh", mem: float = 20.0, disk: float = 40.0, cpu: int = 4, load1: float = 0.2) -> dict:
+    return {
+        "status": status,
+        "cpu_count": cpu,
+        "loadavg": [load1, 0.1, 0.1],
+        "mem": {"pct": mem},
+        "disk": {"pct": disk},
+        "occupants": [],
+    }
+
+
+def _payload(**hosts: dict) -> dict:
+    shaped = {}
+    for host_id, entry in hosts.items():
+        row = dict(entry)
+        row["host_id"] = host_id
+        shaped[host_id] = row
+    return {"schema": "monitor-occupancy.v1", "hosts": shaped}
+
+
+def test_build_remote_command_prefixes_path_and_cds() -> None:
+    remote = jh.build_remote_command(
+        [".venv/bin/python", "scripts/delegate.py", "dispatch", "--agent", "kimi"],
+        remote_repo="/remote/repo",
+    )
+    assert 'export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"' in remote
+    assert "cd /remote/repo &&" in remote
+
+
+def test_build_ssh_argv_is_batchmode() -> None:
+    argv = jh.build_ssh_argv("job-alias", "true")
+    assert argv[:5] == ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=12"]
+    assert argv[5] == "job-alias"
+
+
+def test_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_HOST, raising=False)
+    monkeypatch.delenv(jh.ENV_HOST_FALLBACK, raising=False)
+    monkeypatch.delenv(jh.ENV_REPO, raising=False)
+    monkeypatch.delenv(jh.ENV_TEACHER_HOST, raising=False)
+    monkeypatch.delenv(jh.ENV_TEACHER_REPO, raising=False)
+    monkeypatch.delenv(jh.ENV_DISPATCH_SSH, raising=False)
+    assert jh.job_dispatch_host() == jh.DEFAULT_JOB_SSH
+    assert jh.job_dispatch_repo() == jh.DEFAULT_JOB_REPO
+    assert jh.ssh_alias_for_host_id("host-job") == jh.DEFAULT_JOB_SSH
+    assert jh.ssh_alias_for_host_id("host-teacher") == jh.DEFAULT_TEACHER_SSH
+    assert jh.repo_for_host_id("host-teacher") == jh.DEFAULT_TEACHER_REPO
+
+
+def test_no_marker_stays_notebook(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_ALLOW_NOTEBOOK, raising=False)
+    occupancy = _payload(**{"host-job": _entry(), "host-teacher": _entry(disk=20.0)})
+    placement, reason, host_id = jh.decide_dispatch_placement(repo_root=tmp_path, occupancy=occupancy)
+    assert (placement, reason, host_id) == ("notebook", "no_retire_marker", None)
+
+
+def test_picks_teacher_when_it_has_more_headroom(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_ALLOW_NOTEBOOK, raising=False)
+    root = _marker_root(tmp_path)
+    occupancy = _payload(
+        **{
+            "host-job": _entry(mem=20.0, disk=49.0, load1=0.2),
+            "host-teacher": _entry(mem=20.0, disk=24.0, load1=0.1),
+        }
+    )
+    placement, reason, host_id = jh.decide_dispatch_placement(repo_root=root, occupancy=occupancy)
+    assert (placement, reason, host_id) == ("vps", "available", "host-teacher")
+    blocked = jh.notebook_dispatch_blocked(repo_root=root, occupancy=occupancy)
+    assert blocked is not None
+    assert "host-teacher" in blocked
+    assert "every VPS worker host" in blocked
+
+
+def test_job_full_uses_teacher(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_ALLOW_NOTEBOOK, raising=False)
+    root = _marker_root(tmp_path)
+    occupancy = _payload(
+        **{
+            "host-job": _entry(mem=90.0, disk=40.0),
+            "host-teacher": _entry(mem=20.0, disk=24.0),
+        }
+    )
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=occupancy) == (
+        "vps",
+        "available",
+        "host-teacher",
+    )
+
+
+def test_teacher_full_uses_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_ALLOW_NOTEBOOK, raising=False)
+    root = _marker_root(tmp_path)
+    occupancy = _payload(
+        **{
+            "host-job": _entry(mem=20.0, disk=40.0),
+            "host-teacher": _entry(mem=99.0, disk=99.0),
+        }
+    )
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=occupancy) == (
+        "vps",
+        "available",
+        "host-job",
+    )
+
+
+def test_both_full_or_down_falls_back_to_notebook(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(jh.ENV_ALLOW_NOTEBOOK, raising=False)
+    root = _marker_root(tmp_path)
+    both_full = _payload(**{"host-job": _entry(mem=90.0), "host-teacher": _entry(disk=90.0)})
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=both_full) == ("notebook", "full", None)
+    both_down = _payload(
+        **{
+            "host-job": _entry(status="unavailable"),
+            "host-teacher": _entry(status="unavailable"),
+        }
+    )
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=both_down) == (
+        "notebook",
+        "unavailable",
+        None,
+    )
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=None) == ("notebook", "unavailable", None)
+    assert jh.notebook_dispatch_blocked(repo_root=root, occupancy=None) is None
+
+
+def test_allow_env_bypasses_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(jh.ENV_ALLOW_NOTEBOOK, "1")
+    root = _marker_root(tmp_path)
+    occupancy = _payload(**{"host-job": _entry(), "host-teacher": _entry(disk=10.0)})
+    assert jh.decide_dispatch_placement(repo_root=root, occupancy=occupancy) == (
+        "notebook",
+        "allow_env",
+        None,
+    )
+
+
+def test_ssh_alias_for_teacher_and_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(jh.ENV_DISPATCH_SSH, "host-job=job-alias,host-teacher=teacher-alias")
+    assert jh.ssh_alias_for_host_id("host-teacher") == "teacher-alias"
+    assert jh.ssh_alias_for_host_id("host-job") == "job-alias"
+    monkeypatch.delenv(jh.ENV_DISPATCH_SSH, raising=False)
+    monkeypatch.setenv(jh.ENV_TEACHER_HOST, "teacher-from-env")
+    monkeypatch.setenv(jh.ENV_HOST, "job-from-env")
+    assert jh.ssh_alias_for_host_id("host-teacher") == "teacher-from-env"
+    assert jh.ssh_alias_for_host_id("host-job") == "job-from-env"
+
+
+def test_main_uses_ssh_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_TEACHER_HOST, "teacher-alias")
+    monkeypatch.setenv(jh.ENV_TEACHER_REPO, "/remote/repo")
+    rc = jh.main(
+        ["--host-id", "host-teacher", "--", ".venv/bin/python", "scripts/delegate.py", "dispatch"]
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert "BatchMode=yes" in recorded
+    assert "teacher-alias" in recorded
+    assert "cd /remote/repo" in recorded
+    assert "scripts/delegate.py" in recorded
+
+
+def test_forward_dispatch_sets_allow_notebook(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    args_file = tmp_path / "ssh.args"
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {args_file}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    monkeypatch.setenv(jh.ENV_HOST, "job-alias")
+    monkeypatch.setenv(jh.ENV_REPO, "/remote/repo")
+    rc = jh.forward_dispatch(
+        host_id="host-job",
+        argv=["scripts/delegate.py", "dispatch", "--agent", "agy", "--task-id", "smoke"],
+    )
+    assert rc == 0
+    recorded = args_file.read_text(encoding="utf-8")
+    assert "BatchMode=yes" in recorded
+    assert "job-alias" in recorded
+    assert f"export {jh.ENV_ALLOW_NOTEBOOK}=1" in recorded
+    assert "dispatch" in recorded
+    assert "--agent" in recorded
+
+
+def test_notebook_fallback_only_on_transport_failure() -> None:
+    assert jh.notebook_fallback_after_forward(None, error=ValueError("missing host")) is True
+    assert jh.notebook_fallback_after_forward(255) is True
+    assert jh.notebook_fallback_after_forward(0) is False
+    assert jh.notebook_fallback_after_forward(2) is False

--- a/tests/orchestration/test_plane_tunnel_gate.py
+++ b/tests/orchestration/test_plane_tunnel_gate.py
@@ -1,0 +1,77 @@
+"""Notebook driver plane probe: ok when tunneled, degraded fallback when not."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.orchestration import plane_tunnel_gate as gate
+
+
+class _Resp:
+    def __init__(self, payload: dict) -> None:
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._raw
+
+    def __enter__(self) -> _Resp:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_skip_env(monkeypatch) -> None:
+    monkeypatch.setenv(gate.ENV_SKIP, "1")
+    assert gate.check_driver_plane()[0] == "skipped"
+
+
+def test_unreachable_is_degraded_not_refused(monkeypatch) -> None:
+    monkeypatch.delenv(gate.ENV_SKIP, raising=False)
+
+    def boom(*_a, **_k):
+        raise TimeoutError("down")
+
+    monkeypatch.setattr(gate.urllib.request, "urlopen", boom)
+    status, reason = gate.check_driver_plane(timeout=0.1)
+    assert status == "degraded"
+    assert "notebook" in reason
+    assert "retired" in reason
+    line = gate.format_launcher_line(status, reason)
+    assert line.startswith("⚠️")
+    assert gate.main() == 0
+
+
+def test_healthy_observer_is_ok(monkeypatch) -> None:
+    monkeypatch.delenv(gate.ENV_SKIP, raising=False)
+    payloads = {
+        "/api/health": {"status": "ok", "version": "2.0.0"},
+        "/api/fleet/health": {
+            "observer": "fleet-comms-v1",
+            "writes_enabled": False,
+            "schema": {"db_exists": True, "applied_version": 7},
+        },
+    }
+
+    def fake_open(url, timeout=0):
+        for path, body in payloads.items():
+            if path in str(url):
+                return _Resp(body)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(gate.urllib.request, "urlopen", fake_open)
+    status, reason = gate.check_driver_plane()
+    assert status == "ok"
+    assert "loopback" in reason
+
+
+def test_missing_fleet_db_is_degraded(monkeypatch) -> None:
+    monkeypatch.delenv(gate.ENV_SKIP, raising=False)
+
+    def fake_open(url, timeout=0):
+        if "/api/health" in str(url):
+            return _Resp({"status": "ok"})
+        return _Resp({"schema": {"db_exists": False}})
+
+    monkeypatch.setattr(gate.urllib.request, "urlopen", fake_open)
+    assert gate.check_driver_plane()[0] == "degraded"

--- a/tests/orchestration/test_plane_tunnel_gate.py
+++ b/tests/orchestration/test_plane_tunnel_gate.py
@@ -39,7 +39,7 @@ def test_unreachable_is_degraded_not_refused(monkeypatch) -> None:
     assert "retired" in reason
     line = gate.format_launcher_line(status, reason)
     assert line.startswith("⚠️")
-    assert gate.main() == 0
+    assert gate.main([]) == 0
 
 
 def test_healthy_observer_is_ok(monkeypatch) -> None:
@@ -75,3 +75,14 @@ def test_missing_fleet_db_is_degraded(monkeypatch) -> None:
 
     monkeypatch.setattr(gate.urllib.request, "urlopen", fake_open)
     assert gate.check_driver_plane()[0] == "degraded"
+
+
+def test_help_contract() -> None:
+    help_text = gate.build_parser().format_help()
+    assert "Probe the tunneled job-host Monitor before notebook driver launch." in help_text
+    assert "do not use it to start a second Monitor" in help_text
+    assert "Examples:" in help_text
+    assert "Outputs:" in help_text
+    assert "Exit codes:" in help_text
+    assert "Related:" in help_text
+    assert "Issue: #7062" in help_text

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -31,6 +31,8 @@ from agent_runtime.adapters.base import InvocationPlan
 from agent_runtime.result import ParseResult
 from agent_runtime.telemetry import InvocationTelemetry
 
+from scripts.orchestration import job_host_exec
+
 
 @pytest.fixture
 def tmp_tasks_dir(tmp_path, monkeypatch):
@@ -136,6 +138,12 @@ def _fixture_runtime_tmp_root(tmp_path, monkeypatch):
     monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(runtime_tmp))
     monkeypatch.delenv("LU_RUNTIME_TMP_BASE_ROOT", raising=False)
     return runtime_tmp
+
+
+@pytest.fixture(autouse=True)
+def _keep_delegate_unit_tests_local(monkeypatch):
+    """Isolate delegate unit tests from a live checkout's VPS occupancy marker."""
+    monkeypatch.setenv(job_host_exec.ENV_ALLOW_NOTEBOOK, "1")
 
 
 def _sanitize_git_env_for_test(monkeypatch) -> None:
@@ -4552,6 +4560,16 @@ def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(
         delegate,
         "_sweep_runtime_tmp_orphans",
         lambda: pytest.fail("dry-run must not sweep ambient runtime tmp leases"),
+    )
+    monkeypatch.setattr(
+        job_host_exec,
+        "decide_dispatch_placement",
+        lambda **_kwargs: pytest.fail("dry-run must not query VPS placement"),
+    )
+    monkeypatch.setattr(
+        job_host_exec,
+        "forward_dispatch",
+        lambda **_kwargs: pytest.fail("dry-run must not forward to a VPS"),
     )
     args = delegate.build_parser().parse_args(
         [

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -44,6 +44,8 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     helper = HELPER.read_text(encoding="utf-8")
     assert "fleet_comms_cold_clause" in helper
     assert "fleet_comms_resolve_plane_mode" in helper
+    assert "fleet_comms_warn_if_plane_unreachable" in helper
+    assert "plane_tunnel_gate" in helper
     assert "fleet-comms-coordination.md" in helper
     assert "drive-epic" in helper
     assert "authoritative" in helper
@@ -67,6 +69,7 @@ def test_prompt_injecting_launchers_include_plane_and_cf_surfaces() -> None:
     assert "fleet_comms_cold_clause" in text or "plane-status" in text
     assert "fleet-comms" in text
     assert 'source "$LC_ROOT/scripts/lib/fleet_comms_cold_start.sh"' in text
+    assert "fleet_comms_warn_if_plane_unreachable" in text
     assert (
         'FLEET_COMMS_PLANE_MODE="${FLEET_COMMS_PLANE_MODE:-$(fleet_comms_resolve_plane_mode)}"'
         in text


### PR DESCRIPTION
## Summary
- Notebook `delegate.py dispatch` SSHs onto the least-loaded occupancy host (`host-job` / `host-teacher`) instead of spawning Darwin workers while a VPS is free.
- If occupancy is unavailable/full or SSH transport fails (rc 255), spawn falls back to the notebook. Drivers probe the tunneled job-host plane and still start when it is down; they do not reopen the retired Mac sqlite or start a second Monitor.

## Changes
- `scripts/orchestration/job_host_exec.py` — occupancy placement, BatchMode SSH, notebook fallback, prompt-file bodies sent over SSH stdin.
- `scripts/orchestration/plane_tunnel_gate.py` — loopback Monitor probe (`ok` / `degraded`).
- `scripts/delegate.py` — auto-forward + fallback.
- Shared `start-*-driver.sh` path via `launcher_core.sh` / `fleet_comms_cold_start.sh`.

## Testing
- [x] `pytest tests/orchestration/test_job_host_exec.py tests/orchestration/test_plane_tunnel_gate.py tests/test_fleet_comms_launcher_awareness.py`
- Website build N/A (infra)
- Ukrainian text N/A (infra)

## Related Issues
Refs #7062. This PR leaves #7060 open.

## CF review
Author: Cursor. Independent cross-family review requested: Codex / OpenAI (not Grok, not Cursor). Exact head SHA in the review. Sealed review-pr stays retired — verdict + findings on this PR.