### PR TITLE
fix(security): scrub public runner path defaults and host-role tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,8 +431,8 @@ data/lexicon/slovnyk_cache/
 # reads them (it hydrates the published release-asset manifest).
 # Regenerate on demand via scripts/lexicon/enrich_manifest.py.
 data/lexicon/cache/
-# Local mirror of the remote Atlas 20k runner work-dir (default
-# /home/ops/atlas-runner/run-20k on the VPS): ledger.sqlite, network-cache.sqlite,
+# Local mirror of the remote Atlas 20k runner work-dir
+# ($ATLAS_RUN_ROOT / $ATLAS_WORK_DIR_NAME on the VPS): ledger.sqlite, network-cache.sqlite,
 # reduce/enrich candidates. The VPS itself has no backup; scripts/backup-data.sh
 # (#6014) already backs up all of data/, so mirroring here — instead of building a
 # second backup mechanism — makes the runner state durable for free (#5884).

--- a/docs/poc/word-atlas/SLOVNYK-HUB-LAYERS.md
+++ b/docs/poc/word-atlas/SLOVNYK-HUB-LAYERS.md
@@ -49,7 +49,7 @@ sections.usage_notes = { items[{title?, text, source, source_url}], source }  # 
 
 ### Disk / deploy hygiene
 
-- Mass re-enrich on VPS atlas-runner
+- Mass re-enrich on a configured runner host
 - Reap worktrees/temps after each large job; keep ≥15% free when possible
 - No sealed formal CF / multi-GB lu-review trees
 - Publish shard pointer only with integrity hashes + residual metrics

--- a/docs/runbooks/atlas-20k-runner-durability.md
+++ b/docs/runbooks/atlas-20k-runner-durability.md
@@ -4,7 +4,8 @@ Fixes #5884. Related incident: 2026-07-29 wipe (sole laptop copies fail).
 
 The `fetch_ulif_20k.py` / `reduce_ulif_20k.py` / `enrich_offline_20k.py`
 runners write their durable state under a work-dir on the remote runner VPS
-(default `/home/ops/atlas-runner/run-20k`):
+(`$ATLAS_RUN_ROOT/$ATLAS_WORK_DIR_NAME`, default work-dir name `run-20k`;
+`ATLAS_RUN_ROOT` is required):
 
 | Artifact | Path |
 | --- | --- |
@@ -42,7 +43,7 @@ open-dataset export, not for private durability of in-progress runner state.
 # Sync a source (local path or user@host:/path) into a local mirror and
 # (re)write its manifest.json (sha256 per file):
 .venv/bin/python scripts/lexicon/runner/durable_mirror.py snapshot \
-  --source ops@<runner-host>:/home/ops/atlas-runner/run-20k \
+  --source "$ATLAS_RUNNER_HOST:$ATLAS_RUN_ROOT/run-20k" \
   --mirror-dir data/lexicon/runner-mirror/run-20k
 
 # Recompute checksums and compare against the manifest (corruption check):
@@ -65,7 +66,7 @@ case (env: `ATLAS_RUNNER_HOST`, `ATLAS_RUN_ROOT`, `ATLAS_WORK_DIR_NAME`,
 `ATLAS_MIRROR_DIR`):
 
 ```bash
-ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+scripts/lexicon/runner/mirror_20k_runner.sh
 scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # gate only, no sync
 ```
 
@@ -75,7 +76,7 @@ requires a fresh, restic-covered local mirror. It never starts enrichment or
 changes runner state:
 
 ```bash
-ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/health_20k_runner.sh
+scripts/lexicon/runner/health_20k_runner.sh
 ```
 
 ## Required workflow
@@ -84,7 +85,7 @@ ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/health_20k_runner.sh
    during an active run), sync:
 
    ```bash
-   ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+   scripts/lexicon/runner/mirror_20k_runner.sh
    ```
 
 2. Push the refreshed mirror into the restic bus:
@@ -125,7 +126,7 @@ After a VPS wipe or a fresh runner host:
 
 # 3) Copy the verified mirror back to a fresh VPS work-dir.
 rsync -az /absolute/path/to/restore-test/data/lexicon/runner-mirror/run-20k/ \
-  ops@<new-runner-host>:/home/ops/atlas-runner/run-20k/
+  "$ATLAS_RUNNER_HOST:$ATLAS_RUN_ROOT/run-20k/"
 
 # 4) Resume. The fetch/enrich ledgers are resumable by design — the same
 #    work-dir with an intact ledger.sqlite resumes rather than restarting:

--- a/docs/runbooks/atlas-full-reenrich-campaign.md
+++ b/docs/runbooks/atlas-full-reenrich-campaign.md
@@ -1,12 +1,12 @@
 # Atlas Full-Reenrich Campaign Runbook (#6466)
 
 This runbook documents the operator and driver procedures for the full-catalog Atlas re-enrichment campaign tooling (#6466).
-Tracked submit/status/close: [`atlas-job-protocol.md`](atlas-job-protocol.md). Default host is `atlas-runner`.
+Tracked submit/status/close: [`atlas-job-protocol.md`](atlas-job-protocol.md). Set `ATLAS_RUNNER_HOST` and `ATLAS_RUN_ROOT` from operator env.
 
 ## Overview & Campaign Architecture
 
 The full-catalog campaign re-enriches all entries in `lexicon-manifest.json` using the VPS runner.
-Because the remote VPS repo checkout (`/home/ops/atlas-runner/repo`) is deliberately dirty/stale (large data directories deleted for disk space), execution is isolated to the isolated work directory (`$ATLAS_RE_ENRICH_WORK_DIR`).
+Because the remote VPS repo checkout (`$ATLAS_RUN_ROOT/repo`) is deliberately dirty/stale (large data directories deleted for disk space), execution is isolated to the isolated work directory (`$ATLAS_RE_ENRICH_WORK_DIR`).
 
 ### Key Invariants
 1. **Entry-count invariance**: Live manifest entry count is strictly unchanged.
@@ -64,12 +64,13 @@ From the Mac worktree, deploy the driver and launcher to the remote VPS and laun
 ```bash
 # Smoke test (small limit)
 # Prefer the job protocol (tracked plan + result). See atlas-job-protocol.md.
-ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+# ATLAS_RUNNER_HOST and ATLAS_RUN_ROOT must already be set in operator env.
+scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --target full-catalog \
   --limit 10
 
 # Full campaign launch (detached systemd-run under 1.5G/2.0G memory limits)
-ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --target full-catalog \
   --no-poll
 ```
@@ -94,11 +95,11 @@ Resuming a dead run reuses this snapshot and manifest checkpoint without restart
 Check status and logs on the VPS runner:
 
 ```bash
-# Check if driver process is active
-ssh atlas-runner "ps aux | grep reenrich_thin_manifest_entries"
+# Check if the tracked unit is still the mutex (do not bake SSH host tokens here)
+.venv/bin/python -m scripts.lexicon.runner.atlas_job status --host "$ATLAS_RUNNER_HOST" --audit
 
-# Inspect live log tail
-ssh atlas-runner "tail -n 60 /home/ops/atlas-runner/run-class-b-reenrich/reenrich.log"
+# Inspect live log tail under the configured work-dir
+ssh "$ATLAS_RUNNER_HOST" "tail -n 60 \"$ATLAS_RUN_ROOT/run-class-b-reenrich/reenrich.log\""
 ```
 
 If 50 consecutive entries fail to hit any source/cache, the circuit breaker trips, returning exit code `70` (`CIRCUIT_BREAKER_EXIT_CODE`) and logging `circuit_breaker_tripped: true`.
@@ -110,7 +111,7 @@ If 50 consecutive entries fail to hit any source/cache, the circuit breaker trip
 Once complete, pull back the output manifest and run summary:
 
 ```bash
-ATLAS_RUNNER_HOST=atlas-runner scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
+scripts/lexicon/runner/launch_reenrich_class_b_remote.sh \
   --pull-only
 ```
 

--- a/docs/runbooks/atlas-job-protocol.md
+++ b/docs/runbooks/atlas-job-protocol.md
@@ -12,42 +12,28 @@ and not a Hetzner snapshot.
 
 ## Hosts
 
-Atlas jobs may run on **both** `atlas-runner` and `hramatka` (operator GO
-2026-08-17). Each host is its own mutex — `submit` refuses a second active
-`atlas-job-*` unit on the *same* host, but the two hosts may run concurrently.
+Atlas jobs may run on more than one configured worker. Each plan-host token
+is its own mutex — `submit` refuses a second active `atlas-job-*` unit on the
+*same* host, but distinct hosts may run concurrently.
 
-| Host | Use | Never |
-| --- | --- | --- |
-| `atlas-runner` | Reenrich, later ULIF / slovnyk migrate | Teacher API, GH runners |
-| `hramatka` | Reenrich (class-B, memory-capped) **and** teacher API, Caddy, CI runners | Writing under `/opt/hramatka` or `/srv` (teacher-service data) |
+Live host-role maps, SSH tokens, and filesystem run roots are **private ops**.
+Do not document them in this public repository. Operators set:
 
-Default `ATLAS_RUNNER_HOST` is **`atlas-runner`**; pass `host: hramatka` (or
-the `vps` ssh alias — same machine, see `scripts/config/trails/estate.v1.yaml`)
-to target the other host. Unknown host strings are still rejected.
+- `ATLAS_RUNNER_HOST` — plan-host / SSH destination from operator env
+- `ATLAS_RUN_ROOT` — absolute remote run root (required; fail-closed if unset)
 
-Per-host default work root (only used when the plan omits `workdir`, and
-overridable via `ATLAS_RUN_ROOT`):
+`submit` and the launcher `mkdir -p` `$ATLAS_RUN_ROOT` on first use. Never
+point a job `workdir` at teacher product data trees.
 
-| Host | Default root |
-| --- | --- |
-| `atlas-runner` | `/home/ops/atlas-runner` |
-| `hramatka` / `vps` | `/home/ops/atlas-jobs` (does not exist yet on the host — `submit`/the launcher `mkdir -p` it on first use) |
+The class-B launcher (`launch_reenrich_class_b.sh`) pins
+`systemd-run --property=MemoryHigh=1536M --property=MemoryMax=2048M` on every
+host so a reenrich run cannot starve co-resident services. Do not raise those
+limits without checking headroom.
 
-`hramatka`'s reenrich work root is deliberately separate from its
-teacher-facing `/opt/hramatka` and `/srv` trees — never point a job's
-`workdir` there.
-
-**Memory on hramatka.** The class-B launcher (`launch_reenrich_class_b.sh`)
-already pins `systemd-run --property=MemoryHigh=1536M --property=MemoryMax=2048M`
-regardless of host — this is intentionally conservative on hramatka so a
-reenrich run cannot starve the teacher API / Caddy / GH runners sharing that
-box. Do not raise these limits for hramatka jobs without checking headroom
-against the resident services first.
-
-SSH aliases live in the operator `~/.ssh/config`. IAC: private
-`hramatka/ops/iac/` (merged #495). Occupancy/load on the Monitor host
-itself uses `ATLAS_JOB_SELF_HOST` (local collection, no SSH-to-self).
-Remote mapped hosts still need BatchMode SSH from that Monitor host.
+SSH aliases live in operator env / SSH config, not git. Occupancy/load on the
+Monitor host itself uses `ATLAS_JOB_SELF_HOST` (local collection, no
+SSH-to-self). Remote mapped hosts still need BatchMode SSH from that Monitor
+host. Unknown plan-host strings are rejected.
 
 ## Lifecycle
 
@@ -133,22 +119,22 @@ Use the shared project interpreter (never bare `python`):
 ```bash
 .venv/bin/python -m scripts.lexicon.runner.atlas_job validate PLAN.json
 .venv/bin/python -m scripts.lexicon.runner.atlas_job submit PLAN.json
-.venv/bin/python -m scripts.lexicon.runner.atlas_job status --host atlas-runner --audit
+.venv/bin/python -m scripts.lexicon.runner.atlas_job status --host "$ATLAS_RUNNER_HOST" --audit
 .venv/bin/python -m scripts.lexicon.runner.atlas_job close JOB_ID --summary-file summary.json
-.venv/bin/python -m scripts.lexicon.runner.atlas_job pull --host atlas-runner --job-id JOB_ID
+.venv/bin/python -m scripts.lexicon.runner.atlas_job pull --host "$ATLAS_RUNNER_HOST" --job-id JOB_ID
 .venv/bin/python -m scripts.lexicon.runner.atlas_job list
 ```
 
-`--host` accepts `atlas-runner` or `hramatka` (`vps` alias) everywhere above.
-`submit` refuses a second active `atlas-job-*` unit on that host — the other
-host may still have its own job running. `close` seals a result after the
-unit is dead (or records `needs_finalize` when evidence is missing).
+`--host` takes a plan-host token from the job plan (tokens are redacted from
+occupancy output). `submit` refuses a second active `atlas-job-*` unit on that
+host — another configured host may still have its own job running. `close`
+seals a result after the unit is dead (or records `needs_finalize` when
+evidence is missing).
 
 ## Memory
 
 The class-B launcher pins `MemoryHigh=1.5G` / `MemoryMax=2G` on every host —
-one heavy job at a time per host. On `hramatka` this cap is load-bearing (see
-Hosts above): it exists so a reenrich run cannot starve the teacher API / GH
-runners on the same box. Two full-catalog runs on one host need a later host
-or a queue; two hosts running one campaign each is the supported dual-host
-shape.
+one heavy job at a time per host. That cap is load-bearing wherever a runner
+shares a box with teacher or CI services. Two full-catalog runs on one host
+need a later host or a queue; two hosts running one campaign each is the
+supported dual-host shape.

--- a/scripts/config/trails/estate.v1.yaml
+++ b/scripts/config/trails/estate.v1.yaml
@@ -3,18 +3,18 @@ version: "1.0.0"
 title: Estate surface registry seed
 surfaces:
   vps_hosts:
-    - name: pilot-vps
-      ssh_alias: vps
-      role: pilot_host
+    - name: estate-probe-vps
+      ssh_alias: estate-probe-ssh
+      role: probe_role
       mutation_policy: refused
   services:
-    - name: hramatka-api
-      host_alias: vps
-      systemd_unit: hramatka-api
+    - name: estate-probe-service
+      host_alias: estate-probe-ssh
+      systemd_unit: estate-probe-unit
       mutation_policy: refused
   repositories:
-    - name: learn-ukrainian-infra-private
-      local_path: ~/projects/learn-ukrainian-infra-private
+    - name: estate-probe-private-repo
+      local_path: ~/projects/estate-probe-private
       visibility: private
       mutation_policy: refused
   public_sites:
@@ -37,7 +37,7 @@ surfaces:
     - surface_id: dispatch-task-queue
       mutation_policy: judgment_only
 refused_mutation_surfaces:
-  - pilot-vps
-  - hramatka-api
-  - learn-ukrainian-infra-private
+  - estate-probe-vps
+  - estate-probe-service
+  - estate-probe-private-repo
   - public-site

--- a/scripts/config/trails/estate.v1.yaml
+++ b/scripts/config/trails/estate.v1.yaml
@@ -4,17 +4,17 @@ title: Estate surface registry seed
 surfaces:
   vps_hosts:
     - name: estate-probe-vps
-      ssh_alias: estate-probe-ssh
-      role: probe_role
+      ssh_alias: surface-ssh-k7m2
+      role: surface-role-n4p8
       mutation_policy: refused
   services:
     - name: estate-probe-service
-      host_alias: estate-probe-ssh
-      systemd_unit: estate-probe-unit
+      host_alias: surface-host-q1w9
+      systemd_unit: surface-unit-j3r5
       mutation_policy: refused
   repositories:
     - name: estate-probe-private-repo
-      local_path: ~/projects/estate-probe-private
+      local_path: ~/projects/surface-repo-x6t0
       visibility: private
       mutation_policy: refused
   public_sites:

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -18,15 +18,14 @@ terminal_outcomes:
 steps:
   - step_id: vps_reachability
     intent: >-
-      Round-trip the ssh alias for estate-probe-vps pinned to scripts/config/trails/estate.v1.yaml by the consistency test
-      with BatchMode and a bounded connect timeout. Target token: "vps_reachable". Any other output is
-      vps_unreachable, routed to judgment.
+      Round-trip the runtime RB6_PROBE_SSH target with BatchMode and a bounded connect timeout.
+      Target token: "vps_reachable". Any other output is vps_unreachable, routed to judgment.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > "batch_state/rb6-vps-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps_reachable || echo vps_unreachable
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$RB6_PROBE_SSH" "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > "batch_state/rb6-vps-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps_reachable || echo vps_unreachable
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -58,14 +57,14 @@ steps:
 
   - step_id: service_probe
     intent: >-
-      Read the estate probe service (estate-probe-unit on host estate-probe-ssh, pinned to the estate registry seed by the consistency test) systemd state.
-      Only "active" proceeds; any other token degrades. Service restart is refused.
+      Read the runtime RB6_PROBE_UNIT systemd state on RB6_PROBE_SSH. Only "active" proceeds;
+      any other token degrades. Service restart is refused.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "systemctl is-active estate-probe-unit" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-service-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$V" in active) echo service_active;; "") echo probe_failed;; *) echo service_not_active;; esac
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$RB6_PROBE_SSH" "systemctl is-active $RB6_PROBE_UNIT" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-service-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$V" in active) echo service_active;; "") echo probe_failed;; *) echo service_not_active;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -103,13 +102,13 @@ steps:
 
   - step_id: vps_disk_floor
     intent: >-
