### PR TITLE
fix(cost): flag empty dispatch-meta ledger instead of silent $0 week (#7086)

### DIFF
--- a/dashboards/cost.html
+++ b/dashboards/cost.html
@@ -174,11 +174,15 @@ function renderSummary(payload) {
     const totals = data.totals || {};
     const active = key === activeWindow ? ' style="border-color:var(--red)"' : '';
     const label = key === 'all_time' ? 'All-time' : key === 'last_7_days' ? 'Last 7 days' : 'Last 30 days';
+    const runtimeNote = data.ledger_empty
+      ? `<div class="muted" style="color:var(--yellow)">ledger empty · ${fmtInt(data.runtime_calls_total)} runtime call(s) not costed</div>`
+      : `<div class="muted">${fmtInt(data.runtime_calls_total)} runtime call(s) recorded</div>`;
     return `<div class="stat"${active}>
       <div class="label">${label}</div>
       <div class="value">${fmtCost(totals.cost_usd_est)}</div>
       <div class="muted">${fmtInt(totals.prompt_tokens_est)} prompt est. · ${fmtInt(totals.response_tokens_est)} output est.</div>
       <div class="muted">${totals.calls || 0} call(s)</div>
+      ${runtimeNote}
     </div>`;
   }).join('');
 }

--- a/dashboards/cost.html
+++ b/dashboards/cost.html
@@ -177,9 +177,12 @@ function renderSummary(payload) {
     const runtimeNote = data.ledger_empty
       ? `<div class="muted" style="color:var(--yellow)">ledger empty · ${fmtInt(data.runtime_calls_total)} runtime call(s) not costed</div>`
       : `<div class="muted">${fmtInt(data.runtime_calls_total)} runtime call(s) recorded</div>`;
+    const heroValue = data.ledger_empty
+      ? '<div class="value" style="color:var(--yellow)">ledger empty</div>'
+      : `<div class="value">${fmtCost(totals.cost_usd_est)}</div>`;
     return `<div class="stat"${active}>
       <div class="label">${label}</div>
-      <div class="value">${fmtCost(totals.cost_usd_est)}</div>
+      ${heroValue}
       <div class="muted">${fmtInt(totals.prompt_tokens_est)} prompt est. · ${fmtInt(totals.response_tokens_est)} output est.</div>
       <div class="muted">${totals.calls || 0} call(s)</div>
       ${runtimeNote}

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -430,8 +430,13 @@ async function loadStats() {
   }
 
   if (cost) {
-    const amount = Number(cost.windows?.last_7_days?.totals?.cost_usd_est || 0);
-    setStat('card-stat-cost', `~$${amount.toFixed(2)} last 7d`);
+    const week = cost.windows?.last_7_days || {};
+    if (week.ledger_empty) {
+      setStat('card-stat-cost', `ledger empty · ${Number(week.runtime_calls_total || 0)} runtime calls (7d)`);
+    } else {
+      const amount = Number(week.totals?.cost_usd_est || 0);
+      setStat('card-stat-cost', `~$${amount.toFixed(2)} last 7d`);
+    }
   }
 
   // Visualize the contracts (definition authority for public surface) per Claude review.

--- a/scripts/analytics/cost_report.py
+++ b/scripts/analytics/cost_report.py
@@ -9,7 +9,7 @@ import re
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from statistics import median
 from typing import Any
@@ -18,6 +18,7 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+API_USAGE_DIR = PROJECT_ROOT / "batch_state" / "api_usage"
 COST_RATES_PATH = PROJECT_ROOT / "scripts" / "analytics" / "cost_rates.yaml"
 DEFAULT_DIVISOR = 3.8
 PROMPT_BLOAT_THRESHOLD = 30_000
@@ -211,9 +212,7 @@ def _record_from_meta(path: Path, meta: dict[str, Any], rates: dict[str, dict[st
 
     rate_model = _resolve_rate_model(model, rates)
     rate = rates[rate_model]
-    cost_usd_est = (
-        (prompt_tokens_est * rate["input"]) + (response_tokens_est * rate["output"])
-    ) / 1_000_000
+    cost_usd_est = ((prompt_tokens_est * rate["input"]) + (response_tokens_est * rate["output"])) / 1_000_000
 
     return CostRecord(
         path=path,
@@ -253,6 +252,57 @@ def load_cost_records(
             continue
         records.append(_record_from_meta(path, meta, rates))
     return records
+
+
+def _usage_day_from_name(path: Path) -> date | None:
+    stem = path.stem
+    if not stem.startswith("usage_"):
+        return None
+    try:
+        return date.fromisoformat(stem.rsplit("_", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def count_runtime_calls(
+    *,
+    days: int | None,
+    now: datetime | None = None,
+    usage_dir: Path | None = None,
+) -> int:
+    """Count runtime usage rows (batch_state/api_usage/usage_*.jsonl) for a window.
+
+    Runtime rows record every fleet invoke but carry no reliable token data,
+    so they are surfaced as a call count only — never folded into USD estimates.
+    Day granularity: a N-day window covers the last N calendar days, which is a
+    slight superset of the cost window's exact N*24h mtime cutoff.
+    """
+    directory = usage_dir or API_USAGE_DIR
+    if not directory.exists():
+        return 0
+    today = (now or datetime.now(UTC)).date()
+    earliest = None if days is None else today - timedelta(days=max(1, days) - 1)
+    total = 0
+    for path in sorted(directory.glob("usage_*.jsonl")):
+        if earliest is not None:
+            day = _usage_day_from_name(path)
+            if day is None or day < earliest or day > today:
+                continue
+        try:
+            with open(path, encoding="utf-8") as handle:
+                for raw in handle:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        data = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(data, dict):
+                        total += 1
+        except OSError:
+            continue
+    return total
 
 
 def _filter_records(
@@ -374,13 +424,12 @@ def build_cost_summary(
             f"({counts['model_agent']} inferred, {counts['model_missing']} missing)."
         )
     if unknown_models:
-        warnings.append(
-            "Unknown model rates fell back to the YAML default for: "
-            + ", ".join(sorted(unknown_models))
-        )
+        warnings.append("Unknown model rates fell back to the YAML default for: " + ", ".join(sorted(unknown_models)))
 
     prompt_bloat_watch = []
-    for phase_name, values in sorted(phase_prompt_sizes.items(), key=lambda item: (_PHASE_SORT.get(item[0], 99), item[0])):
+    for phase_name, values in sorted(
+        phase_prompt_sizes.items(), key=lambda item: (_PHASE_SORT.get(item[0], 99), item[0])
+    ):
         phase_median = round(median(values))
         if phase_median > PROMPT_BLOAT_THRESHOLD:
             prompt_bloat_watch.append(
@@ -454,13 +503,14 @@ def build_cost_windows(
     slug: str | None = None,
     phase: str | None = None,
     now: datetime | None = None,
+    usage_dir: Path | None = None,
 ) -> dict[str, Any]:
     current_time = now or datetime.now(UTC)
     records = load_cost_records(root=root, rates_path=rates_path)
     windows: dict[str, Any] = {}
     for key, days in _WINDOW_SPECS:
         since = None if days is None else current_time - timedelta(days=days)
-        windows[key] = build_cost_summary(
+        window = build_cost_summary(
             records=records,
             track=track,
             level=level,
@@ -468,6 +518,17 @@ def build_cost_windows(
             phase=phase,
             since=since,
         )
+        runtime_calls = count_runtime_calls(days=days, now=current_time, usage_dir=usage_dir)
+        window["runtime_calls_total"] = runtime_calls
+        ledger_empty = window["records_total"] == 0 and runtime_calls > 0
+        window["ledger_empty"] = ledger_empty
+        if ledger_empty:
+            window["warnings"] = [
+                *window["warnings"],
+                f"Dispatch-meta cost ledger is empty for this window, but {runtime_calls} runtime "
+                "call(s) were recorded; those calls are not reflected in the cost estimates.",
+            ]
+        windows[key] = window
     return {
         "scope": {
             "track": level or track,
@@ -611,13 +672,15 @@ def render_markdown(summary: dict[str, Any]) -> str:
     def add_table(title: str, rows: list[dict[str, Any]]) -> None:
         if not rows:
             return
-        lines.extend([
-            "",
-            f"### {title}",
-            "",
-            "| Name | Calls | Prompt est. | Output est. | USD est. |",
-            "| --- | ---: | ---: | ---: | ---: |",
-        ])
+        lines.extend(
+            [
+                "",
+                f"### {title}",
+                "",
+                "| Name | Calls | Prompt est. | Output est. | USD est. |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
         for row in rows:
             lines.append(
                 f"| {row['name']} | {row['calls']} | {_fmt_int(int(row['prompt_tokens_est']))} | "

--- a/tests/test_cost_runtime_ledger.py
+++ b/tests/test_cost_runtime_ledger.py
@@ -1,0 +1,168 @@
+"""Tests for runtime-ledger empty-state signals in cost windows (#7086)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import scripts.analytics.cost_report as cost_report
+from tests.project_python import project_python
+
+_NOW = datetime(2026, 8, 22, 12, 0, 0, tzinfo=UTC)
+
+
+def _write_meta(root: Path, *, level: str = "a1", slug: str = "my-family") -> None:
+    dispatch_dir = root / level / "orchestration" / slug / "dispatch"
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+    (dispatch_dir / "01-write-meta.json").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-08-20T12:00:00Z",
+                "phase": "write",
+                "agent": "kimi (k2)",
+                "model": "k2",
+                "ok": True,
+                "returncode": 0,
+                "prompt_chars": 3800,
+                "response_chars": 380,
+                "prompt_tokens_est": 1000,
+                "response_tokens_est": 100,
+                "duration_s": 9.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_usage_rows(usage_dir: Path, *, day: str, rows: int, agent: str = "kimi") -> None:
+    usage_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(
+            {
+                "ts": f"{day}T08:{32 + idx:02d}:00+00:00",
+                "agent": agent,
+                "entrypoint": "delegate",
+                "outcome": "ok",
+                "duration_s": 9.0,
+                "tokens": None,
+            }
+        )
+        for idx in range(rows)
+    ]
+    (usage_dir / f"usage_{agent}-delegate_{day}.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_empty_ledger_with_runtime_rows_flags_ledger_empty(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    usage_dir = tmp_path / "api_usage"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", usage_dir)
+    curriculum.mkdir()
+    _write_usage_rows(usage_dir, day="2026-08-22", rows=28)
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    week = payload["windows"]["last_7_days"]
+    assert week["records_total"] == 0
+    assert week["totals"]["cost_usd_est"] == 0.0
+    assert week["runtime_calls_total"] == 28
+    assert week["ledger_empty"] is True
+    assert any("ledger is empty" in warning for warning in week["warnings"])
+    assert payload["windows"]["last_30_days"]["runtime_calls_total"] == 28
+    assert payload["windows"]["all_time"]["runtime_calls_total"] == 28
+    assert payload["windows"]["all_time"]["ledger_empty"] is True
+
+
+def test_populated_ledger_is_not_flagged(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    usage_dir = tmp_path / "api_usage"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", usage_dir)
+    _write_meta(curriculum)
+    _write_usage_rows(usage_dir, day="2026-08-22", rows=5)
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    week = payload["windows"]["last_7_days"]
+    assert week["records_total"] == 1
+    assert week["runtime_calls_total"] == 5
+    assert week["ledger_empty"] is False
+    assert not any("ledger is empty" in warning for warning in week["warnings"])
+
+
+def test_empty_everything_is_not_flagged(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    usage_dir = tmp_path / "api_usage"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", usage_dir)
+    curriculum.mkdir()
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    for window in payload["windows"].values():
+        assert window["runtime_calls_total"] == 0
+        assert window["ledger_empty"] is False
+
+
+def test_missing_usage_dir_is_not_flagged(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", tmp_path / "does-not-exist")
+    curriculum.mkdir()
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    assert payload["windows"]["last_7_days"]["runtime_calls_total"] == 0
+    assert payload["windows"]["last_7_days"]["ledger_empty"] is False
+
+
+def test_old_usage_rows_only_count_in_all_time(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    usage_dir = tmp_path / "api_usage"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", usage_dir)
+    curriculum.mkdir()
+    _write_usage_rows(usage_dir, day="2026-07-01", rows=10)
+    _write_usage_rows(usage_dir, day="2026-08-10", rows=3)
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    assert payload["windows"]["last_7_days"]["runtime_calls_total"] == 0
+    assert payload["windows"]["last_7_days"]["ledger_empty"] is False
+    assert payload["windows"]["last_30_days"]["runtime_calls_total"] == 3
+    assert payload["windows"]["last_30_days"]["ledger_empty"] is True
+    assert payload["windows"]["all_time"]["runtime_calls_total"] == 13
+
+
+def test_malformed_usage_lines_are_skipped(tmp_path, monkeypatch):
+    curriculum = tmp_path / "curriculum"
+    usage_dir = tmp_path / "api_usage"
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", curriculum)
+    monkeypatch.setattr(cost_report, "API_USAGE_DIR", usage_dir)
+    curriculum.mkdir()
+    usage_dir.mkdir()
+    (usage_dir / "usage_kimi-delegate_2026-08-22.jsonl").write_text(
+        '{"agent": "kimi", "outcome": "ok"}\nnot-json\n\n[]\n', encoding="utf-8"
+    )
+
+    payload = cost_report.build_cost_windows(now=_NOW)
+
+    assert payload["windows"]["last_7_days"]["runtime_calls_total"] == 1
+    assert payload["windows"]["last_7_days"]["ledger_empty"] is True
+
+
+def test_cost_report_cli_still_runs():
+    result = subprocess.run(
+        [str(project_python()), "scripts/analytics/cost_report.py", "--all", "--json"],
+        cwd=Path(__file__).resolve().parent.parent,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "records_total" in payload

--- a/tests/test_cost_runtime_ledger.py
+++ b/tests/test_cost_runtime_ledger.py
@@ -166,3 +166,34 @@ def test_cost_report_cli_still_runs():
     assert result.returncode == 0
     payload = json.loads(result.stdout)
     assert "records_total" in payload
+
+
+def test_cost_html_hero_never_shows_zero_dollar_when_ledger_empty():
+    """renderSummary must not present a $0 week when ledger_empty (#7086)."""
+    html_path = Path(__file__).resolve().parent.parent / "dashboards" / "cost.html"
+    html = html_path.read_text(encoding="utf-8")
+    helpers = html[html.index("let activeWindow") : html.index("function renderWindow")]
+    script = f"""
+    {helpers}
+    const stubs = {{ summary: {{ innerHTML: '' }} }};
+    global.document = {{ getElementById: (id) => stubs[id] }};
+    renderSummary({{ windows: {{ last_7_days: {{
+      ledger_empty: true,
+      runtime_calls_total: 28,
+      totals: {{ cost_usd_est: 0, prompt_tokens_est: 0, response_tokens_est: 0, calls: 0 }},
+    }} }} }});
+    const emptyHero = stubs.summary.innerHTML;
+    renderSummary({{ windows: {{ last_7_days: {{
+      ledger_empty: false,
+      runtime_calls_total: 28,
+      totals: {{ cost_usd_est: 12.34, prompt_tokens_est: 1000, response_tokens_est: 100, calls: 3 }},
+    }} }} }});
+    console.log(JSON.stringify({{ emptyHero, populatedHero: stubs.summary.innerHTML }}));
+    """
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
+    output = json.loads(result.stdout)
+
+    assert "~$0.00" not in output["emptyHero"]
+    assert 'class="value"' in output["emptyHero"]
+    assert "ledger empty" in output["emptyHero"]
+    assert "~$12.34" in output["populatedHero"]


### PR DESCRIPTION
## Summary
Cost windows and launchpad no longer present a \$0 week when `/api/runtime/usage` has rows. Dispatch-meta ledger empty vs runtime calls is explicit (`ledger_empty` / `runtime_calls_total`).

NOTE substitution: Claude r1 write-denied; Kimi r2 implemented.

## Test plan
- [x] pytest tests/test_cost_runtime_ledger.py
- [ ] CI Gate + fastlane

Refs #7086

X-Agent: grok-infra