### PR TITLE
fix(dashboards): honest Actionable view when OPEN_GITHUB rows are filtered (#7084)

### DIFF
--- a/dashboards/work.html
+++ b/dashboards/work.html
@@ -72,6 +72,28 @@ button, input, select { font: inherit; }
 .detail dd { margin: 2px 0 0; font-size: 13px; line-height: 1.4; overflow-wrap: anywhere; }
 .empty, .error { color: var(--text3); font-size: 13px; line-height: 1.5; padding: 18px 14px; }
 .error { background: rgba(156, 40, 40, .08); border-left: 3px solid var(--red); color: var(--red); margin: 0 0 14px; }
+.actionable-banner {
+  align-items: center;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--blue);
+  color: var(--text2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  line-height: 1.4;
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  font-size: 12px;
+}
+.actionable-banner strong { color: var(--text); }
+.actionable-banner a, .actionable-banner button, .empty a {
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: underline;
+}
 .source-strip { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 0 0 16px; }
 .source-card { background: var(--bg2); border: 1px solid var(--border); padding: 11px 12px; }
 .source-card strong { display: block; font-size: 13px; }
@@ -212,6 +234,8 @@ button, input, select { font: inherit; }
     </div>
   </section>
 
+  <div id="actionable-banner" class="actionable-banner hidden" role="status"></div>
+
   <section class="layout">
     <article class="panel" aria-labelledby="attention-heading">
       <div class="panel-head">
@@ -278,10 +302,14 @@ button, input, select { font: inherit; }
     selectedIndex: -1,
     privateStatusText: 'Checking capability…',
     publicStatusOverride: null,
+    filteredCount: 0,
+    totalMatching: 0,
+    currentView: 'actionable',
   };
 
   const els = {
     error: document.getElementById('error-banner'),
+    actionableBanner: document.getElementById('actionable-banner'),
     list: document.getElementById('attention-list'),
     detail: document.getElementById('detail-panel'),
     publicMeta: document.getElementById('source-public-meta'),
@@ -728,10 +756,9 @@ button, input, select { font: inherit; }
   }
 
   function applyLocalFilters(projection, filters) {
-    if (!projection) return { items: [], attention: [] };
+    if (!projection) return { items: [], attention: [], filteredCount: 0, totalMatching: 0 };
     const view = filters.view || 'actionable';
-    const items = (projection.items || []).filter((item) => {
-      if (view === 'actionable' && !isActionable(item)) return false;
+    const baseItems = (projection.items || []).filter((item) => {
       if (filters.health && item.health !== filters.health) return false;
       if (filters.kind && item.resource_kind !== filters.kind) return false;
       if (filters.lifecycle && item.lifecycle !== filters.lifecycle) return false;
@@ -743,9 +770,49 @@ button, input, select { font: inherit; }
       }
       return true;
     });
+    const items = view === 'actionable'
+      ? baseItems.filter((item) => isActionable(item))
+      : baseItems;
+    const filteredCount = view === 'actionable'
+      ? (baseItems.length - items.length)
+      : 0;
     const idSet = new Set(items.map((i) => i.work_id));
     const attention = (projection.attention || []).filter((row) => idSet.has(row.work_id));
-    return { items: items, attention: attention };
+    return { items: items, attention: attention, filteredCount: filteredCount, totalMatching: baseItems.length };
+  }
+
+  function allViewUrl() {
+    const filters = controlsToFilters();
+    filters.view = 'all';
+    const safe = shareableFilters(filters);
+    const params = new URLSearchParams();
+    Object.keys(safe).sort().forEach((key) => params.set(key, safe[key]));
+    const qs = params.toString();
+    return qs ? (window.location.pathname + '?' + qs) : window.location.pathname;
+  }
+
+  function renderActionableBanner() {
+    if (!els.actionableBanner) return;
+    if (state.currentView !== 'actionable' || state.filteredCount <= 0) {
+      els.actionableBanner.classList.add('hidden');
+      els.actionableBanner.innerHTML = '';
+      return;
+    }
+    const count = state.filteredCount;
+    const total = state.totalMatching;
+    const url = allViewUrl();
+    els.actionableBanner.classList.remove('hidden');
+    els.actionableBanner.innerHTML =
+      '<span>Actionable view filtered out <strong>' + count + '</strong> non-actionable item' + (count === 1 ? '' : 's') + ' (on-track / no urgent action, e.g. OPEN_GITHUB).</span>' +
+      '<a href="' + escapeAttr(url) + '" id="actionable-view-all-link">Switch to All (' + total + ')</a>';
+    const link = els.actionableBanner.querySelector('#actionable-view-all-link');
+    if (link) {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (els.view) els.view.value = 'all';
+        refilterOnly();
+      });
+    }
   }
 
   function railClasses(item) {
@@ -770,6 +837,19 @@ button, input, select { font: inherit; }
     if (!attention.length) {
       if (!state.merged) {
         els.list.innerHTML = '<div class="empty">No source projection is available. Retry refresh.</div>';
+      } else if (state.currentView === 'actionable' && state.filteredCount > 0) {
+        const count = state.filteredCount;
+        const total = state.totalMatching;
+        const url = allViewUrl();
+        els.list.innerHTML = '<div class="empty">No actionable items require immediate attention. <strong>' + count + '</strong> non-actionable item' + (count === 1 ? '' : 's') + ' filtered out (e.g. ON_TRACK / OPEN_GITHUB). <a href="' + escapeAttr(url) + '" id="empty-view-all-link">Switch to All (' + total + ')</a> to inspect all work.</div>';
+        const emptyLink = els.list.querySelector('#empty-view-all-link');
+        if (emptyLink) {
+          emptyLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            if (els.view) els.view.value = 'all';
+            refilterOnly();
+          });
+        }
       } else {
         els.list.innerHTML = '<div class="empty">No attention items for the current public-safe filters. Sources may be empty or degraded — check the source strip.</div>';
       }
