### PR TITLE
feat(ci): add cursor cloud pytest prototype runner and controller verifier

### DIFF
--- a/scripts/ci/cursor_cloud_full_pytest.sh
+++ b/scripts/ci/cursor_cloud_full_pytest.sh
@@ -20,7 +20,7 @@
 # - Emits per shard: plan.json, test-nodeids.txt, main-junit.xml, main.log, exit_code;
 #   shard 1 also playground-junit.xml.
 # - Bundle metadata: git_head, runner_sha256, nonce, build_id, started_at.
-# - Performs final dirty-tree check asserting no tracked files were modified.
+# - Performs final dirty-tree check allowlisting only artifacts/<nonce>/.
 # - Performs ZERO GitHub API calls.
 # =============================================================================
 
@@ -323,10 +323,11 @@ for shard in 1 2 3 4; do
   fi
 done
 
-# 11. Final dirty-tree check (dirty tracked files -> non-zero / UNKNOWN, never PASS)
-if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
-  echo "Error: git working tree has modified tracked files after test execution" >&2
-  git status --short --untracked-files=no >&2
+# 11. Final dirty-tree check (allowlist only artifacts/<nonce>/; any other untracked/tracked dirty -> fail)
+DIRTY_ENTRIES="$(git status --porcelain --untracked-files=all | grep -vE '^\?\? "?artifacts/'"${NONCE}"'(/|$)' || true)"
+if [[ -n "${DIRTY_ENTRIES}" ]]; then
+  echo "Error: git working tree has unallowlisted dirty or untracked files after test execution (only artifacts/${NONCE}/ is allowed)" >&2
+  echo "${DIRTY_ENTRIES}" >&2
   exit 1
 fi
 

--- a/scripts/ci/cursor_cloud_full_pytest.sh
+++ b/scripts/ci/cursor_cloud_full_pytest.sh
@@ -7,7 +7,10 @@
 #
 # Contract:
 # - Takes --sha <40hex> (must match `git rev-parse HEAD`); dirty tree -> non-zero.
-# - Takes --nonce <token> (required); writes exclusively under `artifacts/<nonce>/`.
+# - Takes --nonce <token> (required, charset [A-Za-z0-9._-], max 64 chars);
+#   writes exclusively under `artifacts/<nonce>/`.
+# - Takes --build-id <id> (required, non-empty; may be supplied via BUILD_ID env);
+#   fails closed before the expensive test suite if missing or empty.
 # - Installs CI venv like `ci.yml` (lockfile + CPU torch 2.13.0 carve-out) in a
 #   temporary directory outside the git worktree (never overwriting repo .venv).
 # - Asserts Node 22 (`node -v` is v22); runs `npm ci --ignore-scripts` only if
@@ -20,7 +23,8 @@
 # - Emits per shard: plan.json, test-nodeids.txt, main-junit.xml, main.log, exit_code;
 #   shard 1 also playground-junit.xml.
 # - Bundle metadata: git_head, runner_sha256, nonce, build_id, started_at.
-# - Performs final dirty-tree check allowlisting only artifacts/<nonce>/.
+# - Performs final dirty-tree check allowlisting only artifacts/<nonce>/
+#   (literal string-prefix match; the nonce is never regex-interpolated).
 # - Performs ZERO GitHub API calls.
 # =============================================================================
 
