### PR TITLE
fix(api): dedupe deepseek in /api/runtime/agents (#7082)

### DIFF
--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -357,7 +357,10 @@ def list_runtime_agents() -> list[dict[str, Any]]:
     _refresh_agent_registry_if_changed()
     agents: list[dict[str, Any]] = []
     for path in sorted(ADAPTERS_DIR.glob("*.py")):
-        if path.stem in {"__init__", "acpx", "base", "hermes_grok", "hermes_qwen"} or path.stem.startswith("_"):
+        # Skip non-agent helper modules and alternate-harness adapters that
+        # alias an existing fleet agent name (hermes_* wrap the same grok /
+        # qwen / deepseek identities for ask-hermes only).
+        if path.stem in {"__init__", "acpx", "base", "hermes_deepseek", "hermes_grok", "hermes_qwen"} or path.stem.startswith("_"):
             continue
         try:
             module = importlib.import_module(f"agent_runtime.adapters.{path.stem}")

--- a/tests/test_runtime_agents_dedupe.py
+++ b/tests/test_runtime_agents_dedupe.py
@@ -1,0 +1,34 @@
+"""Regression tests for duplicate agent names in runtime agent listings.
+
+Issue #7082: ``/api/runtime/agents`` (and ``/api/orient`` ``runtime.agents``,
+which shares the same source list) surfaced ``deepseek`` twice because the
+alternate-harness ``hermes_deepseek`` adapter re-exports the fleet name
+``deepseek``. Alternate-harness adapters (``hermes_*``) are ask-hermes-only
+and must not appear as separate fleet agents.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from scripts.api.main import app
+from scripts.api.runtime_router import list_runtime_agents
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_list_runtime_agents_names_are_unique():
+    agents = list_runtime_agents()
+
+    names = [agent["name"] for agent in agents]
+    assert len(names) == len(set(names)), f"duplicate agent names: {sorted(names)}"
+
+
+def test_agents_endpoint_names_are_unique_with_single_deepseek():
+    response = client.get("/api/runtime/agents")
+
+    assert response.status_code == 200
+    agents = response.json()["agents"]
+    names = [agent["name"] for agent in agents]
+    assert len(names) == len(set(names)), f"duplicate agent names: {sorted(names)}"
+    assert names.count("deepseek") == 1


### PR DESCRIPTION
## Summary
- Deduplicate agent names at the `/api/runtime/agents` source list (`deepseek` appeared twice → 11 rows).
- Dedicated tests. `/api/orient` runtime.agents uses the same list.

Refs #7082

X-Agent: kimi/infra-7082-dup-deepseek
Initiator: grok-infra