### PR TITLE
fix(routing): Recent Delegates use local clock for started_at (#7094)

### DIFF
--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -131,6 +131,12 @@ function escapeHtml(value) {
   }[ch]));
 }
 
+function formatTs(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+}
+
 function pct(value) {
   const num = Number(value);
   return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
@@ -275,7 +281,7 @@ function renderDelegates(delegates) {
     <td>${escapeHtml(task.model || '')}</td>
     <td>${statusPill(task.status)}</td>
     <td>${task.duration_s == null ? '' : `${Number(task.duration_s).toFixed(1)}s`}</td>
-    <td>${escapeHtml(task.started_at || '')}</td>
+    <td>${formatTs(task.started_at)}</td>
   </tr>`).join('');
   document.getElementById('delegate-table').innerHTML = `<table>
     <tr><th>Task</th><th>Agent</th><th>Model</th><th>Status</th><th>Duration</th><th>Started</th></tr>


### PR DESCRIPTION
## Summary
- Add `formatTs` to `dashboards/routing.html` matching `delegate.html` (`new Date(value).toLocaleString()`).
- Recent Delegates **Started** column now shows viewer-local time instead of raw UTC ISO.

## Test plan
- [x] `grep` confirms `formatTs` is used for `started_at` and raw `escapeHtml(task.started_at` is absent
- [x] `pytest -q tests -k routing --collect-only`
- [ ] Visual: open `/routing.html` and confirm Recent Delegates timestamps match local clock on `/delegate.html`

Relates to #7094 — issue stays open for QA sign-off.