### PR TITLE
fix(runtime): headroom model from last live dispatch, not gpt-5.6-luna default (#7087)

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -201,7 +201,7 @@ tr:last-child td { border-bottom: none; }
   </section>
 
   <section class="card purple">
-    <div class="card-header"><h2>&#9201; Headroom</h2><div class="muted">Using each agent's default model</div></div>
+    <div class="card-header"><h2>&#9201; Headroom</h2><div class="muted">Using last-used or default model</div></div>
     <div class="banner" id="headroom-banner"></div>
     <div id="headroom-content" class="empty">Loading...</div>
   </section>
@@ -270,11 +270,12 @@ function renderAgents(agents) {
     return;
   }
   document.getElementById('agents-content').innerHTML = `<table>
-    <thead><tr><th>Name</th><th>Binary</th><th>Default Model</th><th>Supported Modes</th></tr></thead>
+    <thead><tr><th>Name</th><th>Binary</th><th>Default Model</th><th>Headroom Model</th><th>Supported Modes</th></tr></thead>
     <tbody>${agents.map(agent => `<tr>
       <td>${escapeHtml(agent.name || '—')}</td>
       <td class="mono">${escapeHtml(agent.binary || '—')}</td>
       <td class="mono">${escapeHtml(agent.default_model || '—')}</td>
+      <td class="mono">${escapeHtml(agent.headroom_model || agent.last_used_model || agent.default_model || '—')}</td>
       <td>${(agent.supported_modes || []).map(mode => `<span class="pill gray">${escapeHtml(mode)}</span>`).join(' ') || '—'}</td>
     </tr>`).join('')}</tbody>
   </table>`;
@@ -805,7 +806,7 @@ async function loadRuntime() {
 
   try {
     if (!agents.length) throw new Error('Need agent list before checking headroom');
-    const cards = await Promise.all(agents.map(agent => fetchJson(`/api/runtime/headroom?agent=${encodeURIComponent(agent.name)}&model=${encodeURIComponent(agent.default_model || '')}`)));
+    const cards = await Promise.all(agents.map(agent => fetchJson(`/api/runtime/headroom?agent=${encodeURIComponent(agent.name)}&model=${encodeURIComponent(agent.headroom_model || agent.last_used_model || agent.default_model || '')}`)));
     renderHeadroom(cards);
     setBanner('headroom-banner', '');
   } catch (error) {

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -353,8 +353,27 @@ def _update_comparison_side(
         side["total_tokens"] += tokens
 
 
+def _last_used_agent_models(*, days: int = 7) -> dict[str, str]:
+    """Extract the most recently used model per agent from runtime usage records."""
+    latest_by_agent: dict[str, tuple[datetime, str]] = {}
+    for record in _iter_usage_records(_usage_files(days=days)):
+        agent = record.get("agent")
+        model = record.get("model")
+        if not isinstance(agent, str) or not isinstance(model, str):
+            continue
+        model_str = model.strip()
+        if not model_str:
+            continue
+        ts = _parse_iso_datetime(record.get("ts")) or datetime.min.replace(tzinfo=UTC)
+        current = latest_by_agent.get(agent)
+        if current is None or ts >= current[0]:
+            latest_by_agent[agent] = (ts, model_str)
+    return {agent: model for agent, (_, model) in latest_by_agent.items()}
+
+
 def list_runtime_agents() -> list[dict[str, Any]]:
     _refresh_agent_registry_if_changed()
+    last_used = _last_used_agent_models()
     agents: list[dict[str, Any]] = []
     for path in sorted(ADAPTERS_DIR.glob("*.py")):
         # Skip non-agent helper modules and alternate-harness adapters that
@@ -390,10 +409,17 @@ def list_runtime_agents() -> list[dict[str, Any]]:
                 binary = "codex"
             else:
                 binary = str(obj.name)
+
+            agent_name = str(obj.name)
+            registry_default = _registry_models.get(agent_name, getattr(obj, "default_model", None))
+            last_model = last_used.get(agent_name)
+            headroom_model = last_model or registry_default
             agents.append({
-                "name": str(obj.name),
+                "name": agent_name,
                 "binary": binary,
-                "default_model": _registry_models.get(str(obj.name), getattr(obj, "default_model", None)),
+                "default_model": registry_default,
+                "last_used_model": last_model,
+                "headroom_model": headroom_model,
                 "supported_modes": sorted(str(mode) for mode in getattr(obj, "supported_modes", [])),
             })
             break

--- a/tests/test_runtime_codex_headroom_model.py
+++ b/tests/test_runtime_codex_headroom_model.py
@@ -1,0 +1,109 @@
+"""Regression tests for Codex runtime inventory default vs live dispatched model.
+
+Issue #7087: ``/runtime.html`` Headroom previously queried ``?agent=codex&model=gpt-5.6-luna``
+because it solely read the static registry default, while all live delegate tasks and recent
+calls use ``gpt-5.6-terra``. ``/api/runtime/agents`` now reports ``last_used_model`` and
+``headroom_model`` derived from live usage records, and ``runtime.html`` queries headroom
+for the active model.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.api import runtime_router
+from scripts.api.config import DASHBOARDS_DIR
+from scripts.api.main import app
+from scripts.api.runtime_router import list_runtime_agents
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _write_usage_record(file_path: Path, records: list[dict]) -> None:
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def test_agents_endpoint_reports_last_used_and_headroom_model(tmp_path: Path, monkeypatch) -> None:
+    usage_dir = tmp_path / "api_usage"
+    now = datetime.now(UTC)
+    monkeypatch.setattr(runtime_router, "USAGE_DIR", usage_dir)
+
+    # 1. Without usage records, last_used_model is None and headroom_model falls back to default_model.
+    agents = list_runtime_agents()
+    codex = next(a for a in agents if a["name"] == "codex")
+    assert codex["default_model"] == "gpt-5.6-luna"
+    assert codex["last_used_model"] is None
+    assert codex["headroom_model"] == "gpt-5.6-luna"
+
+    # 2. Write live usage record for Codex with gpt-5.6-terra.
+    today_file = usage_dir / f"usage_codex-delegate_{now:%Y-%m-%d}.jsonl"
+    _write_usage_record(
+        today_file,
+        [
+            {
+                "ts": (now - timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+                "agent": "codex",
+                "entrypoint": "delegate",
+                "model": "gpt-5.6-terra",
+                "outcome": "ok",
+                "duration_s": 14.2,
+            }
+        ],
+    )
+
+    response = client.get("/api/runtime/agents")
+    assert response.status_code == 200
+    agents_json = response.json()["agents"]
+    codex_json = next(a for a in agents_json if a["name"] == "codex")
+    assert codex_json["default_model"] == "gpt-5.6-luna"
+    assert codex_json["last_used_model"] == "gpt-5.6-terra"
+    assert codex_json["headroom_model"] == "gpt-5.6-terra"
+
+
+def test_agents_endpoint_picks_most_recent_model_when_multiple_records(tmp_path: Path, monkeypatch) -> None:
+    usage_dir = tmp_path / "api_usage"
+    now = datetime.now(UTC)
+    monkeypatch.setattr(runtime_router, "USAGE_DIR", usage_dir)
+
+    usage_file = usage_dir / f"usage_codex-dispatch_{now:%Y-%m-%d}.jsonl"
+    _write_usage_record(
+        usage_file,
+        [
+            {
+                "ts": (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+                "agent": "codex",
+                "entrypoint": "dispatch",
+                "model": "gpt-5.6-luna",
+                "outcome": "ok",
+                "duration_s": 10.0,
+            },
+            {
+                "ts": (now - timedelta(minutes=10)).isoformat().replace("+00:00", "Z"),
+                "agent": "codex",
+                "entrypoint": "delegate",
+                "model": "gpt-5.6-terra",
+                "outcome": "ok",
+                "duration_s": 8.5,
+            },
+        ],
+    )
+
+    response = client.get("/api/runtime/agents")
+    assert response.status_code == 200
+    codex_json = next(a for a in response.json()["agents"] if a["name"] == "codex")
+    assert codex_json["last_used_model"] == "gpt-5.6-terra"
+    assert codex_json["headroom_model"] == "gpt-5.6-terra"
+
+
+def test_runtime_dashboard_queries_headroom_with_headroom_or_last_used_model() -> None:
+    html = (DASHBOARDS_DIR / "runtime.html").read_text(encoding="utf-8")
+    assert "agent.headroom_model || agent.last_used_model || agent.default_model" in html
+    assert "<th>Headroom Model</th>" in html
+    assert "Using last-used or default model" in html


### PR DESCRIPTION
## Summary
`/api/runtime/agents` now exposes `last_used_model` / `headroom_model` from live usage. `/runtime.html` Headroom queries that model instead of the registry default (`gpt-5.6-luna` while live Codex is `gpt-5.6-terra`).

## Test plan
- [x] pytest tests/test_runtime_codex_headroom_model.py (plus related runtime tests)
- [ ] CI Gate + fastlane

Refs #7087

X-Agent: grok-infra