### PR TITLE
fix(dashboard): default empty copy for unfiltered build events (#7096)

### DIFF
--- a/dashboards/build-events.html
+++ b/dashboards/build-events.html
@@ -179,7 +179,12 @@ function renderActive(active) {
 
 function renderRecent(events) {
   if (!events.length) {
-    document.getElementById('recent-content').innerHTML = '<div class="empty">No build events match the current filters</div>';
+    const level = document.getElementById('level-filter')?.value.trim();
+    const slug = document.getElementById('slug-filter')?.value.trim();
+    const message = (level || slug)
+      ? 'No build events match the current filters'
+      : 'No recent build events';
+    document.getElementById('recent-content').innerHTML = `<div class="empty">${message}</div>`;
     return;
   }
   document.getElementById('recent-content').innerHTML = `<table>


### PR DESCRIPTION
## Summary
- `/build-events.html` no longer blames filters on an unfiltered empty recent-events list.
- Filter-applied empty copy still says events do not match the current filters.

Fixes #7096

## Test plan
- [x] Worker grep: both copy strings; filter-blame only when level/slug set
- [x] `tests/test_monitor_ui_contracts.py` and `tests/test_build_events_api.py` (31 passed in worker)
- [ ] Independent CF
- [ ] CI Gate green

X-Agent: agy/infra-7096-build-events-empty
Initiator: grok-infra