### PR TITLE
fix(ops): services.sh fix + SSH LocalForward remote delegate

### DIFF
--- a/scripts/hygiene/lint_raw_rm_rf.py
+++ b/scripts/hygiene/lint_raw_rm_rf.py
@@ -18,23 +18,26 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # Match ``rm -rf``, ``rm -fr``, and compact flag forms such as ``rm -rfv``.
 _RM_RF_RE = re.compile(r"(?:^|[\s;|&])rm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\b")
 
-# Exact ``path:line`` allowlist for already-scoped shell cleanups. Do not expand
-# this to cover new recursive deletes — route those through a guarded helper.
-_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        # services.sh: restart lockdir reclaim/release + Astro/Vite cache dirs
-        # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
-        "services.sh:144",
-        "services.sh:163",
-        "services.sh:775",
-        "services.sh:785",
-        "services.sh:789",
-        # Scratch-dir EXIT traps for one-shot installer scripts.
-        "scripts/entire/install_kimi_external_agent.sh:18",
-        "scripts/entire/install_fleet_external_agent.sh:36",
-        # Actionlint download cleanup (scoped under a local temp dir).
-        "scripts/audit/check_workflows.sh:53",
-    }
+# Exact ``(path, stripped snippet, max_occurrences)`` allowlist for already-scoped
+# shell cleanups. Matched by content, not line number, so insertions above an
+# entry do not re-break the lint. Do not expand this to cover new recursive
+# deletes — route those through a guarded helper.
+_ALLOWLIST: tuple[tuple[str, str, int], ...] = (
+    # services.sh: restart lockdir reclaim/release + Astro/Vite cache dirs
+    # (scoped under $PIDS_DIR / $PROJECT_ROOT/site/…). Do not rewrite.
+    ("services.sh", "rm -rf \"$lockdir\" 2>/dev/null || true", 2),
+    ("services.sh", "rm -rf \"$vite_cache_dir\"", 1),
+    ("services.sh", "rm -rf \"$dist_dir\"", 1),
+    ("services.sh", "rm -rf \"$astro_dir\"", 1),
+    # Scratch-dir EXIT traps for one-shot installer scripts.
+    ("scripts/entire/install_kimi_external_agent.sh", "trap 'rm -rf \"${scratch_dir}\"' EXIT", 1),
+    ("scripts/entire/install_fleet_external_agent.sh", "trap 'rm -rf \"${scratch_dir}\"' EXIT", 1),
+    # Actionlint download cleanup (scoped under a local temp dir).
+    (
+        "scripts/audit/check_workflows.sh",
+        "cleanup() { [[ -n \"$_DOWNLOAD_DIR\" ]] && rm -rf \"$_DOWNLOAD_DIR\"; return 0; }",
+        1,
+    ),
 )
 
 _SCAN_GLOBS: tuple[str, ...] = (
@@ -54,6 +57,10 @@ def _rel(path: Path, repo_root: Path) -> str:
     return path.resolve().relative_to(repo_root.resolve()).as_posix()
 
 
+def _allowlist_lookup() -> dict[tuple[str, str], int]:
+    return {(path, snippet): max_count for path, snippet, max_count in _ALLOWLIST}
+
+
 def iter_scan_paths(repo_root: Path | None = None) -> list[Path]:
     root = (repo_root or REPO_ROOT).resolve()
     found: list[Path] = []
@@ -70,6 +77,8 @@ def iter_scan_paths(repo_root: Path | None = None) -> list[Path]:
 def find_raw_rm_rf(repo_root: Path | None = None) -> list[tuple[str, str]]:
     """Return ``(path:line, snippet)`` findings not covered by the allowlist."""
     root = (repo_root or REPO_ROOT).resolve()
+    allowlist = _allowlist_lookup()
+    usage: dict[tuple[str, str], int] = {}
     findings: list[tuple[str, str]] = []
     for path in iter_scan_paths(root):
         rel = _rel(path, root)
@@ -80,10 +89,14 @@ def find_raw_rm_rf(repo_root: Path | None = None) -> list[tuple[str, str]]:
         for line_no, line in enumerate(lines, start=1):
             if not _RM_RF_RE.search(line):
                 continue
-            key = f"{rel}:{line_no}"
-            if key in _ALLOWLIST:
-                continue
-            findings.append((key, line.strip()))
+            stripped = line.strip()
+            content_key = (rel, stripped)
+            max_allowed = allowlist.get(content_key)
+            if max_allowed is not None:
+                usage[content_key] = usage.get(content_key, 0) + 1
+                if usage[content_key] <= max_allowed:
+                    continue
+            findings.append((f"{rel}:{line_no}", stripped))
     return findings
 
 

--- a/services.sh
+++ b/services.sh
@@ -8,6 +8,8 @@
 #   ./services.sh stop sources       # Stop specific service
 #   ./services.sh restart            # Restart all
 #   ./services.sh restart api        # Restart specific service
+#   ./services.sh fix                # Health-check all; restart only unhealthy
+#   ./services.sh fix api            # Health-check and repair one service
 #   ./services.sh start api --live   # Emergency mutable-checkout API mode
 #   ./services.sh status             # Show what's running
 #   ./services.sh status work        # Show one service
@@ -18,6 +20,14 @@
 #   ./services.sh rebuild astro      # Run Astro clean then build
 #
 # Services: sources, api, astro, work
+#
+# SSH LocalForward (Mac notebook + Host alias hramatka-tunnel):
+#   start/stop/restart auto-delegate to the writer host when any requested
+#   service port is owned by an ssh listener, or when LU_SERVICES_SSH_HOST
+#   is set. They never spawn or signal local processes in that case.
+#   fix curls each health URL; unhealthy tunneled ports get a remote
+#   restart. Overrides: LU_SERVICES_SSH_HOST (default host alias hramatka),
+#   LU_SERVICES_REMOTE_ROOT (default /home/ops/learn-ukrainian).
 #
 # Note: the `sources` service was historically called `rag`. It serves
 # SQLite FTS5 indices over textbook chunks, dictionaries, VESUM, literary
@@ -91,6 +101,12 @@ SVC_HEALTH_ALT[astro]="http://localhost:4321/"
 SVC_MATCH[astro]=".bin/astro dev|astro.mjs dev"
 
 ALL_SERVICES="sources api astro work"
+
+# Remote writer host for tunneled Mac notebooks. LU_SERVICES_SSH_HOST is
+# an SSH config Host alias only; leave it unset for local-process mode.
+# The default target is used only after a tunnel (or an explicit host) is
+# detected — it does not by itself force delegation.
+LU_SERVICES_REMOTE_ROOT="${LU_SERVICES_REMOTE_ROOT:-/home/ops/learn-ukrainian}"
 
 # Legacy aliases: rewrite old service names when passed as CLI args.
 # Accept shell history + scripts that still say `./services.sh start rag`
@@ -274,6 +290,59 @@ _ssh_tunnel_port_pid() {
     done
 
     return 1
+}
+
+_ssh_delegate_host() {
+    printf '%s\n' "${LU_SERVICES_SSH_HOST:-hramatka}"
+}
+
+_requested_has_ssh_tunnel() {
+    local name
+    for name in "$@"; do
+        [[ -z "${SVC_CMD[$name]+x}" ]] && continue
+        if _ssh_tunnel_port_pid "$name" >/dev/null; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Delegate when the operator set LU_SERVICES_SSH_HOST, or when any requested
+# service port is an ssh LocalForward listener. The default host alias is
+# applied only at ssh time — it is not a trigger.
+_should_delegate_remote() {
+    if [[ -n "${LU_SERVICES_SSH_HOST:-}" ]]; then
+        return 0
+    fi
+    _requested_has_ssh_tunnel "$@"
+}
+
+_delegate_remote() {
+    local remote_action="$1"
+    shift
+    local host root
+    host="$(_ssh_delegate_host)"
+    root="${LU_SERVICES_REMOTE_ROOT:-/home/ops/learn-ukrainian}"
+    echo "Delegating ${remote_action}${*:+ $*} to ${host} (ssh LocalForward or LU_SERVICES_SSH_HOST); not starting or stopping local processes."
+    command ssh -o BatchMode=yes "$host" "cd \"$root\" && ./services.sh ${remote_action}${*:+ $*}"
+}
+
+_maybe_delegate_and_exit() {
+    local remote_action="$1"
+    shift
+    if _should_delegate_remote "$@"; then
+        _delegate_remote "$remote_action" "$@"
+        exit $?
+    fi
+}
+
+_abort_if_ssh_owned_port() {
+    local name="$1"
+    if _ssh_tunnel_port_pid "$name" >/dev/null; then
+        echo "ERROR: $name port $(_port_owner_label "$name") is owned by an ssh LocalForward; refusing to spawn locally. Use '$0 fix $name' or '$0 restart $name' to restart the remote service." >&2
+        return 1
+    fi
+    return 0
 }
 
 _foreign_port_pid() {
@@ -566,6 +635,10 @@ _start_service() {
         return 0
     fi
 
+    if ! _abort_if_ssh_owned_port "$name"; then
+        return 1
+    fi
+
     # Self-heal astro deps before spawning the dev server (node_modules can be wiped).
     if [[ "$name" == "astro" ]]; then
         _ensure_astro_deps || return 1
@@ -806,6 +879,46 @@ _ensure_astro_deps() {
     echo "  site deps restored."
 }
 
+_fix_service() {
+    local name="$1"
+
+    if _health_check "$name"; then
+        echo "  $name ok"
+        return 0
+    fi
+
+    echo "  $name unhealthy"
+
+    if [[ -n "${LU_SERVICES_SSH_HOST:-}" ]] || _ssh_tunnel_port_pid "$name" >/dev/null; then
+        echo "  $name is ssh-forwarded (or LU_SERVICES_SSH_HOST is set); restarting remotely."
+        if ! _delegate_remote restart "$name"; then
+            echo "  ERROR: remote restart of $name failed." >&2
+            return 1
+        fi
+        if _health_check "$name"; then
+            echo "  $name ok"
+            return 0
+        fi
+        echo "  ERROR: $name still unhealthy after remote restart." >&2
+        return 1
+    fi
+
+    echo "  Restarting $name locally..."
+    if [[ "$name" == "api" ]]; then
+        _reconcile_api_pid
+    fi
+    _stop_service "$name"
+    if ! _start_service "$name"; then
+        return 1
+    fi
+    if _health_check "$name"; then
+        echo "  $name ok"
+        return 0
+    fi
+    echo "  ERROR: $name still unhealthy after local restart." >&2
+    return 1
+}
+
 _build_astro() {
     echo "  Building astro..."
     cd "$PROJECT_ROOT"
@@ -921,6 +1034,8 @@ fi
 
 case "$action" in
     start)
+        # shellcheck disable=SC2086
+        _maybe_delegate_and_exit start $services
         echo "Starting services..."
         start_failed=0
         for svc in $services; do
@@ -939,6 +1054,8 @@ case "$action" in
         fi
         ;;
     stop)
+        # shellcheck disable=SC2086
+        _maybe_delegate_and_exit stop $services
         echo "Stopping services..."
         for svc in $services; do
             if [[ -z "${SVC_CMD[$svc]+x}" ]]; then
@@ -954,6 +1071,8 @@ case "$action" in
         _status
         ;;
     restart)
+        # shellcheck disable=SC2086
+        _maybe_delegate_and_exit restart $services
         # Serialize across all callers — see _acquire_restart_lock comment.
         if ! _acquire_restart_lock; then
             exit 1
@@ -978,6 +1097,30 @@ case "$action" in
         echo ""
         _status
         if [[ "$restart_failed" -ne 0 ]]; then
+            exit 1
+        fi
+        ;;
+    fix)
+        # Serialize local restarts with restart; remote repair skips spawn.
+        if ! _acquire_restart_lock; then
+            exit 1
+        fi
+        trap _release_restart_lock EXIT INT TERM
+
+        echo "Fixing services..."
+        fix_failed=0
+        for svc in $services; do
+            if [[ -z "${SVC_CMD[$svc]+x}" ]]; then
+                echo "  Unknown service: $svc (available: $ALL_SERVICES)"
+                continue
+            fi
+            if ! _fix_service "$svc"; then
+                fix_failed=1
+            fi
+        done
+        echo ""
+        _status
+        if [[ "$fix_failed" -ne 0 ]]; then
             exit 1
         fi
         ;;
@@ -1080,7 +1223,7 @@ case "$action" in
         _logs "$log_service"
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|status|logs|supervise|build|clean|rebuild} [service ...]"
+        echo "Usage: $0 {start|stop|restart|fix|status|logs|supervise|build|clean|rebuild} [service ...]"
         echo ""
         echo "Services:"
         for name in $ALL_SERVICES; do
