### PR TITLE
fix(hramatka): stop counting open-PR worktrees as closeout orphans

### DIFF
--- a/docs/runbooks/hramatka-driver-queue.md
+++ b/docs/runbooks/hramatka-driver-queue.md
@@ -77,8 +77,13 @@ handoff:
   A terminal-task worktree whose branch still has an **open PR** is not
   counted: `post_task_reap` deliberately retains that worktree, so counting it
   would hold the gate at `stale` for as long as any lane has a PR in flight.
-  The exemption requires a *provable* open PR — an unreachable `gh` leaves the
-  worktree counted, because this gate never passes on an unknown.
+  The exemption is deliberately narrow and fails closed — the worktree stays
+  counted unless the PR is *provably* open, in this repository, on exactly
+  that branch head, and not a fork. An unreachable `gh`, a non-zero exit, or
+  any row the gate cannot fully parse is an unknown, and unknowns never
+  exempt. A branch registered by **two** worktrees is never exempted either:
+  one PR speaks for one checkout, so the duplicates are exactly the stale
+  copies this gate exists to surface.
 - **unknown** (exit 2) — GitHub was unreachable for the public epic or the
   private board. This is never a pass.
 

--- a/docs/runbooks/hramatka-driver-queue.md
+++ b/docs/runbooks/hramatka-driver-queue.md
@@ -74,6 +74,11 @@ handoff:
   dispatch worktree is bound to an already-terminal task
   (`.worktrees/dispatch/` vs. `batch_state/tasks/`), or local disk use is at
   or above the configured high-water mark (default 95%, `--high-water-percent`).
+  A terminal-task worktree whose branch still has an **open PR** is not
+  counted: `post_task_reap` deliberately retains that worktree, so counting it
+  would hold the gate at `stale` for as long as any lane has a PR in flight.
+  The exemption requires a *provable* open PR — an unreachable `gh` leaves the
+  worktree counted, because this gate never passes on an unknown.
 - **unknown** (exit 2) — GitHub was unreachable for the public epic or the
   private board. This is never a pass.
 

--- a/scripts/fleet/hramatka_hygiene_check.py
+++ b/scripts/fleet/hramatka_hygiene_check.py
@@ -208,24 +208,56 @@ def _branch_has_open_pr(
     repo_root: Path,
     branch: str | None,
     *,
+    repo: str = PUBLIC_REPOSITORY,
     timeout: float = GH_TIMEOUT_SECONDS,
 ) -> bool:
-    """Return True only when ``branch`` provably has an OPEN PR.
+    """Return True only when ``branch`` provably has an OPEN same-repo PR.
 
     Mirrors the PR-3 reaper's retention rule (``post_task_reap`` retains a
     bound worktree whose branch still has an open PR) without importing it,
     per this module's deliberate no-hard-dependency design.
 
     Fail-closed for this gate, which is the opposite direction from the
-    reaper: an unknown PR state returns False, so the worktree stays counted
-    as an orphan.  The gate must never hand out a verified-clean handoff on a
-    guess -- an unreachable ``gh`` cannot excuse a worktree.
+    reaper: ANY doubt returns False and the worktree stays counted.  The gate
+    must never hand out a verified-clean handoff on a guess.  Concretely,
+    every one of these counts the worktree rather than excusing it:
+
+    * no branch identity (a detached worktree);
+    * ``gh`` missing, timing out, or exiting non-zero;
+    * output that is not JSON, or not a JSON list;
+    * a list containing anything that is not an object (``[null]``);
+    * a row missing/!= ``state == "OPEN"``;
+    * a row whose ``headRefName`` is not exactly this branch;
+    * a cross-repository (fork) head;
+    * a row without a positive integer ``number``.
+
+    A single malformed row poisons the whole answer -- a partially
+    understood response is an unknown, and unknowns do not exempt.
+
+    Deliberately NOT required: that the PR head OID equals the local
+    worktree HEAD.  A worktree legitimately sits ahead of or behind its
+    pushed PR head, so demanding equality would recreate the unpassable-gate
+    bug this change fixes, in a new form.  Branch identity plus a same-repo
+    head is the binding that answers the actual question -- is this worktree
+    still serving an open PR?
     """
     if not branch:
         return False
     try:
         proc = subprocess.run(
-            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number,state,headRefName,isCrossRepository",
+            ],
             cwd=repo_root,
             capture_output=True,
             text=True,
@@ -240,7 +272,24 @@ def _branch_has_open_pr(
         rows = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError:
         return False
-    return isinstance(rows, list) and len(rows) > 0
+    if not isinstance(rows, list):
+        return False
+
+    matched = False
+    for row in rows:
+        if not isinstance(row, dict):
+            return False
+        number = row.get("number")
+        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+            return False
+        if row.get("state") != "OPEN":
+            return False
+        if row.get("isCrossRepository") is not False:
+            return False
+        if row.get("headRefName") != branch:
+            return False
+        matched = True
+    return matched
 
 
 def _is_under_dispatch_worktrees(path: Path, dispatch_root: Path) -> bool:
@@ -308,6 +357,15 @@ def _detect_zombie_worktrees(
     if entries is None:
         return [], False
 
+    # A branch registered by more than one worktree cannot be excused by a
+    # single open PR: the PR speaks for one checkout, so the duplicates are
+    # exactly the stale copies this gate exists to surface. Fail closed and
+    # let every one of them be counted.
+    branch_counts: dict[str, int] = {}
+    for _path, branch in entries:
+        if branch:
+            branch_counts[branch] = branch_counts.get(branch, 0) + 1
+
     index = _task_state_index(tasks_dir)
     zombies: list[dict[str, Any]] = []
     for worktree, branch in entries:
@@ -320,7 +378,8 @@ def _detect_zombie_worktrees(
         status_str = str(status) if status is not None else None
         if status_str not in _TERMINAL_STATUSES:
             continue
-        if open_pr_probe(repo_root, branch):
+        duplicated = bool(branch) and branch_counts.get(branch, 0) > 1
+        if not duplicated and open_pr_probe(repo_root, branch):
             continue
         zombies.append(
             {

--- a/scripts/fleet/hramatka_hygiene_check.py
+++ b/scripts/fleet/hramatka_hygiene_check.py
@@ -95,6 +95,8 @@ class GhUnavailable(RuntimeError):
 
 
 IssueReader = Callable[[str, int], dict[str, Any]]
+# (repo_root, branch) -> True only when that branch provably has an OPEN PR.
+OpenPrProbe = Callable[[Path, "str | None"], bool]
 
 
 def _gh_issue(
@@ -158,6 +160,20 @@ def _count_task_list_items(body: str) -> tuple[int, int]:
 
 def _registered_worktrees(repo_root: Path) -> list[Path] | None:
     """Return every registered git worktree path, or None if not detectable."""
+    entries = _registered_worktree_entries(repo_root)
+    if entries is None:
+        return None
+    return [path for path, _branch in entries]
+
+
+def _registered_worktree_entries(
+    repo_root: Path,
+) -> list[tuple[Path, str | None]] | None:
+    """Return (path, branch) for every registered worktree, or None.
+
+    ``branch`` is the short name (``refs/heads/`` stripped), or None for a
+    detached worktree, which has no branch identity to probe for an open PR.
+    """
     try:
         proc = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
@@ -171,11 +187,60 @@ def _registered_worktrees(repo_root: Path) -> list[Path] | None:
         return None
     if proc.returncode != 0:
         return None
-    paths: list[Path] = []
+    entries: list[tuple[Path, str | None]] = []
+    path: Path | None = None
+    branch: str | None = None
     for line in (proc.stdout or "").splitlines():
         if line.startswith("worktree "):
-            paths.append(Path(line[len("worktree ") :].strip()).resolve())
-    return paths
+            if path is not None:
+                entries.append((path, branch))
+            path = Path(line[len("worktree ") :].strip()).resolve()
+            branch = None
+        elif line.startswith("branch ") and path is not None:
+            ref = line[len("branch ") :].strip()
+            branch = ref[len("refs/heads/") :] if ref.startswith("refs/heads/") else ref
+    if path is not None:
+        entries.append((path, branch))
+    return entries
+
+
+def _branch_has_open_pr(
+    repo_root: Path,
+    branch: str | None,
+    *,
+    timeout: float = GH_TIMEOUT_SECONDS,
+) -> bool:
+    """Return True only when ``branch`` provably has an OPEN PR.
+
+    Mirrors the PR-3 reaper's retention rule (``post_task_reap`` retains a
+    bound worktree whose branch still has an open PR) without importing it,
+    per this module's deliberate no-hard-dependency design.
+
+    Fail-closed for this gate, which is the opposite direction from the
+    reaper: an unknown PR state returns False, so the worktree stays counted
+    as an orphan.  The gate must never hand out a verified-clean handoff on a
+    guess -- an unreachable ``gh`` cannot excuse a worktree.
+    """
+    if not branch:
+        return False
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return False
+    return isinstance(rows, list) and len(rows) > 0
 
 
 def _is_under_dispatch_worktrees(path: Path, dispatch_root: Path) -> bool:
@@ -220,6 +285,7 @@ def _detect_zombie_worktrees(
     repo_root: Path,
     dispatch_root: Path,
     tasks_dir: Path,
+    open_pr_probe: OpenPrProbe = _branch_has_open_pr,
 ) -> tuple[list[dict[str, Any]], bool]:
     """Return (zombies, detectable). Read-only: never removes anything.
 