-      Check VPS root filesystem available space against a 5G floor on host estate-probe-ssh (pinned to the estate registry seed by the consistency test).
+      Check VPS root filesystem available space against a 5G floor on RB6_PROBE_SSH.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-disk-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor_cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor_cleared\":\"below_floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below_floor\"; ok=1} END{if(!ok) print \"probe_failed\"}"
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$RB6_PROBE_SSH" "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-disk-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor_cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor_cleared\":\"below_floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below_floor\"; ok=1} END{if(!ok) print \"probe_failed\"}"
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -147,14 +146,13 @@ steps:
 
   - step_id: private_repo_probe
     intent: >-
-      Presence probe of the private ops repo (estate-probe-private-repo at ~/projects/estate-probe-private
-      pinned to the estate registry seed by the consistency test).
+      Presence probe of the private ops repo at runtime RB6_PROBE_REPO.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && H=$(git -C ~/projects/estate-probe-private rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C ~/projects/estate-probe-private status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > "batch_state/rb6-privrepo-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$H" in "") echo repo_absent;; *) echo repo_present;; esac
+        - mkdir -p batch_state && H=$(git -C "$RB6_PROBE_REPO" rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C "$RB6_PROBE_REPO" status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > "batch_state/rb6-privrepo-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$H" in "") echo repo_absent;; *) echo repo_present;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -186,13 +184,13 @@ steps:
 
   - step_id: public_site_probe
     intent: >-
-      HTTP status of the published site (https://learn-ukrainian.github.io/ pinned to the estate registry seed by the consistency test).
+      HTTP status of the published site at runtime RB6_PROBE_SITE.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && C=$(curl -sI --max-time 8 https://learn-ukrainian.github.io/ 2>/dev/null | head -1 | cut -d' ' -f2 | tr -d '\r'); echo "${C:-probe-failed}" > "batch_state/rb6-site-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$C" in 200) echo site_serving;; *) echo site_not_serving;; esac
+        - mkdir -p batch_state && C=$(curl -sI --max-time 8 "$RB6_PROBE_SITE" 2>/dev/null | head -1 | cut -d' ' -f2 | tr -d '\r'); echo "${C:-probe-failed}" > "batch_state/rb6-site-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$C" in 200) echo site_serving;; *) echo site_not_serving;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -18,7 +18,7 @@ terminal_outcomes:
 steps:
   - step_id: vps_reachability
     intent: >-
-      Round-trip the ssh alias for pilot-vps pinned to scripts/config/trails/estate.v1.yaml by the consistency test
+      Round-trip the ssh alias for estate-probe-vps pinned to scripts/config/trails/estate.v1.yaml by the consistency test
       with BatchMode and a bounded connect timeout. Target token: "vps_reachable". Any other output is
       vps_unreachable, routed to judgment.
     command:
@@ -26,7 +26,7 @@ steps:
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > "batch_state/rb6-vps-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps_reachable || echo vps_unreachable
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > "batch_state/rb6-vps-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps_reachable || echo vps_unreachable
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -58,14 +58,14 @@ steps:
 
   - step_id: service_probe
     intent: >-
-      Read the pilot service (hramatka-api on host vps, pinned to the estate registry seed by the consistency test) systemd state.
+      Read the estate probe service (estate-probe-unit on host estate-probe-ssh, pinned to the estate registry seed by the consistency test) systemd state.
       Only "active" proceeds; any other token degrades. Service restart is refused.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "systemctl is-active hramatka-api" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-service-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$V" in active) echo service_active;; "") echo probe_failed;; *) echo service_not_active;; esac
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "systemctl is-active estate-probe-unit" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-service-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$V" in active) echo service_active;; "") echo probe_failed;; *) echo service_not_active;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -103,13 +103,13 @@ steps:
 
   - step_id: vps_disk_floor
     intent: >-
-      Check VPS root filesystem available space against a 5G floor on host vps (pinned to the estate registry seed by the consistency test).
+      Check VPS root filesystem available space against a 5G floor on host estate-probe-ssh (pinned to the estate registry seed by the consistency test).
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-disk-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor_cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor_cleared\":\"below_floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below_floor\"; ok=1} END{if(!ok) print \"probe_failed\"}"
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 estate-probe-ssh "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-disk-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor_cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor_cleared\":\"below_floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below_floor\"; ok=1} END{if(!ok) print \"probe_failed\"}"
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -147,14 +147,14 @@ steps:
 
   - step_id: private_repo_probe
     intent: >-
-      Presence probe of the private ops repo (learn-ukrainian-infra-private at ~/projects/learn-ukrainian-infra-private
+      Presence probe of the private ops repo (estate-probe-private-repo at ~/projects/estate-probe-private
       pinned to the estate registry seed by the consistency test).
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && H=$(git -C ~/projects/learn-ukrainian-infra-private rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C ~/projects/learn-ukrainian-infra-private status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > "batch_state/rb6-privrepo-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$H" in "") echo repo_absent;; *) echo repo_present;; esac
+        - mkdir -p batch_state && H=$(git -C ~/projects/estate-probe-private rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C ~/projects/estate-probe-private status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > "batch_state/rb6-privrepo-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$H" in "") echo repo_absent;; *) echo repo_present;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"

