### PR TITLE
fix(launchers): pass Gemini drive-epic binding via agy -i

### DIFF
--- a/scripts/launchers/gemini.sh
+++ b/scripts/launchers/gemini.sh
@@ -8,7 +8,18 @@ launcher_adapter_canary() {
 }
 launcher_adapter_exec() {
   local cmd=(agy --model "$LC_MODEL")
-  cmd+=("${LC_FORWARD_ARGS[@]}")
+  local arg
+  # agy rejects positional prompts ("Prompts are read only from -p/-i/stdin").
+  # -i seeds the drive-epic binding and keeps the TUI interactive; -p would exit.
+  if [ -n "${LC_DRIVER_PROMPT:-}" ]; then
+    cmd+=(-i "$LC_DRIVER_PROMPT")
+  fi
+  for arg in "${LC_FORWARD_ARGS[@]}"; do
+    if [ -n "${LC_DRIVER_PROMPT:-}" ] && [ "$arg" = "$LC_DRIVER_PROMPT" ]; then
+      continue
+    fi
+    cmd+=("$arg")
+  done
   if [ "$LC_DRY_RUN" = 1 ]; then printf 'LAUNCHER_DRY_RUN=1: credential_source=%s\nwould exec ' "$LC_AUTH_SOURCE"; printf '%q ' "${cmd[@]}"; printf '\n'; return 0; fi
   launcher_exec_command "${cmd[@]}"
 }

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -2,16 +2,41 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from tests.test_launcher_contract import run_launcher
+
+_DRIVE_EPIC_NEEDLE = "agents_extensions/shared/skills/drive-epic/SKILL.md"
+_AGY_PROMPT_FLAG = re.compile(r"(?:^|\s)(-i|--prompt-interactive)(?:\s|$)")
+
+
+def _would_exec_line(stdout: str) -> str:
+    for line in stdout.splitlines():
+        if line.startswith("would exec "):
+            return line
+    raise AssertionError(f"missing would-exec line:\n{stdout}")
+
+
+def _assert_drive_epic_uses_agy_interactive_flag(exec_line: str) -> None:
+    assert _DRIVE_EPIC_NEEDLE in exec_line, exec_line
+    flag = _AGY_PROMPT_FLAG.search(exec_line)
+    assert flag, f"expected -i/--prompt-interactive before drive-epic text:\n{exec_line}"
+    assert flag.start() < exec_line.find(_DRIVE_EPIC_NEEDLE), exec_line
+    before_prompt = exec_line[: exec_line.find(_DRIVE_EPIC_NEEDLE)]
+    assert re.search(r"(?:-i|--prompt-interactive)\s+\S*$", before_prompt), exec_line
+    assert exec_line.count(_DRIVE_EPIC_NEEDLE) == 1, exec_line
 
 
 def test_gemini_interactive_defaults_to_agy_and_rejects_epic() -> None:
     interactive = run_launcher("start-gemini.sh")
     epic = run_launcher("start-gemini.sh", "--epic", "atlas")
     assert interactive.returncode == 0, interactive.stderr
-    assert "would exec agy --model gemini-3.7-flash-high" in interactive.stdout
+    exec_line = _would_exec_line(interactive.stdout)
+    assert "would exec agy --model gemini-3.7-flash-high" in exec_line
+    assert not _AGY_PROMPT_FLAG.search(exec_line), exec_line
+    assert _DRIVE_EPIC_NEEDLE not in exec_line
     assert epic.returncode == 2
     assert "interactive launchers reject --epic" in epic.stderr
 
@@ -23,6 +48,7 @@ def test_gemini_driver_claims_a_lease_for_supported_selectors(selector: str) -> 
     assert "would claim lease" in result.stdout
     assert "would run provider canary" in result.stdout
     assert "would bind drive-epic" in result.stdout
+    _assert_drive_epic_uses_agy_interactive_flag(_would_exec_line(result.stdout))
 
 
 @pytest.mark.parametrize("model", ("gemini-3.6-flash-high", "gemini-3.1-pro-high"))
@@ -42,4 +68,24 @@ def test_gemini_driver_rejects_uncertified_model_and_non_agy_harness() -> None:
 def test_gemini_forwards_provider_arguments_only_after_separator() -> None:
     result = run_launcher("start-gemini.sh", "--", "--sandbox", "read-only")
     assert result.returncode == 0, result.stderr
