### PR TITLE
fix(ci): skip CI Gate when cancel-in-progress aborts a PR run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1436,7 +1436,11 @@ jobs:
     name: CI Gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: always()
+    # When cancel-in-progress aborts a PR run, Gate must not start and must
+    # not fail-close the superseded SHA; the new head run is the merge
+    # signal (#7136). merge_group keeps cancel-in-progress false so Gate
+    # still always evaluates live merge candidates.
+    if: always() && !cancelled()
     needs:
       - ruff
       - landing-class


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI Gate no longer starts on a cancelled PR run. A re-push that trips `cancel-in-progress` will skip Gate on the superseded SHA instead of fail-closing it red. The new head run remains the merge signal.

Fixes #7136

## Changes

- Change the `ci-gate` job `if:` from `always()` to `always() && !cancelled()` in `.github/workflows/ci.yml`
- Document why: PR cancel-in-progress must not fail-close a superseded SHA; `merge_group` keeps `cancel-in-progress: false` so live merge candidates still evaluate

## Non-goals (intentionally unchanged)

- `gate_required_results.py` still fail-closes on `cancelled` / `skipped` / `failure` / missing for any live run that reaches Gate
- `merge_group` cancel-in-progress stays false
- No CI redesign (#6977 stays out of scope)

## Testing

- [x] `python3 -m pytest tests/test_ci_gate_required_results.py -q` — 14 passed (existing fail-closed semantics for `cancelled` / `skipped` / `failure` / missing)
- [x] Diff is the `ci-gate` job condition plus the comment only
- [ ] Workflow-level proof lands with this PR's CI: cancelled PR runs should skip Gate rather than paint fail-closed red

## Related Issues

Fixes #7136

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9de285e4-1503-44b9-a836-93b62c7c5e9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9de285e4-1503-44b9-a836-93b62c7c5e9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

