### PR TITLE
fix(runtime): expire zombie routing rows and flag stale authority window (#7088)

### DIFF
--- a/dashboards/runtime.html
+++ b/dashboards/runtime.html
@@ -729,12 +729,19 @@ function renderRoutingAssignments(data) {
   const plane = data && typeof data.plane === 'object' ? data.plane : {};
   const assignments = Array.isArray(data?.assignments) ? data.assignments : [];
   const availability = data?.availability || 'unavailable';
+  const window = data && typeof data.window === 'object' && data.window ? data.window : null;
+  const windowLabel = window
+    ? (window.stale ? `stale · latest event ${formatTs(window.newest_at)}` : `recent · latest event ${formatTs(window.newest_at)}`)
+    : 'unreported';
+  const zombieCount = assignments.filter(item => item.zombie_expired === true).length;
   routingUi.plane = plane;
   const planeMarkup = `<div class="routing-status">
     <span class="pill ${plane.mode === 'authority' ? 'ok' : 'warn'}">Plane: ${escapeHtml(displayRouteValue(plane.mode))}</span>
     <span class="pill info">${escapeHtml(displayRouteValue(plane.authority))}</span>
     <span class="pill gray">${escapeHtml(displayRouteValue(plane.cutover))}</span>
     <span class="pill ${availability === 'available' || availability === 'empty' ? 'ok' : 'err'}">History: ${escapeHtml(availability)}</span>
+    <span class="pill ${window && window.stale ? 'warn' : 'gray'}">Window: ${escapeHtml(windowLabel)}</span>
+    ${zombieCount ? `<span class="pill warn">${zombieCount} overdue reserved/running shown as expired</span>` : ''}
   </div>`;
   if (!assignments.length) {
     const reason = data?.reason ? ` (${displayRouteValue(data.reason)})` : '';

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -891,6 +891,59 @@ def _routing_assignment_item(record: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_ROUTING_ACTIVE_STATES = frozenset({"reserved", "running"})
+# Matches the dashboard's STALE_ACTIVITY_MS (45 minutes) so the API and the
+# page agree on when a loaded window no longer counts as recent.
+_ROUTING_WINDOW_STALE_AFTER_S = 45 * 60
+
+
+def _routing_iso_z(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _routing_zombie_expired(item: dict[str, Any], now: datetime) -> bool:
+    """Observer-side TTL check mirroring the ledger's ``_recover_expired_tx``.
+
+    The write-path expiry only runs when Fleet Comms opens a write
+    transaction; if no reservation activity has happened since a row went
+    overdue, its ``reserved``/``running`` status persists indefinitely.  The
+    read-only projection must never write, so it reports those zombies as
+    terminal ``expired`` rows instead of live routing (#7088).
+    """
+    state = str(item.get("current_state") or item.get("reservation_state") or "").lower()
+    if state not in _ROUTING_ACTIVE_STATES:
+        return False
+    expires_at = _parse_iso_datetime(item.get("expires_at"))
+    return expires_at is not None and expires_at <= now
+
+
+def _routing_apply_observer_expiry(item: dict[str, Any], now: datetime) -> None:
+    if not _routing_zombie_expired(item, now):
+        return
+    item["reservation_state"] = "expired"
+    item["terminal_status"] = "expired"
+    item["current_state"] = "expired"
+    if not item.get("failure_classification"):
+        item["failure_classification"] = "ttl_expired_orphan"
+    item["zombie_expired"] = True
+
+
+def _routing_assignment_window(assignments: list[dict[str, Any]], now: datetime) -> dict[str, Any] | None:
+    timestamps = [
+        parsed
+        for parsed in (_parse_iso_datetime(item.get("timestamp")) for item in assignments)
+        if parsed is not None
+    ]
+    if not timestamps:
+        return None
+    newest = max(timestamps)
+    return {
+        "oldest_at": _routing_iso_z(min(timestamps)),
+        "newest_at": _routing_iso_z(newest),
+        "stale": (now - newest).total_seconds() > _ROUTING_WINDOW_STALE_AFTER_S,
+    }
+
+
 def _routing_assignment_aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
     """Collapse decision events into one current reservation assignment."""
     ordered = sorted(records, key=_routing_event_sort_key)
@@ -960,9 +1013,14 @@ def list_routing_assignments(*, limit: int = 100) -> dict[str, Any]:
         reverse=True,
     )
     assignments = assignments[:record_limit]
+    now = datetime.now(UTC)
+    for item in assignments:
+        _routing_apply_observer_expiry(item, now)
     return {
         "availability": "available" if assignments else "empty",
         "plane": plane,
+        "as_of": _routing_iso_z(now),
+        "window": _routing_assignment_window(assignments, now),
         "assignments": assignments,
     }
 

--- a/tests/test_runtime_routing_window.py
+++ b/tests/test_runtime_routing_window.py
@@ -1,0 +1,172 @@
+"""Tests for the routing-assignments recency window and zombie expiry (#7088).
+
+Overdue ``reserved``/``running`` rows persist forever when no write-path
+ledger activity happens; the read-only projection must present them as
+terminal/stale instead of live routing, and report whether the loaded
+window is actually recent.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+
+import scripts.api.runtime_router as runtime_router
+
+_NOW = datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _decision_row(
+    reservation_id: str,
+    *,
+    state: str,
+    created_at: datetime,
+    expires_at: datetime | None = None,
+    failure_classification: str | None = None,
+) -> dict:
+    return {
+        "reservation_id": reservation_id,
+        "authority_key": f"key-{reservation_id}",
+        "decision_id": f"decision-{reservation_id}",
+        "event_type": "started" if state == "running" else state,
+        "state": state,
+        "created_at": _iso(created_at),
+        "evidence": {},
+        "requested": {"initiator": "dispatcher", "route_mode": "auto"},
+        "resolved": {"route": "codex"},
+        "quota": {"snapshot": {}},
+        "retry": {},
+        "replay": {},
+        "lifecycle": {
+            "status": state,
+            "created_at": _iso(created_at),
+            "expires_at": _iso(expires_at) if expires_at else None,
+            "failure_classification": failure_classification,
+        },
+    }
+
+
+def _stub_ledger(monkeypatch, rows: list[dict]) -> None:
+    ledger = types.SimpleNamespace(list_routing_decisions=lambda **_kwargs: rows)
+    monkeypatch.setitem(sys.modules, "scripts.fleet_comms.routing_reservations", ledger)
+    monkeypatch.setattr(
+        runtime_router,
+        "_routing_plane_status",
+        lambda: {"mode": "shadow", "enabled": True, "authority": "test", "cutover": "test"},
+    )
+
+
+def test_zombie_running_row_is_terminal_and_window_stale(monkeypatch):
+    """A running row past its TTL is reported expired, not live (#7088)."""
+    old = _NOW - timedelta(days=14)
+    rows = [
+        _decision_row("res-zombie", state="running", created_at=old, expires_at=old + timedelta(minutes=5)),
+        _decision_row(
+            "res-fresh",
+            state="running",
+            created_at=_NOW - timedelta(minutes=5),
+            expires_at=_NOW + timedelta(minutes=30),
+        ),
+    ]
+    _stub_ledger(monkeypatch, rows)
+
+    result = runtime_router.list_routing_assignments()
+
+    assert result["availability"] == "available"
+    by_id = {item["source_authority_id"]: item for item in result["assignments"]}
+
+    zombie = by_id["res-zombie"]
+    assert zombie["current_state"] == "expired"
+    assert zombie["reservation_state"] == "expired"
+    assert zombie["terminal_status"] == "expired"
+    assert zombie["failure_classification"] == "ttl_expired_orphan"
+    assert zombie["zombie_expired"] is True
+
+    fresh = by_id["res-fresh"]
+    assert fresh["current_state"] == "running"
+    assert "zombie_expired" not in fresh
+
+    window = result["window"]
+    assert window["stale"] is False  # res-fresh keeps the window recent
+    assert result["as_of"]
+
+
+def test_stale_window_reported_when_newest_event_is_old(monkeypatch):
+    """A window whose newest event is older than 45 minutes is stale."""
+    old = _NOW - timedelta(days=14)
+    rows = [
+        _decision_row(
+            "res-zombie",
+            state="reserved",
+            created_at=old,
+            expires_at=old + timedelta(minutes=5),
+        )
+    ]
+    _stub_ledger(monkeypatch, rows)
+
+    result = runtime_router.list_routing_assignments()
+
+    (item,) = result["assignments"]
+    assert item["current_state"] == "expired"
+    assert item["zombie_expired"] is True
+    window = result["window"]
+    assert window["stale"] is True
+    assert window["newest_at"] == _iso(old)
+    assert window["oldest_at"] == _iso(old)
+
+
+def test_zombie_expiry_preserves_recorded_failure(monkeypatch):
+    """Observer-side expiry never overwrites a recorded failure classification."""
+    old = _NOW - timedelta(days=2)
+    rows = [
+        _decision_row(
+            "res-zombie",
+            state="running",
+            created_at=old,
+            expires_at=old + timedelta(minutes=5),
+            failure_classification="provider_unavailable",
+        )
+    ]
+    _stub_ledger(monkeypatch, rows)
+
+    (item,) = runtime_router.list_routing_assignments()["assignments"]
+
+    assert item["current_state"] == "expired"
+    assert item["failure_classification"] == "provider_unavailable"
+
+
+def test_active_row_without_expiry_is_left_alone(monkeypatch):
+    """Active rows lacking expires_at cannot be TTL-judged; they stay active."""
+    rows = [
+        _decision_row("res-no-ttl", state="running", created_at=_NOW - timedelta(days=14), expires_at=None)
+    ]
+    _stub_ledger(monkeypatch, rows)
+
+    (item,) = runtime_router.list_routing_assignments()["assignments"]
+
+    assert item["current_state"] == "running"
+    assert "zombie_expired" not in item
+
+
+def test_terminal_rows_untouched_and_empty_window(monkeypatch):
+    """Complete/failed rows are never reclassified; empty history has no window."""
+    old = _NOW - timedelta(days=14)
+    rows = [_decision_row("res-done", state="complete", created_at=old, expires_at=old)]
+    _stub_ledger(monkeypatch, rows)
+
+    result = runtime_router.list_routing_assignments()
+    (item,) = result["assignments"]
+    assert item["current_state"] == "complete"
+    assert "zombie_expired" not in item
+    assert result["window"]["stale"] is True
+
+    _stub_ledger(monkeypatch, [])
+    empty = runtime_router.list_routing_assignments()
+    assert empty["availability"] == "empty"
+    assert empty["window"] is None
+    assert empty["as_of"]


### PR DESCRIPTION
## Summary
Read-only routing-assignments projection applies observer-side TTL: overdue reserved/running rows become terminal `expired` (`ttl_expired_orphan`) instead of looking like live Aug 6–7 routing. API adds a `window` block; `/runtime.html` shows stale/recent pill and expired count.

## Test plan
- [x] pytest tests/test_runtime_routing_window.py
- [ ] CI Gate + fastlane

Refs #7088

X-Agent: grok-infra