@@ -1094,6 +1237,8 @@ case "$action" in
         echo "  $0 start api --live       # Emergency API fallback (mutable checkout)"
         echo "  $0 stop sources           # Stop one"
         echo "  $0 restart                # Restart all"
+        echo "  $0 fix                    # Health-check all; restart only unhealthy"
+        echo "  $0 fix api                # Health-check and repair one service"
         echo "  $0 supervise api install  # Write the launchd supervisor plist"
         echo "  $0 supervise api uninstall # Disable and remove the supervisor plist"
         echo "  $0 build astro            # Build Astro"
@@ -1102,6 +1247,12 @@ case "$action" in
         echo "  $0 status                 # Show status"
         echo "  $0 status work            # Show adapter status and typed failure reason"
         echo "  $0 logs work              # Show the latest adapter log"
+        echo ""
+        echo "SSH LocalForward: start/stop/restart auto-delegate when a requested"
+        echo "port is owned by ssh (e.g. Host alias hramatka-tunnel), or when"
+        echo "LU_SERVICES_SSH_HOST is set. They do not spawn local processes then."
+        echo "  LU_SERVICES_SSH_HOST      SSH Host alias (default: hramatka)"
+        echo "  LU_SERVICES_REMOTE_ROOT   Remote repo root (default: /home/ops/learn-ukrainian)"
         echo ""
         echo "Note: 'rag' is accepted as a legacy alias for 'sources'; 'site' is accepted as a legacy alias for 'astro'."
         ;;