@@ -35,14 +39,14 @@ SHARD_COUNT=4
 
 usage() {
   cat <<USAGE_EOF
-Usage: $0 --sha <40hex-sha> --nonce <token> [options]
+Usage: $0 --sha <40hex-sha> --nonce <token> --build-id <id> [options]
 
 Required arguments:
   --sha <40hex>          Expected commit SHA; must match HEAD exactly.
   --nonce <token>        Run nonce token; output written to artifacts/<nonce>/
+  --build-id <id>        Build provenance ID, non-empty (may fall back to BUILD_ID env var)
 
 Optional arguments:
-  --build-id <id>        Build provenance ID (default: empty string)
   --durations <path>     Path to durations JSON dataset (default: ci-artifacts/pytest-durations.json)
   --venv <path>          Path to Python virtualenv (default: temp workdir outside git worktree)
   --shard-count <count>  Number of pytest shards to plan and run (fixed: must be 4)
@@ -127,13 +131,23 @@ if [[ -z "$NONCE" ]]; then
   exit 1
 fi
 
-if [[ "$NONCE" =~ [/\] || "$NONCE" == ".." || "$NONCE" == "." ]]; then
-  echo "Error: invalid --nonce value: $NONCE" >&2
+# Strict nonce charset: no regex metacharacters, slashes, or path traversal.
+# The nonce is interpolated into path-prefix comparisons below; a value like
+# 'x|.*' must be impossible so it can never broaden the dirty-tree allowlist.
+if [[ ! "$NONCE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
+  echo "Error: --nonce must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}\$ (got: $NONCE)" >&2
   exit 1
 fi
 
 if [[ "$SHARD_COUNT" -ne 4 ]]; then
   echo "Error: --shard-count must be 4 (fixed four-shard plane), got: $SHARD_COUNT" >&2
+  exit 1
+fi
+
+# Fail closed before any expensive work if Build provenance is absent
+# (the controller verifier never passes an empty build_id; do not invent one).
+if [[ -z "${BUILD_ID//[[:space:]]/}" ]]; then
+  echo "Error: --build-id is required and cannot be empty (missing Build provenance is never PASS); set --build-id or the BUILD_ID env var" >&2
   exit 1
 fi
 
@@ -324,7 +338,35 @@ for shard in 1 2 3 4; do
 done
 
 # 11. Final dirty-tree check (allowlist only artifacts/<nonce>/; any other untracked/tracked dirty -> fail)
-DIRTY_ENTRIES="$(git status --porcelain --untracked-files=all | grep -vE '^\?\? "?artifacts/'"${NONCE}"'(/|$)' || true)"
+# >>> dirty-tree-allowlist-filter (extracted and executed by tests/ci/test_cursor_cloud_pytest_verify.py)
+# Prints porcelain lines that are NOT allowlisted. Allowlist: untracked ('??') entries
+# whose path equals artifacts/<nonce> or sits under artifacts/<nonce>/, matched by
+# literal string prefix (bash glob with quoted variable parts) -- the nonce is never
+# regex-interpolated, so a value like 'x|.*' cannot broaden the allowlist.
+_filter_dirty_entries() {
+  local filter_nonce="$1"
+  local artifact_prefix="artifacts/${filter_nonce}"
+  local status_line status_code entry_path
+  while IFS= read -r status_line; do
+    [[ -z "${status_line}" ]] && continue
+    status_code="${status_line:0:2}"
+    entry_path="${status_line:3}"
+    # Strip the C-style surrounding quotes git adds around paths with special chars
+    if [[ "${entry_path}" == \"*\" ]]; then
+      entry_path="${entry_path#\"}"
+      entry_path="${entry_path%\"}"
+    fi
+    if [[ "${status_code}" == "??" ]]; then
+      case "${entry_path}" in
+        "${artifact_prefix}" | "${artifact_prefix}/"*) continue ;;
+      esac
+    fi
+    printf '%s\n' "${status_line}"
+  done
+}
+# <<< dirty-tree-allowlist-filter
+
+DIRTY_ENTRIES="$(git status --porcelain --untracked-files=all | _filter_dirty_entries "${NONCE}")"
 if [[ -n "${DIRTY_ENTRIES}" ]]; then
   echo "Error: git working tree has unallowlisted dirty or untracked files after test execution (only artifacts/${NONCE}/ is allowed)" >&2
   echo "${DIRTY_ENTRIES}" >&2

--- a/scripts/ci/cursor_cloud_full_pytest.sh
+++ b/scripts/ci/cursor_cloud_full_pytest.sh
@@ -8,16 +8,19 @@
 # Contract:
 # - Takes --sha <40hex> (must match `git rev-parse HEAD`); dirty tree -> non-zero.
 # - Takes --nonce <token> (required); writes exclusively under `artifacts/<nonce>/`.
-# - Installs CI venv like `ci.yml` (lockfile + CPU torch 2.13.0 carve-out).
-# - Sets Node 22; runs `npm ci --ignore-scripts` only if ACP test is in shard.
+# - Installs CI venv like `ci.yml` (lockfile + CPU torch 2.13.0 carve-out) in a
+#   temporary directory outside the git worktree (never overwriting repo .venv).
+# - Asserts Node 22 (`node -v` is v22); runs `npm ci --ignore-scripts` only if
+#   ACP test is in shard.
 # - Runs Stanza provision with 3-attempt 10s/30s fail-closed retry.
 # - Unsets ZNO_LIVE, RUN_BRIDGE_INBOX_INTEGRATION, ENFORCE_LATENCY_ASSERTIONS;
 #   sets CI=true and GITHUB_ACTIONS=true.
-# - Runs 4 duration-balanced shards via `scripts/ci/pytest_shards.py`.
+# - Runs 4 duration-balanced shards via `scripts/ci/pytest_shards.py` (fixed 4-shard plane).
 # - Shard 1 also runs serial playground probe with 3-attempt retry.
 # - Emits per shard: plan.json, test-nodeids.txt, main-junit.xml, main.log, exit_code;
 #   shard 1 also playground-junit.xml.
 # - Bundle metadata: git_head, runner_sha256, nonce, build_id, started_at.
+# - Performs final dirty-tree check asserting no tracked files were modified.
 # - Performs ZERO GitHub API calls.
 # =============================================================================
 
@@ -41,8 +44,8 @@ Required arguments:
 Optional arguments:
   --build-id <id>        Build provenance ID (default: empty string)
   --durations <path>     Path to durations JSON dataset (default: ci-artifacts/pytest-durations.json)
-  --venv <path>          Path to Python virtualenv (default: .venv)
-  --shard-count <count>  Number of pytest shards to plan and run (default: 4)
+  --venv <path>          Path to Python virtualenv (default: temp workdir outside git worktree)
+  --shard-count <count>  Number of pytest shards to plan and run (fixed: must be 4)
   -h, --help             Show this help message and exit
 USAGE_EOF
 }
@@ -129,6 +132,11 @@ if [[ "$NONCE" =~ [/\] || "$NONCE" == ".." || "$NONCE" == "." ]]; then
   exit 1
 fi
 
+if [[ "$SHARD_COUNT" -ne 4 ]]; then
+  echo "Error: --shard-count must be 4 (fixed four-shard plane), got: $SHARD_COUNT" >&2
+  exit 1
+fi
+
 # 1. Assert clean working tree (dirty tree -> non-zero, never PASS)
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "Error: git working tree is dirty; refusing to execute candidate runner" >&2
@@ -160,8 +168,8 @@ export GITHUB_ACTIONS=true
 export PYTEST_BREADCRUMB_DIR="${ARTIFACT_ROOT}/.pytest_breadcrumbs"
 mkdir -p "${PYTEST_BREADCRUMB_DIR}"
 
-# 5. Python virtual environment setup
-VENV_DIR="${VENV_PATH:-.venv}"
+# 5. Python virtual environment setup (write confinement: default outside git worktree)
+VENV_DIR="${VENV_PATH:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cursor-cloud-ci-venv-${NONCE}}"
 if [[ ! -d "${VENV_DIR}" ]]; then
   python3 -m venv "${VENV_DIR}"
 fi
@@ -169,11 +177,14 @@ PYTHON="${VENV_DIR}/bin/python"
 
 # 6. Install CI venv dependencies (lockfile + CPU torch 2.13.0 carve-out)
 if [[ -f "requirements-lock.txt" ]]; then
-  REQS_CI="${ARTIFACT_ROOT}/requirements-ci.txt"
+  REQS_CI="${VENV_DIR}/requirements-ci.txt"
   grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt > "${REQS_CI}"
   for attempt in 1 2 3; do
     echo "CI dependencies pip install attempt ${attempt}/3"
-    if "${PYTHON}" -m pip install --upgrade pip       && "${PYTHON}" -m pip install --no-deps -r "${REQS_CI}"       && "${PYTHON}" -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu torch==2.13.0       && "${PYTHON}" -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
+    if "${PYTHON}" -m pip install --upgrade pip \
+      && "${PYTHON}" -m pip install --no-deps -r "${REQS_CI}" \
+      && "${PYTHON}" -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu torch==2.13.0 \
+      && "${PYTHON}" -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
       break
     fi
     case "${attempt}" in
@@ -208,9 +219,9 @@ if [[ -f "site/src/data/lexicon-manifest.pointer.json" ]]; then
   "${PYTHON}" -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified')" || true
 fi
 
-# 9. Plan pytest shards
+# 9. Plan pytest shards (fixed 4-shard plane)
 PLAN_DIR="${ARTIFACT_ROOT}/plans"
-PLAN_ARGS=("${PYTHON}" scripts/ci/pytest_shards.py plan --output-dir "${PLAN_DIR}" --shard-count "${SHARD_COUNT}")
+PLAN_ARGS=("${PYTHON}" scripts/ci/pytest_shards.py plan --output-dir "${PLAN_DIR}" --shard-count 4)
 if [[ -n "${DURATIONS_PATH}" && -f "${DURATIONS_PATH}" ]]; then
   PLAN_ARGS+=(--durations "${DURATIONS_PATH}")
 elif [[ -f "ci-artifacts/pytest-durations.json" ]]; then
@@ -221,7 +232,7 @@ fi
 # 10. Execute each planned shard
 OVERALL_EXIT=0
 
-for shard in $(seq 1 "${SHARD_COUNT}"); do
+for shard in 1 2 3 4; do
   shard_dir="${ARTIFACT_ROOT}/pytest-shard-${shard}"
   mkdir -p "${shard_dir}"
   cp "${PLAN_DIR}/pytest-shard-${shard}/plan.json" "${shard_dir}/plan.json"
@@ -229,6 +240,30 @@ for shard in $(seq 1 "${SHARD_COUNT}"); do
 
   # ACP protocol test node dependency check (R3)
   if grep -q '^tests/agent_runtime/test_acp_text_agent.py::' "${shard_dir}/test-nodeids.txt"; then
+    # Assert Node 22 before npm (provision if nvm/node 22 exists; fail UNKNOWN/INFRA if missing or != 22)
+    NODE_VER=""
+    if command -v node >/dev/null 2>&1; then
+      NODE_VER="$(node -v 2>/dev/null || true)"
+    fi
+    if [[ ! "$NODE_VER" =~ ^v22\. ]]; then
+      if [[ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+        nvm use 22 >/dev/null 2>&1 || nvm use v22 >/dev/null 2>&1 || true
+      elif [[ -s "/usr/local/nvm/nvm.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "/usr/local/nvm/nvm.sh"
+        nvm use 22 >/dev/null 2>&1 || nvm use v22 >/dev/null 2>&1 || true
+      fi
+      if command -v node >/dev/null 2>&1; then
+        NODE_VER="$(node -v 2>/dev/null || true)"
+      fi
+    fi
+    if [[ ! "$NODE_VER" =~ ^v22\. ]]; then
+      echo "Error: Node 22 is required before running npm (found: ${NODE_VER:-none}); fail UNKNOWN/INFRA" >&2
+      exit 1
+    fi
+
     for attempt in 1 2 3; do
       echo "shard ${shard} npm ci attempt ${attempt}/3"
       if npm ci --ignore-scripts; then
@@ -247,7 +282,11 @@ for shard in $(seq 1 "${SHARD_COUNT}"); do
 
   # Run shard
   set +e
-  "${PYTHON}" scripts/ci/pytest_shards.py run --nodeids "${shard_dir}/test-nodeids.txt" --     -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread     -m 'not atlas_release and not slow'     --junitxml="${shard_dir}/main-junit.xml" --durations=0     2>&1 | tee "${shard_dir}/main.log"
+  "${PYTHON}" scripts/ci/pytest_shards.py run --nodeids "${shard_dir}/test-nodeids.txt" -- \
+    -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread \
+    -m 'not atlas_release and not slow' \
+    --junitxml="${shard_dir}/main-junit.xml" --durations=0 \
+    2>&1 | tee "${shard_dir}/main.log"
   shard_exit=$?
   set -e
 
@@ -257,7 +296,9 @@ for shard in $(seq 1 "${SHARD_COUNT}"); do
     playground_exit=1
     for attempt in 1 2 3; do
       echo "playground smoke attempt ${attempt}/3"
-      if "${PYTHON}" -m pytest         tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast         -v --tb=short --junitxml="${shard_dir}/playground-junit.xml"; then
+      if "${PYTHON}" -m pytest \
+        tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+        -v --tb=short --junitxml="${shard_dir}/playground-junit.xml"; then
         playground_exit=0
         break
       fi
@@ -282,7 +323,14 @@ for shard in $(seq 1 "${SHARD_COUNT}"); do
   fi
 done
 
-# 11. Write bundle metadata
+# 11. Final dirty-tree check (dirty tracked files -> non-zero / UNKNOWN, never PASS)
+if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+  echo "Error: git working tree has modified tracked files after test execution" >&2
+  git status --short --untracked-files=no >&2
+  exit 1
+fi
+
+# 12. Write bundle metadata
 cat > "${ARTIFACT_ROOT}/metadata.json" <<METADATA_EOF
 {
   "build_id": "${BUILD_ID}",

--- a/scripts/ci/cursor_cloud_full_pytest.sh
+++ b/scripts/ci/cursor_cloud_full_pytest.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/ci/cursor_cloud_full_pytest.sh
+#
+# Pinned prototype runner script for Cursor cloud agent full pytest execution
+# (Actions-outage fallback; design #6977 comment 5320409546 §4).
+#
+# Contract:
+# - Takes --sha <40hex> (must match `git rev-parse HEAD`); dirty tree -> non-zero.
+# - Takes --nonce <token> (required); writes exclusively under `artifacts/<nonce>/`.
+# - Installs CI venv like `ci.yml` (lockfile + CPU torch 2.13.0 carve-out).
+# - Sets Node 22; runs `npm ci --ignore-scripts` only if ACP test is in shard.
+# - Runs Stanza provision with 3-attempt 10s/30s fail-closed retry.
+# - Unsets ZNO_LIVE, RUN_BRIDGE_INBOX_INTEGRATION, ENFORCE_LATENCY_ASSERTIONS;
+#   sets CI=true and GITHUB_ACTIONS=true.
+# - Runs 4 duration-balanced shards via `scripts/ci/pytest_shards.py`.
+# - Shard 1 also runs serial playground probe with 3-attempt retry.
+# - Emits per shard: plan.json, test-nodeids.txt, main-junit.xml, main.log, exit_code;
+#   shard 1 also playground-junit.xml.
+# - Bundle metadata: git_head, runner_sha256, nonce, build_id, started_at.
+# - Performs ZERO GitHub API calls.
+# =============================================================================
+
+set -euo pipefail
+
+SHA=""
+NONCE=""
+BUILD_ID="${BUILD_ID:-}"
+DURATIONS_PATH=""
+VENV_PATH=""
+SHARD_COUNT=4
+
+usage() {
+  cat <<USAGE_EOF
+Usage: $0 --sha <40hex-sha> --nonce <token> [options]
+
+Required arguments:
+  --sha <40hex>          Expected commit SHA; must match HEAD exactly.
+  --nonce <token>        Run nonce token; output written to artifacts/<nonce>/
+
+Optional arguments:
+  --build-id <id>        Build provenance ID (default: empty string)
+  --durations <path>     Path to durations JSON dataset (default: ci-artifacts/pytest-durations.json)
+  --venv <path>          Path to Python virtualenv (default: .venv)
+  --shard-count <count>  Number of pytest shards to plan and run (default: 4)
+  -h, --help             Show this help message and exit
+USAGE_EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)
+      SHA="${2:-}"
+      shift 2
+      ;;
+    --sha=*)
+      SHA="${1#*=}"
+      shift 1
+      ;;
+    --nonce)
+      NONCE="${2:-}"
+      shift 2
+      ;;
+    --nonce=*)
+      NONCE="${1#*=}"
+      shift 1
+      ;;
+    --build-id)
+      BUILD_ID="${2:-}"
+      shift 2
+      ;;
+    --build-id=*)
+      BUILD_ID="${1#*=}"
+      shift 1
+      ;;
+    --durations)
+      DURATIONS_PATH="${2:-}"
+      shift 2
+      ;;
+    --durations=*)
+      DURATIONS_PATH="${1#*=}"
+      shift 1
+      ;;
+    --venv)
+      VENV_PATH="${2:-}"
+      shift 2
+      ;;
+    --venv=*)
+      VENV_PATH="${1#*=}"
+      shift 1
+      ;;
+    --shard-count)
+      SHARD_COUNT="${2:-}"
+      shift 2
+      ;;
+    --shard-count=*)
+      SHARD_COUNT="${1#*=}"
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$SHA" ]]; then
+  echo "Error: --sha is required" >&2
+  exit 1
+fi
+
+if [[ ! "$SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "Error: --sha must be a 40-character hex string, got: $SHA" >&2
+  exit 1
+fi
+
+if [[ -z "$NONCE" ]]; then
+  echo "Error: --nonce is required and cannot be empty" >&2
+  exit 1
+fi
+
+if [[ "$NONCE" =~ [/\] || "$NONCE" == ".." || "$NONCE" == "." ]]; then
+  echo "Error: invalid --nonce value: $NONCE" >&2
+  exit 1
+fi
+
+# 1. Assert clean working tree (dirty tree -> non-zero, never PASS)
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: git working tree is dirty; refusing to execute candidate runner" >&2
+  git status --short >&2
+  exit 1
+fi
+
+# 2. Assert git HEAD matches requested SHA
+CURRENT_HEAD="$(git rev-parse HEAD)"
+if [[ "${CURRENT_HEAD,,}" != "${SHA,,}" ]]; then
+  echo "Error: git rev-parse HEAD ($CURRENT_HEAD) does not match requested --sha ($SHA)" >&2
+  exit 1
+fi
+
+# 3. Setup artifacts root and record timestamps/hashes
+STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+RUNNER_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+RUNNER_SHA256="$(sha256sum "${RUNNER_SCRIPT_PATH}" | cut -d' ' -f1)"
+
+ARTIFACT_ROOT="artifacts/${NONCE}"
+mkdir -p "${ARTIFACT_ROOT}"
+
+# 4. Set environment invariants (R10)
+unset ZNO_LIVE || true
+unset RUN_BRIDGE_INBOX_INTEGRATION || true
+unset ENFORCE_LATENCY_ASSERTIONS || true
+export CI=true
+export GITHUB_ACTIONS=true
+export PYTEST_BREADCRUMB_DIR="${ARTIFACT_ROOT}/.pytest_breadcrumbs"
+mkdir -p "${PYTEST_BREADCRUMB_DIR}"
+
+# 5. Python virtual environment setup
+VENV_DIR="${VENV_PATH:-.venv}"
+if [[ ! -d "${VENV_DIR}" ]]; then
+  python3 -m venv "${VENV_DIR}"
+fi
+PYTHON="${VENV_DIR}/bin/python"
+
+# 6. Install CI venv dependencies (lockfile + CPU torch 2.13.0 carve-out)
+if [[ -f "requirements-lock.txt" ]]; then
+  REQS_CI="${ARTIFACT_ROOT}/requirements-ci.txt"
+  grep -viE '^(torch|torchvision|open_clip_torch)==' requirements-lock.txt > "${REQS_CI}"
+  for attempt in 1 2 3; do
+    echo "CI dependencies pip install attempt ${attempt}/3"
+    if "${PYTHON}" -m pip install --upgrade pip       && "${PYTHON}" -m pip install --no-deps -r "${REQS_CI}"       && "${PYTHON}" -m pip install --no-deps --index-url https://download.pytorch.org/whl/cpu torch==2.13.0       && "${PYTHON}" -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
+      break
+    fi
+    case "${attempt}" in
+      1) sleep 10 ;;
+      2) sleep 30 ;;
+      3)
+        echo "Error: CI dependencies install failed after 3 attempts" >&2
+        exit 1
+        ;;
+    esac
+  done
+fi
+
+# 7. Stanza Ukrainian model provisioning with 3-attempt retry (R5)
+for attempt in 1 2 3; do
+  echo "stanza provision attempt ${attempt}/3"
+  if "${PYTHON}" -c "from scripts.pipeline.stress_annotator import annotate_stress; annotate_stress('Мама читає книжку.')" >/dev/null 2>&1; then
+    break
+  fi
+  case "${attempt}" in
+    1) sleep 10 ;;
+    2) sleep 30 ;;
+    3)
+      echo "Error: Stanza provision failed after 3 attempts" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# 8. Verify Atlas manifest if pointer exists
+if [[ -f "site/src/data/lexicon-manifest.pointer.json" ]]; then
+  "${PYTHON}" -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified')" || true
+fi
+
+# 9. Plan pytest shards
+PLAN_DIR="${ARTIFACT_ROOT}/plans"
+PLAN_ARGS=("${PYTHON}" scripts/ci/pytest_shards.py plan --output-dir "${PLAN_DIR}" --shard-count "${SHARD_COUNT}")
+if [[ -n "${DURATIONS_PATH}" && -f "${DURATIONS_PATH}" ]]; then
+  PLAN_ARGS+=(--durations "${DURATIONS_PATH}")
+elif [[ -f "ci-artifacts/pytest-durations.json" ]]; then
+  PLAN_ARGS+=(--durations "ci-artifacts/pytest-durations.json")
+fi
+"${PLAN_ARGS[@]}"
+
+# 10. Execute each planned shard
+OVERALL_EXIT=0
+
+for shard in $(seq 1 "${SHARD_COUNT}"); do
+  shard_dir="${ARTIFACT_ROOT}/pytest-shard-${shard}"
+  mkdir -p "${shard_dir}"
+  cp "${PLAN_DIR}/pytest-shard-${shard}/plan.json" "${shard_dir}/plan.json"
+  cp "${PLAN_DIR}/pytest-shard-${shard}/test-nodeids.txt" "${shard_dir}/test-nodeids.txt"
+
+  # ACP protocol test node dependency check (R3)
+  if grep -q '^tests/agent_runtime/test_acp_text_agent.py::' "${shard_dir}/test-nodeids.txt"; then
+    for attempt in 1 2 3; do
+      echo "shard ${shard} npm ci attempt ${attempt}/3"
+      if npm ci --ignore-scripts; then
+        break
+      fi
+      case "${attempt}" in
+        1) sleep 10 ;;
+        2) sleep 30 ;;
+        3)
+          echo "Error: npm ci failed after 3 attempts" >&2
+          exit 1
+          ;;
+      esac
+    done
+  fi
+
+  # Run shard
+  set +e
+  "${PYTHON}" scripts/ci/pytest_shards.py run --nodeids "${shard_dir}/test-nodeids.txt" --     -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread     -m 'not atlas_release and not slow'     --junitxml="${shard_dir}/main-junit.xml" --durations=0     2>&1 | tee "${shard_dir}/main.log"
+  shard_exit=$?
+  set -e
+
+  # Shard 1 serial playground probe (R4)
+  if [[ "$shard" -eq 1 ]]; then
+    set +e
+    playground_exit=1
+    for attempt in 1 2 3; do
+      echo "playground smoke attempt ${attempt}/3"
+      if "${PYTHON}" -m pytest         tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast         -v --tb=short --junitxml="${shard_dir}/playground-junit.xml"; then
+        playground_exit=0
+        break
+      fi
+      sleep 3
+    done
+    set -e
+
+    if [[ "$shard_exit" -ne 0 ]]; then
+      echo "$shard_exit" > "${shard_dir}/exit_code"
+      OVERALL_EXIT=1
+    elif [[ "$playground_exit" -ne 0 ]]; then
+      echo "$playground_exit" > "${shard_dir}/exit_code"
+      OVERALL_EXIT=1
+    else
+      echo "0" > "${shard_dir}/exit_code"
+    fi
+  else
+    echo "$shard_exit" > "${shard_dir}/exit_code"
+    if [[ "$shard_exit" -ne 0 ]]; then
+      OVERALL_EXIT=1
+    fi
+  fi
+done
+
+# 11. Write bundle metadata
+cat > "${ARTIFACT_ROOT}/metadata.json" <<METADATA_EOF
+{
+  "build_id": "${BUILD_ID}",
+  "git_head": "${CURRENT_HEAD}",
+  "nonce": "${NONCE}",
+  "runner_sha256": "${RUNNER_SHA256}",
+  "started_at": "${STARTED_AT}"
+}
+METADATA_EOF
+
+exit "$OVERALL_EXIT"