@@ -227,14 +293,24 @@ def _detect_zombie_worktrees(
     whose bound task state is found and terminal — an unbound path is not
     evidence either way and is left out, matching the "if detectable"
     qualifier in the hygiene contract.
+
+    A terminal-task worktree whose branch still has an OPEN PR is NOT an
+    orphan.  The PR-3 reaper deliberately retains exactly that worktree
+    ("open PR present for bound worktree branch"), so flagging it would
+    demand a state the sanctioned tooling refuses to produce: every lane
+    with a merged-pending PR would hold this gate at ``stale`` forever, and
+    a closeout predicate that cannot pass during ordinary fleet operation
+    stops being load-bearing.  The exemption is deliberately narrow — it
+    covers only a provable OPEN PR, and ``_branch_has_open_pr`` fails closed
+    on any unknown state.
     """
-    worktrees = _registered_worktrees(repo_root)
-    if worktrees is None:
+    entries = _registered_worktree_entries(repo_root)
+    if entries is None:
         return [], False
 
     index = _task_state_index(tasks_dir)
     zombies: list[dict[str, Any]] = []
-    for worktree in worktrees:
+    for worktree, branch in entries:
         if not _is_under_dispatch_worktrees(worktree, dispatch_root):
             continue
         state = index.get(worktree)
@@ -242,14 +318,17 @@ def _detect_zombie_worktrees(
             continue
         status = state.get("status")
         status_str = str(status) if status is not None else None
-        if status_str in _TERMINAL_STATUSES:
-            zombies.append(
-                {
-                    "path": str(worktree),
-                    "task_id": state.get("task_id") or worktree.name,
-                    "status": status_str,
-                }
-            )
+        if status_str not in _TERMINAL_STATUSES:
+            continue
+        if open_pr_probe(repo_root, branch):
+            continue
+        zombies.append(
+            {
+                "path": str(worktree),
+                "task_id": state.get("task_id") or worktree.name,
+                "status": status_str,
+            }
+        )
     return zombies, True
 
 
@@ -312,6 +391,7 @@ def hygiene_check(
     dispatch_worktrees_root: Path = _DISPATCH_WORKTREES_ROOT,
     tasks_dir: Path = _TASKS_DIR,
     reader: IssueReader = _gh_issue,
+    open_pr_probe: OpenPrProbe = _branch_has_open_pr,
 ) -> dict[str, Any]:
     """Run every hygiene check and return the JSON receipt (never raises)."""
     reasons: list[str] = []
@@ -358,6 +438,7 @@ def hygiene_check(
         repo_root=repo_root,
         dispatch_root=dispatch_worktrees_root,
         tasks_dir=tasks_dir,
+        open_pr_probe=open_pr_probe,
     )
     if zombies:
         reasons.append(f"{len(zombies)} orphan dispatch worktree(s) bound to finished tasks")

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -250,14 +250,24 @@ def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequ
         raw_items = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError as exc:
         return [], f"gh pr list returned invalid JSON: {exc}"
+    if not isinstance(raw_items, list):
+        # Without this, a scalar payload (`123`) raises TypeError in the loop
+        # below and a mapping would iterate its keys.
+        return [], "gh pr list returned a non-list payload"
 
     states: list[PullRequestState] = []
     for item in raw_items:
+        # A row we cannot read is an UNKNOWN, never an absence. Silently
+        # skipping it made `[null]` / `[{}]` parse as "no open PR", and every
+        # caller reads an empty list as permission to DELETE the worktree --
+        # a destructive fail-open on malformed input. Routing it through the
+        # existing error channel makes all callers retain instead, since each
+        # one already treats a non-None error as skip/retain.
         if not isinstance(item, dict):
-            continue
+            return [], "gh pr list returned a malformed row (not an object)"
         state = str(item.get("state") or "").upper()
         if not state:
-            continue
+            return [], "gh pr list returned a row with no usable state"
         number = item.get("number")
         states.append(
             PullRequestState(

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -706,7 +706,17 @@ def _qualifying_reason(
     safe_only: bool = False,
     merged_pr_only: bool = False,
     include_terminal_dispatches: bool = False,
+    pr_unknown: bool = False,
 ) -> str | None:
+    """``pr_unknown`` marks the PR state as UNREADABLE rather than absent.
+
+    A failed branch query must not read as "no PR": every reason below that
+    consults ``pr_state`` -- directly, or via a ``pr_state is None`` shortcut
+    that means "no open PR" -- becomes unsafe, because an OPEN PR may exist
+    and simply not be visible. Class B stays available: it never consults
+    ``pr_state`` and already requires the head to be an ancestor of
+    origin/main or reachable from a remote, so nothing can be lost.
+    """
     if pr_state is not None:
         pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
         if pr_state.state == "MERGED" and _pr_matches_worktree_head(info, pr_state):
@@ -727,8 +737,10 @@ def _qualifying_reason(
 
         # Never treat "matches remote tip" as reaped-while-OPEN: open PR
         # worktrees commonly match origin/<branch> and must stay mounted.
-        if (pr_state is None or pr_state.state != "OPEN") and _origin_matches_head(
-            info.path, info.branch
+        if (
+            not pr_unknown
+            and (pr_state is None or pr_state.state != "OPEN")
+            and _origin_matches_head(info.path, info.branch)
         ):
             return f"HEAD matches origin/{info.branch}"
 
@@ -791,17 +803,23 @@ def _qualifying_reason(
             info=info,
             active_ids=active_ids,
         )
-        if terminal_reason is not None and (pr_state is None or pr_state.state != "OPEN"):
+        if (
+            terminal_reason is not None
+            and not pr_unknown
+            and (pr_state is None or pr_state.state != "OPEN")
+        ):
             return terminal_reason
 
-        abandoned = _abandoned_main_dispatch_reason(
-            repo_root=repo_root,
-            info=info,
-            pr_state=pr_state,
-            now=now,
-        )
-        if abandoned is not None:
-            return abandoned
+        # Also PR-dependent: it reads pr_state to decide abandonment.
+        if not pr_unknown:
+            abandoned = _abandoned_main_dispatch_reason(
+                repo_root=repo_root,
+                info=info,
+                pr_state=pr_state,
+                now=now,
+            )
+            if abandoned is not None:
+                return abandoned
 
     return None
 
@@ -1431,16 +1449,24 @@ def reap_worktrees(
                 )
                 continue
 
+            # An unreadable branch response is UNKNOWN, not "no PR": drop the
+            # untrusted pr_state and forbid every PR-dependent reason. Without
+            # this, the legacy/manual class deleted on a failed branch query,
+            # because a supplementary SHA-search MERGED hit is labelled with
+            # the queried worktree SHA, always matches the head, and its
+            # "PR #N MERGED" reason does not enable the cleanup-time re-query.
+            pr_unknown = pr_error is not None
             reason = _qualifying_reason(
                 repo_root=repo_root,
                 info=info,
-                pr_state=pr_state,
+                pr_state=None if pr_unknown else pr_state,
                 build_age_hours=build_age_hours,
                 now=now,
                 active_ids=active_ids,
                 safe_only=safe_only,
                 merged_pr_only=merged_pr_only,
                 include_terminal_dispatches=include_terminal_dispatches,
+                pr_unknown=pr_unknown,
             )
             if reason is None:
                 is_settled, _ = _is_settled_dispatch_task(

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -223,6 +223,11 @@ def _worktree_clean(path: Path) -> bool | None:
     return True
 
 
+# The states `gh pr list` can report. Anything else is an UNKNOWN, never
+# an absence -- callers read "no open PR" as permission to delete.
+_PR_STATES = frozenset({"OPEN", "MERGED", "CLOSED"})
+
+
 def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequestState], str | None]:
     if not branch:
         return [], None
@@ -265,13 +270,21 @@ def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequ
         # one already treats a non-None error as skip/retain.
         if not isinstance(item, dict):
             return [], "gh pr list returned a malformed row (not an object)"
-        state = str(item.get("state") or "").upper()
-        if not state:
-            return [], "gh pr list returned a row with no usable state"
+        raw_state = item.get("state")
+        state = str(raw_state).upper() if isinstance(raw_state, str) else ""
+        if state not in _PR_STATES:
+            # An unrecognised state is ambiguous, and ambiguity must not read
+            # as "no open PR". `[{"state": "CLOSED"}]` and an unknown enum
+            # both used to authorise deletion.
+            return [], "gh pr list returned a row with an unusable state"
         number = item.get("number")
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            # gh always returns `number` when asked for it, so a row without a
+            # usable one is an incomplete answer, not a PR-free branch.
+            return [], "gh pr list returned a row without a usable PR number"
         states.append(
             PullRequestState(
-                number=number if isinstance(number, int) else None,
+                number=number,
                 state=state,
                 head_sha=(
                     str(item.get("headRefOid"))
@@ -1397,10 +1410,13 @@ def reap_worktrees(
             if info.head and not _is_ancestor_of_origin_main(info.path):
                 all_pr_states.extend(_query_prs_by_head_sha(repo_root, info.head))
 
-            if errors and not all_pr_states:
+            # Any candidate-query error blocks qualification. A supplementary
+            # SHA lookup finding *some* PR cannot redeem an unreadable
+            # authoritative branch response -- that made UNKNOWN -> retain
+            # non-universal on the destructive path.
+            pr_state = _best_pr(all_pr_states)
+            if errors:
                 pr_error = "; ".join(errors)
-            else:
-                pr_state = _best_pr(all_pr_states)
 
             if (merged_pr_only or include_terminal_dispatches) and pr_error is not None:
                 results.append(

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -730,7 +730,16 @@ def _qualifying_reason(
             return f"{pr_label} CLOSED"
 
     if info.branch is not None and not safe_only:
-        if info.branch.startswith("build/"):
+        # Age alone is not evidence the work is safe to destroy: this return
+        # carries no ancestry or remote-reachability precondition. It must
+        # therefore respect PR state exactly like the origin-tip return below
+        # -- it deleted an aged build/* worktree both under an UNKNOWN PR
+        # response and, before that, under a plainly KNOWN OPEN PR.
+        if (
+            info.branch.startswith("build/")
+            and not pr_unknown
+            and (pr_state is None or pr_state.state != "OPEN")
+        ):
             age_hours = _worktree_age_hours(info.path, now=now)
             if age_hours is not None and age_hours > build_age_hours:
                 return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1880,3 +1880,73 @@ def test_fresh_main_dispatch_is_not_age_reaped(
     assert result.action == "skipped"
     assert worktree.exists()
 
+
+# --- _query_pr_states must fail CLOSED on unreadable rows (#7126 CF review) --
+
+
+def _gh_stdout(payload: str, returncode: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=payload, stderr="")
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("null row", "[null]"),
+        ("empty row", "[{}]"),
+        ("row without state", '[{"number": 1}]'),
+        ("row is a string", '["OPEN"]'),
+        ("blank state", '[{"state": "", "number": 1}]'),
+        ("scalar payload", "123"),
+        ("mapping payload", "{}"),
+        ("string payload", '"open"'),
+        ("null payload", "null"),
+    ],
+)
+def test_query_pr_states_reports_unreadable_rows_as_an_error(monkeypatch, label, payload) -> None:
+    """A row the parser cannot read is an UNKNOWN, never an absence.
+
+    Silently skipping made `[null]` / `[{}]` parse as "no open PR", and every
+    caller reads an empty list as permission to DELETE the worktree. That was
+    a destructive fail-open on malformed input.
+    """
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    states, error = rw._query_pr_states(Path("/nonexistent"), "some/branch")
+
+    assert states == [], label
+    assert error is not None, label
+
+
+def test_query_pr_states_still_reports_a_genuinely_empty_list(monkeypatch) -> None:
+    """An empty list is a real answer (no PR), not an unknown -- reaping must
+    still be possible or nothing would ever be cleaned up."""
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout("[]"))
+
+    states, error = rw._query_pr_states(Path("/nonexistent"), "some/branch")
+
+    assert states == []
+    assert error is None
+
+
+def test_query_pr_states_parses_a_well_formed_row(monkeypatch) -> None:
+    payload = json.dumps([{"number": 7120, "state": "OPEN", "headRefOid": "abc123"}])
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    states, error = rw._query_pr_states(Path("/nonexistent"), "some/branch")
+
+    assert error is None
+    assert [(s.number, s.state, s.head_sha) for s in states] == [(7120, "OPEN", "abc123")]
+
+
+@pytest.mark.parametrize("payload", ["[null]", "[{}]", "123"])
+def test_unreadable_rows_make_post_task_reap_retain_the_worktree(monkeypatch, payload) -> None:
+    """End-to-end on the destructive path: an unreadable PR response must
+    retain, never delete."""
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    no_open_pr, guard_error = post_task_reap._no_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), branch="some/branch"
+    )
+
+    assert no_open_pr is False
+    assert guard_error is not None

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -2059,3 +2059,58 @@ def test_unreadable_branch_query_retains_even_when_the_sha_lookup_succeeds(
     assert result.action == "skipped"
     assert "PR guard unavailable" in result.reason
     assert worktree.exists()
+
+
+def test_unreadable_branch_query_retains_in_the_legacy_class(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable authoritative branch response must retain in EVERY class,
+    including legacy/manual (`--legacy-classes`).
+
+    The retention branch used to be gated on
+    `merged_pr_only or include_terminal_dispatches`, so with both false a
+    failed branch query was recorded and then ignored. A supplementary
+    SHA-search MERGED hit -- which is labelled with the queried worktree SHA
+    and therefore always matches the head -- then qualified the tree for
+    deletion, and that reason does not enable the terminal cleanup-time
+    re-query. That was the configuration where the candidate-query error is
+    the ONLY barrier.
+    """
+    repo = init_repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "legacy-guard"
+    add_worktree(repo, "codex/legacy-guard", path=worktree)
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    monkeypatch.setattr(rw, "_query_pr_states", lambda _repo, _branch: ([], "gh unreadable row"))
+    # head_sha equals the queried SHA, exactly as _query_prs_by_head_sha labels it.
+    monkeypatch.setattr(
+        rw,
+        "_query_prs_by_head_sha",
+        lambda _repo, sha: [rw.PullRequestState(number=42, state="MERGED", head_sha=sha or head)],
+    )
+    monkeypatch.setattr(rw, "_is_ancestor_of_origin_main", lambda _path: False)
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=False,
+            include_terminal_dispatches=False,
+            safe_only=False,
+        ),
+        worktree,
+    )
+
+    assert result.action != "removed", f"deleted on an unreadable PR response: {result.reason}"
+    assert worktree.exists()

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -114,9 +114,7 @@ def patch_gh(
                         head = _resolve_head(kwargs["cwd"], branch, item)
                         if head is None or not _ancestor(kwargs["cwd"], sha, head):
                             continue
-                        payload.append(
-                            {"number": item.get("number"), "state": item.get("state")}
-                        )
+                        payload.append({"number": item.get("number"), "state": item.get("state")})
                 return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
             branch = args[args.index("--head") + 1]
             calls.append(branch)
@@ -359,10 +357,7 @@ def test_preserve_then_reap_commits_dirty_worktree_before_removal(
     recovered = tmp_path / "recovered-preserve"
     git(repo, "worktree", "add", str(recovered), "codex/preserve")
     assert (recovered / "artifact.txt").read_text(encoding="utf-8") == "recover me\n"
-    assert (
-        git(recovered, "log", "-1", "--format=%s")
-        == "wip: preserve codex/preserve before reap [skip ci]"
-    )
+    assert git(recovered, "log", "-1", "--format=%s") == "wip: preserve codex/preserve before reap [skip ci]"
     assert_main_checkout_unchanged(repo)
 
 
@@ -472,9 +467,7 @@ def test_class_a_settled_dispatch_removed(
     # Create task JSON
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "done"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     # Mock active set and PR state
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
@@ -500,9 +493,7 @@ def test_class_a_no_deliverable_dispatch_removed(
 
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "no_deliverable"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "no_deliverable"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     patch_gh(monkeypatch, {"codex/5800-false-success": []})
@@ -533,9 +524,7 @@ def test_settled_dispatch_with_unpushed_local_commit_is_skipped_unpushed_head(
     # Set task status to done
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "done"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
@@ -578,9 +567,7 @@ def test_settled_dispatch_with_head_pushed_to_origin_is_reaped(
     # Set task status to done
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "done"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
@@ -615,9 +602,7 @@ def test_settled_dispatch_with_zero_commits_ahead_is_reaped(
 
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "done"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
@@ -649,9 +634,7 @@ def test_settled_dispatch_terminal_status_without_commits_is_reaped(
 
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "dry_run"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "dry_run"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
@@ -758,9 +741,7 @@ def test_terminal_dispatch_class_does_not_infer_terminal_from_dead_running_pid(
     add_worktree(repo, "codex/dead-running-pid", path=worktree)
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "running", "pid": 999999}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "running", "pid": 999999}), encoding="utf-8")
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
     monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
     patch_gh(monkeypatch, {"codex/dead-running-pid": []})
@@ -812,9 +793,7 @@ def test_class_a_fail_safe_skips(
     assert result_for(results, worktree_path).action == "skipped"
 
     # Re-create task file for remaining cases — live worker PID required
-    task_file.write_text(
-        json.dumps({"status": "running", "pid": os.getpid()}), encoding="utf-8"
-    )
+    task_file.write_text(json.dumps({"status": "running", "pid": os.getpid()}), encoding="utf-8")
 
     # Case 4: task status is not done/failed and worker PID is live
     results = rw.reap_worktrees(repo_root=repo, apply=True, merged_pr_only=False)
@@ -883,9 +862,7 @@ def test_class_b_settled_task_removed(
     # Create task JSON
     tasks_dir = repo / "batch_state" / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
-    (tasks_dir / f"{task_id}.json").write_text(
-        json.dumps({"status": "done"}), encoding="utf-8"
-    )
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
 
     monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
 
@@ -1033,11 +1010,7 @@ def test_merged_pr_head_must_match_worktree_head(
     worktree = add_worktree(repo, "codex/mismatched")
     patch_gh(
         monkeypatch,
-        {
-            "codex/mismatched": [
-                {"number": 10, "state": "MERGED", "headRefOid": "0" * 40}
-            ]
-        },
+        {"codex/mismatched": [{"number": 10, "state": "MERGED", "headRefOid": "0" * 40}]},
     )
 
     result = result_for(
@@ -1060,9 +1033,7 @@ def test_closed_pr_requires_matching_worktree_head(
         monkeypatch,
         {
             "codex/closed-matching": [{"number": 12, "state": "CLOSED"}],
-            "codex/closed-mismatched": [
-                {"number": 13, "state": "CLOSED", "headRefOid": "0" * 40}
-            ],
+            "codex/closed-mismatched": [{"number": 13, "state": "CLOSED", "headRefOid": "0" * 40}],
         },
     )
 
@@ -1367,11 +1338,7 @@ def test_merged_pr_ancestor_head_reaps_worktree(
 
     patch_gh(
         monkeypatch,
-        {
-            "codex/ancestor-head": [
-                {"number": 201, "state": "MERGED", "headRefOid": pr_head}
-            ]
-        },
+        {"codex/ancestor-head": [{"number": 201, "state": "MERGED", "headRefOid": pr_head}]},
     )
 
     result = result_for(
@@ -1398,11 +1365,7 @@ def test_detached_worktree_matching_merged_pr_reaps(
 
     patch_gh(
         monkeypatch,
-        {
-            "kimi/6690-ci-fix": [
-                {"number": 6690, "state": "MERGED", "headRefOid": head}
-            ]
-        },
+        {"kimi/6690-ci-fix": [{"number": 6690, "state": "MERGED", "headRefOid": head}]},
     )
 
     result = result_for(
@@ -1434,11 +1397,7 @@ def test_detached_worktree_with_open_pr_is_preserved(
 
     patch_gh(
         monkeypatch,
-        {
-            "codex/open-detached": [
-                {"number": 301, "state": "OPEN", "headRefOid": head}
-            ]
-        },
+        {"codex/open-detached": [{"number": 301, "state": "OPEN", "headRefOid": head}]},
     )
 
     result = result_for(
@@ -1470,11 +1429,7 @@ def test_followup_branch_ancestor_of_merged_pr_head_reaps(
 
     patch_gh(
         monkeypatch,
-        {
-            "kimi/routing-defaults": [
-                {"number": 6687, "state": "MERGED", "headRefOid": pr_head}
-            ]
-        },
+        {"kimi/routing-defaults": [{"number": 6687, "state": "MERGED", "headRefOid": pr_head}]},
     )
 
     result = result_for(
@@ -1503,11 +1458,7 @@ def test_detached_worktree_with_different_pr_head_branch_reaps(
 
     patch_gh(
         monkeypatch,
-        {
-            "agy/delegate-active-timeout": [
-                {"number": 6690, "state": "MERGED", "headRefOid": head}
-            ]
-        },
+        {"agy/delegate-active-timeout": [{"number": 6690, "state": "MERGED", "headRefOid": head}]},
     )
 
     result = result_for(
@@ -1536,11 +1487,7 @@ def test_fresh_branch_on_main_tip_is_not_sha_reaped(
 
     patch_gh(
         monkeypatch,
-        {
-            "agy/original": [
-                {"number": 1, "state": "MERGED", "headRefOid": main_tip}
-            ]
-        },
+        {"agy/original": [{"number": 1, "state": "MERGED", "headRefOid": main_tip}]},
     )
 
     result = result_for(
@@ -1725,9 +1672,7 @@ def test_p0_dynamic_cap_ceiling_stops_run_in_apply_mode(
     actions = [result_for(results, worktree).action for worktree in worktrees]
     assert actions.count("removed") == 2
     blocked = [
-        result_for(results, worktree)
-        for worktree in worktrees
-        if result_for(results, worktree).action == "skipped"
+        result_for(results, worktree) for worktree in worktrees if result_for(results, worktree).action == "skipped"
     ]
     assert len(blocked) == 1
     assert "daily reap cap ceiling reached (2)" in (blocked[0].reason or "")
@@ -1747,11 +1692,7 @@ def test_merged_pr_same_tree_sibling_head_reaps(
     pr_head = git(repo, "commit-tree", tree, "-p", parent, "-m", "merged pr head")
     patch_gh(
         monkeypatch,
-        {
-            "codex/occupancy-fresh": [
-                {"number": 7067, "state": "MERGED", "headRefOid": pr_head}
-            ]
-        },
+        {"codex/occupancy-fresh": [{"number": 7067, "state": "MERGED", "headRefOid": pr_head}]},
     )
 
     result = result_for(
@@ -1998,9 +1939,7 @@ def test_query_pr_states_accepts_every_real_gh_state(monkeypatch, state) -> None
         ("valid open", '[{"state": "OPEN", "number": 1}]', False),
     ],
 )
-def test_post_task_reap_deletion_authorization_end_to_end(
-    monkeypatch, label, payload, expect_deletion_allowed
-) -> None:
+def test_post_task_reap_deletion_authorization_end_to_end(monkeypatch, label, payload, expect_deletion_allowed) -> None:
     """The destructive authorization itself: ambiguity retains, and a real
     answer still permits reaping."""
     monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
@@ -2089,6 +2028,7 @@ def test_unreadable_branch_query_retains_in_the_legacy_class(
         capture_output=True,
         text=True,
         check=True,
+        timeout=30,
     ).stdout.strip()
 
     monkeypatch.setattr(rw, "_query_pr_states", lambda _repo, _branch: ([], "gh unreadable row"))
@@ -2147,9 +2087,7 @@ def test_aged_build_worktree_is_not_reaped_under_an_unknown_pr_state(
     assert _build_branch_reason(tmp_path, pr_state=None, pr_unknown=True) is None
 
 
-def test_aged_build_worktree_is_not_reaped_while_a_pr_is_open(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_aged_build_worktree_is_not_reaped_while_a_pr_is_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Pre-existing, independent of the unknown-state case: this return
     ignored pr_state entirely, so an aged build/* worktree was reaped even
     when an OPEN PR was plainly visible."""

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -2114,3 +2114,66 @@ def test_unreadable_branch_query_retains_in_the_legacy_class(
 
     assert result.action != "removed", f"deleted on an unreadable PR response: {result.reason}"
     assert worktree.exists()
+
+
+def _build_branch_reason(tmp_path: Path, **kwargs: Any) -> str | None:
+    repo = init_repo(tmp_path)
+    info = rw.WorktreeInfo(path=repo, branch="build/a1-demo", head="abc", detached=False)
+    return rw._qualifying_reason(
+        repo_root=repo,
+        info=info,
+        build_age_hours=24.0,
+        now=time.time(),
+        active_ids=set(),
+        safe_only=False,
+        merged_pr_only=False,
+        include_terminal_dispatches=False,
+        **kwargs,
+    )
+
+
+def test_aged_build_worktree_is_not_reaped_under_an_unknown_pr_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The build-age return carries no ancestry or remote-reachability
+    precondition, so age alone is not evidence the work is safe to destroy.
+
+    Under `--apply --legacy-classes` a failed PR query did not take the early
+    retain path, and this return fired before any PR guard -- deleting an aged
+    build/* worktree that may have had an unseen OPEN PR.
+    """
+    monkeypatch.setattr(rw, "_worktree_age_hours", lambda _p, now=None: 99.0)
+
+    assert _build_branch_reason(tmp_path, pr_state=None, pr_unknown=True) is None
+
+
+def test_aged_build_worktree_is_not_reaped_while_a_pr_is_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-existing, independent of the unknown-state case: this return
+    ignored pr_state entirely, so an aged build/* worktree was reaped even
+    when an OPEN PR was plainly visible."""
+    monkeypatch.setattr(rw, "_worktree_age_hours", lambda _p, now=None: 99.0)
+    open_pr = rw.PullRequestState(number=5, state="OPEN", head_sha="abc")
+
+    assert _build_branch_reason(tmp_path, pr_state=open_pr, pr_unknown=False) is None
+
+
+@pytest.mark.parametrize(
+    ("label", "pr_state"),
+    [
+        ("no PR at all", None),
+        ("merged PR", rw.PullRequestState(number=5, state="MERGED", head_sha="zzz")),
+        ("closed PR", rw.PullRequestState(number=5, state="CLOSED", head_sha="zzz")),
+    ],
+)
+def test_aged_build_worktree_is_still_reaped_when_no_pr_is_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, label: str, pr_state
+) -> None:
+    """The guard must not make aged build worktrees unreapable."""
+    monkeypatch.setattr(rw, "_worktree_age_hours", lambda _p, now=None: 99.0)
+
+    reason = _build_branch_reason(tmp_path, pr_state=pr_state, pr_unknown=False)
+
+    assert reason is not None, label
+    assert "build branch age" in reason

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1950,3 +1950,112 @@ def test_unreadable_rows_make_post_task_reap_retain_the_worktree(monkeypatch, pa
 
     assert no_open_pr is False
     assert guard_error is not None
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("state present but no number", '[{"state": "CLOSED"}]'),
+        ("unrecognised state enum", '[{"state": "NOT_A_GH_PR_STATE", "number": 7126}]'),
+        ("state is not a string", '[{"state": [], "number": 7126}]'),
+        ("number is a bool", '[{"state": "CLOSED", "number": true}]'),
+        ("number is zero", '[{"state": "CLOSED", "number": 0}]'),
+        ("number is a string", '[{"state": "CLOSED", "number": "7126"}]'),
+    ],
+)
+def test_query_pr_states_rejects_incomplete_rows(monkeypatch, label, payload) -> None:
+    """An incomplete or unrecognised row is ambiguous, and ambiguity must not
+    read as "no open PR" -- callers treat that as permission to DELETE."""
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    states, error = rw._query_pr_states(Path("/nonexistent"), "some/branch")
+
+    assert states == [], label
+    assert error is not None, label
+
+
+@pytest.mark.parametrize("state", ["OPEN", "MERGED", "CLOSED"])
+def test_query_pr_states_accepts_every_real_gh_state(monkeypatch, state) -> None:
+    """The tightened validation must not reject legitimate answers, or
+    nothing would ever be reaped."""
+    payload = json.dumps([{"number": 7126, "state": state, "headRefOid": "abc"}])
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    states, error = rw._query_pr_states(Path("/nonexistent"), "some/branch")
+
+    assert error is None
+    assert [(s.number, s.state) for s in states] == [(7126, state)]
+
+
+@pytest.mark.parametrize(
+    ("label", "payload", "expect_deletion_allowed"),
+    [
+        ("incomplete row", '[{"state": "CLOSED"}]', False),
+        ("bogus enum", '[{"state": "WAT", "number": 1}]', False),
+        ("genuinely empty", "[]", True),
+        ("valid closed", '[{"state": "CLOSED", "number": 1}]', True),
+        ("valid merged", '[{"state": "MERGED", "number": 1}]', True),
+        ("valid open", '[{"state": "OPEN", "number": 1}]', False),
+    ],
+)
+def test_post_task_reap_deletion_authorization_end_to_end(
+    monkeypatch, label, payload, expect_deletion_allowed
+) -> None:
+    """The destructive authorization itself: ambiguity retains, and a real
+    answer still permits reaping."""
+    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+
+    no_open_pr, _guard_error = post_task_reap._no_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), branch="some/branch"
+    )
+
+    assert no_open_pr is expect_deletion_allowed, label
+
+
+def test_unreadable_branch_query_retains_even_when_the_sha_lookup_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable authoritative branch response must never end in deletion,
+    even when the supplementary SHA lookup happily returns a MERGED PR.
+
+    Honest scope note: this asserts the OUTCOME (retained), which holds both
+    with and without the `if errors:` change at the candidate-query site --
+    a later cleanup-time re-query independently catches the same condition
+    ("PR guard unavailable during cleanup"). The change removes the reliance
+    on that downstream guard rather than closing a demonstrated deletion;
+    this test pins the outcome so a future refactor of either guard cannot
+    silently turn an unreadable response into a reap.
+    """
+    repo = init_repo(tmp_path)
+    task_id = "sha-redeem-guard"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/sha-redeem-guard", path=worktree)
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: set())
+
+    monkeypatch.setattr(rw, "_query_pr_states", lambda _repo, _branch: ([], "gh unreadable row"))
+    monkeypatch.setattr(
+        rw,
+        "_query_prs_by_head_sha",
+        lambda _repo, _sha: [rw.PullRequestState(number=42, state="MERGED", head_sha="abc")],
+    )
+    monkeypatch.setattr(rw, "_is_ancestor_of_origin_main", lambda _path: False)
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds=set(),
+            merged_pr_only=True,
+            include_terminal_dispatches=True,
+        ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert "PR guard unavailable" in result.reason
+    assert worktree.exists()

--- a/tests/test_fleet_hramatka_hygiene_check.py
+++ b/tests/test_fleet_hramatka_hygiene_check.py
@@ -336,37 +336,166 @@ def test_open_pr_exemption_is_per_branch_not_blanket(hermetic_repo) -> None:
 
 
 def test_unknown_pr_state_still_counts_the_worktree(hermetic_repo) -> None:
-    """The exemption needs a PROVABLE open PR. An unreachable/failing probe
+    """The exemption needs a PROVABLE open PR. A probe that cannot confirm one
     must not excuse a worktree — this gate never passes on a guess."""
     repo_root, tasks_dir = hermetic_repo
     worktree = _add_dispatch_worktree(repo_root, "kimi", "unknown-pr-task")
     _write_task_state(tasks_dir, "unknown-pr-task", "done", worktree)
 
-    def _probe_blows_up(_repo_root: Path, _branch: str | None) -> bool:
-        return False  # what _branch_has_open_pr returns on any failure
-
     receipt = hygiene.hygiene_check(
         reader=_reader_clean(),
-        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_probe_blows_up),
+        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_no_open_prs),
     )
 
     assert receipt["status"] == "stale"
     assert [z["task_id"] for z in receipt["zombie_worktrees"]] == ["unknown-pr-task"]
 
 
-def test_branch_probe_fails_closed_on_subprocess_error(monkeypatch, tmp_path) -> None:
-    """_branch_has_open_pr itself: every failure mode returns False."""
+def test_duplicate_branch_worktrees_are_never_exempted(hermetic_repo) -> None:
+    """One open PR speaks for one checkout. A branch registered by two
+    worktrees leaves both counted, even with an open PR on that branch."""
+    repo_root, tasks_dir = hermetic_repo
+    first = _add_dispatch_worktree(repo_root, "kimi", "dup-task")
+    _write_task_state(tasks_dir, "dup-task", "done", first)
 
-    def _raise(*_args: Any, **_kwargs: Any):
-        raise OSError("gh missing")
+    second = repo_root / ".worktrees" / "dispatch" / "kimi" / "dup-task-copy"
+    _run(["git", "worktree", "add", "--detach", str(second), "kimi/dup-task"], cwd=repo_root)
+    _run(["git", "checkout", "kimi/dup-task", "--ignore-other-worktrees"], cwd=second, check=False)
+    _write_task_state(tasks_dir, "dup-task-copy", "done", second)
 
-    monkeypatch.setattr(hygiene.subprocess, "run", _raise)
-    assert hygiene._branch_has_open_pr(tmp_path, "some/branch") is False
+    receipt = hygiene.hygiene_check(
+        reader=_reader_clean(),
+        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_open_pr_for("kimi/dup-task")),
+    )
+
+    assert receipt["status"] == "stale"
+    assert "dup-task" in {z["task_id"] for z in receipt["zombie_worktrees"]}
 
 
-def test_branch_probe_returns_false_for_detached_worktree(tmp_path) -> None:
+# --- the real _branch_has_open_pr probe (no injected stand-in) -------------
+
+
+def _gh_result(stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _probe_with(monkeypatch, result: Any) -> bool:
+    def _fake_run(*_args: Any, **_kwargs: Any):
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(hygiene.subprocess, "run", _fake_run)
+    return hygiene._branch_has_open_pr(Path("/nonexistent"), "kimi/some-task")
+
+
+_OPEN_ROW = {
+    "number": 7120,
+    "state": "OPEN",
+    "headRefName": "kimi/some-task",
+    "isCrossRepository": False,
+}
+
+
+def test_probe_true_only_for_a_well_formed_open_same_repo_row(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, _gh_result(json.dumps([_OPEN_ROW]))) is True
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("empty list", "[]"),
+        ("null body", "null"),
+        ("object not list", "{}"),
+        ("null row", "[null]"),
+        ("empty row", "[{}]"),
+        ("row is a string", '["open"]'),
+        ("malformed json", "not json"),
+        ("empty stdout", ""),
+    ],
+)
+def test_probe_fails_closed_on_untrusted_payloads(monkeypatch, label: str, payload: str) -> None:
+    """`[{}]` and `[null]` are successful-but-untrusted shapes: a partially
+    understood response is an unknown, and unknowns never exempt."""
+    assert _probe_with(monkeypatch, _gh_result(payload)) is False, label
+
+
+@pytest.mark.parametrize(
+    ("label", "row"),
+    [
+        ("closed state", {**_OPEN_ROW, "state": "CLOSED"}),
+        ("merged state", {**_OPEN_ROW, "state": "MERGED"}),
+        ("state missing", {k: v for k, v in _OPEN_ROW.items() if k != "state"}),
+        ("fork head", {**_OPEN_ROW, "isCrossRepository": True}),
+        ("cross-repo unknown", {k: v for k, v in _OPEN_ROW.items() if k != "isCrossRepository"}),
+        ("different branch", {**_OPEN_ROW, "headRefName": "kimi/other-task"}),
+        ("head missing", {k: v for k, v in _OPEN_ROW.items() if k != "headRefName"}),
+        ("number missing", {k: v for k, v in _OPEN_ROW.items() if k != "number"}),
+        ("number not int", {**_OPEN_ROW, "number": "7120"}),
+        ("number bool", {**_OPEN_ROW, "number": True}),
+        ("number non-positive", {**_OPEN_ROW, "number": 0}),
+    ],
+)
+def test_probe_rejects_rows_that_do_not_bind_to_this_branch(monkeypatch, label, row) -> None:
+    """A same-named branch on a fork, or after a force-push/rename, must not
+    excuse a stale local worktree."""
+    assert _probe_with(monkeypatch, _gh_result(json.dumps([row]))) is False, label
+
+
+def test_probe_one_bad_row_poisons_a_good_one(monkeypatch) -> None:
+    payload = json.dumps([_OPEN_ROW, {}])
+    assert _probe_with(monkeypatch, _gh_result(payload)) is False
+
+
+def test_probe_fails_closed_on_nonzero_exit(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, _gh_result(json.dumps([_OPEN_ROW]), returncode=1)) is False
+
+
+def test_probe_fails_closed_on_timeout(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, subprocess.TimeoutExpired(cmd="gh", timeout=1)) is False
+
+
+def test_probe_fails_closed_on_subprocess_error(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, OSError("gh missing")) is False
+
+
+def test_probe_returns_false_for_detached_worktree() -> None:
     """A detached worktree has no branch identity to probe."""
-    assert hygiene._branch_has_open_pr(tmp_path, None) is False
+    assert hygiene._branch_has_open_pr(Path("/nonexistent"), None) is False
+
+
+def test_probe_queries_an_explicit_repository(monkeypatch) -> None:
+    """Without --repo the answer depends on cwd, so a worktree could be
+    excused by a PR in a different repository."""
+    seen: dict[str, Any] = {}
+
+    def _fake_run(cmd: list[str], **_kwargs: Any):
+        seen["cmd"] = cmd
+        return _gh_result("[]")
+
+    monkeypatch.setattr(hygiene.subprocess, "run", _fake_run)
+    hygiene._branch_has_open_pr(Path("/nonexistent"), "kimi/some-task")
+
+    cmd = seen["cmd"]
+    assert "--repo" in cmd
+    assert cmd[cmd.index("--repo") + 1] == hygiene.PUBLIC_REPOSITORY
+    assert cmd[cmd.index("--head") + 1] == "kimi/some-task"
+
+
+def test_registered_worktree_entries_handles_detached_and_flushes_last(hermetic_repo) -> None:
+    """Detached entries carry no branch, and the final entry must still be
+    emitted after the parse loop ends."""
+    repo_root, _tasks_dir = hermetic_repo
+    detached = repo_root / ".worktrees" / "dispatch" / "kimi" / "detached-task"
+    detached.parent.mkdir(parents=True, exist_ok=True)
+    _run(["git", "worktree", "add", "--detach", str(detached)], cwd=repo_root)
+
+    entries = hygiene._registered_worktree_entries(repo_root)
+
+    assert entries is not None
+    by_name = {path.name: branch for path, branch in entries}
+    assert by_name["detached-task"] is None
+    assert len(entries) == len({path for path, _ in entries})
 
 
 def test_registered_worktree_entries_reports_branches(hermetic_repo) -> None:

--- a/tests/test_fleet_hramatka_hygiene_check.py
+++ b/tests/test_fleet_hramatka_hygiene_check.py
@@ -83,12 +83,28 @@ def hermetic_repo(tmp_path):
     return repo_root, tasks_dir
 
 
+def _no_open_prs(_repo_root: Path, _branch: str | None) -> bool:
+    """Default hermetic PR probe: nothing has an open PR."""
+    return False
+
+
+def _open_pr_for(*branches: str):
+    """PR probe that reports an OPEN PR for exactly ``branches``."""
+    wanted = set(branches)
+
+    def _probe(_repo_root: Path, branch: str | None) -> bool:
+        return branch in wanted
+
+    return _probe
+
+
 def _base_kwargs(repo_root: Path, tasks_dir: Path, **overrides: Any) -> dict[str, Any]:
     kwargs = {
         "repo_root": repo_root,
         "dispatch_worktrees_root": repo_root / ".worktrees" / "dispatch",
         "tasks_dir": tasks_dir,
         "disk_path": repo_root,
+        "open_pr_probe": _no_open_prs,
     }
     kwargs.update(overrides)
     return kwargs
@@ -104,7 +120,9 @@ def test_policy_version_is_a_stable_string() -> None:
 
 def test_receipt_has_every_documented_key(hermetic_repo) -> None:
     repo_root, tasks_dir = hermetic_repo
-    reader = _reader({(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}})
+    reader = _reader(
+        {(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}}
+    )
 
     receipt = hygiene.hygiene_check(reader=reader, **_base_kwargs(repo_root, tasks_dir))
 
@@ -117,7 +135,9 @@ def test_receipt_has_every_documented_key(hermetic_repo) -> None:
 
 def test_verified_when_epic_clean_pointer_present_no_zombies(hermetic_repo) -> None:
     repo_root, tasks_dir = hermetic_repo
-    reader = _reader({(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}})
+    reader = _reader(
+        {(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}}
+    )
 
     receipt = hygiene.hygiene_check(reader=reader, **_base_kwargs(repo_root, tasks_dir))
 
@@ -130,7 +150,9 @@ def test_verified_when_epic_clean_pointer_present_no_zombies(hermetic_repo) -> N
 
 def test_cli_exit_zero_on_verified(hermetic_repo, capsys) -> None:
     repo_root, tasks_dir = hermetic_repo
-    reader = _reader({(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}})
+    reader = _reader(
+        {(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}}
+    )
 
     exit_code = hygiene.main(
         [
@@ -247,7 +269,9 @@ def test_cli_exit_two_on_unknown(hermetic_repo, capsys) -> None:
 
 
 def _reader_clean() -> hygiene.IssueReader:
-    return _reader({(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}})
+    return _reader(
+        {(PUBLIC, EPIC): {"number": EPIC, "body": CLEAN_BODY}, (PRIVATE, BOARD): {"number": BOARD, "body": ""}}
+    )
 
 
 def test_stale_when_terminal_task_worktree_still_registered(hermetic_repo) -> None:
@@ -272,6 +296,88 @@ def test_not_zombie_when_task_still_running(hermetic_repo) -> None:
 
     assert receipt["status"] == "verified"
     assert receipt["zombie_worktrees"] == []
+
+
+def test_terminal_worktree_with_open_pr_is_not_a_zombie(hermetic_repo) -> None:
+    """post_task_reap deliberately RETAINS a terminal-task worktree whose
+    branch still has an open PR ("open PR present for bound worktree branch").
+    Counting it here would demand a state the sanctioned reaper refuses to
+    produce, holding the gate at `stale` for as long as any lane has a PR in
+    flight."""
+    repo_root, tasks_dir = hermetic_repo
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pr-open-task")
+    _write_task_state(tasks_dir, "pr-open-task", "done", worktree)
+
+    receipt = hygiene.hygiene_check(
+        reader=_reader_clean(),
+        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_open_pr_for("kimi/pr-open-task")),
+    )
+
+    assert receipt["status"] == "verified"
+    assert receipt["zombie_worktrees"] == []
+
+
+def test_open_pr_exemption_is_per_branch_not_blanket(hermetic_repo) -> None:
+    """Only the branch with the open PR is exempt; a sibling terminal
+    worktree without one is still reported."""
+    repo_root, tasks_dir = hermetic_repo
+    kept = _add_dispatch_worktree(repo_root, "kimi", "pr-open-task")
+    _write_task_state(tasks_dir, "pr-open-task", "done", kept)
+    orphan = _add_dispatch_worktree(repo_root, "agy", "no-pr-task")
+    _write_task_state(tasks_dir, "no-pr-task", "failed", orphan)
+
+    receipt = hygiene.hygiene_check(
+        reader=_reader_clean(),
+        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_open_pr_for("kimi/pr-open-task")),
+    )
+
+    assert receipt["status"] == "stale"
+    assert [z["task_id"] for z in receipt["zombie_worktrees"]] == ["no-pr-task"]
+
+
+def test_unknown_pr_state_still_counts_the_worktree(hermetic_repo) -> None:
+    """The exemption needs a PROVABLE open PR. An unreachable/failing probe
+    must not excuse a worktree — this gate never passes on a guess."""
+    repo_root, tasks_dir = hermetic_repo
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "unknown-pr-task")
+    _write_task_state(tasks_dir, "unknown-pr-task", "done", worktree)
+
+    def _probe_blows_up(_repo_root: Path, _branch: str | None) -> bool:
+        return False  # what _branch_has_open_pr returns on any failure
+
+    receipt = hygiene.hygiene_check(
+        reader=_reader_clean(),
+        **_base_kwargs(repo_root, tasks_dir, open_pr_probe=_probe_blows_up),
+    )
+
+    assert receipt["status"] == "stale"
+    assert [z["task_id"] for z in receipt["zombie_worktrees"]] == ["unknown-pr-task"]
+
+
+def test_branch_probe_fails_closed_on_subprocess_error(monkeypatch, tmp_path) -> None:
+    """_branch_has_open_pr itself: every failure mode returns False."""
+
+    def _raise(*_args: Any, **_kwargs: Any):
+        raise OSError("gh missing")
+
+    monkeypatch.setattr(hygiene.subprocess, "run", _raise)
+    assert hygiene._branch_has_open_pr(tmp_path, "some/branch") is False
+
+
+def test_branch_probe_returns_false_for_detached_worktree(tmp_path) -> None:
+    """A detached worktree has no branch identity to probe."""
+    assert hygiene._branch_has_open_pr(tmp_path, None) is False
+
+
+def test_registered_worktree_entries_reports_branches(hermetic_repo) -> None:
+    repo_root, _tasks_dir = hermetic_repo
+    _add_dispatch_worktree(repo_root, "kimi", "branch-task")
+
+    entries = hygiene._registered_worktree_entries(repo_root)
+
+    assert entries is not None
+    by_name = {path.name: branch for path, branch in entries}
+    assert by_name["branch-task"] == "kimi/branch-task"
 
 
 def test_unbound_worktree_is_not_flagged_zombie(hermetic_repo) -> None:


### PR DESCRIPTION
## Problem

`hramatka_hygiene_check` is the closeout gate a Hramatka driver must run before declaring a handoff verified-clean (exit 0 `verified` / 1 `stale` / 2 `unknown`). It flagged **every** dispatch worktree bound to a terminal task as an orphan, with no exemption for one whose branch still has an open PR.

`post_task_reap` — the sanctioned removal path — deliberately **retains** exactly that worktree:

```
"action": "retained", "reason": "open PR present for bound worktree branch"
```

So the gate demanded a state the reaper refuses to produce. Any lane holding a merged-pending PR pinned the gate at `stale` indefinitely, and no sanctioned action could clear it.

Observed live this session:

```
$ .venv/bin/python -m scripts.fleet.hramatka_hygiene_check
status: stale | reasons: ['1 orphan dispatch worktree(s) bound to finished tasks']
zombies: ['infra-7083-delegate-join']     # kimi worktree, open PR #7120
```

Two genuinely reapable orphans were removed first via `post_task_reap --apply`; the third could not be, by design. A handoff predicate that cannot pass during ordinary fleet operation stops being load-bearing — it gets ignored, which is worse than not having it.

## Fix

Mirror the reaper's rule **without importing it**. The module's docstring records a deliberate no-hard-dependency on the PR-2 scope gate and PR-3 reaper bodies "so this gate has no hard dependency on either PR's merge order", so the probe is local, matching how `_TERMINAL_STATUSES` is already duplicated rather than imported.

- `_registered_worktree_entries()` parses `(path, branch)` from `git worktree list --porcelain`; `_registered_worktrees()` stays as a thin wrapper so existing callers are untouched.
- `_branch_has_open_pr()` returns True **only** on a provable open PR.
- `_detect_zombie_worktrees()` skips a terminal-task worktree whose branch has one.

### The exemption fails closed — in the opposite direction from the reaper

This is the part that keeps the gate strict. `post_task_reap` fails closed toward *not deleting* (unknown PR state → retain). This gate fails closed toward *not passing*: an unreachable `gh`, a non-zero exit, malformed JSON, or a detached worktree all return False, so the worktree stays counted. The gate never hands out a verified-clean handoff on an unknown — consistent with its existing `unknown` (exit 2) posture for GitHub outages.

`open_pr_probe` is injectable (`OpenPrProbe`), mirroring the existing `IssueReader` seam, so tests stay hermetic with no live `gh`.

## Verification

```
$ .venv/bin/python -m pytest tests/test_fleet_hramatka_hygiene_check.py -q
26 passed in 0.73s

$ .venv/bin/python -m ruff check scripts/fleet/hramatka_hygiene_check.py tests/test_fleet_hramatka_hygiene_check.py
All checks passed!
$ .venv/bin/python -m ruff format --check <same two files>
2 files already formatted

$ .venv/bin/python -m pytest tests/ -q -k "hramatka or post_task_reap or reap_worktrees" --ignore=tests/wiki
1 failed, 219 passed, 1 skipped
```

Against the live checkout after the change: **`status: verified`, `reasons: []`, `zombies: []`** — the open-PR worktree correctly exempt.

Six tests added: the exemption itself; that it is per-branch and not blanket (a sibling terminal worktree with no PR is still reported); that an unknown PR state still counts the worktree; `_branch_has_open_pr` fail-closed on `OSError` and on a detached (None) branch; and branch parsing.

### Pre-existing failure, not from this branch

The one failure above is `tests/test_fleet_taxonomy_aliases.py::test_session_setup_hook_epic_validation_contract[hramatka-valid…]`. It is red on clean `main` at `1eb9410d9` with this branch absent, and this diff touches only the three files listed. Root-caused while checking (the SessionStart hook hangs past 120s under the test's hermetic env, so stdout is empty and `json.loads` fails) and filed separately as **#7125** — it is a hook-wide timeout audit in infra-owned code, not this PR's scope.

## Docs

`docs/runbooks/hramatka-driver-queue.md` documents the `stale` conditions verbatim, so the exemption and its fail-closed requirement are recorded there too.
