### PR TITLE
fix(fleet): name fleet-comms ledger in header chip (#7079)

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -304,8 +304,12 @@ function renderHealth(health) {
   const authority = health.authority_health || {};
   const authorityState = short(authority.state, 'unavailable').replaceAll('_', ' ');
   const healthy = authority.ok === true;
+  const runtimeRecords = health.runtime_activity?.records_in_window;
+  const runtimeCopy = Number.isInteger(runtimeRecords) && runtimeRecords > 0
+    ? ` · ${runtimeRecords} runtime/delegate records in window`
+    : '';
   document.getElementById('plane-mode').textContent = `${mode} · durable authority`;
-  document.getElementById('plane-status').textContent = health.schema?.db_exists ? `Authority ${authorityState} · ${short(authority.jobs?.total, '0')} jobs in the last ${short(authority.window?.hours, '24')}h` : 'Durable database not present yet';
+  document.getElementById('plane-status').textContent = health.schema?.db_exists ? `Authority ${authorityState} · ${short(authority.jobs?.total, '0')} fleet-comms authority jobs in the last ${short(authority.window?.hours, '24')}h${runtimeCopy}` : 'Durable database not present yet';
   document.getElementById('plane-dot').className = `signal-dot ${healthy ? 'live' : 'warn'}`;
 }
 

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -692,6 +692,36 @@ def _authority_health_snapshot(
     }
 
 
+def _runtime_activity_snapshot(since: str) -> dict[str, Any]:
+    """Count runtime/delegate ledger records inside the authority evidence window.
+
+    The authority health window counts only fleet-comms ``authority_jobs``.
+    Runtime and delegate work is recorded in a separate usage ledger, so a
+    "0 jobs" authority window must not be read as "no fleet work today".
+    """
+    try:
+        records = recent_runtime_records(limit=MAX_ACTIVITY_SCAN).get("records", [])
+    except Exception:
+        logger.warning("Fleet observer could not derive runtime activity")
+        return {
+            "ledger": "runtime_delegate_usage",
+            "records_in_window": None,
+            "availability": "unavailable",
+        }
+    total = sum(
+        1
+        for record in records
+        if isinstance(record, dict)
+        and isinstance(record.get("ts"), str)
+        and record["ts"] >= since
+    )
+    return {
+        "ledger": "runtime_delegate_usage",
+        "records_in_window": total,
+        "availability": "available",
+    }
+
+
 def _non_negative_int(value: Any) -> int:
     """Normalize legacy numeric fields without reflecting arbitrary values."""
     if isinstance(value, bool):
@@ -984,12 +1014,20 @@ def fleet_health() -> dict[str, Any]:
                 "dead_letters": 0,
             }
         )
+    window = authority_health.get("window") or {}
+    since = window.get("since")
+    if not isinstance(since, str):
+        since = (datetime.now(UTC) - timedelta(hours=AUTHORITY_HEALTH_WINDOW_HOURS)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    runtime_activity = _runtime_activity_snapshot(since)
     return {
         "ok": bool(status["enabled"]) and bool(authority_health["ok"]),
         "observer": "fleet-comms-v1",
         "read_only": True,
         "writes_enabled": False,
         "authority_health": authority_health,
+        "runtime_activity": runtime_activity,
         **status,
     }
 

--- a/tests/test_fleet_health_runtime_activity.py
+++ b/tests/test_fleet_health_runtime_activity.py
@@ -1,0 +1,113 @@
+"""Fleet header jobs chip must name its ledger and see runtime/delegate work (#7079).
+
+The fleet.html header chip derives its "jobs in the last 24h" count from the
+fleet-comms ``authority_jobs`` table only. Runtime and delegate work is
+recorded in a separate usage ledger, so a zero authority window is idle-now,
+not zero-today. The health payload exposes both ledgers and the chip names
+them.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import scripts.api.fleet_router as fleet_router
+from scripts.fleet_comms.migrations import apply_migrations
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(fleet_router.router, prefix="/api/fleet")
+    return TestClient(app)
+
+
+@pytest.fixture()
+def fleet_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "fleet-comms" / "v1"
+    root.mkdir(parents=True)
+    connection = sqlite3.connect(root / "comms.sqlite3")
+    try:
+        apply_migrations(connection)
+    finally:
+        connection.close()
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(root))
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
+    return root
+
+
+def _runtime_records(*timestamps: str) -> dict[str, list[dict[str, str]]]:
+    return {
+        "records": [
+            {
+                "ts": ts,
+                "source": "operator",
+                "agent": "kimi",
+                "via": "dispatch",
+                "entrypoint": "dispatch",
+                "model": "kimi",
+                "outcome": "ok",
+                "source_provenance": "explicit",
+                "source_task_id": "task-7079",
+            }
+            for ts in timestamps
+        ]
+    }
+
+
+def test_health_names_both_ledgers_when_authority_window_is_empty(
+    client: TestClient, fleet_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Idle authority window + runtime/delegate work must not read as zero-today."""
+    now = fleet_router.datetime.now(fleet_router.UTC)
+    inside = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    outside = (now - fleet_router.timedelta(hours=48)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    monkeypatch.setattr(
+        fleet_router,
+        "recent_runtime_records",
+        lambda *, limit: _runtime_records(inside, inside, outside),
+    )
+
+    health = client.get("/api/fleet/health").json()
+
+    authority = health["authority_health"]
+    assert authority["state"] == "idle"
+    assert authority["jobs"] == {"total": 0, "by_state": {}}
+    runtime = health["runtime_activity"]
+    assert runtime["ledger"] == "runtime_delegate_usage"
+    assert runtime["availability"] == "available"
+    assert runtime["records_in_window"] == 2
+
+
+def test_health_runtime_activity_survives_ledger_read_failure(
+    client: TestClient, fleet_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken runtime ledger degrades the chip hint, never the health verdict."""
+
+    def _boom(*, limit: int) -> dict[str, list[dict[str, str]]]:
+        raise OSError("usage files unreadable")
+
+    monkeypatch.setattr(fleet_router, "recent_runtime_records", _boom)
+
+    response = client.get("/api/fleet/health")
+
+    assert response.status_code == 200
+    runtime = response.json()["runtime_activity"]
+    assert runtime["records_in_window"] is None
+    assert runtime["availability"] == "unavailable"
+    assert response.json()["authority_health"]["state"] == "idle"
+
+
+def test_fleet_page_chip_names_fleet_comms_ledger_and_runtime_delegate() -> None:
+    html = (ROOT / "dashboards" / "fleet.html").read_text(encoding="utf-8")
+
+    assert "fleet-comms authority jobs in the last" in html
+    assert "runtime/delegate records in window" in html
+    assert "health.runtime_activity?.records_in_window" in html


### PR DESCRIPTION
## Summary
- Fleet header chip names the fleet-comms ledger vs runtime/delegate activity.
- Idle-now is fine; zero-today no longer lies when runtime/delegate have work.

Refs #7079

X-Agent: kimi/infra-7079-fleet-jobs
Initiator: grok-infra