@@ -855,6 +935,10 @@ button, input, select { font: inherit; }
     const den = (projection && projection.denominator) || {};
     const pubSections = pub.sections || {};
     const pubStatus = publicStatusOverride || pub.status || '—';
+    const rankedCount = state.attention ? state.attention.length : ((projection.attention || []).length);
+    const metaSuffix = (state.currentView === 'actionable' && state.filteredCount > 0)
+      ? (' (' + state.filteredCount + ' filtered out)')
+      : '';
     if (projection && pub.source_id === PUBLIC_SOURCE_ID) {
       els.publicMeta.textContent = [
         'status=' + pubStatus,
@@ -865,10 +949,10 @@ button, input, select { font: inherit; }
         'class4 d1=' + (den.class4 && den.class4.delegate_active) + ' d2=' + (den.class4 && den.class4.delegate_tasks) + ' r1=' + (den.class4 && den.class4.fleet_reviews),
       ].join(' · ');
       els.foundation.textContent = projection.foundation_status || 'FOUNDATION_COMPLETE';
-      els.attentionMeta.textContent = (state.attention ? state.attention.length : ((projection.attention || []).length)) + ' ranked · cache ' + (projection.cache_age_s ?? 0) + 's';
+      els.attentionMeta.textContent = rankedCount + ' ranked' + metaSuffix + ' · cache ' + (projection.cache_age_s ?? 0) + 's';
     } else if (projection) {
       els.foundation.textContent = projection.foundation_status || 'FOUNDATION_COMPLETE';
-      els.attentionMeta.textContent = (state.attention ? state.attention.length : ((projection.attention || []).length)) + ' ranked · cache ' + (projection.cache_age_s ?? 0) + 's';
+      els.attentionMeta.textContent = rankedCount + ' ranked' + metaSuffix + ' · cache ' + (projection.cache_age_s ?? 0) + 's';
       if (publicStatusOverride) {
         els.publicMeta.textContent = 'status=' + publicStatusOverride;
       }
@@ -1035,6 +1119,9 @@ button, input, select { font: inherit; }
     const filtered = applyLocalFilters(projection, filters);
     state.itemsById = new Map(filtered.items.map((i) => [i.work_id, i]));
     state.attention = filtered.attention;
+    state.filteredCount = filtered.filteredCount || 0;
+    state.totalMatching = filtered.totalMatching || 0;
+    state.currentView = filters.view || 'actionable';
     if (state.selectedId && state.itemsById.has(state.selectedId)) {
       state.selectedIndex = state.attention.findIndex((a) => a.work_id === state.selectedId);
     } else if (state.attention.length) {
@@ -1045,6 +1132,7 @@ button, input, select { font: inherit; }
       state.selectedId = null;
     }
     renderSources(projection, state.privateStatusText, state.publicStatusOverride);
+    renderActionableBanner();
     renderList();
     renderDetail(state.selectedId ? state.itemsById.get(state.selectedId) : null);
   }
@@ -1144,6 +1232,9 @@ button, input, select { font: inherit; }
     state.attention = [];
     state.selectedId = null;
     state.selectedIndex = -1;
