### PR TITLE
fix(api): routing-budget honesty when USD ledger empty but runtime usage exists (#7085)

### DIFF
--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -230,13 +230,24 @@ function renderSummary(routing, usage, delegates) {
   `;
 }
 
-function renderBudget(routing) {
+function renderBudget(routing, usage) {
   const agents = routing.agents || {};
+  const diag = routing.diagnostics || {};
+  const ledgerEmpty = diag.budget_ledger_empty === true || Number(diag.records_loaded || 0) === 0;
+  const runtimeRecords = Number(diag.runtime_usage_records_7d ?? (usage || {}).records_total ?? 0);
+  const ledgerNote = ledgerEmpty
+    ? (runtimeRecords > 0
+      ? `<div class="sub" style="margin-bottom:8px">USD budget ledger is empty — 7d burn/headroom unknown. Runtime usage exists (${runtimeRecords} call(s) in 7d); see Runtime Agents below.</div>`
+      : `<div class="sub" style="margin-bottom:8px">USD budget ledger is empty — 7d burn/headroom unknown; no runtime usage records this week either.</div>`)
+    : '';
+  const unavailableTitle = ledgerEmpty
+    ? 'Burn unknown — USD budget ledger empty'
+    : 'Capacity unavailable';
   const rows = Object.entries(agents).map(([name, data]) => {
     const isUnavailable = data.status === 'unavailable' || data.burn_pct_7d == null || typeof data.burn_pct_7d !== 'number';
     const burnStr = isUnavailable ? 'unavailable' : `${Number(data.burn_pct_7d).toFixed(1)}%`;
     const barCell = isUnavailable
-      ? '<div class="bar unavailable" title="Capacity unavailable"><span style="width:100%"></span></div>'
+      ? `<div class="bar unavailable" title="${escapeHtml(unavailableTitle)}"><span style="width:100%"></span></div>`
       : `<div class="bar"><span style="width:${pct(data.burn_pct_7d)}%"></span></div>`;
     const cap = data.weekly_cap_usd == null ? 'n/a' : `$${Number(data.weekly_cap_usd).toFixed(0)}`;
     return `<tr>
@@ -248,7 +259,7 @@ function renderBudget(routing) {
       <td>${escapeHtml((routing.in_flight || {})[name] ?? 0)}</td>
     </tr>`;
   }).join('');
-  document.getElementById('budget-table').innerHTML = `<table>
+  document.getElementById('budget-table').innerHTML = `${ledgerNote}<table>
     <tr><th>Agent</th><th>Status</th><th>7d Burn</th><th>Headroom</th><th>Weekly Cap</th><th>In Flight</th></tr>
     ${rows || '<tr><td colspan="6">No budget data.</td></tr>'}
   </table>`;
@@ -300,7 +311,7 @@ async function loadRouting() {
       fetchJson(ENDPOINTS.delegates)
     ]);
     renderSummary(routing, usage, delegates);
-    renderBudget(routing);
+    renderBudget(routing, usage);
     renderAgents(agents, usage);
     renderDelegates(delegates);
     status.textContent = `Updated ${new Date().toLocaleTimeString()}`;

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -63,6 +63,7 @@ from . import preparation_state
 from .codexbar_usage import get_provider_usage_data, refresh_provider_usage_data, trigger_background_refresh
 from .config import CURRICULUM_ROOT, LEVELS, LIVE_REPO_ROOT, PROJECT_ROOT
 from .lane_health import compute_lane_health
+from .runtime_router import summarize_runtime_usage
 
 try:
     from agent_runtime.usage import summarize_lane_runtime
@@ -585,6 +586,25 @@ def _recommend_agent(
     }
 
 
+def _runtime_usage_records_7d() -> int | None:
+    """Count agent-runtime usage rows over the same 7-day window served by
+    ``GET /api/runtime/usage?days=7``. Returns None when the probe itself fails.
+
+    The USD cost ledger can be empty while runtime usage exists; diagnostics
+    must say so instead of reporting ``runtime_data_available=false`` just
+    because the 5-minute reactive window (``summarize_lane_runtime``) is quiet.
+    """
+    try:
+        summary = summarize_runtime_usage(days=7)
+    except Exception as exc:  # never break routing-budget on telemetry I/O
+        logging.getLogger("state_router").debug("runtime usage probe failed: %s", exc)
+        return None
+    try:
+        return int(summary.get("records_total") or 0)
+    except (TypeError, ValueError):
+        return None
+
+
 def compute_routing_budget(
     now: datetime | None = None,
     *,
@@ -595,6 +615,7 @@ def compute_routing_budget(
     today = current_time.date()
     window_start = current_time - timedelta(days=7)
     budgets, warnings = _load_agent_budgets()
+    runtime_records_7d = _runtime_usage_records_7d()
     extras = _load_budget_extras(budgets)
     reset_hours = extras["reset_imminent_hours"]
     resets_at = _next_weekly_reset(current_time)
@@ -694,6 +715,9 @@ def compute_routing_budget(
                 "stale": False,
                 "data_age_s": None,
                 "stale_threshold_s": 900,
+                "budget_ledger_empty": True,
+                "runtime_data_available": bool(runtime_records_7d),
+                "runtime_usage_records_7d": runtime_records_7d,
             },
             "ranked_by_headroom": ranked,
         }
@@ -983,6 +1007,16 @@ def compute_routing_budget(
         is_stale = cb_stale
         data_age_s = cb_max_age_s
 
+    # Honest availability: the 5-minute reactive window can be quiet while
+    # the 7-day runtime usage log (what /api/runtime/usage serves) has rows.
+    runtime_data_available = runtime_sourced_any or bool(runtime_records_7d)
+    if not records and runtime_records_7d:
+        warnings.append(
+            f"USD cost ledger empty (records_loaded=0) but runtime usage has "
+            f"{runtime_records_7d} record(s) in 7d — ledger burn unavailable, "
+            f"see /api/runtime/usage?days=7"
+        )
+
     if is_stale:
         warnings.append(
             "generatedAt/data age >15min — advisory downgraded to stale, verify manually (never hard block)"
@@ -1167,7 +1201,9 @@ def compute_routing_budget(
                 fresh_codexbar if refresh_requested is None else refresh_requested
             ),
             "fresh_codexbar_blocking": fresh_codexbar,
-            "runtime_data_available": runtime_sourced_any,
+            "runtime_data_available": runtime_data_available,
+            "runtime_usage_records_7d": runtime_records_7d,
+            "budget_ledger_empty": len(records) == 0,
             "usage_sources": {
                 "allotment": "codexbar",
                 "burn_rate_limit": "agent_runtime_jsonl",

--- a/tests/api/test_routing_budget_runtime_diagnostics.py
+++ b/tests/api/test_routing_budget_runtime_diagnostics.py
@@ -1,0 +1,214 @@
+"""Tests for routing-budget runtime-usage diagnostics honesty (#7085).
+
+The USD cost ledger can be empty while ``/api/runtime/usage`` serves rows.
+``diagnostics.runtime_data_available`` must reflect the same 7-day runtime
+usage, and the ledger-empty state must be stated, not read as "no data".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.api import state_router
+
+
+def _write_budget_config(tmp_path: Path) -> Path:
+    path = tmp_path / "agent_budgets.yaml"
+    path.write_text(
+        """
+claude:
+  interactive:
+    weekly_cap_usd: 460
+  agentic_pool:
+    monthly_cap_usd: 200
+    starts_on: "2026-06-15"
+codex:
+  weekly_cap_usd: 1000
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _empty_runtime(agent: str) -> dict:
+    return {
+        "source": "agent_runtime_jsonl",
+        "window_s": 300,
+        "ok": 0,
+        "error": 0,
+        "rate_limited": 0,
+        "timeout": 0,
+        "other": 0,
+        "total": 0,
+        "last_outcome_at": None,
+        "last_rate_limited_at": None,
+        "models_rate_limited": [],
+        "headroom_blocked": False,
+        "headroom_reason": "",
+    }
+
+
+def _no_codexbar(provider: str) -> dict:
+    return {
+        "lane": provider,
+        "primary_used_pct": None,
+        "weekly_used_pct": None,
+        "monthly_cap_usd": None,
+        "monthly_used_usd": None,
+        "weekly_resets_at": None,
+        "weekly_pace_delta_pct": None,
+        "will_last_to_reset": None,
+        "pace_summary": None,
+        "source": "codexbar",
+        "fetched_at": None,
+        "stale": False,
+        "age_s": None,
+        "status": "unknown",
+    }
+
+
+def _configure(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    runtime_records_7d: int,
+) -> None:
+    """Empty USD ledger, quiet 5-minute reactive window, no CodexBar data."""
+    monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", _no_codexbar)
+    monkeypatch.setattr(state_router, "summarize_lane_runtime", _empty_runtime)
+    monkeypatch.setattr(
+        state_router,
+        "summarize_runtime_usage",
+        lambda *, days=7, agent=None, entrypoint=None: {
+            "window_days": days,
+            "records_total": runtime_records_7d,
+            "by_agent": {},
+            "by_entrypoint": {},
+        },
+    )
+    monkeypatch.setattr(
+        state_router.delegate_api,
+        "list_delegate_tasks",
+        lambda **_kwargs: {"tasks": []},
+    )
+
+
+def test_runtime_data_available_when_7d_usage_exists_but_ledger_empty(monkeypatch, tmp_path):
+    """Acceptance fixture: /api/runtime/usage has rows, USD ledger is empty."""
+    now = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, runtime_records_7d=25)
+
+    data = state_router.compute_routing_budget(now)
+
+    diag = data["diagnostics"]
+    assert diag["records_loaded"] == 0
+    assert diag["budget_ledger_empty"] is True
+    assert diag["runtime_data_available"] is True
+    assert diag["runtime_usage_records_7d"] == 25
+    assert any("ledger empty" in w and "runtime usage" in w for w in data["recommendation"]["warnings"])
+
+
+def test_runtime_data_unavailable_when_no_usage_anywhere(monkeypatch, tmp_path):
+    now = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, runtime_records_7d=0)
+
+    data = state_router.compute_routing_budget(now)
+
+    diag = data["diagnostics"]
+    assert diag["budget_ledger_empty"] is True
+    assert diag["runtime_data_available"] is False
+    assert diag["runtime_usage_records_7d"] == 0
+    assert not any("runtime usage has" in w for w in data["recommendation"]["warnings"])
+
+
+def test_runtime_probe_failure_degrades_without_breaking_budget(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, runtime_records_7d=0)
+
+    def _boom(**_kwargs):
+        raise OSError("usage dir unreadable")
+
+    monkeypatch.setattr(state_router, "summarize_runtime_usage", _boom)
+
+    data = state_router.compute_routing_budget(datetime(2026, 8, 22, 12, 0, tzinfo=UTC))
+
+    diag = data["diagnostics"]
+    assert diag["runtime_data_available"] is False
+    assert diag["runtime_usage_records_7d"] is None
+    assert diag["records_loaded"] == 0
+
+
+def test_reactive_window_alone_still_marks_runtime_available(monkeypatch, tmp_path):
+    """A busy 5-minute window keeps runtime_data_available true even at 0 rows in 7d."""
+    _configure(monkeypatch, tmp_path, runtime_records_7d=0)
+
+    def _busy_runtime(agent: str) -> dict:
+        base = _empty_runtime(agent)
+        base.update({"ok": 2, "total": 2})
+        return base
+
+    monkeypatch.setattr(state_router, "summarize_lane_runtime", _busy_runtime)
+
+    data = state_router.compute_routing_budget(datetime(2026, 8, 22, 12, 0, tzinfo=UTC))
+
+    assert data["diagnostics"]["runtime_data_available"] is True
+
+
+def test_empty_ledger_rec_stays_suppressed_when_runtime_exists(monkeypatch, tmp_path):
+    """Runtime usage is not an authoritative burn source: with ledger and
+    CodexBar both empty, the primary recommendation stays suppressed."""
+    now = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, runtime_records_7d=25)
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["recommendation"]["primary_agent_for_code"] is None
+    for lane in ("claude", "codex"):
+        agent = data["agents"][lane]
+        status = agent.get("status") or agent.get("interactive", {}).get("status")
+        assert status in ("unknown", "unavailable"), f"{lane} must stay unknown on empty ledger"
+
+
+def test_routing_html_states_ledger_empty_when_runtime_usage_exists():
+    """dashboards/routing.html must say "ledger empty, runtime exists" — not a silent $0 week."""
+    import subprocess
+
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync('dashboards/routing.html', 'utf8');
+    const renderBudgetMatch = html.match(/function renderBudget\\(routing, usage\\) \\{[\\s\\S]*?\\n\\}/);
+    if (!renderBudgetMatch) throw new Error('renderBudget not found');
+
+    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[ch]));
+    const pct = (value) => {
+      const num = Number(value);
+      return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
+    };
+    const statusPill = (status) => `<span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span>`;
+
+    let innerHTML = '';
+    const document = {
+      getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
+    };
+
+    eval(renderBudgetMatch[0]);
+
+    const routing = {
+      agents: {
+        codex: { status: 'unknown', burn_pct_7d: null, remaining_pct: null, weekly_cap_usd: 1000 }
+      },
+      in_flight: {},
+      diagnostics: { records_loaded: 0, budget_ledger_empty: true, runtime_usage_records_7d: 25 }
+    };
+    renderBudget(routing, { records_total: 25 });
+    console.log(innerHTML);
+    """
+    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
+    out = res.stdout
+    assert "budget ledger is empty" in out, f"missing ledger-empty note: {out}"
+    assert "Runtime usage exists (25 call(s) in 7d)" in out, f"missing runtime-exists copy: {out}"
+    assert "Burn unknown — USD budget ledger empty" in out, f"missing honest bar title: {out}"

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -772,7 +772,7 @@ def test_dashboard_routing_html_renders_unavailable_explicitly():
     script = """
     const fs = require('fs');
     const html = fs.readFileSync('dashboards/routing.html', 'utf8');
-    const renderBudgetMatch = html.match(/function renderBudget\\(routing\\) \\{[\\s\\S]*?\\n\\}/);
+    const renderBudgetMatch = html.match(/function renderBudget\\(routing, usage\\) \\{[\\s\\S]*?\\n\\}/);
     if (!renderBudgetMatch) throw new Error('renderBudget not found');
 
     const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => ({


### PR DESCRIPTION
## Summary
`GET /api/state/routing-budget` no longer reports `runtime_data_available=false` when `/api/runtime/usage` has 7d rows. Diagnostics add `runtime_usage_records_7d` and `budget_ledger_empty`. `/routing.html` Budget Headroom copy states the ledger is empty instead of a silent $0 week. Empty-ledger recommendation suppression is unchanged (runtime is not joined as a burn source).

## Test plan
- [x] pytest new diagnostics tests + routing-budget + codexbar_usage
- [ ] CI Gate + fastlane

Refs #7085

X-Agent: grok-infra