### PR TITLE
fix(dashboards): honest idle empty-states, work skeleton, live delegate cross-check

### DIFF
--- a/dashboards/delegate.html
+++ b/dashboards/delegate.html
@@ -207,10 +207,35 @@ function observerTaskView(task) {
   return view;
 }
 
-function renderActive(tasks) {
+function isToday(date) {
+  if (!date || Number.isNaN(date.getTime())) return false;
+  const now = new Date();
+  return date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate();
+}
+
+function taskTouchedToday(task) {
+  if (!task || !task.started_at) return false;
+  const start = new Date(task.started_at);
+  if (isToday(start)) return true;
+  if (typeof task.duration_s === 'number' && !Number.isNaN(start.getTime())) {
+    return isToday(new Date(start.getTime() + task.duration_s * 1000));
+  }
+  return false;
+}
+
+function idleCopy(finishedToday) {
+  // Distinguish live-now idle (work happened today) from a genuinely empty day (#7078).
+  return finishedToday > 0
+    ? `Nothing running right now — ${finishedToday} task${finishedToday === 1 ? '' : 's'} finished today. See Completed below.`
+    : 'No tasks today — nothing running and nothing finished yet.';
+}
+
+function renderActive(tasks, finishedToday) {
   document.getElementById('active-muted').textContent = `${tasks.length} visible`;
   if (!tasks.length) {
-    document.getElementById('active-content').innerHTML = '<div class="empty">No active tasks</div>';
+    document.getElementById('active-content').innerHTML = `<div class="empty">${idleCopy(finishedToday || 0)}</div>`;
     return;
   }
   document.getElementById('active-content').innerHTML = `<div class="task-grid">${tasks.map(task => `
@@ -278,7 +303,8 @@ async function loadTasks() {
     const tasks = Array.isArray(data.tasks) ? data.tasks : [];
     const active = tasks.filter(task => ['running', 'spawning', 'zombie'].includes(task.status));
     const completed = tasks.filter(task => ['done', 'failed'].includes(task.status));
-    renderActive(active);
+    const finishedToday = completed.filter(taskTouchedToday).length;
+    renderActive(active, finishedToday);
     renderCompleted(completed);
     setBanner('active-banner', '');
     setBanner('completed-banner', '');

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -213,6 +213,21 @@ async function safeFetch(path) {
   }
 }
 
+function taskTouchedToday(task) {
+  if (!task || !task.started_at) return false;
+  const start = new Date(task.started_at);
+  const now = new Date();
+  const sameDay = (d) => d && !Number.isNaN(d.getTime())
+    && d.getFullYear() === now.getFullYear()
+    && d.getMonth() === now.getMonth()
+    && d.getDate() === now.getDate();
+  if (sameDay(start)) return true;
+  if (typeof task.duration_s === 'number' && !Number.isNaN(start.getTime())) {
+    return sameDay(new Date(start.getTime() + task.duration_s * 1000));
+  }
+  return false;
+}
+
 function setStat(id, text) {
   const el = document.getElementById(id);
   if (el) el.textContent = text || '';
@@ -392,7 +407,11 @@ async function loadStats() {
     const tasks = delegate.tasks || [];
     const active = tasks.filter(task => task.status === 'running' || task.status === 'spawning').length;
     const zombies = tasks.filter(task => task.status === 'zombie').length;
-    setStat('card-stat-delegate', zombies ? `${active} active · ${zombies} zombie` : `${active} active`);
+    const finishedToday = tasks.filter(task => ['done', 'failed'].includes(task.status) && taskTouchedToday(task)).length;
+    const parts = [`${active} active`];
+    if (zombies) parts.push(`${zombies} zombie`);
+    if (!active && finishedToday) parts.push(`${finishedToday} finished today`);
+    setStat('card-stat-delegate', parts.join(' · '));
   }
 
   if (buildEvents) {

--- a/dashboards/orient.html
+++ b/dashboards/orient.html
@@ -297,12 +297,30 @@ function renderRuntime(runtime) {
   }</div>`;
 }
 
-function renderDelegate(delegate) {
-  const recent = Array.isArray(delegate && delegate.recent) ? delegate.recent : [];
-  document.getElementById('delegate-muted').textContent = `${delegate && delegate.active_count ? delegate.active_count : 0} active`;
+async function renderDelegate(delegate) {
+  let recent = Array.isArray(delegate && delegate.recent) ? delegate.recent : [];
+  let activeCount = delegate && delegate.active_count ? delegate.active_count : 0;
+  let liveChecked = false;
+  if (!recent.length) {
+    // The /api/orient snapshot can lag or truncate; cross-check the live
+    // delegate list before claiming there is nothing recent (#7078).
+    try {
+      const live = await fetchJson('/api/delegate/tasks?limit=5');
+      const liveTasks = Array.isArray(live.tasks) ? live.tasks : [];
+      liveChecked = true;
+      if (liveTasks.length) {
+        recent = liveTasks;
+        activeCount = liveTasks.filter(task => ['running', 'spawning', 'zombie'].includes(task.status)).length;
+      }
+    } catch { /* live list unavailable — keep snapshot-honest copy below */ }
+  }
+  const emptyCopy = liveChecked
+    ? 'No recent delegate tasks'
+    : 'Snapshot shows no recent tasks and the live delegate list is unavailable — open <a href="/delegate.html">Delegate</a>.';
+  document.getElementById('delegate-muted').textContent = `${activeCount} active`;
   document.getElementById('delegate-content').innerHTML = `
     <div class="kv-grid">
-      <div class="kv"><div class="label">Active Tasks</div><div class="value">${delegate && delegate.active_count ? delegate.active_count : 0}</div></div>
+      <div class="kv"><div class="label">Active Tasks</div><div class="value">${activeCount}</div></div>
     </div>
     ${recent.length ? `<table><thead><tr><th>Task</th><th>Agent</th><th>Status</th><th>Started</th></tr></thead><tbody>${
       recent.map(task => `<tr>
@@ -311,7 +329,7 @@ function renderDelegate(delegate) {
         <td><span class="pill ${task.status === 'done' ? 'ok' : task.status === 'failed' || task.status === 'zombie' ? 'err' : 'warn'}">${escapeHtml(task.status || 'unknown')}</span></td>
         <td>${formatTimestamp(task.started_at)}</td>
       </tr>`).join('')
-    }</tbody></table>` : '<div class="empty">No recent tasks</div>'}
+    }</tbody></table>` : `<div class="empty">${emptyCopy}</div>`}
   `;
 }
 
@@ -442,7 +460,7 @@ async function loadOrient() {
     renderIssues(Array.isArray(data.issues) ? data.issues : []);
     renderPipeline(data.pipeline || {});
     renderRuntime(data.runtime || {});
-    renderDelegate(data.delegate || {});
+    await renderDelegate(data.delegate || {});
     renderBridgePending(data.bridge_pending || {});
     renderDiscussions(discussions || {});
     if (discussions && discussions.error) {

--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -39,6 +39,10 @@ button, input, select { font: inherit; }
 .panel-head h3 { font-family: Charter, Georgia, serif; font-size: 18px; margin: 0; }
 .panel-head p { color: var(--text3); font-size: 11px; margin: 0; text-align: right; }
 .list { max-height: min(70vh, 760px); overflow: auto; }
+.skeleton-row { border-bottom: 1px solid rgba(212, 205, 184, .68); display: grid; gap: 6px; padding: 12px; }
+.skeleton-bar { animation: skeleton-pulse 1.4s ease-in-out infinite; background: var(--bg2); border-radius: 3px; height: 12px; }
+.skeleton-bar.short { width: 42%; }
+@keyframes skeleton-pulse { 0%, 100% { opacity: .45; } 50% { opacity: 1; } }
 .work-row {
   align-items: stretch; border-bottom: 1px solid rgba(212, 205, 184, .68); cursor: pointer;
   display: grid; gap: 10px; grid-template-columns: 18px minmax(0, 1fr) auto; padding: 10px 12px;
@@ -214,7 +218,12 @@ button, input, select { font: inherit; }
         <h3 id="attention-heading">Attention</h3>
         <p id="attention-meta">Deterministic rank · keyboard j/k · Enter peek</p>
       </div>
-      <div id="attention-list" class="list" role="listbox" aria-label="Attention list" tabindex="0"></div>
+      <div id="attention-list" class="list" role="listbox" aria-label="Attention list" tabindex="0" aria-busy="true">
+        <div class="skeleton-row" aria-hidden="true"><div class="skeleton-bar"></div><div class="skeleton-bar short"></div></div>
+        <div class="skeleton-row" aria-hidden="true"><div class="skeleton-bar"></div><div class="skeleton-bar short"></div></div>
+        <div class="skeleton-row" aria-hidden="true"><div class="skeleton-bar"></div><div class="skeleton-bar short"></div></div>
+        <div class="empty">Loading work projection…</div>
+      </div>
     </article>
     <article class="panel" aria-labelledby="detail-heading">
       <div class="panel-head">
@@ -756,6 +765,7 @@ button, input, select { font: inherit; }
   }
 
   function renderList() {
+    els.list.removeAttribute('aria-busy');
     const attention = state.attention;
     if (!attention.length) {
       if (!state.merged) {
@@ -1141,6 +1151,7 @@ button, input, select { font: inherit; }
     els.publicMeta.textContent = 'status=' + (pubCode === 'schema_mismatch' ? 'schema_mismatch' : 'unavailable');
     els.privateMeta.textContent = state.privateStatusText;
     els.list.innerHTML = '<div class="empty">No source projection is available. Retry refresh.</div>';
+    els.list.removeAttribute('aria-busy');
     renderDetail(null);
   }
 

--- a/tests/test_dashboard_empty_states.py
+++ b/tests/test_dashboard_empty_states.py
@@ -1,0 +1,112 @@
+"""Static + behavioral contracts for #7078 hero empty-states.
+
+Covers delegate.html, work.html, orient.html, and index.html only.
+Deliberately separate from tests/test_dashboards.py: no generate_playground_data
+imports, no shared mutable surface.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DASH = ROOT / "dashboards"
+DELEGATE = DASH / "delegate.html"
+WORK = DASH / "work.html"
+ORIENT = DASH / "orient.html"
+INDEX = DASH / "index.html"
+
+
+def test_delegate_idle_copy_distinguishes_now_from_today():
+    """#7078: 'No active tasks' must not be the hero when work finished today."""
+    html = DELEGATE.read_text(encoding="utf-8")
+    assert "Nothing running right now" in html
+    assert "finished today" in html
+    assert "No tasks today" in html
+    assert "taskTouchedToday" in html
+    assert "renderActive(active, finishedToday)" in html
+    # The unqualified hero lie is gone.
+    assert '<div class="empty">No active tasks</div>' not in html
+
+
+def test_delegate_idle_copy_behavioral_js():
+    """Evaluate the shipped idle-copy JS in Node against fixed scenarios."""
+    if shutil.which("node") is None:
+        pytest.skip("node required for JS parity check")
+    html_path = json.dumps(str(DELEGATE))
+    script = f"""
+    const fs = require('fs');
+    const html = fs.readFileSync({html_path}, 'utf8');
+    const start = html.indexOf('function isToday(');
+    const end = html.indexOf('function renderActive(');
+    if (start < 0 || end <= start) {{ throw new Error('idle-copy block not found'); }}
+    eval(html.slice(start, end));
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 1, 0, 0);
+    const old = new Date(now.getFullYear() - 1, 0, 1);
+    const out = {{
+      emptyToday: idleCopy(0),
+      oneToday: idleCopy(1),
+      manyToday: idleCopy(3),
+      touchedStartedToday: taskTouchedToday({{ started_at: todayStart.toISOString(), duration_s: 60 }}),
+      touchedFinishedToday: taskTouchedToday({{
+        started_at: new Date(todayStart.getTime() - 3600e3).toISOString(), duration_s: 7200
+      }}),
+      untouchedOld: taskTouchedToday({{ started_at: old.toISOString(), duration_s: 60 }}),
+      untouchedMissing: taskTouchedToday({{ status: 'done' }}),
+    }};
+    console.log(JSON.stringify(out));
+    """
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    out = json.loads(result.stdout)
+    assert out["emptyToday"].startswith("No tasks today")
+    assert "Nothing running right now" in out["oneToday"]
+    assert "1 task finished today" in out["oneToday"]
+    assert "3 tasks finished today" in out["manyToday"]
+    assert out["touchedStartedToday"] is True
+    assert out["touchedFinishedToday"] is True
+    assert out["untouchedOld"] is False
+    assert out["untouchedMissing"] is False
+
+
+def test_work_attention_shows_loading_skeleton():
+    """#7078: attention list shows a skeleton during projection load, not a blank box."""
+    html = WORK.read_text(encoding="utf-8")
+    assert "skeleton-row" in html
+    assert "skeleton-bar" in html
+    assert "skeleton-pulse" in html
+    assert "Loading work projection" in html
+    assert 'aria-busy="true"' in html
+    assert "removeAttribute('aria-busy')" in html
+    # Reduced-motion users get no shimmer (global guard already present).
+    assert "prefers-reduced-motion" in html
+
+
+def test_orient_crosschecks_live_delegate_before_empty_claim():
+    """#7078: orient must not claim 'No recent tasks' while /api/delegate/tasks is non-empty."""
+    html = ORIENT.read_text(encoding="utf-8")
+    assert "/api/delegate/tasks?limit=5" in html
+    assert "await renderDelegate(" in html
+    # The bare unqualified claim is no longer renderable.
+    assert '<div class="empty">No recent tasks</div>' not in html
+    assert "delegate.html" in html
+
+
+def test_index_delegate_card_reports_finished_today():
+    """#7078: launchpad delegate card must not read as no work today."""
+    html = INDEX.read_text(encoding="utf-8")
+    assert "finished today" in html
+    assert "taskTouchedToday" in html
+    assert "card-stat-delegate" in html


### PR DESCRIPTION
Refs #7078

## What

Hero/empty copy read as "no work today" while `/api/runtime/recent` and `/api/delegate/tasks` had today's work. This PR makes idle states honest:

- **`dashboards/delegate.html`** — when no tasks are running, the Active Tasks card now distinguishes live-now idle from empty-today: `Nothing running right now — N task(s) finished today. See Completed below.` vs `No tasks today — nothing running and nothing finished yet.` (local-day check over `started_at` / `started_at + duration_s`).
- **`dashboards/work.html`** — the Attention list renders a pulsing skeleton (`aria-busy`, disabled under `prefers-reduced-motion`) during the 2–4s projection load instead of a blank box that reads as empty.
- **`dashboards/orient.html`** — the Delegate section cross-checks `/api/delegate/tasks?limit=5` before rendering an empty claim; if the live list is non-empty it renders those rows, and if the live list is unreachable the copy says the snapshot is empty rather than asserting there is no work.
- **`dashboards/index.html`** — the launchpad Delegate card adds `N finished today` when nothing is active, so `0 active` no longer reads as no work today.

## Tests

New dedicated file `tests/test_dashboard_empty_states.py` (5 tests): static contracts for all four pages plus a Node behavioral parity check that evaluates the shipped `idleCopy` / `taskTouchedToday` JS against fixed scenarios. **`tests/test_dashboards.py` is untouched** — verified: `git diff origin/main -- tests/test_dashboards.py` is empty.

```
tests/test_dashboard_empty_states.py .....  5 passed in 0.35s
ruff check + format --check: clean
tests/test_work_dashboard.py + tests/test_work_dashboard_private_integration.py: 19 passed, 25 skipped (puppeteer unavailable in this env — pre-existing environmental skips)
```

No host IPs in tests. No merge — review gate applies.

X-Agent: kimi/infra-7078-empty-states