+    state.filteredCount = 0;
+    state.totalMatching = 0;
+    renderActionableBanner();
     const pubCode = publicFail === 'schema_mismatch' ? 'schema_mismatch' : 'unreachable';
     const privCode = privateFail || 'unreachable';
     showError('Work projection unavailable · public=' + pubCode + ' · private=' + privCode);

--- a/tests/test_work_actionable_honesty.py
+++ b/tests/test_work_actionable_honesty.py
@@ -1,0 +1,291 @@
+"""Static + behavioral contracts for #7084 Work dashboard actionable view honesty.
+
+Ensures the default view=actionable explains filtered-out non-actionable items
+(such as ON_TRACK + OPEN_GITHUB issues) and provides a link to view=all without
+modifying the #6850 isActionable deny-list semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORK = ROOT / "dashboards" / "work.html"
+
+
+def test_actionable_honesty_banner_and_controls_present_in_work_html():
+    """#7084: Actionable default must include honesty banner, copy, and link to All."""
+    html = WORK.read_text(encoding="utf-8")
+    assert 'id="actionable-banner"' in html
+    assert 'class="actionable-banner' in html or "class='actionable-banner" in html
+    assert ".actionable-banner" in html
+    assert "renderActionableBanner" in html
+    assert "allViewUrl" in html
+    assert "filtered out" in html
+    assert "non-actionable" in html
+    assert "Switch to All" in html
+    assert "actionable-view-all-link" in html
+    assert "filteredCount" in html
+    assert "totalMatching" in html
+
+
+def test_actionable_view_behavioral_js_filtering_and_counts():
+    """#7084: Evaluate applyLocalFilters and banner generation in Node against mixed datasets."""
+    if shutil.which("node") is None:
+        pytest.skip("node required for JS behavioral check")
+
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync(__HTML_PATH__, 'utf8');
+
+    // Extract constants and functions
+    const codeStart = html.indexOf('const NON_ACTIONABLE_ACTION_CODES');
+    const codeEnd = html.indexOf('function railClasses(');
+    if (codeStart < 0 || codeEnd <= codeStart) {
+      throw new Error('Required JS functions not found in work.html');
+    }
+    eval(html.slice(codeStart, codeEnd));
+
+    const sampleProjection = {
+      schema_version: 'work-projection.v1',
+      cache_age_s: 10,
+      sources: [{ source_id: 'public-monitor', status: 'ok' }],
+      items: [
+        {
+          work_id: 'wp1:public-monitor:repo:pr:1',
+          resource_kind: 'pr',
+          remote_id: '1',
+          health: 'AT_RISK',
+          safe_next_action: { code: 'FIX_CI' },
+        },
+        {
+          work_id: 'wp1:public-monitor:repo:issue:7073',
+          resource_kind: 'issue',
+          remote_id: '7073',
+          health: 'ON_TRACK',
+          safe_next_action: { code: 'OPEN_GITHUB' },
+        },
+        {
+          work_id: 'wp1:public-monitor:repo:issue:7074',
+          resource_kind: 'issue',
+          remote_id: '7074',
+          health: 'ON_TRACK',
+          safe_next_action: { code: 'OPEN_GITHUB' },
+        },
+        {
+          work_id: 'wp1:public-monitor:repo:task:100',
+          resource_kind: 'task',
+          remote_id: '100',
+          health: 'UNKNOWN',
+          safe_next_action: { code: 'INSPECT_UNKNOWN' },
+        },
+      ],
+      attention: [
+        { work_id: 'wp1:public-monitor:repo:pr:1', health: 'AT_RISK' },
+        { work_id: 'wp1:public-monitor:repo:task:100', health: 'UNKNOWN' },
+        { work_id: 'wp1:public-monitor:repo:issue:7073', health: 'ON_TRACK' },
+        { work_id: 'wp1:public-monitor:repo:issue:7074', health: 'ON_TRACK' },
+      ],
+    };
+
+    // Scenario 1: default view=actionable
+    const actResult = applyLocalFilters(sampleProjection, { view: 'actionable' });
+
+    // Scenario 2: view=all
+    const allResult = applyLocalFilters(sampleProjection, { view: 'all' });
+
+    // Scenario 3: all items non-actionable
+    const nonActProjection = {
+      items: [
+        { work_id: 'wp1:a', health: 'ON_TRACK', safe_next_action: { code: 'OPEN_GITHUB' } },
+        { work_id: 'wp1:b', health: 'ON_TRACK', safe_next_action: { code: 'OPEN_GITHUB' } },
+      ],
+      attention: [
+        { work_id: 'wp1:a', health: 'ON_TRACK' },
+        { work_id: 'wp1:b', health: 'ON_TRACK' },
+      ],
+    };
+    const emptyActResult = applyLocalFilters(nonActProjection, { view: 'actionable' });
+
+    // Scenario 4: truly empty projection
+    const emptyProjection = { items: [], attention: [] };
+    const emptyResult = applyLocalFilters(emptyProjection, { view: 'actionable' });
+
+    const out = {
+      actItemsCount: actResult.items.length,
+      actFilteredCount: actResult.filteredCount,
+      actTotalMatching: actResult.totalMatching,
+      actItemIds: actResult.items.map(i => i.work_id),
+      allItemsCount: allResult.items.length,
+      allFilteredCount: allResult.filteredCount,
+      allTotalMatching: allResult.totalMatching,
+      emptyActItemsCount: emptyActResult.items.length,
+      emptyActFilteredCount: emptyActResult.filteredCount,
+      emptyActTotalMatching: emptyActResult.totalMatching,
+      trulyEmptyFilteredCount: emptyResult.filteredCount,
+      trulyEmptyTotalMatching: emptyResult.totalMatching,
+    };
+    console.log(JSON.stringify(out));
+    """.replace("__HTML_PATH__", json.dumps(str(WORK)))
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    out = json.loads(result.stdout)
+
+    # In default actionable view: 1 actionable item, 3 non-actionable filtered out, 4 total
+    assert out["actItemsCount"] == 1
+    assert out["actFilteredCount"] == 3
+    assert out["actTotalMatching"] == 4
+    assert out["actItemIds"] == ["wp1:public-monitor:repo:pr:1"]
+
+    # In all view: 4 items shown, 0 filtered out, 4 total
+    assert out["allItemsCount"] == 4
+    assert out["allFilteredCount"] == 0
+    assert out["allTotalMatching"] == 4
+
+    # When all items are non-actionable: 0 items shown, 2 filtered out, 2 total
+    assert out["emptyActItemsCount"] == 0
+    assert out["emptyActFilteredCount"] == 2
+    assert out["emptyActTotalMatching"] == 2
+
+    # When projection is empty: 0 items shown, 0 filtered out, 0 total
+    assert out["trulyEmptyFilteredCount"] == 0
+    assert out["trulyEmptyTotalMatching"] == 0
+
+
+def test_actionable_banner_and_empty_state_dom_behavior():
+    """#7084: Test renderActionableBanner and empty list state formatting in Node."""
+    if shutil.which("node") is None:
+        pytest.skip("node required for JS DOM check")
+
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync(__HTML_PATH__, 'utf8');
+
+    // Mock minimal DOM and state before eval
+    const bannerEl = {
+      classList: {
+        classes: new Set(['hidden']),
+        add(c) { this.classes.add(c); },
+        remove(c) { this.classes.delete(c); },
+        contains(c) { return this.classes.has(c); },
+      },
+      innerHTML: '',
+      querySelector(sel) { return null; },
+    };
+
+    const listEl = {
+      innerHTML: '',
+      removeAttribute(attr) {},
+      querySelectorAll(sel) { return []; },
+      querySelector(sel) { return null; },
+    };
+
+    const mockElements = {
+      'actionable-banner': bannerEl,
+      'attention-list': listEl,
+      'filter-view': { value: 'actionable' },
+      'filter-health': { value: '' },
+      'filter-kind': { value: '' },
+      'filter-lifecycle': { value: '' },
+      'filter-orphan': { value: '' },
+      'filter-source': { value: '' },
+      'filter-repo': { value: '' },
+    };
+
+    global.document = {
+      getElementById(id) {
+        return mockElements[id] || { classList: { add() {}, remove() {}, contains() { return false; } }, textContent: '' };
+      },
+    };
+
+    global.window = {
+      location: { pathname: '/work.html', search: '' },
+      history: { replaceState() {} },
+    };
+
+    // Extract constants and functions up to event listeners
+    const codeStart = html.indexOf('const ALLOWED_FILTER_KEYS');
+    const codeEnd = html.indexOf("document.getElementById('btn-refresh')");
+    if (codeStart < 0 || codeEnd <= codeStart) {
+      throw new Error('Required JS functions not found in work.html');
+    }
+
+    const testSnippet = `
+      state.currentView = 'actionable';
+      state.filteredCount = 583;
+      state.totalMatching = 595;
+      state.attention = [];
+      state.merged = {};
+      state.itemsById = new Map();
+
+      renderActionableBanner();
+      const bannerVisible = !bannerEl.classList.contains('hidden');
+      const bannerHtml = bannerEl.innerHTML;
+
+      renderList();
+      const listEmptyHtml = listEl.innerHTML;
+
+      state.currentView = 'all';
+      state.filteredCount = 0;
+      renderActionableBanner();
+      const bannerHiddenOnAll = bannerEl.classList.contains('hidden');
+
+      console.log(JSON.stringify({
+        bannerVisible,
+        bannerHtml,
+        listEmptyHtml,
+        bannerHiddenOnAll,
+      }));
+    `;
+    eval(html.slice(codeStart, codeEnd) + '\\n' + testSnippet);
+    """.replace("__HTML_PATH__", json.dumps(str(WORK)))
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    out = json.loads(result.stdout)
+
+    assert out["bannerVisible"] is True
+    assert "583" in out["bannerHtml"]
+    assert "Switch to All (595)" in out["bannerHtml"]
+    assert "OPEN_GITHUB" in out["bannerHtml"] or "non-actionable" in out["bannerHtml"]
+    assert "actionable-view-all-link" in out["bannerHtml"]
+
+    assert "No actionable items" in out["listEmptyHtml"]
+    assert "583" in out["listEmptyHtml"]
+    assert "Switch to All" in out["listEmptyHtml"]
+
+    assert out["bannerHiddenOnAll"] is True
+
+
+def test_server_ssot_deny_list_preserves_open_github():
+    """#6850 deny-list still includes OPEN_GITHUB and maintains expected truth table."""
+    from scripts.work.attention import NON_ACTIONABLE_ACTION_CODES, is_actionable
+
+    assert "OPEN_GITHUB" in NON_ACTIONABLE_ACTION_CODES
+    assert "INSPECT_UNKNOWN" in NON_ACTIONABLE_ACTION_CODES
+    assert "NONE" in NON_ACTIONABLE_ACTION_CODES
+
+    # ON_TRACK + OPEN_GITHUB remains non-actionable (must not be pick-list work)
+    assert not is_actionable({"health": "ON_TRACK", "safe_next_action": {"code": "OPEN_GITHUB"}})
+    # UNKNOWN + OPEN_GITHUB is non-actionable
+    assert not is_actionable({"health": "UNKNOWN", "safe_next_action": {"code": "OPEN_GITHUB"}})
+    # AT_RISK or OFF_TRACK demands attention regardless of action code
+    assert is_actionable({"health": "AT_RISK", "safe_next_action": {"code": "OPEN_GITHUB"}})
+    assert is_actionable({"health": "OFF_TRACK", "safe_next_action": {"code": "OPEN_GITHUB"}})
+    assert is_actionable({"health": "OFF_TRACK", "safe_next_action": {"code": "NONE"}})