--- a/scripts/ci/cursor_cloud_pytest_verify.py
+++ b/scripts/ci/cursor_cloud_pytest_verify.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 
 import argparse
 import enum
+import hashlib
 import json
 import re
 import sys
 import xml.etree.ElementTree as element_tree
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -38,10 +39,15 @@ if __package__ in (None, ""):
 
 from scripts.ci.pytest_shards import SHARD_COUNT, verify_artifacts
 
+REQUIRED_SHARD_COUNT = 4
 _HEX_40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _HEX_64_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 _ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
 _REQUIRED_METADATA_FIELDS = ("git_head", "runner_sha256", "nonce", "build_id", "started_at")
+
+
+def _nodeids_digest(nodeids: Iterable[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(nodeids)).encode("utf-8")).hexdigest()
 
 
 class VerificationOutcome(enum.StrEnum):
@@ -145,18 +151,27 @@ def verify_cloud_artifacts(
     expected_runner_blob_sha256: str,
     nonce: str,
     shard_count: int = SHARD_COUNT,
+    *,
+    expected_nodeids: Sequence[str] | None = None,
+    expected_collected_count: int | None = None,
+    expected_collected_digest: str | None = None,
 ) -> VerificationResult:
     """Verify a Cursor cloud agent artifact bundle against controller parameters.
 
     Checks:
-    1. Artifact path and metadata nonce match expected session nonce (C8).
-    2. git_head in metadata matches requested_sha (40-hex exact match).
-    3. runner_sha256 in metadata matches expected_runner_blob_sha256 (64-hex).
-    4. Completeness: all shard plans, nodeid lists, JUnit reports, logs, exit codes,
+    1. Fixed 4-shard plane: shard_count must equal 4 (rejects collapse).
+    2. Nonce path and metadata: bundle directory name and metadata nonce must match
+       expected session nonce (C8).
+    3. git_head in metadata matches requested_sha (40-hex exact match).
+    4. runner_sha256 in metadata matches expected_runner_blob_sha256 (64-hex).
+    5. Completeness: all shard plans, nodeid lists, JUnit reports, logs, exit codes,
        and shard 1 playground JUnit are present and non-empty (R2, R4).
-    5. Partition integrity: verify-artifacts accepts partition with zero omissions/dups.
-    6. Recorded provenance: build_id and started_at present and formatted properly (C7).
-    7. Exit code and test results evaluation:
+    6. Anchored completeness: if expected_nodeids, expected_collected_count, or
+       expected_collected_digest are provided, plans and assigned nodeids must match
+       the anchored expectation (preventing self-reported omission attacks).
+    7. Partition integrity: verify_artifacts accepts partition with zero omissions/dups.
+    8. Recorded provenance: build_id and started_at present and formatted properly (C7).
+    9. Exit code and test results evaluation:
        - PASS if all checks pass and all shard exit_codes == 0 and 0 failures/errors.
        - FAIL if all integrity checks pass but any shard/playground failed.
        - UNKNOWN/INFRA on any integrity, hash, SHA, nonce, structure, or parse anomaly.
@@ -165,6 +180,12 @@ def verify_cloud_artifacts(
     clean_nonce = nonce.strip()
     clean_requested_sha = requested_sha.strip()
     clean_expected_runner_sha = expected_runner_blob_sha256.strip()
+
+    if shard_count != REQUIRED_SHARD_COUNT:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"shard_count must be {REQUIRED_SHARD_COUNT} (fixed four-shard plane), got: {shard_count}"],
+        )
 
     if not clean_nonce:
         return VerificationResult(
@@ -192,7 +213,48 @@ def verify_cloud_artifacts(
             reasons=[f"artifact directory does not exist or is not a directory: {dir_path}"],
         )
 
-    # 1 & 6. Metadata validation
+    # Nonce check on bundle directory path (renamed-dir mutation fails UNKNOWN/INFRA)
+    if dir_path.name != clean_nonce:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[
+                f"nonce mismatch: artifact directory name {dir_path.name!r} does not match expected nonce {clean_nonce!r}"
+            ],
+        )
+
+    # Anchoring setup
+    target_count: int | None = None
+    target_digest: str | None = None
+    target_nodeids_set: set[str] | None = None
+
+    if expected_nodeids is not None:
+        clean_expected_nodeids = sorted({n.strip() for n in expected_nodeids if n.strip()})
+        target_count = len(clean_expected_nodeids)
+        target_digest = _nodeids_digest(clean_expected_nodeids)
+        target_nodeids_set = set(clean_expected_nodeids)
+
+        if expected_collected_count is not None and expected_collected_count != target_count:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"expected_collected_count ({expected_collected_count}) does not match len(expected_nodeids) ({target_count})"
+                ],
+            )
+        if (
+            expected_collected_digest is not None
+            and expected_collected_digest.lower() != target_digest.lower()
+        ):
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"expected_collected_digest ({expected_collected_digest}) does not match digest of expected_nodeids ({target_digest})"
+                ],
+            )
+    else:
+        target_count = expected_collected_count
+        target_digest = expected_collected_digest.strip() if expected_collected_digest else None
+
+    # Metadata validation
     metadata_path = dir_path / "metadata.json"
     if not metadata_path.is_file():
         return VerificationResult(
@@ -226,7 +288,7 @@ def verify_cloud_artifacts(
                 reasons=[f"metadata.json field {field_name!r} must be a string"],
             )
 
-    # Nonce check
+    # Nonce check in metadata
     meta_nonce = metadata["nonce"].strip()
     if meta_nonce != clean_nonce:
         return VerificationResult(
@@ -276,7 +338,8 @@ def verify_cloud_artifacts(
             metadata=metadata,
         )
 
-    # 4. Check shard directory completeness
+    # 4. Check shard directory completeness and plan invariants
+    all_assigned_nodeids: list[str] = []
     for shard_id in range(1, shard_count + 1):
         shard_dir = dir_path / f"pytest-shard-{shard_id}"
         if not shard_dir.is_dir():
@@ -341,6 +404,47 @@ def verify_cloud_artifacts(
             return VerificationResult(
                 VerificationOutcome.UNKNOWN_INFRA,
                 reasons=[f"test-nodeids.txt does not match plan.json assigned_nodeids in shard {shard_id}"],
+                metadata=metadata,
+            )
+
+        # Check plan vs anchored completeness
+        plan_collected_count = plan_data.get("collected_count")
+        plan_collected_digest = plan_data.get("collected_digest")
+
+        if target_count is not None and plan_collected_count != target_count:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"shard {shard_id} plan collected_count ({plan_collected_count}) does not match anchored count ({target_count})"
+                ],
+                metadata=metadata,
+            )
+
+        if target_digest is not None and (
+            not isinstance(plan_collected_digest, str)
+            or plan_collected_digest.lower() != target_digest.lower()
+        ):
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"shard {shard_id} plan collected_digest ({plan_collected_digest!r}) does not match anchored digest ({target_digest!r})"
+                ],
+                metadata=metadata,
+            )
+
+        all_assigned_nodeids.extend(nodeids)
+
+    # Check overall assigned node IDs vs anchored suite
+    if target_nodeids_set is not None:
+        assigned_set = set(all_assigned_nodeids)
+        if assigned_set != target_nodeids_set:
+            missing = sorted(target_nodeids_set - assigned_set)
+            extra = sorted(assigned_set - target_nodeids_set)
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"shard test assignment does not match anchored suite (missing={len(missing)}, extra={len(extra)})"
+                ],
                 metadata=metadata,
             )
 
@@ -462,7 +566,25 @@ def _build_parser() -> argparse.ArgumentParser:
         "--shard-count",
         type=int,
         default=SHARD_COUNT,
-        help=f"Expected shard count (default: {SHARD_COUNT})",
+        help=f"Expected shard count (fixed: must be {REQUIRED_SHARD_COUNT}, default: {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--expected-nodeids-file",
+        type=Path,
+        default=None,
+        help="Optional path to file with expected test node IDs (one per line) to anchor completeness",
+    )
+    parser.add_argument(
+        "--expected-collected-count",
+        type=int,
+        default=None,
+        help="Optional expected total collected test count to anchor completeness",
+    )
+    parser.add_argument(
+        "--expected-collected-digest",
+        type=str,
+        default=None,
+        help="Optional expected SHA-256 digest of sorted collected test node IDs to anchor completeness",
     )
     parser.add_argument(
         "--json",
@@ -476,12 +598,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    expected_nodeids: list[str] | None = None
+    if args.expected_nodeids_file is not None:
+        if not args.expected_nodeids_file.is_file():
+            print("UNKNOWN/INFRA")
+            print(f"- expected-nodeids-file not found: {args.expected_nodeids_file}", file=sys.stderr)
+            return 2
+        expected_nodeids = [
+            line.strip()
+            for line in args.expected_nodeids_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
     result = verify_cloud_artifacts(
         artifact_dir=args.artifact_dir,
         requested_sha=args.requested_sha,
         expected_runner_blob_sha256=args.expected_runner_sha,
         nonce=args.nonce,
         shard_count=args.shard_count,
+        expected_nodeids=expected_nodeids,
+        expected_collected_count=args.expected_collected_count,
+        expected_collected_digest=args.expected_collected_digest,
     )
 
     if args.json:

--- a/scripts/ci/cursor_cloud_pytest_verify.py
+++ b/scripts/ci/cursor_cloud_pytest_verify.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Controller verifier for Cursor cloud agent pytest artifact bundles.
+
+Implements the execution-authenticity verification contract from #6977 design
+(comment 5320409546 §3.3 + §3.4). Evaluates downloaded cloud agent test artifacts
+offline on the trusted controller.
+
+Derived Check Predicate (§3.4):
+- PASS: all verifier checks pass AND every shard + playground exit 0
+- FAIL: all verifier checks pass AND (any shard/playground non-zero)
+- UNKNOWN/INFRA: any completeness, SHA, runner-hash, nonce, Build-provenance,
+  dirty-tree, timeout, or mutation-style inconsistency
+
+NOTE ON TRUSTED BASE:
+In production, this script and `pytest_shards.py` must run from the controller's
+trusted base checkout, never trusting candidate-tree verifiers or running
+unvetted candidate scripts directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import enum
+import json
+import re
+import sys
+import xml.etree.ElementTree as element_tree
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    # Allow execution directly as `python scripts/ci/cursor_cloud_pytest_verify.py`
+    repo_root = str(Path(__file__).resolve().parents[2])
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
+from scripts.ci.pytest_shards import SHARD_COUNT, verify_artifacts
+
+_HEX_40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_HEX_64_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+_REQUIRED_METADATA_FIELDS = ("git_head", "runner_sha256", "nonce", "build_id", "started_at")
+
+
+class VerificationOutcome(enum.StrEnum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    UNKNOWN_INFRA = "UNKNOWN/INFRA"
+
+
+@dataclass
+class ShardArtifactResult:
+    shard_id: int
+    exit_code: int
+    test_count: int
+    failures: int
+    errors: int
+    passed: bool
+
+
+@dataclass
+class VerificationResult:
+    outcome: VerificationOutcome
+    reasons: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    shard_results: list[ShardArtifactResult] = field(default_factory=list)
+
+    @property
+    def is_pass(self) -> bool:
+        return self.outcome == VerificationOutcome.PASS
+
+    @property
+    def is_fail(self) -> bool:
+        return self.outcome == VerificationOutcome.FAIL
+
+    @property
+    def is_unknown_infra(self) -> bool:
+        return self.outcome == VerificationOutcome.UNKNOWN_INFRA
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome.value,
+            "reasons": self.reasons,
+            "metadata": self.metadata,
+            "shard_results": [
+                {
+                    "shard_id": s.shard_id,
+                    "exit_code": s.exit_code,
+                    "test_count": s.test_count,
+                    "failures": s.failures,
+                    "errors": s.errors,
+                    "passed": s.passed,
+                }
+                for s in self.shard_results
+            ],
+        }
+
+
+def parse_junit_stats(path: Path) -> tuple[int, int, int]:
+    """Parse a JUnit XML file and return (test_count, failures, errors).
+
+    Raises:
+        ValueError: if the XML is unparseable or malformed.
+    """
+    try:
+        tree = element_tree.parse(path)
+        root = tree.getroot()
+    except Exception as e:
+        raise ValueError(f"malformed JUnit XML in {path}: {e}") from e
+
+    tests = 0
+    failures = 0
+    errors = 0
+
+    if root.tag == "testsuite":
+        tests = int(root.attrib.get("tests", "0"))
+        failures = int(root.attrib.get("failures", "0"))
+        errors = int(root.attrib.get("errors", "0"))
+    elif root.tag == "testsuites":
+        for suite in root.iter("testsuite"):
+            tests += int(suite.attrib.get("tests", "0"))
+            failures += int(suite.attrib.get("failures", "0"))
+            errors += int(suite.attrib.get("errors", "0"))
+    else:
+        for tc in root.iter("testcase"):
+            tests += 1
+            if tc.find("failure") is not None:
+                failures += 1
+            if tc.find("error") is not None:
+                errors += 1
+
+    tag_failures = len(root.findall(".//failure"))
+    tag_errors = len(root.findall(".//error"))
+    failures = max(failures, tag_failures)
+    errors = max(errors, tag_errors)
+
+    return tests, failures, errors
+
+
+def verify_cloud_artifacts(
+    artifact_dir: Path | str,
+    requested_sha: str,
+    expected_runner_blob_sha256: str,
+    nonce: str,
+    shard_count: int = SHARD_COUNT,
+) -> VerificationResult:
+    """Verify a Cursor cloud agent artifact bundle against controller parameters.
+
+    Checks:
+    1. Artifact path and metadata nonce match expected session nonce (C8).
+    2. git_head in metadata matches requested_sha (40-hex exact match).
+    3. runner_sha256 in metadata matches expected_runner_blob_sha256 (64-hex).
+    4. Completeness: all shard plans, nodeid lists, JUnit reports, logs, exit codes,
+       and shard 1 playground JUnit are present and non-empty (R2, R4).
+    5. Partition integrity: verify-artifacts accepts partition with zero omissions/dups.
+    6. Recorded provenance: build_id and started_at present and formatted properly (C7).
+    7. Exit code and test results evaluation:
+       - PASS if all checks pass and all shard exit_codes == 0 and 0 failures/errors.
+       - FAIL if all integrity checks pass but any shard/playground failed.
+       - UNKNOWN/INFRA on any integrity, hash, SHA, nonce, structure, or parse anomaly.
+    """
+    dir_path = Path(artifact_dir)
+    clean_nonce = nonce.strip()
+    clean_requested_sha = requested_sha.strip()
+    clean_expected_runner_sha = expected_runner_blob_sha256.strip()
+
+    if not clean_nonce:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=["nonce parameter must not be empty"],
+        )
+
+    if not _HEX_40_RE.match(clean_requested_sha):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"requested_sha must be a 40-character hex string, got: {requested_sha!r}"],
+        )
+
+    if not _HEX_64_RE.match(clean_expected_runner_sha):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[
+                f"expected_runner_blob_sha256 must be a 64-character hex string, got: {expected_runner_blob_sha256!r}"
+            ],
+        )
+
+    if not dir_path.exists() or not dir_path.is_dir():
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"artifact directory does not exist or is not a directory: {dir_path}"],
+        )
+
+    # 1 & 6. Metadata validation
+    metadata_path = dir_path / "metadata.json"
+    if not metadata_path.is_file():
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"missing metadata.json in artifact directory: {dir_path}"],
+        )
+
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"corrupted or unparseable metadata.json: {e}"],
+        )
+
+    if not isinstance(metadata, dict):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=["metadata.json must be a JSON object"],
+        )
+
+    for field_name in _REQUIRED_METADATA_FIELDS:
+        if field_name not in metadata:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"metadata.json missing required field: {field_name!r}"],
+            )
+        if not isinstance(metadata[field_name], str):
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"metadata.json field {field_name!r} must be a string"],
+            )
+
+    # Nonce check
+    meta_nonce = metadata["nonce"].strip()
+    if meta_nonce != clean_nonce:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"nonce mismatch: metadata has {meta_nonce!r}, expected {clean_nonce!r}"],
+            metadata=metadata,
+        )
+
+    # Git head check
+    meta_git_head = metadata["git_head"].strip()
+    if not _HEX_40_RE.match(meta_git_head):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"invalid git_head format in metadata: {meta_git_head!r}"],
+            metadata=metadata,
+        )
+    if meta_git_head.lower() != clean_requested_sha.lower():
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"git_head mismatch: metadata has {meta_git_head!r}, expected {clean_requested_sha!r}"],
+            metadata=metadata,
+        )
+
+    # Runner SHA256 check
+    meta_runner_sha = metadata["runner_sha256"].strip()
+    if not _HEX_64_RE.match(meta_runner_sha):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"invalid runner_sha256 format in metadata: {meta_runner_sha!r}"],
+            metadata=metadata,
+        )
+    if meta_runner_sha.lower() != clean_expected_runner_sha.lower():
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[
+                f"runner_sha256 mismatch: metadata has {meta_runner_sha!r}, expected {clean_expected_runner_sha!r}"
+            ],
+            metadata=metadata,
+        )
+
+    # Started_at check
+    started_at = metadata["started_at"].strip()
+    if not started_at or not _ISO_TIMESTAMP_RE.match(started_at):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"metadata.json started_at is not a valid ISO 8601 timestamp: {started_at!r}"],
+            metadata=metadata,
+        )
+
+    # 4. Check shard directory completeness
+    for shard_id in range(1, shard_count + 1):
+        shard_dir = dir_path / f"pytest-shard-{shard_id}"
+        if not shard_dir.is_dir():
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"missing shard directory: pytest-shard-{shard_id}"],
+                metadata=metadata,
+            )
+
+        required_files = ["plan.json", "test-nodeids.txt", "main-junit.xml", "main.log", "exit_code"]
+        for fname in required_files:
+            fpath = shard_dir / fname
+            if not fpath.is_file():
+                return VerificationResult(
+                    VerificationOutcome.UNKNOWN_INFRA,
+                    reasons=[f"missing required file {fname} in shard {shard_id}"],
+                    metadata=metadata,
+                )
+
+        if shard_id == 1:
+            playground_file = shard_dir / "playground-junit.xml"
+            if not playground_file.is_file():
+                return VerificationResult(
+                    VerificationOutcome.UNKNOWN_INFRA,
+                    reasons=["missing playground-junit.xml in shard 1"],
+                    metadata=metadata,
+                )
+        else:
+            playground_file = shard_dir / "playground-junit.xml"
+            if playground_file.exists():
+                return VerificationResult(
+                    VerificationOutcome.UNKNOWN_INFRA,
+                    reasons=[f"unexpected playground-junit.xml found in shard {shard_id} (shard 1 only)"],
+                    metadata=metadata,
+                )
+
+        # Ensure main.log is not empty
+        main_log = shard_dir / "main.log"
+        if main_log.stat().st_size == 0:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"main.log is empty in shard {shard_id}"],
+                metadata=metadata,
+            )
+
+        # Check test-nodeids.txt matches plan.json assigned_nodeids
+        try:
+            plan_data = json.loads((shard_dir / "plan.json").read_text(encoding="utf-8"))
+            nodeids = [
+                line.strip()
+                for line in (shard_dir / "test-nodeids.txt").read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except Exception as e:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"failed reading plan or nodeids for shard {shard_id}: {e}"],
+                metadata=metadata,
+            )
+
+        if plan_data.get("assigned_nodeids") != nodeids:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"test-nodeids.txt does not match plan.json assigned_nodeids in shard {shard_id}"],
+                metadata=metadata,
+            )
+
+    # 5. Shard partition verification (using trusted verify_artifacts)
+    try:
+        verify_artifacts(dir_path, shard_count=shard_count)
+    except Exception as e:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"shard partition verification failed: {e}"],
+            metadata=metadata,
+        )
+
+    # 7. Shard exit codes and JUnit inspection
+    shard_results: list[ShardArtifactResult] = []
+    failure_reasons: list[str] = []
+
+    for shard_id in range(1, shard_count + 1):
+        shard_dir = dir_path / f"pytest-shard-{shard_id}"
+        exit_code_path = shard_dir / "exit_code"
+        try:
+            exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip()
+            exit_code = int(exit_code_raw)
+        except Exception as e:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"invalid or non-integer exit_code in shard {shard_id}: {e}"],
+                metadata=metadata,
+            )
+
+        main_junit_path = shard_dir / "main-junit.xml"
+        try:
+            tests, failures, errors = parse_junit_stats(main_junit_path)
+        except Exception as e:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[f"corrupted main JUnit XML in shard {shard_id}: {e}"],
+                metadata=metadata,
+            )
+
+        if shard_id == 1:
+            playground_junit_path = shard_dir / "playground-junit.xml"
+            try:
+                p_tests, p_failures, p_errors = parse_junit_stats(playground_junit_path)
+            except Exception as e:
+                return VerificationResult(
+                    VerificationOutcome.UNKNOWN_INFRA,
+                    reasons=[f"corrupted playground JUnit XML in shard 1: {e}"],
+                    metadata=metadata,
+                )
+            tests += p_tests
+            failures += p_failures
+            errors += p_errors
+
+        shard_passed = (exit_code == 0) and (failures == 0) and (errors == 0)
+        if not shard_passed:
+            failure_reasons.append(
+                f"shard {shard_id} failed: exit_code={exit_code}, failures={failures}, errors={errors}"
+            )
+
+        shard_results.append(
+            ShardArtifactResult(
+                shard_id=shard_id,
+                exit_code=exit_code,
+                test_count=tests,
+                failures=failures,
+                errors=errors,
+                passed=shard_passed,
+            )
+        )
+
+    if failure_reasons:
+        return VerificationResult(
+            outcome=VerificationOutcome.FAIL,
+            reasons=failure_reasons,
+            metadata=metadata,
+            shard_results=shard_results,
+        )
+
+    return VerificationResult(
+        outcome=VerificationOutcome.PASS,
+        reasons=[],
+        metadata=metadata,
+        shard_results=shard_results,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify Cursor cloud agent pytest artifact bundles (Actions-outage fallback)."
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        required=True,
+        help="Path to the artifact directory for the run (artifacts/<nonce>)",
+    )
+    parser.add_argument(
+        "--requested-sha",
+        type=str,
+        required=True,
+        help="Expected candidate git commit SHA (40 hex)",
+    )
+    parser.add_argument(
+        "--expected-runner-sha",
+        "--expected-runner-blob-sha256",
+        dest="expected_runner_sha",
+        type=str,
+        required=True,
+        help="Expected runner script SHA-256 (64 hex)",
+    )
+    parser.add_argument(
+        "--nonce",
+        type=str,
+        required=True,
+        help="Expected session nonce token",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=SHARD_COUNT,
+        help=f"Expected shard count (default: {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output full verification result in JSON format",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    result = verify_cloud_artifacts(
+        artifact_dir=args.artifact_dir,
+        requested_sha=args.requested_sha,
+        expected_runner_blob_sha256=args.expected_runner_sha,
+        nonce=args.nonce,
+        shard_count=args.shard_count,
+    )
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print(result.outcome.value)
+        if result.reasons:
+            for reason in result.reasons:
+                print(f"- {reason}", file=sys.stderr)
+
+    if result.is_pass:
+        return 0
+    elif result.is_fail:
+        return 1
+    else:
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/cursor_cloud_pytest_verify.py
+++ b/scripts/ci/cursor_cloud_pytest_verify.py
@@ -222,6 +222,22 @@ def verify_cloud_artifacts(
             ],
         )
 
+    # Mandatory completeness anchoring check (exact-head anchor must be present)
+    clean_expected_digest = expected_collected_digest.strip() if expected_collected_digest else None
+    if (
+        expected_nodeids is None
+        and expected_collected_count is None
+        and not clean_expected_digest
+    ):
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[
+                "completeness anchor is mandatory: at least one of expected_nodeids, "
+                "expected_collected_count, or expected_collected_digest must be supplied "
+                "(trusted exact-head node-id digest/file is absent)"
+            ],
+        )
+
     # Anchoring setup
     target_count: int | None = None
     target_digest: str | None = None
@@ -229,6 +245,11 @@ def verify_cloud_artifacts(
 
     if expected_nodeids is not None:
         clean_expected_nodeids = sorted({n.strip() for n in expected_nodeids if n.strip()})
+        if not clean_expected_nodeids:
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=["expected_nodeids must contain at least one non-empty test node ID"],
+            )
         target_count = len(clean_expected_nodeids)
         target_digest = _nodeids_digest(clean_expected_nodeids)
         target_nodeids_set = set(clean_expected_nodeids)
@@ -241,18 +262,18 @@ def verify_cloud_artifacts(
                 ],
             )
         if (
-            expected_collected_digest is not None
-            and expected_collected_digest.lower() != target_digest.lower()
+            clean_expected_digest is not None
+            and clean_expected_digest.lower() != target_digest.lower()
         ):
             return VerificationResult(
                 VerificationOutcome.UNKNOWN_INFRA,
                 reasons=[
-                    f"expected_collected_digest ({expected_collected_digest}) does not match digest of expected_nodeids ({target_digest})"
+                    f"expected_collected_digest ({clean_expected_digest}) does not match digest of expected_nodeids ({target_digest})"
                 ],
             )
     else:
         target_count = expected_collected_count
-        target_digest = expected_collected_digest.strip() if expected_collected_digest else None
+        target_digest = clean_expected_digest
 
     # Metadata validation
     metadata_path = dir_path / "metadata.json"
@@ -287,6 +308,15 @@ def verify_cloud_artifacts(
                 VerificationOutcome.UNKNOWN_INFRA,
                 reasons=[f"metadata.json field {field_name!r} must be a string"],
             )
+
+    # Build ID check (§3.3: missing Build provenance is never PASS)
+    meta_build_id = metadata["build_id"].strip()
+    if not meta_build_id:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=["metadata.json build_id must not be empty (missing Build provenance is never PASS)"],
+            metadata=metadata,
+        )
 
     # Nonce check in metadata
     meta_nonce = metadata["nonce"].strip()
@@ -434,7 +464,17 @@ def verify_cloud_artifacts(
 
         all_assigned_nodeids.extend(nodeids)
 
-    # Check overall assigned node IDs vs anchored suite
+    # 5. Shard partition verification (using trusted verify_artifacts)
+    try:
+        verify_artifacts(dir_path, shard_count=shard_count)
+    except Exception as e:
+        return VerificationResult(
+            VerificationOutcome.UNKNOWN_INFRA,
+            reasons=[f"shard partition verification failed: {e}"],
+            metadata=metadata,
+        )
+
+    # 6. Check overall assigned node IDs vs anchored suite
     if target_nodeids_set is not None:
         assigned_set = set(all_assigned_nodeids)
         if assigned_set != target_nodeids_set:
@@ -448,15 +488,25 @@ def verify_cloud_artifacts(
                 metadata=metadata,
             )
 
-    # 5. Shard partition verification (using trusted verify_artifacts)
-    try:
-        verify_artifacts(dir_path, shard_count=shard_count)
-    except Exception as e:
+    if target_count is not None and len(all_assigned_nodeids) != target_count:
         return VerificationResult(
             VerificationOutcome.UNKNOWN_INFRA,
-            reasons=[f"shard partition verification failed: {e}"],
+            reasons=[
+                f"total assigned test count across shards ({len(all_assigned_nodeids)}) does not match anchored count ({target_count})"
+            ],
             metadata=metadata,
         )
+
+    if target_digest is not None:
+        actual_assigned_digest = _nodeids_digest(all_assigned_nodeids)
+        if actual_assigned_digest.lower() != target_digest.lower():
+            return VerificationResult(
+                VerificationOutcome.UNKNOWN_INFRA,
+                reasons=[
+                    f"digest of all assigned shard test node IDs ({actual_assigned_digest}) does not match anchored digest ({target_digest})"
+                ],
+                metadata=metadata,
+            )
 
     # 7. Shard exit codes and JUnit inspection
     shard_results: list[ShardArtifactResult] = []

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI and automation test suite."""

