### PR TITLE
perf(ci): take coverage xml/html off merge-gate path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1346,6 +1346,10 @@ jobs:
   # Enforces the 35% floor ONCE, over the combined four-shard data. Restores the
   # guarantee cross-family review flagged as a P1 when the reboot dropped it.
   # docs_skills (#7018): no-op success (do not download missing coverage).
+  # Gate path ends at `coverage report --fail-under=35`. XML/HTML rendering is
+  # off-path because nothing in-repo consumes those artifacts; combined
+  # `.coverage` + text report remain downloadable for offline
+  # `coverage html` / `coverage xml`.
   coverage-floor:
     name: Coverage floor
     if: github.event_name != 'pull_request'
@@ -1407,10 +1411,8 @@ jobs:
           if [ "$i" -eq 0 ]; then echo "::error::no coverage data — refusing to pass vacuously"; exit 1; fi
           python -m coverage combine
           python -m coverage report --fail-under=35 | tee coverage-report.txt
-          python -m coverage xml -o coverage.xml
-          python -m coverage html -d coverage-html
 
-      - name: Upload full coverage report
+      - name: Upload coverage report and combined data
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
           && (github.event_name == 'merge_group'
@@ -1420,8 +1422,8 @@ jobs:
           name: coverage-report
           path: |
             coverage-report.txt
-            coverage.xml
-            coverage-html/
+            .coverage
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 14
 

--- a/tests/test_ci_coverage_floor_gate.py
+++ b/tests/test_ci_coverage_floor_gate.py
@@ -1,0 +1,68 @@
+"""Hermetic lock: coverage-floor stays on the gate path without XML/HTML render."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI = _REPO_ROOT / ".github/workflows/ci.yml"
+
+
+def _load_ci() -> dict:
+    data = yaml.safe_load(_CI.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _coverage_floor(jobs: dict) -> dict:
+    job = jobs["coverage-floor"]
+    assert isinstance(job, dict)
+    return job
+
+
+def _named_step(job: dict, name: str) -> dict:
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"coverage-floor is missing step {name!r}")
+
+
+def test_coverage_floor_stays_on_full_tier_gate_path() -> None:
+    jobs = _load_ci()["jobs"]
+    assert "coverage-floor" in jobs["ci-gate"]["needs"]
+    job = _coverage_floor(jobs)
+    assert job["if"] == "github.event_name != 'pull_request'"
+    assert job["needs"] == ["python", "landing-class"]
+
+
+def test_combine_and_enforce_keeps_floor_and_drops_render() -> None:
+    step = _named_step(_coverage_floor(_load_ci()["jobs"]), "Combine and enforce")
+    run = step["run"]
+    assert "coverage combine" in run
+    assert "coverage report --fail-under=35" in run
+    assert "refusing to pass vacuously" in run
+    assert "coverage xml" not in run
+    assert "coverage html" not in run
+    assert "coverage-html" not in run
+
+
+def test_upload_ships_text_report_and_combined_data_only() -> None:
+    job = _coverage_floor(_load_ci()["jobs"])
+    uploads = [
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+    ]
+    assert len(uploads) == 1
+    step = uploads[0]
+    with_block = step["with"]
+    path = with_block["path"]
+    assert "coverage-report.txt" in path
+    assert ".coverage" in path
+    assert with_block["include-hidden-files"] is True
+    assert "coverage.xml" not in path
+    assert "coverage-html/" not in path
+    assert "coverage.xml" not in str(step)
+    assert "coverage-html/" not in str(step)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Take artifact-only `coverage xml` + `coverage html` rendering off the required `coverage-floor` job so Gate no longer waits on ~102s of unused report generation. Measured on main, that is about **1.7 minutes** of wall-clock on every green full-tier (`merge_group` / `push`) run.

The 35% floor itself is unchanged: empty-data still fail-closed, `coverage combine` still runs, and `coverage report --fail-under=35` still decides the job. Combined `.coverage` plus `coverage-report.txt` remain downloadable for offline `coverage html` / `coverage xml`.

Rollback is a single revert of this PR.

## Changes

- `.github/workflows/ci.yml` (`coverage-floor`): delete XML/HTML render from `Combine and enforce`; upload `coverage-report.txt` + `.coverage` only (`include-hidden-files: true`).
- `tests/test_ci_coverage_floor_gate.py`: hermetic lock that the floor stays on `ci-gate.needs` and render stays off the combine/upload path.

## Testing

- [x] `python3 -m pytest tests/test_ci_coverage_floor_gate.py -q` — pass
- [x] Nearby CI-structure suites: `tests/test_ci_queue_starvation.py`, `tests/test_ci_gate_required_results.py` — pass (33 total)

## Non-goals (intentionally untouched)

- Two-tier merge queue (PR light / `merge_group`+`push` full)
- `ci-gate` `if:` / #7137 / Gate `always() && !cancelled()` work
- New advisory `coverage-report` job
- Shard count, planner, path filters, concurrency, or merge_group cancel-in-progress
- venv / pip wheel cache for pytest-plan
- Weakening `--fail-under=35` or moving `coverage-floor` off `ci-gate.needs`

## Related Issues

This PR leaves existing CI-throughput follow-ups open (no issue closeout).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fbec3ce-c2b7-4bcc-9f58-c254214d2c85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fbec3ce-c2b7-4bcc-9f58-c254214d2c85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