--- a/tests/test_work_dashboard.py
+++ b/tests/test_work_dashboard.py
@@ -293,3 +293,12 @@ def test_work_page_actionable_predicate_behavioral_js_parity():
     # Explicit kill for the boolean-inversion residual the substring scan misses.
     assert expected[fixtures.index({"health": "ON_TRACK", "safe_next_action": {"code": "NONE"}})] is False
     assert expected[fixtures.index({"health": "ON_TRACK", "safe_next_action": {"code": "MERGE_WHEN_READY"}})] is True
+
+
+def test_work_page_actionable_honesty_banner_contract():
+    """#7084: Actionable default provides honesty banner and switch to all view."""
+    html = WORK.read_text(encoding="utf-8")
+    assert 'id="actionable-banner"' in html
+    assert "renderActionableBanner" in html
+    assert "actionable-view-all-link" in html
+    assert "filteredCount" in html


### PR DESCRIPTION
## Summary
Default `/work.html` Actionable view no longer reads as an empty day when today's `ON_TRACK` + `OPEN_GITHUB` issues are filtered by the #6850 `isActionable` deny-list. Banner + empty-state copy state the filtered count and link to `view=all`. Predicate unchanged (`OPEN_GITHUB` stays non-actionable).

## Test plan
- [x] `pytest tests/test_work_actionable_honesty.py tests/test_work_dashboard.py` (18 passed)
- [x] ruff on touched tests
- [ ] CI Gate + fastlane

Refs #7084

X-Agent: grok-infra