--- a/tests/ci/test_cursor_cloud_pytest_verify.py
+++ b/tests/ci/test_cursor_cloud_pytest_verify.py
@@ -626,3 +626,233 @@ def test_runner_script_help_flag() -> None:
     )
     assert proc.returncode == 0
     assert "Usage:" in proc.stdout
+
+
+# =============================================================================
+# 5. Delta Fail-Open Invariant Tests (#7113 Review Fixes)
+# =============================================================================
+
+def test_one_shard_synthetic_bundle_rejected_as_unknown_infra(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Fixed four-shard plane: 1-shard synthetic bundle fails closed as UNKNOWN/INFRA (never PASS)."""
+    # Create 1-shard synthetic bundle (node count: 2)
+    bundle_1shard = create_synthetic_bundle(tmp_path, shard_count=1)
+
+    # 1. Verifying with shard_count=1 must be rejected (only 4 is allowed)
+    res_1 = verify_cloud_artifacts(
+        artifact_dir=bundle_1shard,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        shard_count=1,
+    )
+    assert res_1.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert res_1.is_unknown_infra is True
+    assert res_1.is_pass is False
+    assert any("shard_count must be 4" in r for r in res_1.reasons)
+
+    # 2. Verifying with default shard_count=4 fails due to missing shards 2-4
+    res_4 = verify_cloud_artifacts(
+        artifact_dir=bundle_1shard,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        shard_count=4,
+    )
+    assert res_4.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert res_4.is_unknown_infra is True
+    assert res_4.is_pass is False
+
+    # 3. CLI execution with --shard-count 1 exits 2 with UNKNOWN/INFRA
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle_1shard),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+        "--shard-count", "1",
+    ])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "UNKNOWN/INFRA" in captured.out
+
+
+def test_runner_script_rejects_shard_count_collapse() -> None:
+    """Runner script refuses to execute with shard count != 4."""
+    proc = subprocess.run(
+        [
+            "bash",
+            "scripts/ci/cursor_cloud_full_pytest.sh",
+            "--sha", TEST_SHA,
+            "--nonce", "token123",
+            "--shard-count", "1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--shard-count must be 4" in proc.stderr
+
+
+def test_omitted_test_self_consistent_plans_rejected_by_anchoring(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Self-consistent omitted-test bundle (fail-open previously) is rejected as UNKNOWN/INFRA when anchored."""
+    # Expected suite: 8 test nodes across 4 shards (2 tests per shard)
+    expected_all_nodeids = [
+        f"tests/test_module_{s}.py::{case}"
+        for s in range(1, 5)
+        for case in ("test_case_a", "test_case_b")
+    ]
+    assert len(expected_all_nodeids) == 8
+    expected_digest_8 = _sha256_digest(expected_all_nodeids)
+
+    # Create synthetic bundle (8 tests total)
+    bundle = create_synthetic_bundle(tmp_path)
+
+    # Verify happy path with anchored suite passes first
+    green_result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_nodeids=expected_all_nodeids,
+        expected_collected_count=8,
+        expected_collected_digest=expected_digest_8,
+    )
+    assert green_result.outcome == VerificationOutcome.PASS
+
+    # Now mutate the bundle: omit 'tests/test_module_4.py::test_case_b' (leaving 7 tests)
+    omitted_test = "tests/test_module_4.py::test_case_b"
+    surviving_nodeids = [nid for nid in expected_all_nodeids if nid != omitted_test]
+    assert len(surviving_nodeids) == 7
+    surviving_digest_7 = _sha256_digest(surviving_nodeids)
+
+    # 1. Update shard 4 artifacts to execute only 1 test
+    shard4_assigned = ["tests/test_module_4.py::test_case_a"]
+    (bundle / "pytest-shard-4" / "test-nodeids.txt").write_text("\n".join(shard4_assigned) + "\n", encoding="utf-8")
+    junit4_xml = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.50">
+  <testcase classname="tests.test_module_4" name="test_case_a" time="0.50"/>
+</testsuite>
+"""
+    (bundle / "pytest-shard-4" / "main-junit.xml").write_text(junit4_xml, encoding="utf-8")
+
+    # 2. Adjust all 4 plan.json files to self-consistently report collected_count=7 and collected_digest=digest(7)
+    for s in range(1, 5):
+        p_path = bundle / f"pytest-shard-{s}" / "plan.json"
+        p_data = json.loads(p_path.read_text(encoding="utf-8"))
+        p_data["collected_count"] = 7
+        p_data["collected_digest"] = surviving_digest_7
+        if s == 4:
+            p_data["assigned_nodeids"] = shard4_assigned
+            p_data["assigned_digest"] = _sha256_digest(shard4_assigned)
+        p_path.write_text(json.dumps(p_data, indent=2), encoding="utf-8")
+
+    # 3. Confirm that self-reported verify_artifacts() without anchor passes this self-consistent omitted test!
+    from scripts.ci.pytest_shards import verify_artifacts
+    verify_artifacts(bundle, 4)  # Passes because plans and JUnits are self-consistent!
+
+    # 4. Controller anchored verification with expected_nodeids rejects with UNKNOWN/INFRA
+    res_nodeids = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_nodeids=expected_all_nodeids,
+    )
+    assert res_nodeids.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert res_nodeids.is_unknown_infra is True
+    assert any("collected_count" in r or "does not match anchored" in r or "missing=1" in r for r in res_nodeids.reasons)
+
+    # 5. Controller anchored verification with expected_collected_count rejects with UNKNOWN/INFRA
+    res_count = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_collected_count=8,
+    )
+    assert res_count.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("collected_count" in r and "8" in r for r in res_count.reasons)
+
+    # 6. Controller anchored verification with expected_collected_digest rejects with UNKNOWN/INFRA
+    res_digest = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_collected_digest=expected_digest_8,
+    )
+    assert res_digest.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("collected_digest" in r for r in res_digest.reasons)
+
+    # 7. CLI verification with --expected-nodeids-file exits 2 with UNKNOWN/INFRA
+    nodeids_file = tmp_path / "expected_nodeids.txt"
+    nodeids_file.write_text("\n".join(expected_all_nodeids) + "\n", encoding="utf-8")
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+        "--expected-nodeids-file", str(nodeids_file),
+    ])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "UNKNOWN/INFRA" in captured.out
+
+
+def test_renamed_directory_mutation_rejected_as_unknown_infra(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Renaming bundle directory away from controller nonce fails closed as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path, nonce=TEST_NONCE)
+    assert bundle.name == TEST_NONCE
+
+    # Rename the bundle directory on disk
+    renamed_bundle = tmp_path / "tampered-renamed-nonce-dir"
+    bundle.rename(renamed_bundle)
+
+    # Verifying renamed bundle against expected TEST_NONCE must fail as UNKNOWN/INFRA
+    result = verify_cloud_artifacts(
+        artifact_dir=renamed_bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_unknown_infra is True
+    assert any("artifact directory name" in r and "does not match expected nonce" in r for r in result.reasons)
+
+    # CLI execution exits 2
+    exit_code = verifier_main([
+        "--artifact-dir", str(renamed_bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+    ])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "UNKNOWN/INFRA" in captured.out
+
+
+def test_runner_script_contains_node22_confinement_and_dirty_tree_contracts() -> None:
+    """Runner script asserts Node 22, write confinement outside repo, and final dirty-tree check."""
+    script_path = Path("scripts/ci/cursor_cloud_full_pytest.sh")
+    script_text = script_path.read_text(encoding="utf-8")
+
+    # Fixed 4-shard plane
+    assert "SHARD_COUNT must be 4" in script_text or "SHARD_COUNT\" -ne 4" in script_text
+
+    # Node 22 check
+    assert "NODE_VER" in script_text
+    assert "v22" in script_text
+    assert "Node 22" in script_text
+
+    # Write confinement outside git worktree
+    assert "cursor-cloud-ci-venv" in script_text or "TMPDIR" in script_text
+    assert "never overwriting repo .venv" in script_text or "outside git worktree" in script_text
+
+    # Final dirty-tree check
+    assert "git status --porcelain --untracked-files=no" in script_text
+    assert "modified tracked files after test execution" in script_text

--- a/tests/ci/test_cursor_cloud_pytest_verify.py
+++ b/tests/ci/test_cursor_cloud_pytest_verify.py
@@ -1,0 +1,628 @@
+"""Tests for Cursor cloud pytest verifier and runner contract (#6977).
+
+Covers:
+- Synthetic green bundle acceptance (PASS).
+- Synthetic red bundle failure (FAIL).
+- Shard 1 playground failure detection (FAIL).
+- Four offline mutations of green bundle (all fail closed -> UNKNOWN/INFRA, never PASS):
+  (a) runner hash mismatch/corruption
+  (b) git_head / target SHA mismatch
+  (c) exit_code file corruption/non-integer
+  (d) shard artifact corruption (missing file, bad XML, count mismatch, digest tamper)
+- Additional provenance, partition integrity, and edge case rejections (UNKNOWN/INFRA).
+- Runner shell script contract assertions (clean-tree / argument / HEAD checks).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.ci.cursor_cloud_pytest_verify import (
+    VerificationOutcome,
+    verify_cloud_artifacts,
+)
+from scripts.ci.cursor_cloud_pytest_verify import (
+    main as verifier_main,
+)
+from scripts.ci.pytest_shards import REQUIRED_MARKEXPR, SERIAL_TESTS
+
+TEST_SHA = "0123456789abcdef0123456789abcdef01234567"
+TEST_RUNNER_SHA = "a" * 64
+TEST_NONCE = "test-session-nonce-42"
+TEST_BUILD_ID = "build-pilot-001"
+TEST_TIMESTAMP = "2026-08-22T15:00:00Z"
+
+
+def _sha256_digest(items: list[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(items)).encode("utf-8")).hexdigest()
+
+
+def create_synthetic_bundle(
+    root: Path,
+    *,
+    sha: str = TEST_SHA,
+    runner_sha: str = TEST_RUNNER_SHA,
+    nonce: str = TEST_NONCE,
+    build_id: str = TEST_BUILD_ID,
+    started_at: str = TEST_TIMESTAMP,
+    shard_count: int = 4,
+    shard_exit_codes: dict[int, int] | None = None,
+    shard_failures: dict[int, int] | None = None,
+    playground_failures: int = 0,
+    write_metadata: bool = True,
+) -> Path:
+    """Create a fully valid synthetic 4-shard test artifact bundle."""
+    bundle_dir = root / nonce
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    if shard_exit_codes is None:
+        shard_exit_codes = {i: 0 for i in range(1, shard_count + 1)}
+    if shard_failures is None:
+        shard_failures = {i: 0 for i in range(1, shard_count + 1)}
+
+    # 2 tests per shard -> 8 tests total
+    all_collected_nodeids: list[str] = []
+    shard_nodeid_map: dict[int, list[str]] = {}
+    for s in range(1, shard_count + 1):
+        nodeids = [f"tests/test_module_{s}.py::test_case_a", f"tests/test_module_{s}.py::test_case_b"]
+        shard_nodeid_map[s] = nodeids
+        all_collected_nodeids.extend(nodeids)
+
+    collected_digest = _sha256_digest(all_collected_nodeids)
+    collected_count = len(all_collected_nodeids)
+
+    for shard_id in range(1, shard_count + 1):
+        s_dir = bundle_dir / f"pytest-shard-{shard_id}"
+        s_dir.mkdir(parents=True, exist_ok=True)
+
+        assigned = shard_nodeid_map[shard_id]
+        assigned_digest = _sha256_digest(assigned)
+
+        # 1. plan.json
+        plan_data: dict[str, Any] = {
+            "assigned_digest": assigned_digest,
+            "assigned_nodeids": assigned,
+            "collected_count": collected_count,
+            "collected_digest": collected_digest,
+            "estimated_seconds": 2.0,
+            "grouping": "file",
+            "markexpr": REQUIRED_MARKEXPR,
+            "partition_mode": "lpt-durations",
+            "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
+            "shard_count": shard_count,
+            "shard_id": shard_id,
+        }
+        (s_dir / "plan.json").write_text(json.dumps(plan_data, indent=2), encoding="utf-8")
+
+        # 2. test-nodeids.txt
+        (s_dir / "test-nodeids.txt").write_text("\n".join(assigned) + "\n", encoding="utf-8")
+
+        # 3. main-junit.xml
+        failures = shard_failures.get(shard_id, 0)
+        failure_xml = ""
+        if failures > 0:
+            failure_xml = '<failure message="Assertion failed">AssertionError: expected True got False</failure>'
+
+        junit_xml = f"""<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" errors="0" failures="{failures}" skipped="0" tests="{len(assigned)}" time="1.23">
+  <testcase classname="tests.test_module_{shard_id}" name="test_case_a" time="0.50">{failure_xml if failures > 0 else ""}</testcase>
+  <testcase classname="tests.test_module_{shard_id}" name="test_case_b" time="0.50"/>
+</testsuite>
+"""
+        (s_dir / "main-junit.xml").write_text(junit_xml, encoding="utf-8")
+
+        # 4. playground-junit.xml on shard 1
+        if shard_id == 1:
+            p_failure_xml = ""
+            if playground_failures > 0:
+                p_failure_xml = '<failure message="playground probe failed">Timeout</failure>'
+            p_junit_xml = f"""<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" errors="0" failures="{playground_failures}" skipped="0" tests="1" time="0.30">
+  <testcase classname="tests.test_playground_api_stability" name="test_playground_primary_endpoints_keep_health_fast" time="0.30">
+    {p_failure_xml}
+  </testcase>
+</testsuite>
+"""
+            (s_dir / "playground-junit.xml").write_text(p_junit_xml, encoding="utf-8")
+
+        # 5. main.log
+        (s_dir / "main.log").write_text(
+            f"Shard {shard_id} test run completed with exit code {shard_exit_codes.get(shard_id, 0)}\n",
+            encoding="utf-8",
+        )
+
+        # 6. exit_code
+        (s_dir / "exit_code").write_text(str(shard_exit_codes.get(shard_id, 0)) + "\n", encoding="utf-8")
+
+    # 7. metadata.json
+    if write_metadata:
+        metadata_data = {
+            "build_id": build_id,
+            "git_head": sha,
+            "nonce": nonce,
+            "runner_sha256": runner_sha,
+            "started_at": started_at,
+        }
+        (bundle_dir / "metadata.json").write_text(json.dumps(metadata_data, indent=2), encoding="utf-8")
+
+    return bundle_dir
+
+
+# =============================================================================
+# 1. Happy Path: Green and Red Bundle Acceptance
+# =============================================================================
+
+def test_synthetic_green_bundle_passes(tmp_path: Path) -> None:
+    """A complete and authentic green bundle returns PASS with zero failure reasons."""
+    bundle = create_synthetic_bundle(tmp_path)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+
+    assert result.outcome == VerificationOutcome.PASS
+    assert result.is_pass is True
+    assert result.is_fail is False
+    assert result.is_unknown_infra is False
+    assert result.reasons == []
+    assert len(result.shard_results) == 4
+    assert all(sr.passed for sr in result.shard_results)
+    assert result.metadata["git_head"] == TEST_SHA
+
+
+def test_synthetic_green_bundle_cli_output_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI execution outputs PASS and exits 0 on a green bundle."""
+    bundle = create_synthetic_bundle(tmp_path)
+
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+    ])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "PASS"
+
+    # Test --json flag
+    exit_code_json = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+        "--json",
+    ])
+    assert exit_code_json == 0
+    json_out = json.loads(capsys.readouterr().out)
+    assert json_out["outcome"] == "PASS"
+    assert json_out["reasons"] == []
+
+
+def test_synthetic_red_bundle_shard_exit_code_fails(tmp_path: Path) -> None:
+    """An authentic bundle with a non-zero shard exit code returns FAIL (red detection)."""
+    bundle = create_synthetic_bundle(
+        tmp_path,
+        shard_exit_codes={1: 0, 2: 1, 3: 0, 4: 0},
+        shard_failures={1: 0, 2: 1, 3: 0, 4: 0},
+    )
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+
+    assert result.outcome == VerificationOutcome.FAIL
+    assert result.is_fail is True
+    assert result.is_pass is False
+    assert result.is_unknown_infra is False
+    assert any("shard 2 failed" in reason for reason in result.reasons)
+
+
+def test_synthetic_red_bundle_cli_exits_one(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI exits 1 on FAIL outcome."""
+    bundle = create_synthetic_bundle(
+        tmp_path,
+        shard_exit_codes={1: 0, 2: 1, 3: 0, 4: 0},
+        shard_failures={1: 0, 2: 1, 3: 0, 4: 0},
+    )
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+    ])
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.out
+
+
+def test_shard1_playground_probe_failure_fails(tmp_path: Path) -> None:
+    """Shard 1 serial playground failure returns FAIL even if main tests had 0 failures."""
+    bundle = create_synthetic_bundle(
+        tmp_path,
+        shard_exit_codes={1: 1, 2: 0, 3: 0, 4: 0},
+        playground_failures=1,
+    )
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+
+    assert result.outcome == VerificationOutcome.FAIL
+    assert result.is_fail is True
+    assert any("shard 1 failed" in reason for reason in result.reasons)
+
+
+# =============================================================================
+# 2. Four Offline Mutations of a Green Bundle (Fail Closed -> UNKNOWN/INFRA)
+# =============================================================================
+
+def test_mutation_a_corrupted_runner_sha_rejected(tmp_path: Path) -> None:
+    """Mutation (a): Runner blob hash corruption must be rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+
+    # 1. Tamper runner_sha256 in metadata.json
+    metadata_path = bundle / "metadata.json"
+    meta = json.loads(metadata_path.read_text(encoding="utf-8"))
+    meta["runner_sha256"] = "f" * 64
+    metadata_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_unknown_infra is True
+    assert any("runner_sha256 mismatch" in r for r in result.reasons)
+
+    # CLI exit code on UNKNOWN/INFRA is 2
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+    ])
+    assert exit_code == 2
+
+
+def test_mutation_b_target_sha_mismatch_rejected(tmp_path: Path) -> None:
+    """Mutation (b): git_head / target SHA mismatch must be rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+
+    # Controller requests a different SHA than recorded git_head
+    different_sha = "9876543210fedcba9876543210fedcba98765432"
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=different_sha,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_unknown_infra is True
+    assert any("git_head mismatch" in r for r in result.reasons)
+
+
+def test_mutation_c_corrupted_exit_code_file_rejected(tmp_path: Path) -> None:
+    """Mutation (c): Non-integer or corrupted exit_code file must be rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+
+    # Corrupt exit_code in shard 3
+    exit_code_file = bundle / "pytest-shard-3" / "exit_code"
+    exit_code_file.write_text("CORRUPTED_NON_INT\n", encoding="utf-8")
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_unknown_infra is True
+    assert any("invalid or non-integer exit_code" in r for r in result.reasons)
+
+
+def test_mutation_d_shard_artifact_corruptions_rejected(tmp_path: Path) -> None:
+    """Mutation (d): Corruption of shard artifacts must be rejected as UNKNOWN/INFRA."""
+
+    # Sub-case d1: Missing test-nodeids.txt
+    b1 = create_synthetic_bundle(tmp_path / "d1")
+    (b1 / "pytest-shard-2" / "test-nodeids.txt").unlink()
+    r1 = verify_cloud_artifacts(b1, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    assert r1.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("missing required file test-nodeids.txt" in r for r in r1.reasons)
+
+    # Sub-case d2: Corrupted XML in main-junit.xml
+    b2 = create_synthetic_bundle(tmp_path / "d2")
+    (b2 / "pytest-shard-2" / "main-junit.xml").write_text("<invalid <xml >>>", encoding="utf-8")
+    r2 = verify_cloud_artifacts(b2, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    assert r2.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("shard partition verification failed" in r or "corrupted main JUnit XML" in r for r in r2.reasons)
+
+    # Sub-case d3: JUnit count mismatch vs plan assigned_nodeids
+    b3 = create_synthetic_bundle(tmp_path / "d3")
+    bad_junit = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" errors="0" failures="0" skipped="0" tests="99" time="1.0">
+  <testcase classname="tests.test_module_2" name="test_case_a" time="0.50"/>
+</testsuite>
+"""
+    (b3 / "pytest-shard-2" / "main-junit.xml").write_text(bad_junit, encoding="utf-8")
+    r3 = verify_cloud_artifacts(b3, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    assert r3.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("main JUnit count does not match plan" in r for r in r3.reasons)
+
+    # Sub-case d4: Missing shard 1 playground-junit.xml
+    b4 = create_synthetic_bundle(tmp_path / "d4")
+    (b4 / "pytest-shard-1" / "playground-junit.xml").unlink()
+    r4 = verify_cloud_artifacts(b4, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    assert r4.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("missing playground-junit.xml" in r for r in r4.reasons)
+
+
+# =============================================================================
+# 3. Provenance and Partition Invariant Security Tests
+# =============================================================================
+
+def test_nonce_mismatch_rejected(tmp_path: Path) -> None:
+    """Nonce mismatch between controller expectation and bundle metadata is rejected."""
+    bundle = create_synthetic_bundle(tmp_path)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce="different-nonce-token",
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("nonce mismatch" in r for r in result.reasons)
+
+
+def test_missing_metadata_json_rejected(tmp_path: Path) -> None:
+    """Missing metadata.json fails closed as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path, write_metadata=False)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("missing metadata.json" in r for r in result.reasons)
+
+
+def test_invalid_metadata_timestamp_rejected(tmp_path: Path) -> None:
+    """Invalid or empty started_at timestamp in metadata fails closed."""
+    bundle = create_synthetic_bundle(tmp_path, started_at="invalid-timestamp")
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("started_at is not a valid ISO 8601 timestamp" in r for r in result.reasons)
+
+
+def test_missing_build_id_in_metadata_rejected(tmp_path: Path) -> None:
+    """Missing build_id field in metadata fails closed."""
+    bundle = create_synthetic_bundle(tmp_path)
+    meta_path = bundle / "metadata.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    del meta["build_id"]
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("missing required field: 'build_id'" in r for r in result.reasons)
+
+
+def test_unexpected_playground_on_shard_two_rejected(tmp_path: Path) -> None:
+    """Serial playground-junit.xml found on shard 2 fails closed."""
+    bundle = create_synthetic_bundle(tmp_path)
+    (bundle / "pytest-shard-2" / "playground-junit.xml").write_text("<testsuite tests='1'/>", encoding="utf-8")
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("unexpected playground-junit.xml" in r for r in result.reasons)
+
+
+def test_empty_main_log_rejected(tmp_path: Path) -> None:
+    """Empty main.log file in a shard fails closed as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+    (bundle / "pytest-shard-1" / "main.log").write_text("", encoding="utf-8")
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("main.log is empty" in r for r in result.reasons)
+
+
+def test_duplicate_nodeid_between_shards_rejected(tmp_path: Path) -> None:
+    """Duplicate node IDs across shards fail partition integrity."""
+    bundle = create_synthetic_bundle(tmp_path)
+    # Put test from shard 1 into shard 2 plan as well
+    plan2_path = bundle / "pytest-shard-2" / "plan.json"
+    plan2 = json.loads(plan2_path.read_text(encoding="utf-8"))
+    dup_nodeid = "tests/test_module_1.py::test_case_a"
+    plan2["assigned_nodeids"].append(dup_nodeid)
+    plan2["assigned_digest"] = _sha256_digest(plan2["assigned_nodeids"])
+    plan2_path.write_text(json.dumps(plan2), encoding="utf-8")
+    (bundle / "pytest-shard-2" / "test-nodeids.txt").write_text(
+        "\n".join(plan2["assigned_nodeids"]) + "\n",
+        encoding="utf-8",
+    )
+
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("assigned to more than one shard" in r or "verification failed" in r for r in result.reasons)
+
+
+# =============================================================================
+# 4. Runner Shell Script Contract Tests
+# =============================================================================
+
+def test_runner_script_rejects_missing_sha() -> None:
+    """Runner script exits non-zero if --sha is not provided."""
+    proc = subprocess.run(
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--nonce", "token123"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--sha is required" in proc.stderr
+
+
+def test_runner_script_rejects_invalid_sha() -> None:
+    """Runner script exits non-zero if --sha is not 40 hex characters."""
+    proc = subprocess.run(
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", "invalid-sha", "--nonce", "token123"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "40-character hex string" in proc.stderr
+
+
+def test_runner_script_rejects_missing_nonce() -> None:
+    """Runner script exits non-zero if --nonce is not provided."""
+    proc = subprocess.run(
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", TEST_SHA],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--nonce is required" in proc.stderr
+
+
+def test_runner_script_rejects_head_sha_mismatch() -> None:
+    """Runner script exits non-zero if requested --sha does not match git HEAD."""
+    dummy_sha = "0000000000000000000000000000000000000000"
+    proc = subprocess.run(
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", dummy_sha, "--nonce", "token123"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "does not match requested --sha" in proc.stderr or "dirty" in proc.stderr
+
+
+def test_invalid_requested_sha_format_rejected(tmp_path: Path) -> None:
+    """Non-40-hex requested_sha is rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha="short-sha",
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("requested_sha must be a 40-character hex string" in r for r in result.reasons)
+
+
+def test_invalid_runner_sha_format_rejected(tmp_path: Path) -> None:
+    """Non-64-hex expected_runner_blob_sha256 is rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256="short-hash",
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("expected_runner_blob_sha256 must be a 64-character hex string" in r for r in result.reasons)
+
+
+def test_empty_nonce_rejected(tmp_path: Path) -> None:
+    """Empty nonce parameter is rejected as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce="   ",
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("nonce parameter must not be empty" in r for r in result.reasons)
+
+
+def test_nonexistent_artifact_directory_rejected(tmp_path: Path) -> None:
+    """Nonexistent artifact directory is rejected as UNKNOWN/INFRA."""
+    nonexistent = tmp_path / "nonexistent-dir"
+    result = verify_cloud_artifacts(
+        artifact_dir=nonexistent,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("does not exist or is not a directory" in r for r in result.reasons)
+
+
+def test_missing_shard_directory_rejected(tmp_path: Path) -> None:
+    """Missing a shard directory entirely fails closed as UNKNOWN/INFRA."""
+    bundle = create_synthetic_bundle(tmp_path)
+    import shutil
+    shutil.rmtree(bundle / "pytest-shard-3")
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("missing shard directory: pytest-shard-3" in r for r in result.reasons)
+
+
+def test_nodeids_txt_mismatch_with_plan_rejected(tmp_path: Path) -> None:
+    """Discrepancy between test-nodeids.txt and plan.json assigned_nodeids is rejected."""
+    bundle = create_synthetic_bundle(tmp_path)
+    (bundle / "pytest-shard-2" / "test-nodeids.txt").write_text("tests/test_different.py::test_x\n", encoding="utf-8")
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("test-nodeids.txt does not match plan.json" in r for r in result.reasons)
+
+
+def test_runner_script_help_flag() -> None:
+    """Runner script with --help displays usage and exits 0."""
+    proc = subprocess.run(
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "Usage:" in proc.stdout

--- a/tests/ci/test_cursor_cloud_pytest_verify.py
+++ b/tests/ci/test_cursor_cloud_pytest_verify.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -559,7 +560,7 @@ def test_runner_script_rejects_head_sha_mismatch() -> None:
     """Runner script exits non-zero if requested --sha does not match git HEAD."""
     dummy_sha = "0000000000000000000000000000000000000000"
     proc = subprocess.run(
-        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", dummy_sha, "--nonce", "token123"],
+        ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", dummy_sha, "--nonce", "token123", "--build-id", "build-test"],
         capture_output=True,
         text=True,
     )
@@ -977,3 +978,143 @@ def test_empty_build_id_in_metadata_rejected_as_unknown_infra(tmp_path: Path) ->
     assert result_ws.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert result_ws.is_pass is False
 
+
+
+# =============================================================================
+# 6. Delta r3 — Nonce Regex-Injection and Build-ID Fail-Closed Tests (#7113)
+# =============================================================================
+
+RUNNER_SCRIPT = Path("scripts/ci/cursor_cloud_full_pytest.sh")
+_FILTER_START_MARKER = "# >>> dirty-tree-allowlist-filter"
+_FILTER_END_MARKER = "# <<< dirty-tree-allowlist-filter"
+
+
+def _extract_dirty_tree_filter(tmp_path: Path) -> Path:
+    """Extract the runner's dirty-tree allowlist filter into an executable script.
+
+    The extracted block is the exact code shipped in the runner (delimited by
+    sentinels), so executing it tests the production filter, not a copy.
+    """
+    script_text = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    start = script_text.index(_FILTER_START_MARKER)
+    end = script_text.index(_FILTER_END_MARKER)
+    assert start < end
+    block = script_text[start:end]
+    filter_script = tmp_path / "dirty_tree_filter.sh"
+    filter_script.write_text(block + '\n_filter_dirty_entries "$1"\n', encoding="utf-8")
+    return filter_script
+
+
+def test_runner_script_rejects_regex_metachar_nonce() -> None:
+    """Runner rejects a regex-injection nonce ('x|.*') before any work is done."""
+    proc = subprocess.run(
+        [
+            "bash", "scripts/ci/cursor_cloud_full_pytest.sh",
+            "--sha", TEST_SHA,
+            "--nonce", "x|.*",
+            "--build-id", "build-test",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--nonce must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$" in proc.stderr
+
+
+def test_runner_script_rejects_path_nonce() -> None:
+    """Runner rejects nonce values containing slashes or path traversal."""
+    for bad_nonce in ("a/b", "../x", ".", ".."):
+        proc = subprocess.run(
+            [
+                "bash", "scripts/ci/cursor_cloud_full_pytest.sh",
+                "--sha", TEST_SHA,
+                "--nonce", bad_nonce,
+                "--build-id", "build-test",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode != 0, f"nonce {bad_nonce!r} was accepted"
+        assert "--nonce must match" in proc.stderr
+
+
+def test_runner_script_rejects_missing_build_id() -> None:
+    """Runner fails closed (before the expensive suite) when --build-id is absent and BUILD_ID is unset."""
+    env = {k: v for k, v in os.environ.items() if k != "BUILD_ID"}
+    proc = subprocess.run(
+        [
+            "bash", "scripts/ci/cursor_cloud_full_pytest.sh",
+            "--sha", TEST_SHA,
+            "--nonce", "token123",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode != 0
+    assert "--build-id is required and cannot be empty" in proc.stderr
+
+
+def test_runner_script_rejects_empty_build_id() -> None:
+    """Runner fails closed on empty or whitespace-only --build-id values."""
+    for bad_build_id in ("", "   "):
+        proc = subprocess.run(
+            [
+                "bash", "scripts/ci/cursor_cloud_full_pytest.sh",
+                "--sha", TEST_SHA,
+                "--nonce", "token123",
+                "--build-id", bad_build_id,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode != 0, f"build_id {bad_build_id!r} was accepted"
+        assert "--build-id is required and cannot be empty" in proc.stderr
+
+
+def test_dirty_tree_filter_nonce_regex_injection_cannot_hide_dirty_file(tmp_path: Path) -> None:
+    """Executable proof: nonce 'x|.*' cannot hide ' M source.py' from the dirty-tree filter.
+
+    With the old regex interpolation, 'x|.*' made the allowlist match every
+    porcelain line (ERE alternation '.*(/|$)'), silently hiding dirty files.
+    The literal-prefix filter must report them instead.
+    """
+    filter_script = _extract_dirty_tree_filter(tmp_path)
+    porcelain = " M source.py\n?? artifacts/evil/main.log\n?? source.py\n"
+    proc = subprocess.run(
+        ["bash", str(filter_script), "x|.*"],
+        input=porcelain,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    # Every dirty line must survive the filter (nothing is allowlisted by 'x|.*'
+    # unless the path literally starts with 'artifacts/x|.*/').
+    assert " M source.py" in proc.stdout
+    assert "?? artifacts/evil/main.log" in proc.stdout
+    assert "?? source.py" in proc.stdout
+
+
+def test_dirty_tree_filter_allowlists_only_untracked_nonce_prefix(tmp_path: Path) -> None:
+    """Executable proof: the filter allowlists exactly untracked artifacts/<nonce>/ paths."""
+    filter_script = _extract_dirty_tree_filter(tmp_path)
+    allowlisted = (
+        "?? artifacts/token123/pytest-shard-1/main.log\n"
+        '?? "artifacts/token123/weird file.log"\n'
+    )
+    reported = (
+        "?? artifacts/token1234/main.log\n"   # prefix boundary: token1234 != token123
+        " M artifacts/token123/tracked.py\n"  # tracked modification is never allowlisted
+        " M source.py\n"
+    )
+    proc = subprocess.run(
+        ["bash", str(filter_script), "token123"],
+        input=allowlisted + reported,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "?? artifacts/token123/pytest-shard-1/main.log" not in proc.stdout
+    assert '?? "artifacts/token123/weird file.log"' not in proc.stdout
+    for line in reported.splitlines():
+        assert line in proc.stdout

--- a/tests/ci/test_cursor_cloud_pytest_verify.py
+++ b/tests/ci/test_cursor_cloud_pytest_verify.py
@@ -37,10 +37,19 @@ TEST_RUNNER_SHA = "a" * 64
 TEST_NONCE = "test-session-nonce-42"
 TEST_BUILD_ID = "build-pilot-001"
 TEST_TIMESTAMP = "2026-08-22T15:00:00Z"
+TEST_COLLECTED_COUNT = 8
+TEST_ALL_NODEIDS = [
+    f"tests/test_module_{s}.py::{case}"
+    for s in range(1, 5)
+    for case in ("test_case_a", "test_case_b")
+]
 
 
 def _sha256_digest(items: list[str]) -> str:
     return hashlib.sha256("\n".join(sorted(items)).encode("utf-8")).hexdigest()
+
+
+TEST_COLLECTED_DIGEST = _sha256_digest(TEST_ALL_NODEIDS)
 
 
 def create_synthetic_bundle(
@@ -166,6 +175,8 @@ def test_synthetic_green_bundle_passes(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
+        expected_collected_digest=TEST_COLLECTED_DIGEST,
     )
 
     assert result.outcome == VerificationOutcome.PASS
@@ -187,6 +198,8 @@ def test_synthetic_green_bundle_cli_output_and_json(tmp_path: Path, capsys: pyte
         "--requested-sha", TEST_SHA,
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
+        "--expected-collected-count", str(TEST_COLLECTED_COUNT),
+        "--expected-collected-digest", TEST_COLLECTED_DIGEST,
     ])
     assert exit_code == 0
     captured = capsys.readouterr()
@@ -198,6 +211,8 @@ def test_synthetic_green_bundle_cli_output_and_json(tmp_path: Path, capsys: pyte
         "--requested-sha", TEST_SHA,
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
+        "--expected-collected-count", str(TEST_COLLECTED_COUNT),
+        "--expected-collected-digest", TEST_COLLECTED_DIGEST,
         "--json",
     ])
     assert exit_code_json == 0
@@ -218,6 +233,7 @@ def test_synthetic_red_bundle_shard_exit_code_fails(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
 
     assert result.outcome == VerificationOutcome.FAIL
@@ -239,6 +255,7 @@ def test_synthetic_red_bundle_cli_exits_one(tmp_path: Path, capsys: pytest.Captu
         "--requested-sha", TEST_SHA,
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
+        "--expected-collected-count", str(TEST_COLLECTED_COUNT),
     ])
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -257,6 +274,7 @@ def test_shard1_playground_probe_failure_fails(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
 
     assert result.outcome == VerificationOutcome.FAIL
@@ -283,6 +301,7 @@ def test_mutation_a_corrupted_runner_sha_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert result.is_unknown_infra is True
@@ -294,6 +313,7 @@ def test_mutation_a_corrupted_runner_sha_rejected(tmp_path: Path) -> None:
         "--requested-sha", TEST_SHA,
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
+        "--expected-collected-count", str(TEST_COLLECTED_COUNT),
     ])
     assert exit_code == 2
 
@@ -309,6 +329,7 @@ def test_mutation_b_target_sha_mismatch_rejected(tmp_path: Path) -> None:
         requested_sha=different_sha,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert result.is_unknown_infra is True
@@ -328,6 +349,7 @@ def test_mutation_c_corrupted_exit_code_file_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert result.is_unknown_infra is True
@@ -340,14 +362,14 @@ def test_mutation_d_shard_artifact_corruptions_rejected(tmp_path: Path) -> None:
     # Sub-case d1: Missing test-nodeids.txt
     b1 = create_synthetic_bundle(tmp_path / "d1")
     (b1 / "pytest-shard-2" / "test-nodeids.txt").unlink()
-    r1 = verify_cloud_artifacts(b1, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    r1 = verify_cloud_artifacts(b1, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE, expected_collected_count=TEST_COLLECTED_COUNT)
     assert r1.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("missing required file test-nodeids.txt" in r for r in r1.reasons)
 
     # Sub-case d2: Corrupted XML in main-junit.xml
     b2 = create_synthetic_bundle(tmp_path / "d2")
     (b2 / "pytest-shard-2" / "main-junit.xml").write_text("<invalid <xml >>>", encoding="utf-8")
-    r2 = verify_cloud_artifacts(b2, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    r2 = verify_cloud_artifacts(b2, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE, expected_collected_count=TEST_COLLECTED_COUNT)
     assert r2.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("shard partition verification failed" in r or "corrupted main JUnit XML" in r for r in r2.reasons)
 
@@ -359,14 +381,14 @@ def test_mutation_d_shard_artifact_corruptions_rejected(tmp_path: Path) -> None:
 </testsuite>
 """
     (b3 / "pytest-shard-2" / "main-junit.xml").write_text(bad_junit, encoding="utf-8")
-    r3 = verify_cloud_artifacts(b3, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    r3 = verify_cloud_artifacts(b3, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE, expected_collected_count=TEST_COLLECTED_COUNT)
     assert r3.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("main JUnit count does not match plan" in r for r in r3.reasons)
 
     # Sub-case d4: Missing shard 1 playground-junit.xml
     b4 = create_synthetic_bundle(tmp_path / "d4")
     (b4 / "pytest-shard-1" / "playground-junit.xml").unlink()
-    r4 = verify_cloud_artifacts(b4, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE)
+    r4 = verify_cloud_artifacts(b4, TEST_SHA, TEST_RUNNER_SHA, TEST_NONCE, expected_collected_count=TEST_COLLECTED_COUNT)
     assert r4.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("missing playground-junit.xml" in r for r in r4.reasons)
 
@@ -383,6 +405,7 @@ def test_nonce_mismatch_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce="different-nonce-token",
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("nonce mismatch" in r for r in result.reasons)
@@ -396,6 +419,7 @@ def test_missing_metadata_json_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("missing metadata.json" in r for r in result.reasons)
@@ -409,6 +433,7 @@ def test_invalid_metadata_timestamp_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("started_at is not a valid ISO 8601 timestamp" in r for r in result.reasons)
@@ -427,6 +452,7 @@ def test_missing_build_id_in_metadata_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("missing required field: 'build_id'" in r for r in result.reasons)
@@ -442,6 +468,7 @@ def test_unexpected_playground_on_shard_two_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("unexpected playground-junit.xml" in r for r in result.reasons)
@@ -457,6 +484,7 @@ def test_empty_main_log_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("main.log is empty" in r for r in result.reasons)
@@ -482,7 +510,10 @@ def test_duplicate_nodeid_between_shards_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert any("assigned to more than one shard" in r or "verification failed" in r for r in result.reasons)
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("assigned to more than one shard" in r or "verification failed" in r for r in result.reasons)
 
@@ -544,6 +575,7 @@ def test_invalid_requested_sha_format_rejected(tmp_path: Path) -> None:
         requested_sha="short-sha",
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("requested_sha must be a 40-character hex string" in r for r in result.reasons)
@@ -557,6 +589,7 @@ def test_invalid_runner_sha_format_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256="short-hash",
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("expected_runner_blob_sha256 must be a 64-character hex string" in r for r in result.reasons)
@@ -570,6 +603,7 @@ def test_empty_nonce_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce="   ",
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("nonce parameter must not be empty" in r for r in result.reasons)
@@ -583,6 +617,7 @@ def test_nonexistent_artifact_directory_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("does not exist or is not a directory" in r for r in result.reasons)
@@ -598,6 +633,7 @@ def test_missing_shard_directory_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("missing shard directory: pytest-shard-3" in r for r in result.reasons)
@@ -612,6 +648,7 @@ def test_nodeids_txt_mismatch_with_plan_rejected(tmp_path: Path) -> None:
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert any("test-nodeids.txt does not match plan.json" in r for r in result.reasons)
@@ -646,6 +683,7 @@ def test_one_shard_synthetic_bundle_rejected_as_unknown_infra(
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
         shard_count=1,
+        expected_collected_count=2,
     )
     assert res_1.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert res_1.is_unknown_infra is True
@@ -659,6 +697,7 @@ def test_one_shard_synthetic_bundle_rejected_as_unknown_infra(
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
         shard_count=4,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert res_4.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert res_4.is_unknown_infra is True
@@ -671,6 +710,7 @@ def test_one_shard_synthetic_bundle_rejected_as_unknown_infra(
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
         "--shard-count", "1",
+        "--expected-collected-count", "2",
     ])
     assert exit_code == 2
     captured = capsys.readouterr()
@@ -819,6 +859,7 @@ def test_renamed_directory_mutation_rejected_as_unknown_infra(
         requested_sha=TEST_SHA,
         expected_runner_blob_sha256=TEST_RUNNER_SHA,
         nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
     )
     assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
     assert result.is_unknown_infra is True
@@ -830,6 +871,7 @@ def test_renamed_directory_mutation_rejected_as_unknown_infra(
         "--requested-sha", TEST_SHA,
         "--expected-runner-sha", TEST_RUNNER_SHA,
         "--nonce", TEST_NONCE,
+        "--expected-collected-count", str(TEST_COLLECTED_COUNT),
     ])
     assert exit_code == 2
     captured = capsys.readouterr()
@@ -854,5 +896,84 @@ def test_runner_script_contains_node22_confinement_and_dirty_tree_contracts() ->
     assert "never overwriting repo .venv" in script_text or "outside git worktree" in script_text
 
     # Final dirty-tree check
-    assert "git status --porcelain --untracked-files=no" in script_text
-    assert "modified tracked files after test execution" in script_text
+    assert "git status --porcelain --untracked-files=all" in script_text
+    assert "DIRTY_ENTRIES" in script_text
+    assert "artifacts/" in script_text
+
+
+def test_default_public_api_without_anchors_rejects_as_unknown_infra(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Default verify() / CLI with no optional kwargs/flags rejects as UNKNOWN/INFRA (anchoring is mandatory)."""
+    bundle = create_synthetic_bundle(tmp_path)
+
+    # 1. Default verify_cloud_artifacts call with no optional kwargs on authentic bundle
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_pass is False
+    assert result.is_unknown_infra is True
+    assert any("completeness anchor is mandatory" in r for r in result.reasons)
+
+    # 2. Mutated omitted-test bundle with default public API (no optional kwargs) must NOT be PASS
+    (bundle / "pytest-shard-4" / "test-nodeids.txt").write_text("tests/test_module_4.py::test_case_a\n", encoding="utf-8")
+    (bundle / "pytest-shard-4" / "main-junit.xml").write_text(
+        '<testsuite tests="1" failures="0" errors="0"><testcase name="test_case_a"/></testsuite>',
+        encoding="utf-8",
+    )
+    res_mutated = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+    )
+    assert res_mutated.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert res_mutated.is_pass is False
+
+    # 3. CLI execution with no extra flags exits 2 with UNKNOWN/INFRA
+    exit_code = verifier_main([
+        "--artifact-dir", str(bundle),
+        "--requested-sha", TEST_SHA,
+        "--expected-runner-sha", TEST_RUNNER_SHA,
+        "--nonce", TEST_NONCE,
+    ])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "UNKNOWN/INFRA" in captured.out
+
+
+def test_empty_build_id_in_metadata_rejected_as_unknown_infra(tmp_path: Path) -> None:
+    """Empty build_id string in metadata fails closed as UNKNOWN/INFRA (missing Build provenance is never PASS)."""
+    bundle = create_synthetic_bundle(tmp_path, build_id="")
+    result = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
+    )
+    assert result.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result.is_pass is False
+    assert result.is_unknown_infra is True
+    assert any("build_id must not be empty" in r for r in result.reasons)
+
+    # Also test whitespace-only build_id
+    meta_path = bundle / "metadata.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["build_id"] = "   "
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    result_ws = verify_cloud_artifacts(
+        artifact_dir=bundle,
+        requested_sha=TEST_SHA,
+        expected_runner_blob_sha256=TEST_RUNNER_SHA,
+        nonce=TEST_NONCE,
+        expected_collected_count=TEST_COLLECTED_COUNT,
+    )
+    assert result_ws.outcome == VerificationOutcome.UNKNOWN_INFRA
+    assert result_ws.is_pass is False
+

--- a/tests/ci/test_cursor_cloud_pytest_verify.py
+++ b/tests/ci/test_cursor_cloud_pytest_verify.py
@@ -529,6 +529,7 @@ def test_runner_script_rejects_missing_sha() -> None:
         ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--nonce", "token123"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "--sha is required" in proc.stderr
@@ -540,6 +541,7 @@ def test_runner_script_rejects_invalid_sha() -> None:
         ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", "invalid-sha", "--nonce", "token123"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "40-character hex string" in proc.stderr
@@ -551,6 +553,7 @@ def test_runner_script_rejects_missing_nonce() -> None:
         ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", TEST_SHA],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "--nonce is required" in proc.stderr
@@ -563,6 +566,7 @@ def test_runner_script_rejects_head_sha_mismatch() -> None:
         ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--sha", dummy_sha, "--nonce", "token123", "--build-id", "build-test"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "does not match requested --sha" in proc.stderr or "dirty" in proc.stderr
@@ -661,6 +665,7 @@ def test_runner_script_help_flag() -> None:
         ["bash", "scripts/ci/cursor_cloud_full_pytest.sh", "--help"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode == 0
     assert "Usage:" in proc.stdout
@@ -730,6 +735,7 @@ def test_runner_script_rejects_shard_count_collapse() -> None:
         ],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "--shard-count must be 4" in proc.stderr
@@ -1016,6 +1022,7 @@ def test_runner_script_rejects_regex_metachar_nonce() -> None:
         ],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode != 0
     assert "--nonce must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$" in proc.stderr
@@ -1033,6 +1040,7 @@ def test_runner_script_rejects_path_nonce() -> None:
             ],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         assert proc.returncode != 0, f"nonce {bad_nonce!r} was accepted"
         assert "--nonce must match" in proc.stderr
@@ -1049,6 +1057,7 @@ def test_runner_script_rejects_missing_build_id() -> None:
         ],
         capture_output=True,
         text=True,
+        timeout=30,
         env=env,
     )
     assert proc.returncode != 0
@@ -1067,6 +1076,7 @@ def test_runner_script_rejects_empty_build_id() -> None:
             ],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         assert proc.returncode != 0, f"build_id {bad_build_id!r} was accepted"
         assert "--build-id is required and cannot be empty" in proc.stderr
@@ -1086,6 +1096,7 @@ def test_dirty_tree_filter_nonce_regex_injection_cannot_hide_dirty_file(tmp_path
         input=porcelain,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode == 0
     # Every dirty line must survive the filter (nothing is allowlisted by 'x|.*'
@@ -1112,6 +1123,7 @@ def test_dirty_tree_filter_allowlists_only_untracked_nonce_prefix(tmp_path: Path
         input=allowlisted + reported,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert proc.returncode == 0
     assert "?? artifacts/token123/pytest-shard-1/main.log" not in proc.stdout


### PR DESCRIPTION
## Summary

Implements the pilot build item for #6977 (design comment 5320409546 §3.3, §3.4, §4; Codex confirmation 5320438179):
1. Pinned prototype runner script: `scripts/ci/cursor_cloud_full_pytest.sh`
   - Strict `--sha <40hex>` match against `HEAD` and clean working tree assertion.
   - Required `--nonce <token>` writing strictly under `artifacts/<nonce>/`.
   - CI environment setup with lockfile dependencies + CPU torch 2.13.0 carve-out.
   - Node 22 runtime and conditional `npm ci --ignore-scripts` only when ACP test is present in shard.
   - Stanza provisioning with 3-attempt 10s/30s fail-closed retry.
   - Unsets `ZNO_LIVE`, `RUN_BRIDGE_INBOX_INTEGRATION`, `ENFORCE_LATENCY_ASSERTIONS`; sets `CI=true` and `GITHUB_ACTIONS=true`.
   - Executes 4 duration-balanced shards via `scripts/ci/pytest_shards.py` plus shard 1 serial playground probe (3-attempt retry).
   - Emits per shard: `plan.json`, `test-nodeids.txt`, `main-junit.xml`, `main.log`, `exit_code`; shard 1 also `playground-junit.xml`.
   - Emits bundle metadata: `git_head`, `runner_sha256`, `nonce`, `build_id`, `started_at`.
   - Zero GitHub API calls.

2. Controller verifier: `scripts/ci/cursor_cloud_pytest_verify.py`
   - Offline verification on trusted controller evaluating nonce, git HEAD, runner SHA-256 blob digest, shard file completeness, partition integrity via `verify_artifacts`, and shard exit codes / JUnit failures.
   - Implements design §3.4 predicate: `PASS`, `FAIL`, `UNKNOWN/INFRA`.

3. Test suite: `tests/ci/test_cursor_cloud_pytest_verify.py`
   - Unit tests covering happy-path green (`PASS`), happy-path red detection (`FAIL`), playground probe failures (`FAIL`).
   - Four required offline mutations of a green bundle (corrupted runner SHA, target SHA mismatch, corrupted exit code, corrupted shard artifact) all rejected as `UNKNOWN/INFRA`.
   - Partition invariant, provenance, and runner script contract assertions.

Refs #6977

X-Agent: agy/infra-6977-runner