--- a/services.sh
+++ b/services.sh
@@ -25,6 +25,14 @@
 #   start/stop/restart auto-delegate to the writer host when any requested
 #   service port is owned by an ssh listener, or when LU_SERVICES_SSH_HOST
 #   is set. They never spawn or signal local processes in that case.
+#   ``start`` with no service args requests ALL services; when any one of
+#   those ports is tunneled (or LU_SERVICES_SSH_HOST is set), the whole
+#   batch is delegated remotely — not just the tunneled service.
+#   ``--live`` and ``--force`` are local API recovery flags; delegated
+#   start/stop/restart never forwards them to the remote services.sh.
+#   When lsof is absent (or SVC_LSOF_BIN is not executable), port-owner
+#   lookup is a no-op: tunnel auto-delegation and foreign-listener checks
+#   are skipped until a working lsof is available.
 #   fix curls each health URL; unhealthy tunneled ports get a remote
 #   restart. Overrides: LU_SERVICES_SSH_HOST (default host alias hramatka),
 #   LU_SERVICES_REMOTE_ROOT (default /home/ops/learn-ukrainian).
@@ -320,17 +328,28 @@ _should_delegate_remote() {
 _delegate_remote() {
     local remote_action="$1"
     shift
-    local host root
+    local host root remote_cmd arg
     host="$(_ssh_delegate_host)"
     root="${LU_SERVICES_REMOTE_ROOT:-/home/ops/learn-ukrainian}"
+    remote_cmd="./services.sh $(printf '%q' "$remote_action")"
+    for arg in "$@"; do
+        remote_cmd+=" $(printf '%q' "$arg")"
+    done
     echo "Delegating ${remote_action}${*:+ $*} to ${host} (ssh LocalForward or LU_SERVICES_SSH_HOST); not starting or stopping local processes."
-    command ssh -o BatchMode=yes "$host" "cd \"$root\" && ./services.sh ${remote_action}${*:+ $*}"
+    command ssh -o BatchMode=yes "$host" "cd $(printf '%q' "$root") && ${remote_cmd}"
 }
 
 _maybe_delegate_and_exit() {
     local remote_action="$1"
     shift
+    local name
     if _should_delegate_remote "$@"; then
+        for name in "$@"; do
+            if [[ -z "${SVC_CMD[$name]+x}" ]]; then
+                echo "  Unknown service: $name (available: $ALL_SERVICES)"
+                exit 1
+            fi
+        done
         _delegate_remote "$remote_action" "$@"
         exit $?
     fi

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -185,11 +185,24 @@ def cleanup_pids_and_logs():
     elif api_start_file.exists():
         api_start_file.unlink()
 
-def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
+def _patch_script_pids_dir(script_path: Path, pids_dir: Path) -> None:
+    """Point a patched services.sh copy at an isolated pid directory."""
+    content = script_path.read_text(encoding="utf-8")
+    content = content.replace(
+        'PIDS_DIR="$PROJECT_ROOT/.pids"',
+        f'PIDS_DIR="{pids_dir}"',
+    )
+    script_path.write_text(content, encoding="utf-8")
+
+
+def test_pid_reconciliation(temp_services_sh, mock_lsof_env, tmp_path):
     """Test stale pid file / listener interactions hermetically."""
     script_path, port = temp_services_sh
+    pids_dir = tmp_path / "pids"
+    pids_dir.mkdir()
+    _patch_script_pids_dir(script_path, pids_dir)
     set_pids, clear_pids, env = mock_lsof_env
-    api_pid_file = PIDS_DIR / "api.pid"
+    api_pid_file = pids_dir / "api.pid"
 
     # Start a dummy sleep process to act as the listener process.
     proc = subprocess.Popen([
@@ -329,10 +342,13 @@ def test_stop_disables_supervision_before_killing_api_listener(temp_services_sh,
     shutil.which("lsof") is None or sys.platform != "darwin",
     reason="macOS local-ops integration; logic covered hermetically above"
 )
-def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
+def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env, tmp_path):
     """Integration test using real sockets and real lsof on macOS."""
     script_path, port = temp_services_sh_real
-    api_pid_file = PIDS_DIR / "api.pid"
+    pids_dir = tmp_path / "pids"
+    pids_dir.mkdir()
+    _patch_script_pids_dir(script_path, pids_dir)
+    api_pid_file = pids_dir / "api.pid"
     set_pids, _, env = mock_lsof_env
 
     # Start a dummy listener process with the API signature configured for our dynamic port
@@ -833,6 +849,64 @@ def _start_named_ssh_process(tmp_path: Path) -> subprocess.Popen[object]:
     return proc
 
 
+def test_is_ssh_tunnel_pid_detects_ssh_and_rejects_non_ssh(tmp_path) -> None:
+    """``_is_ssh_tunnel_pid`` matches ssh comm/argv and rejects other owners."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    tunnel = _start_named_ssh_process(tmp_path)
+    non_ssh = subprocess.Popen([str(VENV_PYTHON), "-c", "import time; time.sleep(30)"])
+    reap_process_on_exit(non_ssh)
+    helper = "\n".join(
+        [
+            _extract_bash_function(source, "_cmdline_for_pid"),
+            _extract_bash_function(source, "_is_ssh_tunnel_pid"),
+            f"if _is_ssh_tunnel_pid {tunnel.pid}; then echo SSH_TUNNEL; else echo NOT_SSH; fi",
+            f"if _is_ssh_tunnel_pid {non_ssh.pid}; then echo NON_SSH_MATCH; else echo NON_SSH_OK; fi",
+        ]
+    )
+    try:
+        result = subprocess.run(
+            ["bash", "-c", helper],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "SSH_TUNNEL" in result.stdout
+        assert "NON_SSH_OK" in result.stdout
+        assert "NON_SSH_MATCH" not in result.stdout
+    finally:
+        tunnel.terminate()
+        non_ssh.terminate()
+        tunnel.wait(timeout=5)
+        non_ssh.wait(timeout=5)
+
+
+def test_delegate_rejects_injection_payload(
+    temp_services_sh, mock_lsof_env, tmp_path
+) -> None:
+    """Shell metacharacters in service args must never reach the ssh delegate."""
+    script_path, _port = temp_services_sh
+    _, _, env = mock_lsof_env
+    shim_dir, capture = _ssh_recorder(tmp_path)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', os.defpath)}"
+    env["LU_SERVICES_SSH_HOST"] = "fakehost"
+
+    payload = "api;touch /tmp/ssh_inject_test/PWNED"
+    result = subprocess.run(
+        [str(script_path), "start", payload],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "Unknown service" in combined, combined
+    assert result.returncode != 0
+    assert not capture.exists() or capture.read_text(encoding="utf-8") == ""
+
+
 def test_should_delegate_remote_env_or_tunnel() -> None:
     """Delegation triggers on LU_SERVICES_SSH_HOST or an ssh-owned port, not the default alias."""
     source = SERVICES_SH.read_text(encoding="utf-8")
@@ -938,7 +1012,8 @@ def test_start_delegates_when_ssh_host_set(temp_services_sh, mock_lsof_env, tmp_
     args = capture.read_text(encoding="utf-8")
     assert "BatchMode=yes" in args
     assert "hramatka" in args
-    assert 'cd "/home/ops/learn-ukrainian" && ./services.sh start api' in args
+    assert "/home/ops/learn-ukrainian" in args
+    assert "./services.sh start api" in args
     assert "Delegating start api" in result.stdout
     assert _supervisor_was_not_called(env)
 

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -144,6 +144,7 @@ def mock_lsof_env(tmp_path):
             mock_file.unlink()
 
     env = os.environ.copy()
+    env.pop("LU_SERVICES_SSH_HOST", None)
     if os.environ.get("MOCK_LSOF_EMPTY") == "1":
         env["SVC_LSOF_BIN"] = "/nonexistent/lsof"
     else:
@@ -796,3 +797,281 @@ def test_local_service_ports_do_not_collide_with_bridge_or_kubedojo() -> None:
         assert {name: declared[name] for name in kubedojo_ports} == kubedojo_ports
 
     assert set(learn_ports.values()).isdisjoint(kubedojo_ports.values())
+
+
+def _supervisor_was_not_called(env: dict[str, str]) -> bool:
+    """Local API start writes this file; missing/empty means no local spawn."""
+    path = Path(env["SVC_API_SUPERVISOR_CAPTURE"])
+    if not path.exists():
+        return True
+    return path.read_text(encoding="utf-8") == ""
+
+
+def _ssh_recorder(tmp_path: Path, exit_code: int = 0) -> tuple[Path, Path]:
+    """Return (shim_dir, capture_file) for a PATH-first ``ssh`` recorder."""
+    capture = tmp_path / "ssh_args.txt"
+    shim_dir = tmp_path / "ssh_bin"
+    shim_dir.mkdir()
+    ssh = shim_dir / "ssh"
+    ssh.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{capture}'\nexit {exit_code}\n",
+        encoding="utf-8",
+    )
+    ssh.chmod(0o755)
+    return shim_dir, capture
+
+
+def _start_named_ssh_process(tmp_path: Path) -> subprocess.Popen[object]:
+    """Spawn a process whose argv looks like ``…/ssh -N …`` for tunnel detection."""
+    tunnel_dir = tmp_path / "tunnel_proc"
+    tunnel_dir.mkdir()
+    tunnel_ssh = tunnel_dir / "ssh"
+    tunnel_ssh.write_text("#!/bin/sh\nwhile true; do sleep 30; done\n", encoding="utf-8")
+    tunnel_ssh.chmod(0o755)
+    proc = subprocess.Popen([str(tunnel_ssh), "-N", "hramatka-tunnel"])
+    reap_process_on_exit(proc)
+    return proc
+
+
+def test_should_delegate_remote_env_or_tunnel() -> None:
+    """Delegation triggers on LU_SERVICES_SSH_HOST or an ssh-owned port, not the default alias."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    helper = "\n".join(
+        [
+            "declare -A SVC_CMD",
+            "SVC_CMD[api]=dummy",
+            _extract_bash_function(source, "_requested_has_ssh_tunnel"),
+            _extract_bash_function(source, "_should_delegate_remote"),
+            "_ssh_tunnel_port_pid() { return 1; }",
+            "unset LU_SERVICES_SSH_HOST",
+            "if _should_delegate_remote api; then echo TRIGGER; else echo LOCAL; fi",
+            "LU_SERVICES_SSH_HOST=hramatka",
+            "if _should_delegate_remote api; then echo ENV; else echo NOENV; fi",
+            "unset LU_SERVICES_SSH_HOST",
+            "_ssh_tunnel_port_pid() { return 0; }",
+            "if _should_delegate_remote api; then echo TUNNEL; else echo NOTUNNEL; fi",
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", helper],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["LOCAL", "ENV", "TUNNEL"]
+
+
+def test_abort_if_ssh_owned_port_refuses_spawn() -> None:
+    """Local spawn must refuse an ssh LocalForward owner with a fix/restart hint."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    helper = "\n".join(
+        [
+            _extract_bash_function(source, "_abort_if_ssh_owned_port"),
+            '_port_owner_label() { printf "127.0.0.1:8765"; }',
+            "_ssh_tunnel_port_pid() { return 1; }",
+            "if _abort_if_ssh_owned_port api; then echo ALLOW; else echo REFUSE; fi",
+            "_ssh_tunnel_port_pid() { return 0; }",
+            "if _abort_if_ssh_owned_port api; then echo ALLOW2; else echo REFUSE2; fi",
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", helper],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ALLOW" in result.stdout
+    assert "REFUSE2" in result.stdout
+    assert "owned by an ssh LocalForward" in result.stderr
+    assert "fix api" in result.stderr
+    assert "restart api" in result.stderr
+
+
+def test_usage_documents_fix_and_ssh_env() -> None:
+    """Header comments and help list fix plus the SSH Host / remote-root overrides."""
+    source = SERVICES_SH.read_text(encoding="utf-8")
+    assert "./services.sh fix" in source
+    assert "./services.sh fix api" in source
+    assert "LU_SERVICES_SSH_HOST" in source
+    assert "LU_SERVICES_REMOTE_ROOT" in source
+    assert "auto-delegate" in source
+
+    env = os.environ.copy()
+    env.pop("LU_SERVICES_SSH_HOST", None)
+    result = subprocess.run(
+        ["bash", str(SERVICES_SH), "help"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "fix" in result.stdout
+    assert "LU_SERVICES_SSH_HOST" in result.stdout
+    assert "LU_SERVICES_REMOTE_ROOT" in result.stdout
+    assert "auto-delegate" in result.stdout
+
+
+def test_start_delegates_when_ssh_host_set(temp_services_sh, mock_lsof_env, tmp_path) -> None:
+    """An explicit LU_SERVICES_SSH_HOST must ssh to remote services.sh and not spawn locally."""
+    script_path, _port = temp_services_sh
+    _, _, env = mock_lsof_env
+    shim_dir, capture = _ssh_recorder(tmp_path)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', os.defpath)}"
+    env["LU_SERVICES_SSH_HOST"] = "hramatka"
+    env["LU_SERVICES_REMOTE_ROOT"] = "/home/ops/learn-ukrainian"
+
+    result = subprocess.run(
+        [str(script_path), "start", "api"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    args = capture.read_text(encoding="utf-8")
+    assert "BatchMode=yes" in args
+    assert "hramatka" in args
+    assert 'cd "/home/ops/learn-ukrainian" && ./services.sh start api' in args
+    assert "Delegating start api" in result.stdout
+    assert _supervisor_was_not_called(env)
+
+
+def test_start_delegates_when_ssh_owns_port(temp_services_sh, mock_lsof_env, tmp_path) -> None:
+    """An ssh LocalForward listener on the service port delegates start without a host override."""
+    script_path, _port = temp_services_sh
+    set_pids, _, env = mock_lsof_env
+    shim_dir, capture = _ssh_recorder(tmp_path)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', os.defpath)}"
+    env.pop("LU_SERVICES_SSH_HOST", None)
+
+    tunnel = _start_named_ssh_process(tmp_path)
+    set_pids([tunnel.pid])
+    try:
+        result = subprocess.run(
+            [str(script_path), "start", "api"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+        args = capture.read_text(encoding="utf-8")
+        assert "BatchMode=yes" in args
+        assert "hramatka" in args
+        assert "./services.sh start api" in args
+        assert _supervisor_was_not_called(env)
+    finally:
+        tunnel.terminate()
+        tunnel.wait(timeout=5)
+
+
+def test_failed_remote_delegate_does_not_spawn_local(
+    temp_services_sh, mock_lsof_env, tmp_path
+) -> None:
+    """A failed ssh delegate must not fall through to local uvicorn/launchd."""
+    script_path, _port = temp_services_sh
+    _, _, env = mock_lsof_env
+    shim_dir, _capture = _ssh_recorder(tmp_path, exit_code=1)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', os.defpath)}"
+    env["LU_SERVICES_SSH_HOST"] = "hramatka"
+
+    result = subprocess.run(
+        [str(script_path), "start", "api"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert _supervisor_was_not_called(env)
+
+
+def test_fix_prints_ok_when_healthy(temp_services_sh, mock_lsof_env) -> None:
+    """Healthy services print ok and do not restart."""
+    script_path, port = temp_services_sh
+    _, _, env = mock_lsof_env
+    env.pop("LU_SERVICES_SSH_HOST", None)
+
+    health = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+                f"port = {port}\n"
+                "class H(BaseHTTPRequestHandler):\n"
+                "    def do_GET(self):\n"
+                "        body = b'ok'\n"
+                "        self.send_response(200)\n"
+                "        self.send_header('Content-Type', 'text/plain')\n"
+                "        self.send_header('Content-Length', str(len(body)))\n"
+                "        self.end_headers()\n"
+                "        self.wfile.write(body)\n"
+                "    def log_message(self, *args):\n"
+                "        return\n"
+                "HTTPServer(('127.0.0.1', port), H).serve_forever()\n"
+            ),
+        ]
+    )
+    reap_process_on_exit(health)
+    try:
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if not is_port_free(port):
+                break
+            time.sleep(0.05)
+        result = subprocess.run(
+            [str(script_path), "fix", "api"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+        assert "api ok" in result.stdout
+        assert _supervisor_was_not_called(env)
+    finally:
+        health.terminate()
+        health.wait(timeout=5)
+
+
+def test_fix_unhealthy_ssh_tunnel_delegates_restart(
+    temp_services_sh, mock_lsof_env, tmp_path
+) -> None:
+    """Unhealthy tunneled ports remote-restart; they must not spawn local listeners."""
+    script_path, _port = temp_services_sh
+    set_pids, _, env = mock_lsof_env
+    shim_dir, capture = _ssh_recorder(tmp_path)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', os.defpath)}"
+    env.pop("LU_SERVICES_SSH_HOST", None)
+
+    tunnel = _start_named_ssh_process(tmp_path)
+    set_pids([tunnel.pid])
+    try:
+        result = subprocess.run(
+            [str(script_path), "fix", "api"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            timeout=30,
+        )
+        # Remote restart is recorded; local health stays down without a real writer.
+        args = capture.read_text(encoding="utf-8")
+        assert "BatchMode=yes" in args
+        assert "./services.sh restart api" in args
+        assert _supervisor_was_not_called(env)
+        assert "not starting or stopping local processes" in result.stdout
+    finally:
+        tunnel.terminate()
+        tunnel.wait(timeout=5)

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -131,3 +131,33 @@ def test_raw_rm_rf_lint_detects_unscoped_line(tmp_path: Path) -> None:
 
     findings = lint_raw_rm_rf.find_raw_rm_rf(repo_root=tmp_path)
     assert findings == [("scripts/evil.sh:1", 'rm -rf "$HOME"')]
+
+
+def test_raw_rm_rf_lint_allowlist_keyed_by_content_not_line(tmp_path: Path) -> None:
+    """Allowlisted snippets survive line shifts; excess copies still fail."""
+    lockdir_rm = "rm -rf \"$lockdir\" 2>/dev/null || true"
+    services = tmp_path / "services.sh"
+    services.write_text(
+        "\n".join(
+            [
+                "# preamble inserted above allowlisted cleanups",
+                "# more lines to shift line numbers",
+                lockdir_rm,
+                lockdir_rm,
+                "rm -rf \"$vite_cache_dir\"",
+                "rm -rf \"$dist_dir\"",
+                "rm -rf \"$astro_dir\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = lint_raw_rm_rf.find_raw_rm_rf(repo_root=tmp_path)
+    assert findings == [], f"shifted allowlisted snippets should pass: {findings}"
+
+    services.write_text(services.read_text(encoding="utf-8") + lockdir_rm + "\n", encoding="utf-8")
+    findings = lint_raw_rm_rf.find_raw_rm_rf(repo_root=tmp_path)
+    assert len(findings) == 1
+    assert findings[0][1] == lockdir_rm
+    assert findings[0][0].startswith("services.sh:")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./services.sh start|stop|restart` on a Mac notebook with `hramatka-tunnel` LocalForwards no longer binds local uvicorn/node on 8765/8766/8769/4321. Those actions detect an `ssh` listener (or `LU_SERVICES_SSH_HOST`) and run the same action on the writer host.

New `./services.sh fix [services…]` curls each health URL: healthy prints `ok`; unhealthy tunneled ports remote-`restart`; unhealthy local ports use the existing local restart path. Local spawn on an ssh-owned port is refused with a one-line `fix`/`restart` hint.

## Changes

- Detect ssh LocalForward owners via existing `lsof` + `COMMAND ssh` helpers
- Auto-delegate `start`/`stop`/`restart` when any requested port is tunneled, or when `LU_SERVICES_SSH_HOST` is set
- Add `fix`; defaults `LU_SERVICES_SSH_HOST=hramatka`, `LU_SERVICES_REMOTE_ROOT=/home/ops/learn-ukrainian`
- Update header Usage + help; keep ports, health URLs, and Work private-root logic unchanged

## Testing

- `bash -n services.sh`
- `python3 -m pytest tests/api/test_services_ops.py` helpers for delegate triggers, spawn refusal, usage, env/tunnel start delegate, failed-ssh no local spawn, `fix` ok, and tunneled `fix` → remote `restart`

## Related Issues

No linked issue. This PR leaves existing tracker items open.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a13a179-2acc-4712-b007-292c0768108c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a13a179-2acc-4712-b007-292c0768108c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