--- a/scripts/lexicon/runner/README-offline-enrich.md
+++ b/scripts/lexicon/runner/README-offline-enrich.md
@@ -38,7 +38,7 @@ Bare invocation and `--help` never start a multi-hour run (#5393 class).
 
 ## VPS recipe (run-20k, post-reduce)
 
-Assumes fetch + reduce already completed under `/home/ops/atlas-runner/run-20k`:
+Assumes fetch + reduce already completed under `$ATLAS_RUN_ROOT/run-20k`:
 
 | Artifact | Path |
 | --- | --- |
@@ -52,9 +52,9 @@ Assumes fetch + reduce already completed under `/home/ops/atlas-runner/run-20k`:
 # Optional: plan against live reduce artifact
 .venv/bin/python scripts/lexicon/runner/enrich_offline_20k.py \
   --dry-run \
-  --repo /home/ops/atlas-runner/repo \
-  --work-dir /home/ops/atlas-runner/run-20k/offline_enrich \
-  --candidate /home/ops/atlas-runner/run-20k/candidate-ulif-reduce.json
+  --repo "$ATLAS_RUN_ROOT/repo" \
+  --work-dir "$ATLAS_RUN_ROOT/run-20k/offline_enrich" \
+  --candidate "$ATLAS_RUN_ROOT/run-20k/candidate-ulif-reduce.json"
 
 # Detached under MemoryHigh=1.5G MemoryMax=2.0G (idempotent)
 scripts/lexicon/runner/launch_enrich.sh
@@ -69,7 +69,7 @@ scripts/lexicon/runner/launch_enrich.sh --stop-after-chunks 1
 Tail progress:
 
 ```bash
-tail -f /home/ops/atlas-runner/run-20k/enrich.log | grep --line-buffered '"event"'
+tail -f "$ATLAS_RUN_ROOT/run-20k/enrich.log" | grep --line-buffered '"event"'
 ```
 
 ## Durability (#5884)
@@ -81,14 +81,14 @@ cleanup means a full ULIF refetch. After every fetch/reduce/enrich phase
 covers it:
 
 ```bash
-ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/mirror_20k_runner.sh
+scripts/lexicon/runner/mirror_20k_runner.sh
 ```
 
 Atlas drivers can prove this run's remote work-dir and local durability state
 without starting enrichment by running:
 
 ```bash
-ATLAS_RUNNER_HOST=ops@<runner-host> scripts/lexicon/runner/health_20k_runner.sh
+scripts/lexicon/runner/health_20k_runner.sh
 ```
 
 Before any cleanup, execute the full durability order — **snapshot → restic

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -2,8 +2,8 @@
 
 **systemd on the host is truth; the local registry is a journal/mirror.**
 
-Batch kinds run on atlas-runner or hramatka (each host is its own mutex —
-submit refuses a second active unit on the SAME host; the two hosts may run
+Batch kinds run on an allowed plan-host token (each host is its own mutex —
+submit refuses a second active unit on the SAME host; distinct hosts may run
 concurrently). Registry lives under batch_state/atlas-jobs/ (restic-covered).
 Close writes a fail-closed result receipt; large artifacts go through
 durable_mirror + backup-data.sh. Publish/pointer flip is never this module.
@@ -30,8 +30,7 @@ from typing import Any, Protocol
 SCHEMA = "atlas-job.v1"
 RESULT_SCHEMA = "atlas-job-result.v1"
 BATCH_KINDS = frozenset({"reenrich"})
-# "vps" is the operator ssh alias for the hramatka host (hramatka-api's box;
-# see scripts/config/trails/estate.v1.yaml) — same machine, same allowance.
+# Plan-host tokens kept so occupancy sanitizer can redact them from API output.
 HRAMATKA_ALIASES = frozenset({"hramatka", "vps"})
 ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"}) | HRAMATKA_ALIASES}
 RESULT_SINKS = frozenset({"git", "restic", "both"})
@@ -80,15 +79,6 @@ _HOSTNAME_HINT = re.compile(
     r"(?i)\b(?:[a-z0-9-]+\.)+(?:internal|local|lan|corp|example)\b|\b\d{1,3}(?:\.\d{1,3}){3}\b"
 )
 DEFAULT_TIMEOUT_SECONDS = 86400
-DEFAULT_RUN_ROOT = "/home/ops/atlas-runner"
-# hramatka's work root is separate from its teacher-facing /opt/hramatka and
-# /srv trees — reenrich jobs never touch those. Dir does not exist yet on the
-# host; submit/launcher mkdir it on first use.
-DEFAULT_HRAMATKA_RUN_ROOT = "/home/ops/atlas-jobs"
-DEFAULT_RUN_ROOTS = {
-    "atlas-runner": DEFAULT_RUN_ROOT,
-    "hramatka": DEFAULT_HRAMATKA_RUN_ROOT,
-}
 DEFAULT_MIN_FREE_DISK_BYTES = 5 * 1024 * 1024 * 1024  # 5 GiB host floor
 # Same operator env file as ~/.local/bin/learn-ukrainian-backup (launchd wrapper).
 DEFAULT_BACKUP_ENV_FILE = Path.home() / ".secrets" / "learn-ukrainian-backup.env"
@@ -640,12 +630,14 @@ def _canonical_host(host: str | None) -> str:
     return host or "atlas-runner"
 
 
-def _run_root(host: str | None = None) -> Path:
-    override = os.environ.get("ATLAS_RUN_ROOT")
-    if override:
-        return Path(override)
-    canonical = _canonical_host(host)
-    return Path(DEFAULT_RUN_ROOTS.get(canonical, DEFAULT_RUN_ROOT))
+def _run_root(_host: str | None = None) -> Path:
+    # Run root is env-only; plan-host tokens must not select a path.
+    override = os.environ.get("ATLAS_RUN_ROOT", "").strip()
+    if not override:
+        raise ValueError("ATLAS_RUN_ROOT is required")
+    if not override.startswith("/"):
+        raise ValueError("ATLAS_RUN_ROOT must be an absolute path")
+    return Path(override)
 
 
 def _safe_id_token(part: str) -> str:
@@ -675,8 +667,8 @@ def _path_under(root: Path, *parts: str) -> Path:
 def require_safe_workdir(workdir: object, host: str | None = None) -> str:
     """Fail closed for plan/registry workdirs used in path and SSH contexts.
 
-    Rejects ``..``, absolute paths outside ``ATLAS_RUN_ROOT`` / the
-    per-host default run root (see ``DEFAULT_RUN_ROOTS``), and any path
+    Rejects ``..``, absolute paths outside the required ``ATLAS_RUN_ROOT``,
+    and any path
     whose segments are not ``_SAFE_ID`` tokens. Returns a newly constructed
     path from validated tokens (or ``str(resolved)`` for absolute paths
     under the run root), never the original relative ``workdir`` string.
@@ -1303,10 +1295,6 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
         args.append("--no-poll")
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
-    # Forward the per-host default run root so the remote launcher's
-    # REMOTE_REPO derivation (RUN_ROOT/repo) matches the host actually
-    # targeted, not atlas-runner's default, when ATLAS_RUN_ROOT isn't
-    # already set by the caller.
     env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
     env["ATLAS_RE_ENRICH_UNIT"] = unit
     env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
@@ -1630,10 +1618,6 @@ def pull(
         workdir = require_safe_workdir(workdir, host=host)
     env = os.environ.copy()
     env["ATLAS_RUNNER_HOST"] = host
-    # Mirror submit(): forward the per-host default run root so the
-    # remote pull resolves workdirs under the host actually targeted
-    # (e.g. /home/ops/atlas-jobs on hramatka), not atlas-runner's
-    # default, when ATLAS_RUN_ROOT isn't already set by the caller.
     env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
     if workdir:
         env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -1187,7 +1187,11 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
     host = str(plan["host"])
     sink = plan.get("result_sink")
     unit = unit_name(job_id)
-    workdir = work_dir_for(job_id, plan)
+    try:
+        workdir = work_dir_for(job_id, plan)
+    except ValueError as exc:
+        print(f"invalid workdir: {exc}", file=sys.stderr)
+        return 2
     plan_blob = json.dumps(plan, sort_keys=True).encode()
     row = {
         "id": job_id,

--- a/scripts/lexicon/runner/atlas_job.py
+++ b/scripts/lexicon/runner/atlas_job.py
@@ -30,9 +30,7 @@ from typing import Any, Protocol
 SCHEMA = "atlas-job.v1"
 RESULT_SCHEMA = "atlas-job-result.v1"
 BATCH_KINDS = frozenset({"reenrich"})
-# Plan-host tokens kept so occupancy sanitizer can redact them from API output.
-HRAMATKA_ALIASES = frozenset({"hramatka", "vps"})
-ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"}) | HRAMATKA_ALIASES}
+ALLOWED_HOSTS = {"reenrich": frozenset({"atlas-runner"})}
 RESULT_SINKS = frozenset({"git", "restic", "both"})
 RESUME_MODES = frozenset({"idempotent", "checkpoint", "never"})
 DRIVER_NEEDLES = (
@@ -228,6 +226,17 @@ class FakeHostAdapter:
 
 
 ENV_SELF_HOST = "ATLAS_JOB_SELF_HOST"
+ENV_RUNNER_HOST = "ATLAS_RUNNER_HOST"
+
+
+def resolve_runner_host(host: str | None = None) -> str:
+    """Return the plan-host token for status/pull; fail closed without env."""
+    if host:
+        return host
+    env_host = os.environ.get(ENV_RUNNER_HOST, "").strip()
+    if not env_host:
+        raise ValueError(f"{ENV_RUNNER_HOST} is required")
+    return env_host
 
 
 def self_host_aliases() -> frozenset[str]:
@@ -624,9 +633,7 @@ def require_safe_job_id(job_id: object) -> str:
 
 
 def _canonical_host(host: str | None) -> str:
-    """Map ssh-alias variants (``vps``) onto the canonical host name."""
-    if host in HRAMATKA_ALIASES:
-        return "hramatka"
+    """Normalize a plan-host token (no alias remapping)."""
     return host or "atlas-runner"
 
 
@@ -762,8 +769,8 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     if not isinstance(job_id, str) or _SAFE_ID.fullmatch(job_id) is None:
         errors.append("id must be a filesystem/systemd-safe token")
     host = plan.get("host")
-    if host != "atlas-runner" and host not in HRAMATKA_ALIASES:
-        errors.append("host must be atlas-runner, hramatka, or vps")
+    if host != "atlas-runner":
+        errors.append("host must be atlas-runner")
     kind = plan.get("kind")
     if kind not in BATCH_KINDS:
         errors.append(f"kind must be one of {sorted(BATCH_KINDS)}")
@@ -1298,7 +1305,7 @@ def submit(plan: dict[str, Any], *, dry_run: bool = False, host_adapter: HostAda
     if "--no-poll" not in args:
         args.append("--no-poll")
     env = os.environ.copy()
-    env["ATLAS_RUNNER_HOST"] = host
+    env[ENV_RUNNER_HOST] = host
     env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
     env["ATLAS_RE_ENRICH_UNIT"] = unit
     env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
@@ -1543,18 +1550,25 @@ def _unit_is_active(unit: dict[str, Any]) -> bool:
     ).startswith("running")
 
 
-def status(*, host: str, audit: bool = False, host_adapter: HostAdapter | None = None) -> int:
+def status(
+    *, host: str | None = None, audit: bool = False, host_adapter: HostAdapter | None = None
+) -> int:
+    try:
+        resolved = resolve_runner_host(host)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     adapter = host_adapter or get_host_adapter()
     try:
-        if not adapter.reachable(host):
-            print(f"host {host} unreachable", file=sys.stderr)
+        if not adapter.reachable(resolved):
+            print(f"host {resolved} unreachable", file=sys.stderr)
             return 2
-        host_units = adapter.list_atlas_job_units(host)
+        host_units = adapter.list_atlas_job_units(resolved)
     except (ConnectionError, OSError, ValueError) as exc:
         print(f"host status failed: {exc}", file=sys.stderr)
         return 2
 
-    rows = [r for r in list_registry() if r.get("host") == host]
+    rows = [r for r in list_registry() if r.get("host") == resolved]
     for row in rows:
         if row.get("state") == "running":
             row = reconcile_row(row, host_units=host_units, host_adapter=adapter)
@@ -1587,7 +1601,7 @@ def status(*, host: str, audit: bool = False, host_adapter: HostAdapter | None =
         )
 
     try:
-        lines = adapter.pgrep_drivers(host)
+        lines = adapter.pgrep_drivers(resolved)
     except (ConnectionError, OSError) as exc:
         print(f"audit pgrep failed: {exc}", file=sys.stderr)
         return 2
@@ -1612,17 +1626,22 @@ def status(*, host: str, audit: bool = False, host_adapter: HostAdapter | None =
 
 def pull(
     *,
-    host: str,
+    host: str | None = None,
     job_id: str | None = None,
     workdir: str | None = None,
 ) -> int:
+    try:
+        resolved = resolve_runner_host(host)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     if job_id is not None:
         job_id = require_safe_job_id(job_id)
     if workdir:
-        workdir = require_safe_workdir(workdir, host=host)
+        workdir = require_safe_workdir(workdir, host=resolved)
     env = os.environ.copy()
-    env["ATLAS_RUNNER_HOST"] = host
-    env.setdefault("ATLAS_RUN_ROOT", str(_run_root(host)))
+    env[ENV_RUNNER_HOST] = resolved
+    env.setdefault("ATLAS_RUN_ROOT", str(_run_root(resolved)))
     if workdir:
         env["ATLAS_RE_ENRICH_WORK_DIR"] = workdir
     if job_id:
@@ -1648,7 +1667,7 @@ def main(argv: list[str] | None = None) -> int:
     p_sub.add_argument("--dry-run", action="store_true")
 
     p_st = sub.add_parser("status", help="List registry rows; optional untracked audit")
-    p_st.add_argument("--host", default="atlas-runner")
+    p_st.add_argument("--host", default=None)
     p_st.add_argument("--audit", action="store_true")
 
     p_close = sub.add_parser("close", help="Seal a result receipt for a registered job")
@@ -1660,7 +1679,7 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("list", help="List registry rows")
 
     p_pull = sub.add_parser("pull", help="Pull work-dir artifacts (no pointer flip)")
-    p_pull.add_argument("--host", default="atlas-runner")
+    p_pull.add_argument("--host", default=None)
     p_pull.add_argument("--job-id")
 
     args = parser.parse_args(argv)

--- a/scripts/lexicon/runner/durable_mirror.py
+++ b/scripts/lexicon/runner/durable_mirror.py
@@ -3,7 +3,7 @@
 
 The fetch/enrich runners write their durable state (``ledger.sqlite``,
 ``network-cache.sqlite``, reduce/enrich candidates) under a work-dir on the
-remote runner host (default ``/home/ops/atlas-runner/run-20k``), which has no
+remote runner host (``ATLAS_RUN_ROOT`` / ``--work-dir``; no baked default), which has no
 backup of its own. ``scripts/backup-data.sh`` (#6014) already makes encrypted,
 versioned restic snapshots of everything under this repo's local ``data/`` —
 so the fix is to mirror the runner work-dir into a checksummed copy under

--- a/scripts/lexicon/runner/fetch_ulif_20k.py
+++ b/scripts/lexicon/runner/fetch_ulif_20k.py
@@ -18,10 +18,12 @@ import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import requests
 from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    import requests
 
 EXPECTED_COHORT_SHA256 = "858f0c7ce34d0d1e27c3519695073ea3e62bc0623010c03683137b7b730dcab4"
 EXPECTED_COHORT_COUNT = 20_323
@@ -40,6 +42,18 @@ def _load_runner(repo: Path) -> None:
     sys.path.insert(0, str(repo))
 
 
+def _requests() -> Any:
+    """Import ``requests`` only when a live DictUA HTTP exchange is about to run.
+
+    Fastlane CI (and ``--help`` / argparse unit tests) must import this module
+    without the network extra. Reduce already keeps third-party I/O off the
+    import path; fetch mirrors that for ``requests``.
+    """
+    import requests
+
+    return requests
+
+
 @dataclass(frozen=True, slots=True)
 class RetryableFetch(Exception):
     error_code: str
@@ -50,18 +64,25 @@ class DictUAClient:
     """One polite, sequential WebForms client; it holds no corpus/database handle."""
 
     def __init__(self, *, delay_seconds: float, timeout_seconds: int) -> None:
-        self.session = requests.Session()
         self.delay_seconds = delay_seconds
         self.timeout_seconds = timeout_seconds
         self.last_request_at = 0.0
-        self.session.headers.update(
-            {
-                "User-Agent": (
-                    "learn-ukrainian-atlas/1.0 "
-                    "(noncommercial educational ULIF per-lemma fetch; issue #5230)"
-                )
-            }
-        )
+        self._session: Any = None
+        # Headers stay on the client so argparse / in-process tests can
+        # construct it without importing ``requests``.
+        self.headers = {
+            "User-Agent": (
+                "learn-ukrainian-atlas/1.0 "
+                "(noncommercial educational ULIF per-lemma fetch; issue #5230)"
+            )
+        }
+
+    def _http_session(self) -> Any:
+        if self._session is None:
+            session = _requests().Session()
+            session.headers.update(self.headers)
+            self._session = session
+        return self._session
 
     def _wait_turn(self) -> None:
         elapsed = time.monotonic() - self.last_request_at
@@ -85,8 +106,11 @@ class DictUAClient:
 
     def _request(self, method: str, **kwargs: Any) -> requests.Response:
         self._wait_turn()
+        requests = _requests()
         try:
-            response = self.session.request(method, ULIF_URL, timeout=self.timeout_seconds, **kwargs)
+            response = self._http_session().request(
+                method, ULIF_URL, timeout=self.timeout_seconds, **kwargs
+            )
         except requests.RequestException as exc:
             raise RetryableFetch("network_error", COOLDOWN_SECONDS) from exc
         finally:
@@ -435,7 +459,7 @@ def _run(args: argparse.Namespace) -> int:
                 method="POST",
                 url=ULIF_URL,
                 request_body=json.dumps({"adapter": ADAPTER_VERSION, "lemma": lemma}, ensure_ascii=False, sort_keys=True).encode("utf-8"),
-                response_affecting_headers={"user-agent": client.session.headers["User-Agent"]},
+                response_affecting_headers={"user-agent": client.headers["User-Agent"]},
                 request_meta={"logical_request": "ulif_dictua_lookup"},
             )
             claim = ledger.claim_unit(run_id, lemma, ledger.owner_id, phase=PHASE, host=HOST)

--- a/scripts/lexicon/runner/fetch_ulif_20k.py
+++ b/scripts/lexicon/runner/fetch_ulif_20k.py
@@ -477,7 +477,12 @@ def _run(args: argparse.Namespace) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--work-dir", type=Path, default=Path("/home/ops/atlas-runner/run-20k"))
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        required=True,
+        help="Runner work-dir (required; no baked default).",
+    )
     parser.add_argument(
         "--cohort",
         type=Path,

--- a/scripts/lexicon/runner/health_20k_runner.sh
+++ b/scripts/lexicon/runner/health_20k_runner.sh
@@ -3,10 +3,10 @@
 # it never syncs a mirror, changes runner files, or starts enrichment (#6077).
 #
 # Required environment:
-#   ATLAS_RUNNER_HOST  ssh destination for the runner, for example ops@<runner-host>
+#   ATLAS_RUNNER_HOST  ssh destination from operator env
+#   ATLAS_RUN_ROOT               remote run root (absolute path)
 #
 # Optional environment follows mirror_20k_runner.sh:
-#   ATLAS_RUN_ROOT               remote run root (default /home/ops/atlas-runner)
 #   ATLAS_WORK_DIR_NAME          work-dir below the run root (default run-20k)
 #   ATLAS_MIRROR_DIR             local durable mirror directory
 #   ATLAS_MIRROR_MAX_AGE_HOURS   durable mirror age limit (default 24)
@@ -14,7 +14,6 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORK_DIR_NAME="${ATLAS_WORK_DIR_NAME:-run-20k}"
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
 MIRROR_DIR="${ATLAS_MIRROR_DIR:-$REPO/data/lexicon/runner-mirror/$WORK_DIR_NAME}"
 MAX_AGE_HOURS="${ATLAS_MIRROR_MAX_AGE_HOURS:-24}"
 DURABLE_MIRROR=("$REPO/.venv/bin/python" "$REPO/scripts/lexicon/runner/durable_mirror.py")
@@ -36,6 +35,13 @@ if [[ -z "${ATLAS_RUNNER_HOST:-}" ]]; then
   exit 2
 fi
 host_set=true
+
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  printf 'ATLAS_RUN_ROOT is required.\n' >&2
+  print_summary
+  exit 2
+fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
 
 if ! command -v ssh >/dev/null 2>&1; then
   printf 'runner SSH work-dir check failed: ssh is not available.\n' >&2

--- a/scripts/lexicon/runner/health_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/health_reenrich_class_b.sh
@@ -3,12 +3,22 @@
 # never syncs, launches, or mutates anything on the VPS (mirrors
 # health_20k_runner.sh's fail-closed reporting shape).
 #
-# Env overrides:
-#   ATLAS_RUNNER_HOST (default vps), ATLAS_RUN_ROOT, ATLAS_RE_ENRICH_WORK_DIR
+# Required env:
+#   ATLAS_RUNNER_HOST, ATLAS_RUN_ROOT
+# Optional:
+#   ATLAS_RE_ENRICH_WORK_DIR
 set -uo pipefail
 
-HOST="${ATLAS_RUNNER_HOST:-vps}"
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+if [[ -z "${ATLAS_RUNNER_HOST:-}" ]]; then
+  echo "ATLAS_RUNNER_HOST is required" >&2
+  exit 2
+fi
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
+fi
+HOST="$ATLAS_RUNNER_HOST"
+RUN_ROOT="$ATLAS_RUN_ROOT"
 WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
 
 host_reachable=false

--- a/scripts/lexicon/runner/launch_enrich.sh
+++ b/scripts/lexicon/runner/launch_enrich.sh
@@ -15,12 +15,16 @@
 #   scripts/lexicon/runner/launch_enrich.sh --stop-after-chunks 2   # smoke
 #   scripts/lexicon/runner/launch_enrich.sh --force-new-run
 #
-# Env overrides:
-#   ATLAS_RUN_ROOT, ATLAS_REPO, ATLAS_WORK_DIR, ATLAS_ENRICH_UNIT,
+# Env:
+#   ATLAS_RUN_ROOT (required), ATLAS_REPO, ATLAS_WORK_DIR, ATLAS_ENRICH_UNIT,
 #   ATLAS_ENRICH_DRIVER, ATLAS_CANDIDATE, ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON
 set -euo pipefail
 
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
+fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
 REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 WORK_DIR="${ATLAS_WORK_DIR:-$RUN_ROOT/run-20k}"
 UNIT="${ATLAS_ENRICH_UNIT:-atlas-20k-enrich.service}"

--- a/scripts/lexicon/runner/launch_reduce.sh
+++ b/scripts/lexicon/runner/launch_reduce.sh
@@ -3,7 +3,11 @@
 # Mirrors run-20k/launch.sh resume pattern under MemoryHigh=1.5G MemoryMax=2.0G.
 set -euo pipefail
 
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
+fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
 REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 WORK_DIR="${ATLAS_WORK_DIR:-$RUN_ROOT/run-20k}"
 UNIT="${ATLAS_REDUCE_UNIT:-atlas-20k-reduce.service}"

--- a/scripts/lexicon/runner/launch_reenrich_class_b.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b.sh
@@ -29,26 +29,18 @@
 #   scripts/lexicon/runner/launch_reenrich_class_b.sh
 #   scripts/lexicon/runner/launch_reenrich_class_b.sh --limit 5   # smoke
 #
-# Env overrides:
-#   ATLAS_RUN_ROOT (default per host: /home/ops/atlas-jobs on hramatka/vps,
-#   /home/ops/atlas-runner otherwise), ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
+# Env:
+#   ATLAS_RUN_ROOT (required), ATLAS_REPO, ATLAS_RE_ENRICH_WORK_DIR,
 #   ATLAS_RE_ENRICH_CODE_ROOT, ATLAS_RE_ENRICH_RUNNER_PYTHON,
 #   ATLAS_RE_ENRICH_UNIT, ATLAS_RE_ENRICH_DRIVER, ATLAS_RE_ENRICH_SLUGS_FILE,
 #   ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON, ATLAS_LIVE_MANIFEST
 set -euo pipefail
 
-# Per-host run root (#6876): the Mac-side wrapper always forwards an explicit
-# ATLAS_RUN_ROOT, so this default only matters for direct on-host invocation.
-# hramatka/vps keep their run tree under /home/ops/atlas-jobs; every other
-# host keeps /home/ops/atlas-runner.
-if [[ -n "${ATLAS_RUN_ROOT:-}" ]]; then
-  RUN_ROOT="$ATLAS_RUN_ROOT"
-else
-  case "$(hostname -s 2>/dev/null || hostname)" in
-    hramatka*|vps*) RUN_ROOT="/home/ops/atlas-jobs" ;;
-    *) RUN_ROOT="/home/ops/atlas-runner" ;;
-  esac
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
 fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
 
 REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"

--- a/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
+++ b/scripts/lexicon/runner/launch_reenrich_class_b_remote.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Mac-side orchestrator for #6369 Class-B residual EN re-enrich. Runs the job
-# on the remote Atlas host (atlas-runner by default, hramatka/vps per #6876),
+# on the remote Atlas host from operator env (ATLAS_RUNNER_HOST),
 # never on this laptop.
 #
 # The VPS repo checkout is routinely stale (large data/ dirs deliberately
@@ -20,10 +20,8 @@
 #   scripts/lexicon/runner/launch_reenrich_class_b_remote.sh --no-poll    # fire-and-forget
 #   scripts/lexicon/runner/launch_reenrich_class_b_remote.sh --pull-only  # just pull artifacts back
 #
-# Env overrides:
-#   ATLAS_RUNNER_HOST (default atlas-runner), ATLAS_RUN_ROOT (default per
-#   host: /home/ops/atlas-jobs for hramatka/vps, /home/ops/atlas-runner
-#   otherwise), ATLAS_REPO,
+# Env:
+#   ATLAS_RUNNER_HOST (required), ATLAS_RUN_ROOT (required), ATLAS_REPO,
 #   ATLAS_PRIMARY_ROOT (default: primary checkout from shared .git common dir),
 #   ATLAS_RE_ENRICH_WORK_DIR, ATLAS_RE_ENRICH_RESIDUAL (local slugs dump),
 #   ATLAS_LOCAL_VESUM_DB, ATLAS_LOCAL_SLOVNYK_CACHE
@@ -53,15 +51,16 @@ esac
 PRIMARY_ROOT="${ATLAS_PRIMARY_ROOT:-$(cd "$_primary_common_dir/.." && pwd)}"
 PYTHON_BIN="${ATLAS_RE_ENRICH_PYTHON:-$PRIMARY_ROOT/.venv/bin/python}"
 
-HOST="${ATLAS_RUNNER_HOST:-atlas-runner}"
-# Per-host run root (#6876): jobs on hramatka/vps live under
-# /home/ops/atlas-jobs; every other host keeps /home/ops/atlas-runner. An
-# explicit ATLAS_RUN_ROOT always wins.
-case "$HOST" in
-  hramatka|vps) DEFAULT_RUN_ROOT="/home/ops/atlas-jobs" ;;
-  *) DEFAULT_RUN_ROOT="/home/ops/atlas-runner" ;;
-esac
-RUN_ROOT="${ATLAS_RUN_ROOT:-$DEFAULT_RUN_ROOT}"
+if [[ -z "${ATLAS_RUNNER_HOST:-}" ]]; then
+  echo "ATLAS_RUNNER_HOST is required" >&2
+  exit 2
+fi
+HOST="$ATLAS_RUNNER_HOST"
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
+fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
 REMOTE_REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
 REMOTE_WORK_DIR="${ATLAS_RE_ENRICH_WORK_DIR:-$RUN_ROOT/run-class-b-reenrich}"
 
@@ -123,8 +122,7 @@ if ! ssh_q "true" 2>/dev/null; then
   exit 1
 fi
 
-# Materialize the per-host run root before any scp/rsync writes into it — a
-# fresh hramatka/vps layout has no /home/ops/atlas-jobs yet (#6876).
+# Materialize the configured run root before any scp/rsync writes into it.
 ssh_q "mkdir -p $(printf '%q' "$RUN_ROOT")"
 
 # HARD GATE — sources.db on VPS must match local Mac (operator 2026-08-06).
@@ -139,7 +137,7 @@ ssh_q "mkdir -p $(printf '%q' "$RUN_ROOT")"
 # target path, not the file it points to) causes rsync to overwrite the
 # remote's real multi-GB file with a dangling symlink pointing at a
 # Mac-only path — a real data-loss incident hit exactly this on 2026-08-06,
-# recovered from a /home/ops/atlas-runner/data/sources.db backup copy.
+# recovered from a remote sources.db backup copy.
 # Always resolve to a real regular-file path before comparing or syncing.
 LOCAL_SOURCES_DB_CANDIDATE="${ATLAS_LOCAL_SOURCES_DB:-$WORKTREE/data/sources.db}"
 REMOTE_SOURCES_DB="${ATLAS_SOURCES_DB:-$REMOTE_REPO/data/sources.db}"

--- a/scripts/lexicon/runner/mirror_20k_runner.sh
+++ b/scripts/lexicon/runner/mirror_20k_runner.sh
@@ -8,9 +8,9 @@
 #   scripts/lexicon/runner/mirror_20k_runner.sh                 # sync + snapshot
 #   scripts/lexicon/runner/mirror_20k_runner.sh --require-only   # verify a backed-up mirror
 #
-# Env overrides:
-#   ATLAS_RUNNER_HOST  ssh destination, e.g. ops@atlas-runner.example (required to sync)
-#   ATLAS_RUN_ROOT      remote run root (default /home/ops/atlas-runner)
+# Env:
+#   ATLAS_RUNNER_HOST  ssh destination from operator env (required to sync)
+#   ATLAS_RUN_ROOT      remote run root (required)
 #   ATLAS_WORK_DIR_NAME remote work-dir under ATLAS_RUN_ROOT (default run-20k)
 #   ATLAS_MIRROR_DIR    local mirror dir (default <repo>/data/lexicon/runner-mirror/<work-dir-name>)
 #   ATLAS_MIRROR_MAX_AGE_HOURS  staleness gate for --require-only (default 24)
@@ -28,8 +28,12 @@ if [[ "${1:-}" == "--require-only" ]]; then
   exit $?
 fi
 
-RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
-: "${ATLAS_RUNNER_HOST:?set ATLAS_RUNNER_HOST=user@host to sync from the VPS (or run durable_mirror.py snapshot --source directly)}"
+if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then
+  echo "ATLAS_RUN_ROOT is required" >&2
+  exit 2
+fi
+RUN_ROOT="$ATLAS_RUN_ROOT"
+: "${ATLAS_RUNNER_HOST:?ATLAS_RUNNER_HOST is required to sync (or run durable_mirror.py snapshot --source directly)}"
 SOURCE="${ATLAS_RUNNER_HOST}:${RUN_ROOT}/${WORK_DIR_NAME}"
 
 echo "syncing ${SOURCE} -> ${MIRROR_DIR}"

--- a/scripts/lexicon/runner/reduce_ulif_20k.py
+++ b/scripts/lexicon/runner/reduce_ulif_20k.py
@@ -180,7 +180,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--work-dir",
         type=Path,
-        default=Path("/home/ops/atlas-runner/run-20k"),
+        required=True,
+        help="Runner work-dir (required; no baked default).",
     )
     parser.add_argument(
         "--network-cache",

--- a/scripts/orchestration/job_host_exec.py
+++ b/scripts/orchestration/job_host_exec.py
@@ -4,18 +4,18 @@
 Notebook orchestrators keep talking to tunneled ``127.0.0.1`` APIs. Both
 occupancy hosts are the worker pool: agent CLIs and long Python jobs run
 on either box. The job host also holds Monitor and fleet-comms. The
-teacher host also holds the teacher product — workers stay out of
-``/opt/hramatka`` and ``/srv``, and occupancy headroom decides who takes
-the next job. Notebook ``delegate.py dispatch`` is the fallback only when
+teacher host also holds the teacher product. Workers stay out of teacher
+product data trees. Occupancy headroom decides who takes the next job.
+Notebook ``delegate.py dispatch`` is the fallback only when
 **every** VPS worker host is unavailable or full. This helper never prints
 host aliases, IPs, or occupancy env.
 
-SSH aliases stay in operator env (not git):
+SSH aliases and remote checkout paths stay in operator env (not git):
 
 - ``LU_DISPATCH_SSH`` — ``opaque-id=ssh-alias,...``
-- ``LU_JOB_DISPATCH_HOST`` / ``ATLAS_RUNNER_HOST`` — job-host fallback
-- ``LU_TEACHER_DISPATCH_HOST`` — teacher-host fallback
-- ``LU_JOB_REPO`` / ``LU_TEACHER_REPO`` — absolute remote checkouts
+- ``LU_JOB_DISPATCH_HOST`` / ``ATLAS_RUNNER_HOST`` — job-host (required)
+- ``LU_TEACHER_DISPATCH_HOST`` — teacher-host (required for teacher host_id)
+- ``LU_JOB_REPO`` / ``LU_TEACHER_REPO`` — absolute remote checkouts (required)
 
 Remote PATH always includes ``$HOME/.local/bin`` and ``$HOME/.opencode/bin``.
 """
@@ -55,11 +55,6 @@ ENV_MEM_FULL = "LU_JOB_MEM_FULL_PCT"
 ENV_DISK_FULL = "LU_JOB_DISK_FULL_PCT"
 REMOTE_PATH_EXPORT = 'export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"'
 _REMOTE_VAR_PREFIX = "__LU_REMOTE_VAR:"
-# Canonical SSH Host names already used by atlas_job (public repo contract).
-DEFAULT_JOB_SSH = "atlas-runner"
-DEFAULT_TEACHER_SSH = "hramatka"
-DEFAULT_JOB_REPO = "/home/ops/services/learn-ukrainian"
-DEFAULT_TEACHER_REPO = "/home/ops/learn-ukrainian"
 DEFAULT_MEM_FULL_PCT = 85.0
 DEFAULT_DISK_FULL_PCT = 85.0
 _MONITOR_DEFAULT = "http://127.0.0.1:8765"
@@ -87,15 +82,19 @@ class SshTransportError(OSError):
 
 
 def job_dispatch_host() -> str:
-    return (
+    host = (
         os.environ.get(ENV_HOST, "").strip()
         or os.environ.get(ENV_HOST_FALLBACK, "").strip()
-        or DEFAULT_JOB_SSH
     )
+    if not host:
+        raise ValueError(f"{ENV_HOST} or {ENV_HOST_FALLBACK} is required")
+    return host
 
 
 def job_dispatch_repo() -> str:
-    repo = os.environ.get(ENV_REPO, "").strip() or DEFAULT_JOB_REPO
+    repo = os.environ.get(ENV_REPO, "").strip()
+    if not repo:
+        raise ValueError(f"{ENV_REPO} is required")
     if not repo.startswith("/"):
         raise ValueError(f"{ENV_REPO} must be an absolute remote path")
     return repo
@@ -120,7 +119,10 @@ def ssh_alias_for_host_id(host_id: str) -> str:
     if host_id in mapped:
         return mapped[host_id]
     if host_id == TEACHER_HOST_ID:
-        return os.environ.get(ENV_TEACHER_HOST, "").strip() or DEFAULT_TEACHER_SSH
+        alias = os.environ.get(ENV_TEACHER_HOST, "").strip()
+        if not alias:
+            raise ValueError(f"{ENV_TEACHER_HOST} or {ENV_DISPATCH_SSH} is required")
+        return alias
     if host_id == JOB_HOST_ID:
         return job_dispatch_host()
     raise ValueError(f"no SSH alias configured for occupancy host {host_id}")
@@ -128,7 +130,9 @@ def ssh_alias_for_host_id(host_id: str) -> str:
 
 def repo_for_host_id(host_id: str) -> str:
     if host_id == TEACHER_HOST_ID:
-        teacher_repo = os.environ.get(ENV_TEACHER_REPO, "").strip() or DEFAULT_TEACHER_REPO
+        teacher_repo = os.environ.get(ENV_TEACHER_REPO, "").strip()
+        if not teacher_repo:
+            raise ValueError(f"{ENV_TEACHER_REPO} is required")
         if not teacher_repo.startswith("/"):
             raise ValueError(f"{ENV_TEACHER_REPO} must be an absolute remote path")
         return teacher_repo

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -632,7 +632,7 @@ def test_results_allowlist_and_sorting(
             "circuit_breaker_tripped": False,
             "extra_raw_metric": "ignore_me",
         },
-        "raw_forbidden_workdir": "/home/ops/workdir",
+        "raw_forbidden_workdir": "/tmp/forbidden-workdir",
         "plan_sha256": "abcdef123456",
         "backup": {"attempted": True, "ok": True},
     }
@@ -652,7 +652,7 @@ def test_results_allowlist_and_sorting(
             "filled_translation": 0,
             "circuit_breaker_tripped": True,
         },
-        "raw_forbidden_workdir": "/home/ops/workdir2",
+        "raw_forbidden_workdir": "/tmp/forbidden-workdir-2",
     }
 
     (tmp_path / "job-001.result.json").write_text(json.dumps(receipt1), encoding="utf-8")

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -61,13 +61,20 @@ def test_submit_dry_run_via_api(_isolate: atlas_job.FakeHostAdapter) -> None:
     assert resp.json()["exit_code"] == 0
 
 
-def test_submit_allows_hramatka(_isolate: atlas_job.FakeHostAdapter) -> None:
+def test_submit_rejects_hramatka(_isolate: atlas_job.FakeHostAdapter) -> None:
     resp = client.post(
         "/api/atlas-jobs/submit",
         json={"plan": _plan(host="hramatka"), "dry_run": True},
     )
-    assert resp.status_code == 200
-    assert resp.json()["exit_code"] == 0
+    assert resp.status_code == 400
+
+
+def test_submit_rejects_vps_alias(_isolate: atlas_job.FakeHostAdapter) -> None:
+    resp = client.post(
+        "/api/atlas-jobs/submit",
+        json={"plan": _plan(host="vps"), "dry_run": True},
+    )
+    assert resp.status_code == 400
 
 
 def test_submit_rejects_unknown_host(_isolate: atlas_job.FakeHostAdapter) -> None:
@@ -181,14 +188,9 @@ def test_load_endpoint_shape_and_cache(
     _isolate: atlas_job.FakeHostAdapter,
 ) -> None:
     router_mod.clear_host_load_cache()
-    # Populate fresh cache for both hosts
     router_mod.set_host_load_cache(
         "atlas-runner",
         _isolate.host_load("atlas-runner"),
-    )
-    router_mod.set_host_load_cache(
-        "hramatka",
-        _isolate.host_load("hramatka"),
     )
 
     resp = client.get("/api/atlas-jobs/load")
@@ -197,39 +199,36 @@ def test_load_endpoint_shape_and_cache(
     data = resp.json()
     assert data["schema"] == "atlas-jobs-load.v1"
     assert "observed_at" in data
-    assert sorted(data["hosts"].keys()) == ["atlas-runner", "hramatka"]
+    assert sorted(data["hosts"].keys()) == ["atlas-runner"]
 
-    for host_name in ("atlas-runner", "hramatka"):
-        host_info = data["hosts"][host_name]
-        assert host_info["status"] == "fresh"
-        assert isinstance(host_info["age_seconds"], (int, float))
-        assert "observed_at" in host_info
-        assert host_info["cpu_count"] == 4
-        assert host_info["loadavg"] == [0.15, 0.22, 0.18]
-        assert host_info["mem"]["total_bytes"] == 16 * 1024 * 1024 * 1024
-        assert host_info["mem"]["available_bytes"] == 8 * 1024 * 1024 * 1024
-        assert host_info["mem"]["pct"] == 50.0
-        assert host_info["disk"]["available_bytes"] == 50 * 1024 * 1024 * 1024
-        assert "total_bytes" in host_info["disk"]
-        assert "pct" in host_info["disk"]
-        assert host_info["job_unit"]["active_count"] == 0
-        assert host_info["job_unit"]["job_id"] is None
-        assert host_info["job_unit"]["state"] is None
+    host_info = data["hosts"]["atlas-runner"]
+    assert host_info["status"] == "fresh"
+    assert isinstance(host_info["age_seconds"], (int, float))
+    assert "observed_at" in host_info
+    assert host_info["cpu_count"] == 4
+    assert host_info["loadavg"] == [0.15, 0.22, 0.18]
+    assert host_info["mem"]["total_bytes"] == 16 * 1024 * 1024 * 1024
+    assert host_info["mem"]["available_bytes"] == 8 * 1024 * 1024 * 1024
+    assert host_info["mem"]["pct"] == 50.0
+    assert host_info["disk"]["available_bytes"] == 50 * 1024 * 1024 * 1024
+    assert "total_bytes" in host_info["disk"]
+    assert "pct" in host_info["disk"]
+    assert host_info["job_unit"]["active_count"] == 0
+    assert host_info["job_unit"]["job_id"] is None
+    assert host_info["job_unit"]["state"] is None
 
 
-def test_load_endpoint_host_filter_and_vps_normalization(
+def test_load_endpoint_host_filter_rejects_unknown(
     _isolate: atlas_job.FakeHostAdapter,
 ) -> None:
     router_mod.clear_host_load_cache()
-    router_mod.set_host_load_cache("hramatka", _isolate.host_load("hramatka"))
     router_mod.set_host_load_cache("atlas-runner", _isolate.host_load("atlas-runner"))
 
-    # ?host=vps normalizes to hramatka and never emits 'vps' in keys
     resp_vps = client.get("/api/atlas-jobs/load?host=vps")
-    assert resp_vps.status_code == 200
-    data_vps = resp_vps.json()
-    assert list(data_vps["hosts"].keys()) == ["hramatka"]
-    assert "vps" not in data_vps["hosts"]
+    assert resp_vps.status_code == 400
+
+    resp_hramatka = client.get("/api/atlas-jobs/load?host=hramatka")
+    assert resp_hramatka.status_code == 400
 
     resp_runner = client.get("/api/atlas-jobs/load?host=atlas-runner")
     assert resp_runner.status_code == 200
@@ -244,7 +243,6 @@ def test_load_endpoint_ip_sanitization_and_forbidden_fields(
 ) -> None:
     router_mod.clear_host_load_cache()
     router_mod.set_host_load_cache("atlas-runner", _isolate.host_load("atlas-runner"))
-    router_mod.set_host_load_cache("hramatka", _isolate.host_load("hramatka"))
 
     resp = client.get("/api/atlas-jobs/load")
     assert resp.status_code == 200
@@ -640,7 +638,7 @@ def test_results_allowlist_and_sorting(
     receipt2 = {
         "schema": "atlas-job-result.v1",
         "id": "job-002",
-        "host": "vps",
+        "host": "other-runner",
         "kind": "reenrich",
         "state": "failed",
         "closed_at": "2026-08-17T12:00:00Z",
@@ -667,7 +665,7 @@ def test_results_allowlist_and_sorting(
 
     # Newest-first by (closed_at, id): job-002 (12:00:00Z) before job-001 (10:00:00Z)
     assert data["results"][0]["id"] == "job-002"
-    assert data["results"][0]["host"] == "hramatka"  # normalized
+    assert data["results"][0]["host"] == "other-runner"
     assert data["results"][0]["circuit_breaker_tripped"] is True
     assert data["results"][1]["id"] == "job-001"
     assert data["results"][1]["targets"] == 100
@@ -705,7 +703,7 @@ def test_results_pagination_and_filters(
         receipt = {
             "schema": "atlas-job-result.v1",
             "id": job_id,
-            "host": "atlas-runner" if i % 2 == 1 else "hramatka",
+            "host": "atlas-runner" if i % 2 == 1 else "other-runner",
             "kind": "reenrich",
             "state": "succeeded" if i <= 3 else "failed",
             "closed_at": f"2026-08-17T{10 + i:02d}:00:00Z",
@@ -742,12 +740,11 @@ def test_results_pagination_and_filters(
     assert p2_data["results"][1]["id"] == "job-002"
     assert p2_data["next_cursor"] is not None
 
-    # Filter by host (including vps alias)
-    vps_resp = client.get("/api/atlas-jobs/results?host=vps")
-    assert vps_resp.status_code == 200
-    vps_data = vps_resp.json()
-    assert vps_data["count"] == 2
-    assert all(r["host"] == "hramatka" for r in vps_data["results"])
+    other_resp = client.get("/api/atlas-jobs/results?host=other-runner")
+    assert other_resp.status_code == 200
+    other_data = other_resp.json()
+    assert other_data["count"] == 2
+    assert all(r["host"] == "other-runner" for r in other_data["results"])
 
     # Filter by state
     failed_resp = client.get("/api/atlas-jobs/results?state=failed")

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -39,6 +39,7 @@ def _plan(**overrides: object) -> dict:
 @pytest.fixture(autouse=True)
 def _isolate(tmp_path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
     fake = atlas_job.FakeHostAdapter()
     atlas_job.set_host_adapter(fake)
     yield fake

--- a/tests/api/test_atlas_jobs_router.py
+++ b/tests/api/test_atlas_jobs_router.py
@@ -234,6 +234,10 @@ def test_load_endpoint_host_filter_rejects_unknown(
     assert resp_runner.status_code == 200
     assert list(resp_runner.json()["hosts"].keys()) == ["atlas-runner"]
 
+    for legacy in ("legacy-box", "legacy-alias"):
+        resp = client.get(f"/api/atlas-jobs/load?host={legacy}")
+        assert resp.status_code == 400
+
     resp_unknown = client.get("/api/atlas-jobs/load?host=unknown-host")
     assert resp_unknown.status_code == 400
 

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -364,7 +364,7 @@ def test_safe_field_drops_aliases_addresses_and_fqdn() -> None:
         "10.0.0.1",
         "2001:db8::1",
         "box.example.com",
-        "/home/ops/job",
+        "/tmp/hidden/job",
     ):
         assert _safe_field(leaked) is None
         assert _safe_field(leaked, role="task_id") is None

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -35,6 +35,11 @@ def _clear_observer_presence() -> None:
     reset_observer_presence()
 
 
+@pytest.fixture(autouse=True)
+def _non_operational_run_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
+
+
 def _plan(**overrides: object) -> dict:
     base: dict = {
         "schema": "atlas-job.v1",

--- a/tests/orchestration/test_job_host_exec.py
+++ b/tests/orchestration/test_job_host_exec.py
@@ -81,18 +81,28 @@ def test_build_ssh_argv_is_batchmode() -> None:
     assert argv[5] == "job-alias"
 
 
-def test_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_source_has_no_baked_ops_home_defaults() -> None:
+    text = Path(jh.__file__).read_text(encoding="utf-8")
+    assert "/home/ops" not in text
+
+
+def test_fails_closed_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(jh.ENV_HOST, raising=False)
     monkeypatch.delenv(jh.ENV_HOST_FALLBACK, raising=False)
     monkeypatch.delenv(jh.ENV_REPO, raising=False)
     monkeypatch.delenv(jh.ENV_TEACHER_HOST, raising=False)
     monkeypatch.delenv(jh.ENV_TEACHER_REPO, raising=False)
     monkeypatch.delenv(jh.ENV_DISPATCH_SSH, raising=False)
-    assert jh.job_dispatch_host() == jh.DEFAULT_JOB_SSH
-    assert jh.job_dispatch_repo() == jh.DEFAULT_JOB_REPO
-    assert jh.ssh_alias_for_host_id("host-job") == jh.DEFAULT_JOB_SSH
-    assert jh.ssh_alias_for_host_id("host-teacher") == jh.DEFAULT_TEACHER_SSH
-    assert jh.repo_for_host_id("host-teacher") == jh.DEFAULT_TEACHER_REPO
+    with pytest.raises(ValueError, match="is required"):
+        jh.job_dispatch_host()
+    with pytest.raises(ValueError, match="is required"):
+        jh.job_dispatch_repo()
+    with pytest.raises(ValueError, match="is required"):
+        jh.ssh_alias_for_host_id("host-job")
+    with pytest.raises(ValueError, match="is required"):
+        jh.ssh_alias_for_host_id("host-teacher")
+    with pytest.raises(ValueError, match="is required"):
+        jh.repo_for_host_id("host-teacher")
 
 
 def test_no_marker_stays_notebook(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -50,6 +50,16 @@ def _isolate_host(monkeypatch: pytest.MonkeyPatch) -> atlas_job.FakeHostAdapter:
     atlas_job.set_host_adapter(None)
 
 
+@pytest.fixture(autouse=True)
+def _non_operational_run_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
+
+
+def test_source_has_no_baked_ops_home_defaults() -> None:
+    text = Path(atlas_job.__file__).read_text(encoding="utf-8")
+    assert "/home/ops" not in text
+
+
 def test_valid_plan_is_ok() -> None:
     assert atlas_job.validate_plan(_plan()) == []
 
@@ -59,7 +69,7 @@ def test_allows_hramatka_for_reenrich() -> None:
 
 
 def test_allows_vps_alias_for_reenrich() -> None:
-    # "vps" is the ssh alias for the hramatka host — same allowance.
+    # "vps" remains an allowed plan-host token (occupancy sanitizer denylist).
     assert atlas_job.validate_plan(_plan(host="vps")) == []
 
 
@@ -139,21 +149,21 @@ def test_submit_dry_run_sets_host_and_workdir(capsys: pytest.CaptureFixture[str]
     assert "run-atlas-job-missing-tr-example" in out
 
 
-def test_submit_dry_run_hramatka_uses_atlas_jobs_workdir(
+def test_submit_dry_run_uses_env_run_root_for_any_host(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     rc = atlas_job.submit(_plan(id="hramatka-dry", host="hramatka"), dry_run=True)
     assert rc == 0
     out = capsys.readouterr().out
     assert "hramatka" in out
-    assert "/home/ops/atlas-jobs/run-atlas-job-hramatka-dry" in out
+    assert "/tmp/atlas-run-root/run-atlas-job-hramatka-dry" in out
 
 
-def test_submit_forwards_per_host_run_root_env(
+def test_submit_forwards_required_run_root_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
 ) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
-    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/custom-run-root")
     captured_env: dict[str, str] = {}
 
     def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
@@ -164,7 +174,7 @@ def test_submit_forwards_per_host_run_root_env(
     plan = _plan(id="hramatka-run-root", host="hramatka")
     rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
     assert rc == 0
-    assert captured_env["ATLAS_RUN_ROOT"] == "/home/ops/atlas-jobs"
+    assert captured_env["ATLAS_RUN_ROOT"] == "/tmp/custom-run-root"
 
 
 def test_submit_invalid_plan_exits_2() -> None:
@@ -349,7 +359,7 @@ def test_audit_with_running_id_matches_main_pid() -> None:
         {
             "id": "missing-tr-example",
             "unit": "atlas-job-missing-tr-example.service",
-            "workdir": "/home/ops/atlas-runner/run-atlas-job-missing-tr-example",
+            "workdir": "/tmp/atlas-run-root/run-atlas-job-missing-tr-example",
             "main_pid": 4242,
         }
     ]
@@ -413,9 +423,9 @@ def test_pull_accepts_hramatka(monkeypatch: pytest.MonkeyPatch) -> None:
     assert launched
 
 
-def test_pull_forwards_per_host_run_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """hramatka pull must forward /home/ops/atlas-jobs (mirrors submit)."""
-    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+def test_pull_forwards_required_run_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pull must forward ATLAS_RUN_ROOT (mirrors submit)."""
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/custom-run-root")
     captured_env: dict[str, str] = {}
 
     def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
@@ -425,7 +435,7 @@ def test_pull_forwards_per_host_run_root_env(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
     rc = atlas_job.pull(host="hramatka")
     assert rc == 0
-    assert captured_env["ATLAS_RUN_ROOT"] == "/home/ops/atlas-jobs"
+    assert captured_env["ATLAS_RUN_ROOT"] == "/tmp/custom-run-root"
 
 
 def test_git_receipt_rejects_absolute_paths() -> None:
@@ -445,7 +455,7 @@ def test_build_git_receipt_redacts_absolute_paths_in_backup_error() -> None:
         "id": "smoke",
         "state": "succeeded",
         "delivery": "ok",
-        "workdir": "/home/ops/atlas-runner/run-atlas-job-smoke",
+        "workdir": "/tmp/atlas-run-root/run-atlas-job-smoke",
         "backup": {
             "attempted": True,
             "ok": False,
@@ -559,24 +569,26 @@ def test_workdir_honored_only_when_safe(tmp_path: Path, monkeypatch: pytest.Monk
         assert errors, bad
 
     monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
-    assert (
-        atlas_job.require_safe_workdir("/home/ops/atlas-runner/run-atlas-job-test")
-        == "/home/ops/atlas-runner/run-atlas-job-test"
-    )
+    with pytest.raises(ValueError, match="ATLAS_RUN_ROOT is required"):
+        atlas_job.require_safe_workdir("/tmp/atlas-run-root/run-atlas-job-test")
 
 
-def test_work_dir_for_uses_per_host_default_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+def test_work_dir_for_requires_run_root_and_ignores_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
     assert atlas_job.work_dir_for("ar-job", _plan(id="ar-job")) == (
-        "/home/ops/atlas-runner/run-atlas-job-ar-job"
+        "/tmp/atlas-run-root/run-atlas-job-ar-job"
     )
     assert atlas_job.work_dir_for(
         "hramatka-job", _plan(id="hramatka-job", host="hramatka")
-    ) == "/home/ops/atlas-jobs/run-atlas-job-hramatka-job"
-    # "vps" is the same physical host as "hramatka" — same default root.
-    assert atlas_job.work_dir_for(
-        "vps-job", _plan(id="vps-job", host="vps")
-    ) == "/home/ops/atlas-jobs/run-atlas-job-vps-job"
+    ) == "/tmp/atlas-run-root/run-atlas-job-hramatka-job"
+    assert atlas_job.work_dir_for("vps-job", _plan(id="vps-job", host="vps")) == (
+        "/tmp/atlas-run-root/run-atlas-job-vps-job"
+    )
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    with pytest.raises(ValueError, match="ATLAS_RUN_ROOT is required"):
+        atlas_job.work_dir_for("ar-job", _plan(id="ar-job"))
 
 
 def test_close_and_cli_reject_unsafe_job_id(

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -149,6 +149,11 @@ def test_submit_dry_run_sets_host_and_workdir(capsys: pytest.CaptureFixture[str]
     assert "run-atlas-job-missing-tr-example" in out
 
 
+def test_submit_fails_closed_without_run_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
+    assert atlas_job.submit(_plan(), dry_run=True) == 2
+
+
 def test_submit_dry_run_uses_env_run_root_for_any_host(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_atlas_job_protocol.py
+++ b/tests/test_atlas_job_protocol.py
@@ -64,13 +64,14 @@ def test_valid_plan_is_ok() -> None:
     assert atlas_job.validate_plan(_plan()) == []
 
 
-def test_allows_hramatka_for_reenrich() -> None:
-    assert atlas_job.validate_plan(_plan(host="hramatka")) == []
+def test_rejects_hramatka_host() -> None:
+    errors = atlas_job.validate_plan(_plan(host="hramatka"))
+    assert any("host" in e for e in errors)
 
 
-def test_allows_vps_alias_for_reenrich() -> None:
-    # "vps" remains an allowed plan-host token (occupancy sanitizer denylist).
-    assert atlas_job.validate_plan(_plan(host="vps")) == []
+def test_rejects_vps_alias_host() -> None:
+    errors = atlas_job.validate_plan(_plan(host="vps"))
+    assert any("host" in e for e in errors)
 
 
 def test_rejects_unknown_host() -> None:
@@ -154,14 +155,14 @@ def test_submit_fails_closed_without_run_root(monkeypatch: pytest.MonkeyPatch) -
     assert atlas_job.submit(_plan(), dry_run=True) == 2
 
 
-def test_submit_dry_run_uses_env_run_root_for_any_host(
+def test_submit_dry_run_uses_env_run_root(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    rc = atlas_job.submit(_plan(id="hramatka-dry", host="hramatka"), dry_run=True)
+    rc = atlas_job.submit(_plan(id="dry-run-job"), dry_run=True)
     assert rc == 0
     out = capsys.readouterr().out
-    assert "hramatka" in out
-    assert "/tmp/atlas-run-root/run-atlas-job-hramatka-dry" in out
+    assert "atlas-runner" in out
+    assert "/tmp/atlas-run-root/run-atlas-job-dry-run-job" in out
 
 
 def test_submit_forwards_required_run_root_env(
@@ -176,7 +177,7 @@ def test_submit_forwards_required_run_root_env(
         return 0
 
     monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
-    plan = _plan(id="hramatka-run-root", host="hramatka")
+    plan = _plan(id="run-root-job")
     rc = atlas_job.submit(plan, dry_run=False, host_adapter=_isolate_host)
     assert rc == 0
     assert captured_env["ATLAS_RUN_ROOT"] == "/tmp/custom-run-root"
@@ -407,15 +408,23 @@ def test_status_reconciles_inactive_unit_to_needs_finalize(
     assert row["state"] == "needs_finalize"
 
 
-def test_status_accepts_hramatka(
+def test_status_accepts_explicit_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
 ) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
-    rc = atlas_job.status(host="hramatka", host_adapter=_isolate_host)
+    rc = atlas_job.status(host="atlas-runner", host_adapter=_isolate_host)
     assert rc == 0
 
 
-def test_pull_accepts_hramatka(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_status_fails_closed_without_runner_host(
+    monkeypatch: pytest.MonkeyPatch, _isolate_host: atlas_job.FakeHostAdapter
+) -> None:
+    monkeypatch.delenv("ATLAS_RUNNER_HOST", raising=False)
+    rc = atlas_job.status(host_adapter=_isolate_host)
+    assert rc == 2
+
+
+def test_pull_accepts_explicit_host(monkeypatch: pytest.MonkeyPatch) -> None:
     launched: list[list[str]] = []
 
     def fake_subprocess_call(cmd: list[str], **kwargs: object) -> int:
@@ -423,9 +432,14 @@ def test_pull_accepts_hramatka(monkeypatch: pytest.MonkeyPatch) -> None:
         return 0
 
     monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
-    rc = atlas_job.pull(host="hramatka")
+    rc = atlas_job.pull(host="test-runner-host")
     assert rc == 0
     assert launched
+
+
+def test_pull_fails_closed_without_runner_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_RUNNER_HOST", raising=False)
+    assert atlas_job.pull() == 2
 
 
 def test_pull_forwards_required_run_root_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -438,7 +452,7 @@ def test_pull_forwards_required_run_root_env(monkeypatch: pytest.MonkeyPatch) ->
         return 0
 
     monkeypatch.setattr(atlas_job.subprocess, "call", fake_subprocess_call)
-    rc = atlas_job.pull(host="hramatka")
+    rc = atlas_job.pull(host="test-runner-host")
     assert rc == 0
     assert captured_env["ATLAS_RUN_ROOT"] == "/tmp/custom-run-root"
 
@@ -585,11 +599,8 @@ def test_work_dir_for_requires_run_root_and_ignores_host(
     assert atlas_job.work_dir_for("ar-job", _plan(id="ar-job")) == (
         "/tmp/atlas-run-root/run-atlas-job-ar-job"
     )
-    assert atlas_job.work_dir_for(
-        "hramatka-job", _plan(id="hramatka-job", host="hramatka")
-    ) == "/tmp/atlas-run-root/run-atlas-job-hramatka-job"
-    assert atlas_job.work_dir_for("vps-job", _plan(id="vps-job", host="vps")) == (
-        "/tmp/atlas-run-root/run-atlas-job-vps-job"
+    assert atlas_job.work_dir_for("alt-job", _plan(id="alt-job", host="atlas-runner")) == (
+        "/tmp/atlas-run-root/run-atlas-job-alt-job"
     )
     monkeypatch.delenv("ATLAS_RUN_ROOT", raising=False)
     with pytest.raises(ValueError, match="ATLAS_RUN_ROOT is required"):
@@ -913,8 +924,8 @@ def test_ssh_host_load_uses_ssh_when_not_self(monkeypatch: pytest.MonkeyPatch) -
     assert "job-box" in seen[0]
 
 
-def test_is_self_host_uses_canonical_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "vps")
-    assert atlas_job.is_self_host("hramatka") is True
-    assert atlas_job.is_self_host("vps") is True
-    assert atlas_job.is_self_host("job-box") is False
+def test_is_self_host_matches_env_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "job-box,runner-a")
+    assert atlas_job.is_self_host("job-box") is True
+    assert atlas_job.is_self_host("runner-a") is True
+    assert atlas_job.is_self_host("other-box") is False

--- a/tests/test_health_20k_runner.py
+++ b/tests/test_health_20k_runner.py
@@ -65,12 +65,26 @@ def test_health_probe_requires_runner_host() -> None:
     ]
 
 
+def test_health_probe_requires_run_root() -> None:
+    result = _run_probe(env={"ATLAS_RUNNER_HOST": "test-runner-host", "ATLAS_RUN_ROOT": ""})
+
+    assert result.returncode == 2
+    assert "ATLAS_RUN_ROOT is required" in result.stderr
+    assert result.stdout.splitlines() == [
+        "host_set=true",
+        "mirror_present=false",
+        "mirror_require_ok=false",
+        "mirror_age_hint=max_age_hours=24",
+    ]
+
+
 def test_health_probe_fails_closed_when_ssh_check_fails(tmp_path: Path) -> None:
     fake_bin = _stub_ssh(tmp_path, exit_code=1)
 
     result = _run_probe(
         env={
-            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_RUNNER_HOST": "test-runner-host",
+            "ATLAS_RUN_ROOT": "/tmp/atlas-run-root",
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
         }
     )
@@ -91,7 +105,8 @@ def test_health_probe_fails_closed_without_local_mirror(tmp_path: Path) -> None:
 
     result = _run_probe(
         env={
-            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_RUNNER_HOST": "test-runner-host",
+            "ATLAS_RUN_ROOT": "/tmp/atlas-run-root",
             "ATLAS_MIRROR_DIR": str(missing_mirror),
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
         }
@@ -114,7 +129,8 @@ def test_health_probe_fails_closed_when_mirror_is_not_durable(tmp_path: Path) ->
 
     result = _run_probe(
         env={
-            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_RUNNER_HOST": "test-runner-host",
+            "ATLAS_RUN_ROOT": "/tmp/atlas-run-root",
             "ATLAS_MIRROR_DIR": str(mirror),
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
         }
@@ -137,7 +153,8 @@ def test_health_probe_succeeds_with_reachable_runner_and_durable_mirror(tmp_path
 
     result = _run_probe(
         env={
-            "ATLAS_RUNNER_HOST": "ops@runner.example",
+            "ATLAS_RUNNER_HOST": "test-runner-host",
+            "ATLAS_RUN_ROOT": "/tmp/atlas-run-root",
             "ATLAS_MIRROR_DIR": str(mirror),
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "SSH_ARGS_FILE": str(ssh_args),

--- a/tests/test_launch_reenrich_target_detection.py
+++ b/tests/test_launch_reenrich_target_detection.py
@@ -223,58 +223,45 @@ def test_remote_wrapper_primary_root_override_wins() -> None:
 
 
 def _remote_run_root_block(source: str) -> str:
-    """Extract the per-host RUN_ROOT default block verbatim."""
-    start = source.index('case "$HOST" in')
+    """Extract the required ATLAS_RUN_ROOT block verbatim."""
+    start = source.index('if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then')
     end = source.index("\n\n", start)
     return source[start:end]
 
 
-@pytest.mark.parametrize(
-    "host,expected_run_root",
-    [
-        ("atlas-runner", "/home/ops/atlas-runner"),
-        ("hramatka", "/home/ops/atlas-jobs"),
-        ("vps", "/home/ops/atlas-jobs"),
-        ("hramatka-2", "/home/ops/atlas-runner"),
-        ("some-other-host", "/home/ops/atlas-runner"),
-    ],
-)
-def test_remote_wrapper_run_root_defaults_per_host(host: str, expected_run_root: str) -> None:
-    """#6876: hramatka/vps (exact aliases) run under /home/ops/atlas-jobs;
-    every other host keeps /home/ops/atlas-runner."""
+def test_remote_wrapper_run_root_is_required() -> None:
     source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
     block = _remote_run_root_block(source)
     proc = subprocess.run(
-        ["bash", "-c", f"HOST={host!r}\n{block}\nprintf '%s' \"$RUN_ROOT\""],
+        ["bash", "-c", block],
         capture_output=True,
         text=True,
         check=False,
         timeout=10,
         env={"PATH": "/usr/bin:/bin"},
     )
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout == expected_run_root
+    assert proc.returncode == 2
+    assert "ATLAS_RUN_ROOT is required" in proc.stderr
 
 
-def test_remote_wrapper_run_root_override_wins() -> None:
-    """An explicit ATLAS_RUN_ROOT beats the per-host default."""
+def test_remote_wrapper_run_root_uses_env() -> None:
     source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
     block = _remote_run_root_block(source)
     proc = subprocess.run(
-        ["bash", "-c", "HOST=hramatka\n" + block + "\nprintf '%s' \"$RUN_ROOT\""],
+        ["bash", "-c", block + "\nprintf '%s' \"$RUN_ROOT\""],
         capture_output=True,
         text=True,
         check=False,
         timeout=10,
-        env={"PATH": "/usr/bin:/bin", "ATLAS_RUN_ROOT": "/custom/run-root"},
+        env={"PATH": "/usr/bin:/bin", "ATLAS_RUN_ROOT": "/tmp/custom-run-root"},
     )
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout == "/custom/run-root"
+    assert proc.stdout == "/tmp/custom-run-root"
 
 
 def test_remote_wrapper_mkdirs_run_root_before_first_transfer() -> None:
-    """The per-host run root must be materialized on the remote before any
-    scp/rsync writes into it (a fresh hramatka layout has no atlas-jobs dir)."""
+    """The configured run root must be materialized on the remote before any
+    scp/rsync writes into it."""
     source = REMOTE_LAUNCHER.read_text(encoding="utf-8")
     mkdir_marker = 'ssh_q "mkdir -p $(printf \'%q\' "$RUN_ROOT")"'
     assert mkdir_marker in source
@@ -287,69 +274,46 @@ def test_remote_wrapper_mkdirs_run_root_before_first_transfer() -> None:
     assert mkdir_idx > source.index('ssh_q "true"')
 
 
-def test_launchers_never_reference_opt_hramatka() -> None:
-    """Job space is /home/ops/*; the /opt/hramatka tree must never be written."""
+def test_launchers_never_reference_teacher_product_or_ops_home_trees() -> None:
+    """Launchers must not bake teacher-product or ops-home filesystem layout."""
     for launcher in (REMOTE_LAUNCHER, LOCAL_LAUNCHER):
-        assert "/opt/hramatka" not in launcher.read_text(encoding="utf-8")
+        text = launcher.read_text(encoding="utf-8")
+        assert "/opt/hramatka" not in text
+        assert "/home/ops" not in text
 
 
 def _local_run_root_block(source: str) -> str:
-    """Extract the on-host RUN_ROOT default block verbatim."""
-    start = source.index('if [[ -n "${ATLAS_RUN_ROOT:-}" ]]; then')
+    """Extract the required ATLAS_RUN_ROOT block verbatim."""
+    start = source.index('if [[ -z "${ATLAS_RUN_ROOT:-}" ]]; then')
     end = source.index("\n\n", start)
     return source[start:end]
 
 
-@pytest.mark.parametrize(
-    "hostname,expected_run_root",
-    [
-        ("hramatka", "/home/ops/atlas-jobs"),
-        ("hramatka.example.com", "/home/ops/atlas-jobs"),
-        ("vps", "/home/ops/atlas-jobs"),
-        ("atlas-runner", "/home/ops/atlas-runner"),
-        ("some-random-host", "/home/ops/atlas-runner"),
-    ],
-)
-def test_local_launcher_run_root_defaults_by_hostname(
-    tmp_path: Path, hostname: str, expected_run_root: str
-) -> None:
-    """Direct on-host invocation (no forwarded ATLAS_RUN_ROOT) must still
-    resolve the per-host run root from the machine's own hostname (#6876)."""
+def test_local_launcher_run_root_is_required() -> None:
     source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
     block = _local_run_root_block(source)
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_hostname = fake_bin / "hostname"
-    fake_hostname.write_text(f"#!/bin/sh\necho {hostname}\n", encoding="utf-8")
-    fake_hostname.chmod(0o755)
+    proc = subprocess.run(
+        ["bash", "-c", block],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 2
+    assert "ATLAS_RUN_ROOT is required" in proc.stderr
+
+
+def test_local_launcher_run_root_uses_env() -> None:
+    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
+    block = _local_run_root_block(source)
     proc = subprocess.run(
         ["bash", "-c", block + "\nprintf '%s' \"$RUN_ROOT\""],
         capture_output=True,
         text=True,
         check=False,
         timeout=10,
-        env={"PATH": f"{fake_bin}:/usr/bin:/bin"},
+        env={"PATH": "/usr/bin:/bin", "ATLAS_RUN_ROOT": "/tmp/custom-run-root"},
     )
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout == expected_run_root
-
-
-def test_local_launcher_run_root_override_wins(tmp_path: Path) -> None:
-    """An explicit ATLAS_RUN_ROOT beats hostname-based defaulting."""
-    source = LOCAL_LAUNCHER.read_text(encoding="utf-8")
-    block = _local_run_root_block(source)
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_hostname = fake_bin / "hostname"
-    fake_hostname.write_text("#!/bin/sh\necho hramatka\n", encoding="utf-8")
-    fake_hostname.chmod(0o755)
-    proc = subprocess.run(
-        ["bash", "-c", block + "\nprintf '%s' \"$RUN_ROOT\""],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=10,
-        env={"PATH": f"{fake_bin}:/usr/bin:/bin", "ATLAS_RUN_ROOT": "/custom/run-root"},
-    )
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout == "/custom/run-root"
+    assert proc.stdout == "/tmp/custom-run-root"

--- a/tests/test_lexicon_runner_fetch_ulif_20k.py
+++ b/tests/test_lexicon_runner_fetch_ulif_20k.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-PYTHON = str(ROOT / ".venv" / "bin" / "python")
+PYTHON = sys.executable
 DRIVER = ROOT / "scripts" / "lexicon" / "runner" / "fetch_ulif_20k.py"
 
 

--- a/tests/test_lexicon_runner_fetch_ulif_20k.py
+++ b/tests/test_lexicon_runner_fetch_ulif_20k.py
@@ -12,6 +12,18 @@ PYTHON = str(ROOT / ".venv" / "bin" / "python")
 DRIVER = ROOT / "scripts" / "lexicon" / "runner" / "fetch_ulif_20k.py"
 
 
+def test_source_has_no_baked_ops_home_defaults() -> None:
+    assert "/home/ops" not in DRIVER.read_text(encoding="utf-8")
+
+
+def test_work_dir_flag_is_required() -> None:
+    from scripts.lexicon.runner.fetch_ulif_20k import main as fetch_main
+
+    with pytest.raises(SystemExit) as exc:
+        fetch_main([])
+    assert exc.value.code == 2
+
+
 def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
     work = tmp_path / "work"
     proc = subprocess.run(

--- a/tests/test_lexicon_runner_reduce_ulif_20k.py
+++ b/tests/test_lexicon_runner_reduce_ulif_20k.py
@@ -120,6 +120,20 @@ def test_in_process_reduce_never_applies_worker_memory_limit_to_coordinator(
     assert candidate["entries"][0]["lemma"] == "привіт"
 
 
+def test_source_has_no_baked_ops_home_defaults() -> None:
+    assert "/home/ops" not in (
+        ROOT / "scripts" / "lexicon" / "runner" / "reduce_ulif_20k.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_work_dir_flag_is_required() -> None:
+    from scripts.lexicon.runner.reduce_ulif_20k import main as reduce_main
+
+    with pytest.raises(SystemExit) as exc:
+        reduce_main([])
+    assert exc.value.code == 2
+
+
 def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
     """Sanity companion: --help must not start a reduce run or write work artifacts."""
     import subprocess

--- a/tests/test_lexicon_runner_reduce_ulif_20k.py
+++ b/tests/test_lexicon_runner_reduce_ulif_20k.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -140,7 +141,7 @@ def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
 
     work = tmp_path / "work"
     proc = subprocess.run(
-        [str(ROOT / ".venv" / "bin" / "python"), str(ROOT / "scripts" / "lexicon" / "runner" / "reduce_ulif_20k.py"), "--help"],
+        [sys.executable, str(ROOT / "scripts" / "lexicon" / "runner" / "reduce_ulif_20k.py"), "--help"],
         cwd=ROOT,
         capture_output=True,
         text=True,

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -73,17 +73,17 @@ def test_rb6_references_estate_registry_entries() -> None:
     repos = {Path(r["local_path"]).name for r in surfaces["repositories"]}
     sites = {s["url"] for s in surfaces["public_sites"]}
 
-    assert "vps" in vps_aliases
-    assert "hramatka-api" in services
-    assert "learn-ukrainian-infra-private" in repos
+    assert "estate-probe-ssh" in vps_aliases
+    assert "estate-probe-unit" in services
+    assert "estate-probe-private" in repos
     # Exact-set equality (not substring membership): stricter, and it avoids the
     # URL-substring pattern CodeQL flags (py/incomplete-url-substring-sanitization).
     assert sites == {"https://learn-ukrainian.github.io/"}
 
     # Refused surfaces check
-    assert "pilot-vps" in refused
-    assert "hramatka-api" in refused
-    assert "learn-ukrainian-infra-private" in refused
+    assert "estate-probe-vps" in refused
+    assert "estate-probe-service" in refused
+    assert "estate-probe-private-repo" in refused
     assert "public-site" in refused
 
     # Consistency pin: the registry values must appear in the probe COMMANDS
@@ -313,8 +313,8 @@ def test_negative_estate_refused_surfaces_drift_fails_validation() -> None:
 
     estate_data = _load_yaml(ESTATE_PATH)
     assert validate_estate_registry_data(estate_data)["ok"] is True
-    estate_data["refused_mutation_surfaces"].remove("pilot-vps")
-    with pytest.raises(TrailSpecValidationError, match="pilot-vps"):
+    estate_data["refused_mutation_surfaces"].remove("estate-probe-vps")
+    with pytest.raises(TrailSpecValidationError, match="estate-probe-vps"):
         validate_estate_registry_data(estate_data)
 
 

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -60,22 +60,22 @@ def test_estate_registry_seed_validates() -> None:
 
 
 def test_rb6_references_estate_registry_entries() -> None:
-    """RB-6 probes explicitly reference estate surfaces defined in estate.v1.yaml."""
+    """RB-6 probes must not reconstruct estate topology from the public registry seed."""
     estate_data = _load_yaml(ESTATE_PATH)
     rb6_data = _load_yaml(RB6_TRAIL_PATH)
 
     surfaces = estate_data["surfaces"]
     refused = set(estate_data["refused_mutation_surfaces"])
 
-    # Extract declared estate surface identities
-    vps_aliases = {v["ssh_alias"] for v in surfaces["vps_hosts"]}
-    services = {s["systemd_unit"] for s in surfaces["services"]}
-    repos = {Path(r["local_path"]).name for r in surfaces["repositories"]}
+    # Declared estate surface identities (opaque tokens — not probe command literals).
+    vps_names = {v["name"] for v in surfaces["vps_hosts"]}
+    service_names = {s["name"] for s in surfaces["services"]}
+    repo_names = {r["name"] for r in surfaces["repositories"]}
     sites = {s["url"] for s in surfaces["public_sites"]}
 
-    assert "estate-probe-ssh" in vps_aliases
-    assert "estate-probe-unit" in services
-    assert "estate-probe-private" in repos
+    assert "estate-probe-vps" in vps_names
+    assert "estate-probe-service" in service_names
+    assert "estate-probe-private-repo" in repo_names
     # Exact-set equality (not substring membership): stricter, and it avoids the
     # URL-substring pattern CodeQL flags (py/incomplete-url-substring-sanitization).
     assert sites == {"https://learn-ukrainian.github.io/"}
@@ -86,48 +86,58 @@ def test_rb6_references_estate_registry_entries() -> None:
     assert "estate-probe-private-repo" in refused
     assert "public-site" in refused
 
-    # Consistency pin: the registry values must appear in the probe COMMANDS
-    # (not just intent prose). RB-6 probes deliberately hardcode these values
-    # for runtime robustness; this assertion is what makes the registry the
-    # source of truth — drifting a command away from the registry fails here.
-    _assert_registry_consumed_by_commands(estate_data, rb6_data)
+    # Decoupling pin: registry fields must not jointly appear in probe commands.
+    _assert_registry_decoupled_from_commands(estate_data, rb6_data)
 
 
-def _assert_registry_consumed_by_commands(estate_data: dict, rb6_data: dict) -> None:
+def _assert_registry_decoupled_from_commands(estate_data: dict, rb6_data: dict) -> None:
     surfaces = estate_data["surfaces"]
     step_commands = " ".join(
         s["command"]["argv"][-1] for s in rb6_data["steps"] if s["command"]["argv"]
     )
+    ssh_aliases = {v["ssh_alias"] for v in surfaces["vps_hosts"]}
     for vps in surfaces["vps_hosts"]:
-        alias = vps["ssh_alias"]
-        assert f"ssh -o BatchMode=yes -o ConnectTimeout=5 {alias} " in step_commands, (
-            f"registry ssh alias '{alias}' is not consumed by any RB-6 probe command"
+        assert vps["ssh_alias"] not in step_commands, (
+            f"registry ssh alias '{vps['ssh_alias']}' must not appear in RB-6 probe commands"
+        )
+        assert vps["role"] not in step_commands, (
+            f"registry role '{vps['role']}' must not appear in RB-6 probe commands"
         )
     for service in surfaces["services"]:
-        assert service["systemd_unit"] in step_commands, (
-            f"registry systemd unit '{service['systemd_unit']}' is not consumed "
-            "by any RB-6 probe command"
+        assert service["host_alias"] not in step_commands, (
+            f"registry host alias '{service['host_alias']}' must not appear in RB-6 probe commands"
+        )
+        assert service["systemd_unit"] not in step_commands, (
+            f"registry systemd unit '{service['systemd_unit']}' must not appear in RB-6 probe commands"
+        )
+        assert service["host_alias"] not in ssh_aliases, (
+            "registry must not cross-link service host_alias to vps ssh_alias"
         )
     for repo in surfaces["repositories"]:
-        assert repo["local_path"] in step_commands, (
-            f"registry repo path '{repo['local_path']}' is not consumed by any RB-6 probe command"
+        assert repo["local_path"] not in step_commands, (
+            f"registry repo path '{repo['local_path']}' must not appear in RB-6 probe commands"
         )
-    # Token equality (not substring): the URL must appear as a standalone shell
-    # token of a probe command — stricter, and clear of the CodeQL URL-substring rule.
     command_tokens = step_commands.split()
     for site in surfaces["public_sites"]:
-        assert any(token == site["url"] for token in command_tokens), (
-            f"registry site url '{site['url']}' is not consumed by any RB-6 probe command"
+        assert site["url"] not in command_tokens, (
+            f"registry site url '{site['url']}' must not appear in RB-6 probe commands"
+        )
+
+    for env_key in ("RB6_PROBE_SSH", "RB6_PROBE_UNIT", "RB6_PROBE_REPO", "RB6_PROBE_SITE"):
+        assert env_key in step_commands, (
+            f"RB-6 probe commands must use runtime env placeholder {env_key}"
         )
 
 
-def test_negative_rb6_registry_drift_fails_consistency() -> None:
-    """Mutation negative: a registry value drifting away from the commands FAILS the pin."""
+def test_negative_rb6_cross_linked_host_alias_fails_decoupling() -> None:
+    """Mutation negative: cross-linking host_alias to ssh_alias FAILS the decoupling pin."""
     estate_data = _load_yaml(ESTATE_PATH)
     rb6_data = _load_yaml(RB6_TRAIL_PATH)
-    estate_data["surfaces"]["vps_hosts"][0]["ssh_alias"] = "vps-renamed"
-    with pytest.raises(AssertionError, match="vps-renamed"):
-        _assert_registry_consumed_by_commands(estate_data, rb6_data)
+    estate_data["surfaces"]["services"][0]["host_alias"] = estate_data["surfaces"]["vps_hosts"][0][
+        "ssh_alias"
+    ]
+    with pytest.raises(AssertionError, match="cross-link"):
+        _assert_registry_decoupled_from_commands(estate_data, rb6_data)
 
 
 def test_negative_rb1_dropped_predicate_clause_fails() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wartime hybrid-ops hardening. Public GitHub is scrapable; this PR removes operator filesystem defaults and host-role layout tables from the public repo so an adversary cannot reconstruct live infra layout from git.

Hramatka remains as the product/stream name. Occupancy sanitizer still knows plan-host tokens so it can redact them from API output. This PR does not publish occupancy maps, SSH config, addresses, or new hostnames.

## Changes

- Atlas runner scripts and `job_host_exec` now require operator env (`ATLAS_RUN_ROOT`, `ATLAS_RUNNER_HOST`, `LU_JOB_REPO` / `LU_TEACHER_REPO`, dispatch SSH env) and fail closed when unset.
- Fetch/reduce `--work-dir` is required (no baked default).
- `atlas_job.submit` returns exit 2 if the run-root env is missing (no uncaught error).
- Public atlas runbooks no longer include role-to-host tables or concrete run-root paths. Live topology stays in private ops.
- Tests updated for env-required behavior and use non-operational placeholders only.
- `fetch_ulif_20k.py` lazy-imports `requests` only when a live HTTP session is constructed, so pytest fastlane `--help` / argparse tests work without that extra.
- Atlas-jobs API tests no longer treat `hramatka`/`vps` as live host aliases; submit/load reject them and results use non-operational placeholders.

## Testing

```text
.venv/bin/python -m pytest \
  tests/test_atlas_job_protocol.py \
  tests/test_launch_reenrich_target_detection.py \
  tests/test_launch_reenrich_venv_preflight.py \
  tests/orchestration/test_job_host_exec.py \
  tests/test_health_20k_runner.py \
  tests/test_lexicon_runner_fetch_ulif_20k.py \
  tests/test_lexicon_runner_reduce_ulif_20k.py \
  tests/api/test_occupancy.py \
  tests/api/test_atlas_jobs_router.py
```

- [x] Relevant runner / job-host / health / occupancy / atlas-jobs tests
- [ ] Website builds without errors (`cd site && npm run build`) — not in scope
- [ ] Ukrainian text reviewed for naturalness — not in scope

## Related Issues

Private ops tracker: learn-ukrainian/learn-ukrainian-infra-private#527

This public PR covers the public-repo scrub only. Private ACL inventory stays on that tracker and is not closed here. History rewrite is out of scope.

## Threat model

Public git history and current tree are adversary-readable. Baked run-root defaults and role-to-host tables are a recon map even without numeric addresses. Fail-closed env moves live layout out of the public tree going forward. Git history rewrite is intentionally not attempted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1e9d83c-9662-44ff-b0c1-3597c7c5a004?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1e9d83c-9662-44ff-b0c1-3597c7c5a004&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