-    assert "--sandbox read-only" in result.stdout
+    exec_line = _would_exec_line(result.stdout)
+    assert "--sandbox read-only" in exec_line
+    assert not _AGY_PROMPT_FLAG.search(exec_line), exec_line
+
+
+def test_gemini_driver_passes_binding_via_agy_interactive_flag() -> None:
+    result = run_launcher("start-gemini-driver.sh", "--epic", "hramatka")
+    assert result.returncode == 0, result.stderr
+    exec_line = _would_exec_line(result.stdout)
+    assert "would exec agy --model" in exec_line
+    _assert_drive_epic_uses_agy_interactive_flag(exec_line)
+
+
+def test_gemini_driver_forwards_provider_args_without_duplicating_prompt() -> None:
+    result = run_launcher(
+        "start-gemini-driver.sh", "--epic", "devops", "--", "--sandbox", "read-only"
+    )
+    assert result.returncode == 0, result.stderr
+    exec_line = _would_exec_line(result.stdout)
+    assert "--sandbox read-only" in exec_line
+    _assert_drive_epic_uses_agy_interactive_flag(exec_line)

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -10,6 +10,11 @@ from tests.test_launcher_contract import run_launcher
 
 _DRIVE_EPIC_NEEDLE = "agents_extensions/shared/skills/drive-epic/SKILL.md"
 _AGY_PROMPT_FLAG = re.compile(r"(?:^|\s)(-i|--prompt-interactive)(?:\s|$)")
+# Dry-run uses bash %q, so the prompt may appear as Load\ agents_extensions/...
+# or as a quoted string. The flag must attach to that argument.
+_AGY_BOUND_PROMPT = re.compile(
+    r"(?:-i|--prompt-interactive)\s+(?:Load\\ |'Load |\"Load )"
+)
 
 
 def _would_exec_line(stdout: str) -> str:
@@ -21,12 +26,12 @@ def _would_exec_line(stdout: str) -> str:
 
 def _assert_drive_epic_uses_agy_interactive_flag(exec_line: str) -> None:
     assert _DRIVE_EPIC_NEEDLE in exec_line, exec_line
-    flag = _AGY_PROMPT_FLAG.search(exec_line)
-    assert flag, f"expected -i/--prompt-interactive before drive-epic text:\n{exec_line}"
-    assert flag.start() < exec_line.find(_DRIVE_EPIC_NEEDLE), exec_line
-    before_prompt = exec_line[: exec_line.find(_DRIVE_EPIC_NEEDLE)]
-    assert re.search(r"(?:-i|--prompt-interactive)\s+\S*$", before_prompt), exec_line
+    bound = _AGY_BOUND_PROMPT.search(exec_line)
+    assert bound, f"expected -i/--prompt-interactive before drive-epic text:\n{exec_line}"
+    assert bound.start() < exec_line.find(_DRIVE_EPIC_NEEDLE), exec_line
     assert exec_line.count(_DRIVE_EPIC_NEEDLE) == 1, exec_line
+    # Regression: --model <id> followed by the prompt with no -i.
+    assert not re.search(r"--model\s+\S+\s+Load\\?\s", exec_line), exec_line
 
 
 def test_gemini_interactive_defaults_to_agy_and_rejects_epic() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`start-gemini-driver.sh --epic <selector>` claimed the lease, then exited 2 because `agy` rejected the drive-epic binding as a bare positional:

`Prompts are read only from -p/--print, -i/--prompt-interactive, or stdin`.

Root cause: `launcher_bind_drive_epic` still appends `LC_DRIVER_PROMPT` to `LC_FORWARD_ARGS` (correct for grok/claude, which accept positional prompts). `scripts/launchers/gemini.sh` then forwarded that string as a positional. `agy` does not.

## Changes

- Gemini adapter only: when `LC_DRIVER_PROMPT` is set, pass it as `agy --model <model> -i "$LC_DRIVER_PROMPT"`.
- Skip any `LC_FORWARD_ARGS` entry that equals the binding so it is not also appended as a positional.
- Leave interactive `start-gemini.sh` as `agy --model <default>` with no `-i`.
- Do not change grok/claude launchers or `launcher_bind_drive_epic`.
- Extend `tests/test_start_gemini_launcher.py` to require `-i`/`--prompt-interactive` before the drive-epic text, and to keep the existing interactive / harness / certified-model / `--sandbox read-only` assertions.

## Testing

- [x] `python3 -m pytest tests/test_start_gemini_launcher.py` — 11 passed
- [x] `LAUNCHER_DRY_RUN=1 ./start-gemini-driver.sh --epic hramatka` shows `agy --model gemini-3.7-flash-high -i Load\ agents_extensions/...` with no bare positional prompt
- [x] Interactive dry-run remains `agy --model gemini-3.7-flash-high` with no `-i`
- [x] `-- --sandbox read-only` still appears on the interactive exec line

Curriculum/website audit boxes do not apply (launcher-only).

## Related Issues

No GitHub issue is attached. This is a verified launcher regression against the `agy` prompt-intake contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4efec6c-8a49-458b-b79c-96446227a9a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4efec6c-8a49-458b-b79c-96446227a9a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

