### PR TITLE
perf(ci): slim pytest ML provisioning (#7099)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,19 @@
+# GitHub default setup consumes this file only when repository property
+# github-codeql-config-file is set to .github/codeql/codeql-config.yml.
+# Keep default setup's pull-request incremental overlay enabled.
+name: Default setup scope
+
+paths-ignore:
+  # Curriculum is content data, not executable product source.
+  - curriculum/**
+
+  # Generated lexicon artifacts and generated TypeScript declarations.
+  - site/public/lexicon/**
+  - site/src/data/lexicon-*.json
+  - packages/activity-kit/src/*.generated.ts
+
+  # The repository has only these incidental Go and Swift sources. Default
+  # setup language selection is still an administrator setting; these ignores
+  # keep their generated/external implementation out of source analysis.
+  - scripts/entire/external_agents/entire-agent-kimi/**
+  - scripts/rag/apple_vision_ocr.swift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,16 +180,16 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv .venv
-          grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt \
+          # The planner collects `not atlas_release and not slow`: retain the
+          # offline ukrainian_word_stress trie, but never install the live
+          # Stanza/torch stack for a selection that excludes its tests.
+          grep -viE '^(torch|torchvision|open_clip_torch|stanza)==' requirements-lock.txt \
             > "${RUNNER_TEMP}/requirements-ci.txt"
-          # Bounded retry absorbs transient PyPI / pytorch.org blips (#7002;
-          # same 3× / 10s / 30s idiom as Stanza provision below).
+          # Bounded retry absorbs transient PyPI blips (#7002).
           for attempt in 1 2 3; do
             echo "planner pip install attempt ${attempt}/3"
             if .venv/bin/python -m pip install --upgrade pip \
               && .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt" \
-              && .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
-                torch==2.13.0 \
               && .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
               exit 0
             fi
@@ -248,37 +248,6 @@ jobs:
         with:
           python-version-file: '.python-version'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install fastlane test dependencies
-        run: |
-          set -euo pipefail
-          python -m venv .venv
-          grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt \
-            > "${RUNNER_TEMP}/requirements-ci.txt"
-          # Bounded retry absorbs transient PyPI / pytorch.org blips (#7002;
-          # same 3× / 10s / 30s idiom as Stanza provision).
-          for attempt in 1 2 3; do
-            echo "fastlane pip install attempt ${attempt}/3"
-            if .venv/bin/python -m pip install --upgrade pip \
-              && .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt" \
-              && .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
-                torch==2.13.0 \
-              && .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
-              exit 0
-            fi
-            case "${attempt}" in
-              1) sleep 10 ;;
-              2) sleep 30 ;;
-            esac
-          done
-          echo "::error::Install fastlane test dependencies failed after 3 attempts" >&2
-          exit 1
-
       - name: Select directly changed test modules
         id: plan
         env:
@@ -290,7 +259,7 @@ jobs:
             base_ref="origin/main"
           fi
           mkdir -p ci-artifacts
-          .venv/bin/python scripts/ci/changed_tests.py \
+          python scripts/ci/changed_tests.py \
             --base "$base_ref" \
             --output ci-artifacts/fastlane-test-files.txt
           if [[ -s ci-artifacts/fastlane-test-files.txt ]]; then
@@ -302,13 +271,74 @@ jobs:
             echo "No directly changed test modules; fastlane has an empty advisory plan."
           fi
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.plan.outputs.has_tests == 'true'
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install slim fastlane test dependencies
+        if: steps.plan.outputs.has_tests == 'true'
+        run: |
+          set -euo pipefail
+          python -m venv .venv
+          python scripts/ci/fastlane_requirements.py \
+            --tests ci-artifacts/fastlane-test-files.txt \
+            --base scripts/ci/requirements-fastlane.txt \
+            --lock requirements-lock.txt \
+            --output "${RUNNER_TEMP}/requirements-fastlane.txt"
+          # The checked-in profile plus the selected tests' reviewed direct
+          # imports resolve under the full lock as constraints; do not install
+          # every pinned package merely to run a small changed-test plan.
+          for attempt in 1 2 3; do
+            echo "fastlane slim pip install attempt ${attempt}/3"
+            if .venv/bin/python -m pip install --upgrade pip \
+              && .venv/bin/python -m pip install \
+                -c requirements-lock.txt -r "${RUNNER_TEMP}/requirements-fastlane.txt"; then
+              exit 0
+            fi
+            case "${attempt}" in
+              1) sleep 10 ;;
+              2) sleep 30 ;;
+            esac
+          done
+          echo "::error::Install slim fastlane test dependencies failed after 3 attempts" >&2
+          exit 1
+
       - name: Run directly changed test modules
         if: steps.plan.outputs.has_tests == 'true'
         run: |
           set -euo pipefail
           mapfile -t test_files < ci-artifacts/fastlane-test-files.txt
+
+          run_tests() {
+            local label="$1"
+            .venv/bin/python -m pytest \
+              --strict-markers --timeout=120 --timeout-method=thread --durations=10 \
+              -m 'not atlas_release and not slow' \
+              "${test_files[@]}" 2>&1 | tee "ci-artifacts/fastlane-pytest-${label}.log"
+          }
+
+          install_with_retry() {
+            local label="$1"
+            shift
+            for attempt in 1 2 3; do
+              echo "${label} install attempt ${attempt}/3"
+              if "$@"; then
+                return 0
+              fi
+              case "${attempt}" in
+                1) sleep 10 ;;
+                2) sleep 30 ;;
+              esac
+            done
+            echo "::error::${label} install failed after 3 attempts" >&2
+            return 1
+          }
+
           if printf '%s\n' "${test_files[@]}" | grep -qx 'tests/agent_runtime/test_acp_text_agent.py'; then
-            # npm registry blips (#7002; Stanza provision idiom).
+            # npm registry blips (#7002).
             for attempt in 1 2 3; do
               echo "fastlane npm ci attempt ${attempt}/3"
               if npm ci --ignore-scripts; then
@@ -324,10 +354,45 @@ jobs:
               esac
             done
           fi
-          .venv/bin/python -m pytest \
-            --strict-markers --timeout=120 --timeout-method=thread --durations=10 \
-            -m 'not atlas_release and not slow' \
-            "${test_files[@]}"
+
+          set +e
+          run_tests initial
+          status=$?
+          set -e
+
+          # The offline stress trie is intentionally independent of Stanza.
+          # Install it only after selected test execution proves it is needed.
+          if [[ "$status" -ne 0 ]] \
+            && grep -Eq "No module named ['\"](ukrainian_word_stress|marisa_trie)([.'\"]|$)" \
+              ci-artifacts/fastlane-pytest-initial.log; then
+            install_with_retry "offline stress dictionary" \
+              .venv/bin/python -m pip install --no-deps \
+              ukrainian_word_stress==2.1.0 marisa-trie==1.4.1
+            set +e
+            run_tests offline-stress
+            status=$?
+            set -e
+          fi
+
+          # A CPU torch/Stanza install is a fail-closed, per-run escalation:
+          # it follows an actual missing live-model import in selected tests,
+          # never a filename/import heuristic or the default fastlane path.
+          if [[ "$status" -ne 0 ]] \
+            && grep -Eq "No module named ['\"](torch|stanza)([.'\"]|$)" \
+              ci-artifacts/fastlane-pytest-*.log; then
+            install_with_retry "CPU torch" \
+              .venv/bin/python -m pip install --no-deps \
+                --index-url https://download.pytorch.org/whl/cpu torch==2.13.0
+            install_with_retry "Stanza live-model dependencies" \
+              .venv/bin/python -m pip install --no-deps \
+                stanza==1.13.0 ukrainian_word_stress==2.1.0
+            set +e
+            run_tests live-model
+            status=$?
+            set -e
+          fi
+
+          exit "$status"
 
   # ---------------------------------------------------------------------
   # 3. python — execute the planner's four unconditional test partitions.
@@ -395,8 +460,7 @@ jobs:
 
       # Sole owner of ~/.cache/pip for this job (setup-python cache disabled).
       # Cache-service errors are recoverable: continue to a cold pip install.
-      # A restore miss or outage must not kill the shard (#7002; same posture
-      # as the Stanza model-cache restore below).
+      # A restore miss or outage must not kill the shard (#7002).
       - name: Restore pip wheel cache
         if: needs.landing-class.outputs.class != 'docs_skills'
         id: pip-wheel-cache
@@ -404,29 +468,25 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
-          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch-cpu
+          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-no-live-ml
 
-      # pytest exercises scripts/pipeline/stress_annotator.py::_get_stressifier,
-      # which imports ukrainian_word_stress.Stressifier; Stressifier imports
-      # stanza, and Stanza imports torch. Keep torchvision and open_clip_torch
-      # out of this environment: the suite does not import either package.
-      # Install the CPU-only torch wheel to avoid the much larger CUDA build.
+      # Required shards select `not atlas_release and not slow`. Keep the
+      # offline ukrainian_word_stress trie available for its unmarked oracle,
+      # but exclude Stanza and torch: every live Stressifier test is slow and
+      # belongs to the dedicated scheduled model-provisioning lane.
       - name: Install dependencies
         if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
           set -euo pipefail
           python -m venv .venv
-          grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt \
+          grep -viE '^(torch|torchvision|open_clip_torch|stanza)==' requirements-lock.txt \
             > "${RUNNER_TEMP}/requirements-ci.txt"
-          # Bounded retry absorbs transient PyPI / pytorch.org blips (#7002;
-          # same 3× / 10s / 30s idiom as Stanza provision below).
+          # Bounded retry absorbs transient PyPI blips (#7002).
           # ruff lives in its own job after the two-tier cutover (#6989).
           for attempt in 1 2 3; do
             echo "python-shard pip install attempt ${attempt}/3"
             if .venv/bin/python -m pip install --upgrade pip \
               && .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt" \
-              && .venv/bin/python -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
-                torch==2.13.0 \
               && .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
               exit 0
             fi
@@ -443,51 +503,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
-          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch-cpu
-
-      # Stressifier lazily provisions this model when it creates its Stanza
-      # pipeline. Cache the model package separately from pip wheels so a
-      # cold runner does not redownload it in every CI run. Version the key and
-      # couple it to the lockfile: a model cache is valid only for the Stanza
-      # dependency set that produced it.
-      # Cache-service errors are recoverable: continue to the provision path.
-      # A restore miss or outage must not kill the shard; provision is the gate.
-      - name: Restore Stanza Ukrainian model cache
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        id: stanza-model-cache
-        continue-on-error: true
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/stanza_resources
-          key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
-
-      # Run this smoke regardless of cache state. Besides provisioning a cold
-      # cache, it verifies a restored archive before pytest workers can start
-      # lazy model downloads. Bounded retry absorbs transient Hugging Face /
-      # GitHub network blips (3 attempts, 10s then 30s backoff).
-      - name: Provision and verify Stanza Ukrainian model
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "stanza provision attempt ${attempt}/3"
-            if .venv/bin/python -c "from scripts.pipeline.stress_annotator import annotate_stress; print(annotate_stress('Мама читає книжку.'))"; then
-              exit 0
-            fi
-            case "${attempt}" in
-              1) sleep 10 ;;
-              2) sleep 30 ;;
-            esac
-          done
-          echo "::error::Provision and verify Stanza Ukrainian model failed after 3 attempts" >&2
-          exit 1
-
-      - name: Save Stanza Ukrainian model cache
-        if: needs.landing-class.outputs.class != 'docs_skills' && steps.stanza-model-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/stanza_resources
-          key: stanza-uk-model-v2-${{ runner.os }}-${{ hashFiles('requirements-lock.txt') }}
+          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-no-live-ml
 
       - name: Download the single planner's shard plans
         if: needs.landing-class.outputs.class != 'docs_skills'

--- a/docs/runbooks/ci-gate.md
+++ b/docs/runbooks/ci-gate.md
@@ -88,6 +88,15 @@ implementation-only changes. It currently does not infer tests from changed
 implementation files; the unconditional shards remain responsible for that
 coverage.
 
+`CI Gate` remains the only required check. CodeQL stays on GitHub default
+setup and, after a repository administrator sets
+`github-codeql-config-file=.github/codeql/codeql-config.yml`, reads the
+in-repository scope exclusions for curriculum, generated lexicon/type outputs,
+and the incidental Go/Swift paths. Keep default setup's pull-request
+incremental overlay enabled; CodeQL language selection and merge protection
+are repository-admin settings, so do not add CodeQL to `CI Gate` or create a
+second workflow merely to change its requiredness.
+
 ## Quarantine convention (documentation only)
 
 If a future CI-capacity exception must be recorded, describe it in the PR or
@@ -123,4 +132,3 @@ trufflehog git file://$PWD --results=verified,unknown --exclude-paths=.truffleho
 ```
 
 Because the repository does not use Lob credentials, excluding the `Lob` detector in `.github/workflows/ci.yml` via `--exclude-detectors=Lob` permanently eliminates these false-positives.
-

--- a/scripts/ci/fastlane_requirements.py
+++ b/scripts/ci/fastlane_requirements.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Build a slim dependency file, constrained by the repository lock, for changed pytest modules.
+
+Use this helper only for CI's advisory changed-test fastlane. It maps direct
+third-party imports in selected tests through an explicit, reviewed mapping;
+unknown imports fail closed instead of guessing a distribution name. The
+required full pytest tier remains responsible for the complete dependency set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+# Import roots whose distribution names do not follow a safe one-to-one rule
+# are deliberately listed here rather than inferred. Keep this small and add a
+# mapping with a regression test when a selected test needs a new dependency.
+IMPORT_DISTRIBUTIONS = {
+    "aiosqlite": "aiosqlite",
+    "bs4": "beautifulsoup4",
+    "dateutil": "python-dateutil",
+    "fastapi": "fastapi",
+    "httpx": "httpx",
+    "huggingface_hub": "huggingface_hub",
+    "jsonschema": "jsonschema",
+    "lxml": "lxml",
+    "numpy": "numpy",
+    "PIL": "pillow",
+    "pymorphy3": "pymorphy3",
+    "pypdf": "pypdf",
+    "psutil": "psutil",
+    "pytest": "pytest",
+    "rapidfuzz": "RapidFuzz",
+    "requests": "requests",
+    "ruamel": "ruamel.yaml",
+    "tokenizers": "tokenizers",
+    "uvicorn": "uvicorn",
+    "yaml": "PyYAML",
+}
+
+# requirements-lock.txt predates the project's direct pyahocorasick declaration
+# in requirements.txt. Keep its reviewed, exact fastlane pin explicit until the
+# lock is regenerated as separate dependency maintenance.
+EXPLICIT_REQUIREMENTS = {"ahocorasick": "pyahocorasick==2.3.1"}
+
+# These modules must not inflate the normal fastlane profile merely because a
+# slow-marked test imports them. The workflow retries only after pytest proves
+# that selected, non-deselected work actually needs the live ML stack.
+LIVE_MODEL_IMPORTS = frozenset({"stanza", "torch", "ukrainian_word_stress"})
+_LOCK_LINE = re.compile(r"^([A-Za-z0-9_.-]+)==")
+_NORMALIZE_NAME = re.compile(r"[-_.]+")
+
+
+class RequirementSelectionError(RuntimeError):
+    """Raised when a selected test has no reviewed dependency mapping."""
+
+
+def canonical_name(name: str) -> str:
+    """Return the PEP 503 comparison form without importing packaging."""
+    return _NORMALIZE_NAME.sub("-", name).lower()
+
+
+def import_roots(path: Path) -> set[str]:
+    """Return absolute top-level imports from one Python test module."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+def read_lock(path: Path) -> dict[str, str]:
+    """Read exact version pins from the lock file, keyed canonically."""
+    requirements: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = _LOCK_LINE.match(line)
+        if match:
+            requirements.setdefault(canonical_name(match.group(1)), line)
+    return requirements
+
+
+def read_requirements(path: Path) -> list[str]:
+    """Read non-comment requirement lines while retaining their source order."""
+    return [
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and not line.lstrip().startswith("#")
+    ]
+
+
+def is_project_import(root: str, project_root: Path) -> bool:
+    """Whether a root can resolve from the repository or its scripts package."""
+    candidates = (
+        project_root / root,
+        project_root / f"{root}.py",
+        project_root / "scripts" / root,
+        project_root / "scripts" / f"{root}.py",
+    )
+    return any(candidate.exists() for candidate in candidates)
+
+
+def select_requirements(
+    test_paths: Iterable[Path],
+    *,
+    base_requirements: Iterable[str],
+    lock_requirements: dict[str, str],
+    project_root: Path,
+) -> list[str]:
+    """Return the base profile plus pins for reviewed direct test imports."""
+    roots = set().union(*(import_roots(path) for path in test_paths))
+    unknown: set[str] = set()
+    additions: set[str] = set()
+
+    for root in roots:
+        if root in LIVE_MODEL_IMPORTS or root == "__future__":
+            continue
+        if requirement := EXPLICIT_REQUIREMENTS.get(root):
+            additions.add(requirement)
+            continue
+        distribution = IMPORT_DISTRIBUTIONS.get(root)
+        if distribution:
+            requirement = lock_requirements.get(canonical_name(distribution))
+            if requirement is None:
+                raise RequirementSelectionError(
+                    f"{root!r} maps to {distribution!r}, which is missing from requirements-lock.txt"
+                )
+            additions.add(requirement)
+        elif root in sys.stdlib_module_names or is_project_import(root, project_root):
+            continue
+        else:
+            unknown.add(root)
+
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise RequirementSelectionError(
+            f"selected tests import unmapped third-party module(s): {names}; "
+            "add a reviewed mapping instead of installing the full lock"
+        )
+
+    selected: list[str] = []
+    for requirement in [*base_requirements, *sorted(additions, key=str.lower)]:
+        if requirement not in selected:
+            selected.append(requirement)
+    return selected
+
+
+def read_test_plan(path: Path) -> list[Path]:
+    """Read the newline-delimited changed-test plan emitted by changed_tests.py."""
+    return [Path(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests", type=Path, required=True, help="newline-delimited selected test-module plan")
+    parser.add_argument("--base", type=Path, required=True, help="checked-in slim requirements profile")
+    parser.add_argument("--lock", type=Path, required=True, help="repository lock file supplying exact pins")
+    parser.add_argument("--output", type=Path, required=True, help="generated requirements file for pip")
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path("."),
+        help="repository root used to recognize local imports (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        selected = select_requirements(
+            [args.project_root / path for path in read_test_plan(args.tests)],
+            base_requirements=read_requirements(args.base),
+            lock_requirements=read_lock(args.lock),
+            project_root=args.project_root,
+        )
+    except (OSError, RequirementSelectionError, SyntaxError) as exc:
+        print(f"fastlane requirements failed: {exc}", file=sys.stderr)
+        return 1
+
+    args.output.write_text("\n".join(selected) + "\n", encoding="utf-8")
+    print(f"fastlane slim requirements: {len(selected)} requirement(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/requirements-fastlane.txt
+++ b/scripts/ci/requirements-fastlane.txt
@@ -1,0 +1,22 @@
+# Direct, reviewed dependencies for the advisory changed-test fastlane.
+#
+# Install this file with ``-c requirements-lock.txt`` so transitive packages
+# stay on the repository's resolved versions. Keep the profile deliberately
+# small: the required full tier remains the authority for broad integration
+# coverage. Add a package only when a selected test imports it at runtime.
+
+# Test runner.
+pytest==9.0.3
+pytest-timeout==2.4.0
+
+# FastAPI/TestClient paths.
+fastapi==0.139.0
+httpx==0.28.1
+beautifulsoup4==4.14.3
+filelock==3.32.2
+jsonschema==4.26.0
+lxml==6.1.1
+psutil==7.2.2
+pyahocorasick==2.3.1
+python-multipart==0.0.32
+PyYAML==6.0.3

--- a/tests/test_ci_fastlane_requirements.py
+++ b/tests/test_ci_fastlane_requirements.py
@@ -1,0 +1,101 @@
+"""Regression tests for the changed-test fastlane dependency profile."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import fastlane_requirements
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _lock(tmp_path: Path) -> dict[str, str]:
+    lock = _write(
+        tmp_path / "requirements-lock.txt",
+        """\
+fastapi==0.139.0
+PyYAML==6.0.3
+pytest==9.0.3
+requests==2.34.2
+""",
+    )
+    return fastlane_requirements.read_lock(lock)
+
+
+def test_selected_direct_imports_add_reviewed_exact_lock_pins(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    _write(project_root / "scripts" / "ci" / "__init__.py", "")
+    test_path = _write(
+        project_root / "tests" / "test_example.py",
+        """\
+from __future__ import annotations
+
+import yaml
+from fastapi import FastAPI
+from requests import get
+from scripts.ci import changed_tests
+""",
+    )
+
+    selected = fastlane_requirements.select_requirements(
+        [test_path],
+        base_requirements=["pytest==9.0.3", "fastapi==0.139.0"],
+        lock_requirements=_lock(tmp_path),
+        project_root=project_root,
+    )
+
+    assert selected == ["pytest==9.0.3", "fastapi==0.139.0", "PyYAML==6.0.3", "requests==2.34.2"]
+
+
+def test_unknown_third_party_import_fails_closed(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    test_path = _write(project_root / "tests" / "test_example.py", "import unreviewed_vendor\n")
+
+    with pytest.raises(fastlane_requirements.RequirementSelectionError, match="unreviewed_vendor"):
+        fastlane_requirements.select_requirements(
+            [test_path],
+            base_requirements=[],
+            lock_requirements=_lock(tmp_path),
+            project_root=project_root,
+        )
+
+
+def test_explicit_non_lock_runtime_import_has_a_reviewed_pin(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    test_path = _write(project_root / "tests" / "test_example.py", "import ahocorasick\n")
+
+    selected = fastlane_requirements.select_requirements(
+        [test_path],
+        base_requirements=[],
+        lock_requirements=_lock(tmp_path),
+        project_root=project_root,
+    )
+
+    assert selected == ["pyahocorasick==2.3.1"]
+
+
+def test_live_model_imports_do_not_expand_the_default_profile(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    test_path = _write(
+        project_root / "tests" / "test_example.py",
+        """\
+import stanza
+import torch
+from ukrainian_word_stress import Stressifier
+""",
+    )
+
+    selected = fastlane_requirements.select_requirements(
+        [test_path],
+        base_requirements=["pytest==9.0.3"],
+        lock_requirements=_lock(tmp_path),
+        project_root=project_root,
+    )
+
+    assert selected == ["pytest==9.0.3"]

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.ci import pytest_shards
 
@@ -209,6 +210,48 @@ def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
     assert "Create or update infra issue on failure" in nightly
     assert "area:infra" in nightly
     assert nightly.splitlines()[0] == "name: Pytest slow nightly"
+
+
+def test_required_lanes_exclude_live_model_setup_and_fastlane_is_slim() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    workflow = yaml.safe_load((repo_root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    planner_install = next(step for step in jobs["pytest-plan"]["steps"] if step.get("name") == "Install planner dependencies")
+    shard_steps = jobs["python"]["steps"]
+    shard_install = next(step for step in shard_steps if step.get("name") == "Install dependencies")
+    fastlane_steps = jobs["pytest-fastlane"]["steps"]
+    fastlane_install = next(step for step in fastlane_steps if step.get("name") == "Install slim fastlane test dependencies")
+    fastlane_run = next(step for step in fastlane_steps if step.get("name") == "Run directly changed test modules")
+
+    for step in (planner_install, shard_install):
+        run = step["run"]
+        assert "torch==2.13.0" not in run
+        assert "download.pytorch.org" not in run
+        assert "|stanza)" in run
+    assert "stanza_resources" not in "\n".join(str(step) for step in shard_steps)
+
+    assert "requirements-fastlane.txt" in fastlane_install["run"]
+    assert "-c requirements-lock.txt" in fastlane_install["run"]
+    assert "pip install --no-deps -r" not in fastlane_install["run"]
+    assert "No module named" in fastlane_run["run"]
+    assert "CPU torch" in fastlane_run["run"]
+    names = [step.get("name", "") for step in fastlane_steps]
+    assert names.index("Select directly changed test modules") < names.index("Install slim fastlane test dependencies")
+
+
+def test_codeql_default_setup_scope_excludes_content_generated_and_sparse_paths() -> None:
+    config_path = Path(__file__).resolve().parents[1] / ".github" / "codeql" / "codeql-config.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert set(config["paths-ignore"]) >= {
+        "curriculum/**",
+        "site/public/lexicon/**",
+        "packages/activity-kit/src/*.generated.ts",
+        "scripts/entire/external_agents/entire-agent-kimi/**",
+        "scripts/rag/apple_vision_ocr.swift",
+    }
+
 
 def test_required_markexpr_constant_matches_ci_and_addopts_boundary() -> None:
     """addopts stays atlas-only; required gate adds not slow via CLI -m everywhere."""


### PR DESCRIPTION
## Summary

- Remove CPU torch, Stanza, and `~/stanza_resources` provisioning from the planner and four required shards, while retaining the offline stress trie and the existing scheduled live-model lane.
- Select changed fastlane tests before installation; install a lock-constrained slim profile and escalate to the offline dictionary or CPU torch/Stanza only after a real missing import proves it is needed.
- Add the default-setup CodeQL scope config and document the sole-required-`CI Gate` contract.

## Verification

- `/home/ops/services/learn-ukrainian/.venv/bin/python -m pytest tests/test_ci_fastlane_requirements.py tests/test_ci_shard_partition.py tests/test_ci_queue_starvation.py tests/test_ci_changed_tests.py -q`
- `/home/ops/services/learn-ukrainian/.venv/bin/python scripts/ci/slot_inventory.py --check` (28 / 31 slots; four shards unchanged)
- Generated the fastlane profile for the #7097 API test modules: 12 packages, no torch or Stanza.

## CodeQL activation

GitHub default setup consumes `.github/codeql/codeql-config.yml` only after a repository administrator sets `github-codeql-config-file=.github/codeql/codeql-config.yml`. Default setup PR incremental analysis remains enabled. CodeQL language selection and merge protection are repository-admin settings; `CI Gate` remains the only required check.

Closes #7099
Refs #6943