### PR TITLE
fix(hygiene): drop stale fetch refspecs after origin-head sweep (#7121)

### DIFF
--- a/scripts/hygiene/fetch_refspecs.py
+++ b/scripts/hygiene/fetch_refspecs.py
@@ -220,7 +220,7 @@ def add_fetch_branch(
             "refspec": spec,
             "duplicates": current.count(spec) - 1,
         }
-    desired = current + [spec]
+    desired = [*current, spec]
     _write_fetch_refspecs(repo_root, remote, desired, current)
     return {
         "added": True,

--- a/scripts/hygiene/fetch_refspecs.py
+++ b/scripts/hygiene/fetch_refspecs.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Reconcile stale ``remote.<remote>.fetch`` refspecs in narrow clones (#7121).
+
+A configured fetch refspec that names a deleted remote head is a hard error
+for ``git fetch`` / ``git pull`` — Git does not skip the missing ref. Narrow
+clones accumulate these entries via ``git remote set-branches --add`` when
+pulling PR branches; post-merge head deletion then arms the landmine.
+
+This module:
+
+* drops the matching fetch refspec when a merged/closed origin head is deleted
+* reconciles configured refspecs against ``git ls-remote --heads`` (preflight)
+* keeps the canonical ``main`` refspec
+* adds per-branch refspecs idempotently (no duplicates)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Dual-flavor import: delegate workers put only ``scripts/`` on sys.path.
+try:
+    from scripts.common.git_context import sanitized_git_env
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.git_context import sanitized_git_env  # type: ignore[no-redef]
+
+CANONICAL_MAIN_BRANCH = "main"
+DEFAULT_REMOTE = "origin"
+_LS_REMOTE_TIMEOUT_S = 60
+_GIT_TIMEOUT_S = 30
+
+__all__ = [
+    "CANONICAL_MAIN_BRANCH",
+    "DEFAULT_REMOTE",
+    "add_fetch_branch",
+    "canonical_main_refspec",
+    "drop_fetch_refspec_for_branch",
+    "head_refspec",
+    "list_fetch_refspecs",
+    "list_live_remote_heads",
+    "main",
+    "reconcile_fetch_refspecs",
+]
+
+
+def canonical_main_refspec(remote: str = DEFAULT_REMOTE) -> str:
+    return head_refspec(CANONICAL_MAIN_BRANCH, remote)
+
+
+def head_refspec(branch: str, remote: str = DEFAULT_REMOTE) -> str:
+    return f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}"
+
+
+def _run_git(
+    repo_root: Path,
+    *args: str,
+    timeout: int = _GIT_TIMEOUT_S,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+        env=sanitized_git_env(),
+    )
+
+
+def _config_key(remote: str) -> str:
+    return f"remote.{remote}.fetch"
+
+
+def _validate_remote(remote: str) -> str:
+    if not remote or not all(ch.isalnum() or ch in "-_" for ch in remote):
+        raise ValueError(f"invalid remote name: {remote!r}")
+    return remote
+
+
+def _validate_branch(repo_root: Path, branch: str) -> str:
+    if not branch or branch.startswith("-") or any(ch in branch for ch in " \t:*?[^~\\"):
+        raise ValueError(f"invalid branch name: {branch!r}")
+    proc = _run_git(repo_root, "check-ref-format", "--branch", branch)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "invalid ref").strip()
+        raise ValueError(f"invalid branch name {branch!r}: {detail}")
+    return branch
+
+
+def _single_head_name(refspec: str) -> str | None:
+    """Return the single ``refs/heads/<name>`` source, or None if not exact."""
+    spec = refspec.strip()
+    if not spec or spec.startswith("^"):
+        return None
+    if spec.startswith("+"):
+        spec = spec[1:]
+    if ":" not in spec:
+        return None
+    src, _dst = spec.split(":", 1)
+    prefix = "refs/heads/"
+    if not src.startswith(prefix):
+        return None
+    name = src[len(prefix) :]
+    if not name or any(ch in name for ch in "*?[\\"):
+        return None
+    return name
+
+
+def _covers_all_heads(refspec: str) -> bool:
+    spec = refspec.strip()
+    if spec.startswith("+"):
+        spec = spec[1:]
+    if ":" not in spec:
+        return False
+    src, _dst = spec.split(":", 1)
+    return src == "refs/heads/*"
+
+
+def _has_main_coverage(refspecs: list[str]) -> bool:
+    return any(
+        _covers_all_heads(spec) or _single_head_name(spec) == CANONICAL_MAIN_BRANCH
+        for spec in refspecs
+    )
+
+
+def _dedup_preserve(refspecs: list[str]) -> tuple[list[str], list[str]]:
+    kept: list[str] = []
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for spec in refspecs:
+        if spec in seen:
+            duplicates.append(spec)
+            continue
+        seen.add(spec)
+        kept.append(spec)
+    return kept, duplicates
+
+
+def list_fetch_refspecs(repo_root: Path, remote: str = DEFAULT_REMOTE) -> list[str]:
+    """Return configured ``remote.<remote>.fetch`` values in file order."""
+    remote = _validate_remote(remote)
+    proc = _run_git(repo_root, "config", "--get-all", _config_key(remote))
+    if proc.returncode == 1:
+        return []
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "git config failed").strip()
+        raise RuntimeError(f"could not read {_config_key(remote)}: {detail}")
+    return [line for line in (proc.stdout or "").splitlines() if line]
+
+
+def list_live_remote_heads(
+    repo_root: Path, remote: str = DEFAULT_REMOTE
+) -> set[str] | None:
+    """Return live remote head names, or None when ls-remote is unavailable."""
+    remote = _validate_remote(remote)
+    proc = _run_git(
+        repo_root,
+        "ls-remote",
+        "--heads",
+        remote,
+        timeout=_LS_REMOTE_TIMEOUT_S,
+    )
+    if proc.returncode != 0:
+        return None
+    heads: set[str] = set()
+    for line in (proc.stdout or "").splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        ref = parts[1]
+        prefix = "refs/heads/"
+        if ref.startswith(prefix):
+            heads.add(ref[len(prefix) :])
+    return heads
+
+
+def _write_fetch_refspecs(
+    repo_root: Path,
+    remote: str,
+    desired: list[str],
+    previous: list[str],
+) -> None:
+    key = _config_key(remote)
+    unset = _run_git(repo_root, "config", "--unset-all", key)
+    if unset.returncode not in (0, 5):
+        detail = (unset.stderr or unset.stdout or "git config --unset-all failed").strip()
+        raise RuntimeError(f"could not clear {key}: {detail}")
+    try:
+        for spec in desired:
+            added = _run_git(repo_root, "config", "--add", key, spec)
+            if added.returncode != 0:
+                detail = (added.stderr or added.stdout or "git config --add failed").strip()
+                raise RuntimeError(f"could not add {key}={spec}: {detail}")
+    except Exception:
+        restore = _run_git(repo_root, "config", "--unset-all", key)
+        if restore.returncode in (0, 5):
+            for spec in previous:
+                _run_git(repo_root, "config", "--add", key, spec)
+        raise
+
+
+def add_fetch_branch(
+    repo_root: Path,
+    branch: str,
+    remote: str = DEFAULT_REMOTE,
+) -> dict[str, Any]:
+    """Add one per-branch fetch refspec if it is not already present."""
+    remote = _validate_remote(remote)
+    branch = _validate_branch(repo_root, branch)
+    spec = head_refspec(branch, remote)
+    current = list_fetch_refspecs(repo_root, remote)
+    if spec in current:
+        return {
+            "added": False,
+            "already_present": True,
+            "refspec": spec,
+            "duplicates": current.count(spec) - 1,
+        }
+    desired = current + [spec]
+    _write_fetch_refspecs(repo_root, remote, desired, current)
+    return {
+        "added": True,
+        "already_present": False,
+        "refspec": spec,
+        "duplicates": 0,
+    }
+
+
+def drop_fetch_refspec_for_branch(
+    repo_root: Path,
+    branch: str,
+    remote: str = DEFAULT_REMOTE,
+) -> bool:
+    """Drop every exact-head fetch refspec for ``branch``. Never drops ``main``."""
+    remote = _validate_remote(remote)
+    branch = _validate_branch(repo_root, branch)
+    if branch == CANONICAL_MAIN_BRANCH:
+        return False
+    current = list_fetch_refspecs(repo_root, remote)
+    remaining = [spec for spec in current if _single_head_name(spec) != branch]
+    remaining, _dups = _dedup_preserve(remaining)
+    if not _has_main_coverage(remaining):
+        remaining.insert(0, canonical_main_refspec(remote))
+    if remaining == current:
+        return False
+    _write_fetch_refspecs(repo_root, remote, remaining, current)
+    return True
+
+
+def reconcile_fetch_refspecs(
+    repo_root: Path,
+    remote: str = DEFAULT_REMOTE,
+    *,
+    apply: bool = True,
+) -> dict[str, Any]:
+    """Prune gone-head refspecs, dedup, and keep the canonical main refspec."""
+    remote = _validate_remote(remote)
+    before = list_fetch_refspecs(repo_root, remote)
+    live = list_live_remote_heads(repo_root, remote)
+
+    unique, duplicates = _dedup_preserve(before)
+    pruned: list[str] = []
+    kept: list[str] = []
+    for spec in unique:
+        head = _single_head_name(spec)
+        if (
+            live is not None
+            and head is not None
+            and head != CANONICAL_MAIN_BRANCH
+            and head not in live
+        ):
+            pruned.append(spec)
+            continue
+        kept.append(spec)
+
+    restored_main = False
+    if not _has_main_coverage(kept):
+        kept.insert(0, canonical_main_refspec(remote))
+        restored_main = True
+
+    error: str | None = None
+    after = list(before)
+    applied = False
+    if apply and kept != before:
+        try:
+            _write_fetch_refspecs(repo_root, remote, kept, before)
+            after = list_fetch_refspecs(repo_root, remote)
+            applied = True
+        except Exception as exc:
+            error = str(exc)
+            after = list_fetch_refspecs(repo_root, remote)
+    elif not apply:
+        after = list(kept)
+
+    return {
+        "ok": error is None,
+        "remote": remote,
+        "applied": applied,
+        "before": before,
+        "after": after,
+        "pruned": pruned,
+        "deduped": duplicates,
+        "restored_main": restored_main,
+        "live_heads_available": live is not None,
+        "error": error,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reconcile remote fetch refspecs against live heads so a stale "
+            "set-branches entry cannot hard-fail git fetch (#7121)."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository (or worktree) to repair. Default: cwd.",
+    )
+    parser.add_argument(
+        "--remote",
+        default=DEFAULT_REMOTE,
+        help=f"Remote name (default: {DEFAULT_REMOTE}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing git config.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report.")
+    args = parser.parse_args(argv)
+
+    report = reconcile_fetch_refspecs(
+        args.repo_root,
+        remote=args.remote,
+        apply=not args.dry_run,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        pruned = ", ".join(report["pruned"]) or "(none)"
+        deduped = len(report["deduped"])
+        print(
+            f"fetch refspecs remote={report['remote']} "
+            f"pruned={len(report['pruned'])} deduped={deduped} "
+            f"restored_main={report['restored_main']} "
+            f"applied={report['applied']}"
+        )
+        if report["pruned"]:
+            print(f"  pruned: {pruned}")
+        if report["error"]:
+            print(f"  error: {report['error']}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -29,7 +29,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.hygiene import home_session_retention_check
+from scripts.hygiene import fetch_refspecs, home_session_retention_check
 from scripts.orchestration import reap_worktrees
 from scripts.orchestration.tmp_leak_sweep import sweep_tmp_leaks
 from scripts.review.isolation import sweep_review_temp_orphans
@@ -363,6 +363,18 @@ def cleanup_stale_origin_branches(
             branch=branch,
             expected_head=head_sha,
         )
+        # Deleting the origin head without dropping the matching fetch
+        # refspec is the #7121 landmine: the next bare fetch hard-fails.
+        refspec_dropped = False
+        if error is None or error == "origin HEAD disappeared during cleanup":
+            try:
+                refspec_dropped = fetch_refspecs.drop_fetch_refspec_for_branch(
+                    repo_root,
+                    branch,
+                )
+            except Exception as exc:
+                if error is None:
+                    error = f"origin head deleted but fetch refspec drop failed: {exc}"
         results.append(
             {
                 "action": "error" if error else "deleted",
@@ -370,6 +382,7 @@ def cleanup_stale_origin_branches(
                 "head_sha": head_sha,
                 "reason": reason,
                 "error": error,
+                "refspec_dropped": refspec_dropped,
             }
         )
     return results
@@ -698,6 +711,7 @@ def _empty_repo_result(repo_root: Path) -> dict[str, Any]:
     return {
         "repo_root": str(repo_root),
         "fetch": None,
+        "fetch_refspecs": None,
         "worktree_prune": None,
         "activity_probe": None,
         "results": [],
@@ -717,6 +731,22 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
     if not (repo_root / ".git").exists():
         result["errors"].append("repository .git metadata is missing")
         return result
+
+    # Self-heal stale per-branch fetch refspecs before fetch (#7121).
+    # A configured refspec whose remote head is gone is a hard error, so
+    # this must run before the first `git fetch --prune`.
+    try:
+        refspec_report = fetch_refspecs.reconcile_fetch_refspecs(
+            repo_root, apply=True
+        )
+        result["fetch_refspecs"] = refspec_report
+        if not refspec_report.get("ok"):
+            result["errors"].append(
+                f"fetch refspec reconcile failed ({refspec_report.get('error')})"
+            )
+    except Exception as exc:
+        result["fetch_refspecs"] = {"ok": False, "error": str(exc)}
+        result["errors"].append(f"fetch refspec reconcile failed: {exc}")
 
     fetch = _run_git(repo_root, "fetch", "--prune", "origin")
     result["fetch"] = {
@@ -776,6 +806,15 @@ def _repo_result_unlocked(repo_root: Path, *, apply: bool) -> dict[str, Any]:
         else:
             origin_branches = cleanup_stale_origin_branches(repo_root, apply=apply)
             if apply:
+                if any(row.get("action") == "deleted" for row in origin_branches):
+                    try:
+                        fetch_refspecs.reconcile_fetch_refspecs(
+                            repo_root, apply=True
+                        )
+                    except Exception as exc:
+                        result["errors"].append(
+                            f"post-origin fetch refspec reconcile failed: {exc}"
+                        )
                 prune_after = _run_git(repo_root, "fetch", "--prune", "origin")
                 if prune_after.returncode != 0:
                     result["errors"].append(

--- a/tests/hygiene/test_fetch_refspecs.py
+++ b/tests/hygiene/test_fetch_refspecs.py
@@ -1,0 +1,303 @@
+"""Tests for stale remote fetch-refspec hygiene (#7121).
+
+A narrow clone with a configured refspec pointing at a deleted remote head
+cannot `git fetch` at all. The cleaner/guard must drop that entry, keep the
+canonical main refspec, and make fetch succeed again.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.hygiene import fetch_refspecs
+from scripts.orchestration import scheduled_worktree_cleanup as cleanup
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+        and not key.startswith("PRE_COMMIT")
+        and key != "AGENT_NO_MERGE"
+    }
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+        env=_git_env(),
+        timeout=30,
+    )
+
+
+def _git_ok(cwd: Path, *args: str) -> str:
+    return _git(cwd, *args).stdout.strip()
+
+
+def _narrow_clone(tmp_path: Path) -> Path:
+    """Bare origin + single-branch clone whose fetch config is main-only."""
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    clone = tmp_path / "narrow"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "init", "--initial-branch=main", str(seed))
+    _git(seed, "config", "user.email", "test@example.invalid")
+    _git(seed, "config", "user.name", "Test User")
+    (seed / "README.md").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "base")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    _git(
+        tmp_path,
+        "clone",
+        "--filter=blob:none",
+        "--single-branch",
+        "--branch",
+        "main",
+        str(remote),
+        str(clone),
+    )
+    _git(clone, "config", "user.email", "test@example.invalid")
+    _git(clone, "config", "user.name", "Test User")
+    return clone
+
+
+def _fetch_refspecs(repo: Path) -> list[str]:
+    return fetch_refspecs.list_fetch_refspecs(repo)
+
+
+def _add_stale_refspec(repo: Path, branch: str) -> str:
+    spec = fetch_refspecs.head_refspec(branch)
+    _git(repo, "config", "--add", "remote.origin.fetch", spec)
+    return spec
+
+
+def test_stale_refspec_hard_fails_fetch_until_guard_runs(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    stale = "cursor/scrub-public-ops-paths-a004"
+    spec = _add_stale_refspec(repo, stale)
+
+    before = _git(repo, "fetch", "origin", check=False)
+    assert before.returncode != 0
+    assert "couldn't find remote ref" in (before.stderr or before.stdout)
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=True)
+
+    assert report["ok"] is True
+    assert spec in report["pruned"]
+    assert fetch_refspecs.canonical_main_refspec() in report["after"]
+    assert spec not in _fetch_refspecs(repo)
+
+    after = _git(repo, "fetch", "origin", check=False)
+    assert after.returncode == 0, after.stderr or after.stdout
+
+
+def test_add_fetch_branch_is_idempotent(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    branch = "cursor/infra-7095-progress-backlog"
+    _git(repo, "branch", branch, "main")
+    _git(repo, "push", "origin", branch)
+
+    first = fetch_refspecs.add_fetch_branch(repo, branch)
+    second = fetch_refspecs.add_fetch_branch(repo, branch)
+
+    assert first["added"] is True
+    assert second["added"] is False
+    assert second["already_present"] is True
+    assert _fetch_refspecs(repo).count(first["refspec"]) == 1
+
+    fetched = _git(repo, "fetch", "origin", check=False)
+    assert fetched.returncode == 0, fetched.stderr or fetched.stdout
+
+
+def test_reconcile_dedups_duplicate_refspecs(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    branch = "cursor/infra-7095-progress-backlog"
+    _git(repo, "branch", branch, "main")
+    _git(repo, "push", "origin", branch)
+    spec = fetch_refspecs.head_refspec(branch)
+    _git(repo, "config", "--add", "remote.origin.fetch", spec)
+    _git(repo, "config", "--add", "remote.origin.fetch", spec)
+
+    assert _fetch_refspecs(repo).count(spec) == 2
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=True)
+
+    assert report["ok"] is True
+    assert report["deduped"] == [spec]
+    assert _fetch_refspecs(repo).count(spec) == 1
+    assert fetch_refspecs.canonical_main_refspec() in _fetch_refspecs(repo)
+
+    fetched = _git(repo, "fetch", "origin", check=False)
+    assert fetched.returncode == 0, fetched.stderr or fetched.stdout
+
+
+def test_reconcile_keeps_live_extra_branch_refspec(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    branch = "feat/still-open"
+    _git(repo, "branch", branch, "main")
+    _git(repo, "push", "origin", branch)
+    spec = fetch_refspecs.head_refspec(branch)
+    _git(repo, "config", "--add", "remote.origin.fetch", spec)
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=True)
+
+    assert spec in report["after"]
+    assert spec not in report["pruned"]
+    assert spec in _fetch_refspecs(repo)
+
+
+def test_reconcile_restores_canonical_main_refspec(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    stale = fetch_refspecs.head_refspec("gone/only-entry")
+    _git(repo, "config", "--unset-all", "remote.origin.fetch")
+    _git(repo, "config", "--add", "remote.origin.fetch", stale)
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=True)
+
+    assert report["restored_main"] is True
+    assert fetch_refspecs.canonical_main_refspec() in _fetch_refspecs(repo)
+    assert stale not in _fetch_refspecs(repo)
+    fetched = _git(repo, "fetch", "origin", check=False)
+    assert fetched.returncode == 0, fetched.stderr or fetched.stdout
+
+
+def test_reconcile_does_not_drop_live_specs_when_ls_remote_fails(
+    tmp_path: Path,
+) -> None:
+    repo = _narrow_clone(tmp_path)
+    branch = "feat/keep-when-offline"
+    spec = fetch_refspecs.head_refspec(branch)
+    _git(repo, "config", "--add", "remote.origin.fetch", spec)
+    _git(repo, "remote", "set-url", "origin", "file:///no/such/remote.git")
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=True)
+
+    assert report["live_heads_available"] is False
+    assert spec in _fetch_refspecs(repo)
+    assert spec not in report["pruned"]
+
+
+def test_drop_never_removes_canonical_main(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    assert fetch_refspecs.drop_fetch_refspec_for_branch(repo, "main") is False
+    assert fetch_refspecs.canonical_main_refspec() in _fetch_refspecs(repo)
+
+
+def test_origin_head_delete_also_drops_matching_refspec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _narrow_clone(tmp_path)
+    branch = "codex/merged-origin"
+    _git(repo, "branch", branch, "main")
+    _git(repo, "push", "origin", branch)
+    spec = fetch_refspecs.add_fetch_branch(repo, branch)["refspec"]
+    _git(repo, "fetch", "origin")
+    head_sha = _git_ok(repo, "rev-parse", branch)
+
+    def _prs(_repo: Path, candidate: str | None):
+        if candidate != branch:
+            return [], None
+        return (
+            [
+                cleanup.reap_worktrees.PullRequestState(
+                    number=77,
+                    state="MERGED",
+                    head_sha=head_sha,
+                )
+            ],
+            None,
+        )
+
+    monkeypatch.setattr(cleanup.reap_worktrees, "_query_pr_states", _prs)
+
+    applied = cleanup.cleanup_stale_origin_branches(repo, apply=True)
+
+    deleted = next(item for item in applied if item["branch"] == branch)
+    assert deleted["action"] == "deleted"
+    assert deleted["refspec_dropped"] is True
+    assert spec not in _fetch_refspecs(repo)
+    assert fetch_refspecs.canonical_main_refspec() in _fetch_refspecs(repo)
+
+    fetched = _git(repo, "fetch", "origin", check=False)
+    assert fetched.returncode == 0, fetched.stderr or fetched.stdout
+
+
+def test_dry_run_reconcile_does_not_write(tmp_path: Path) -> None:
+    repo = _narrow_clone(tmp_path)
+    spec = _add_stale_refspec(repo, "cursor/stale-dry-run")
+    before = _fetch_refspecs(repo)
+
+    report = fetch_refspecs.reconcile_fetch_refspecs(repo, apply=False)
+
+    assert report["applied"] is False
+    assert spec in report["pruned"]
+    assert _fetch_refspecs(repo) == before
+
+
+def test_scheduled_hygiene_heals_stale_refspec_before_fetch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _narrow_clone(tmp_path)
+    spec = _add_stale_refspec(repo, "kimi/infra-7080-audit-dashboard-r2")
+    monkeypatch.setattr(
+        cleanup, "_worktree_prune", lambda _repo, *, apply: {"ok": True}
+    )
+    monkeypatch.setattr(cleanup.reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+    monkeypatch.setattr(cleanup.reap_worktrees, "reap_worktrees", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        cleanup.reap_worktrees, "adopt_dispatch_worktrees", lambda _repo: []
+    )
+    monkeypatch.setattr(cleanup, "cleanup_gone_local_branches", lambda *_a, **_k: [])
+    monkeypatch.setattr(cleanup, "cleanup_stale_origin_branches", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        cleanup, "cleanup_untracked_local_branches", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(cleanup, "find_orphaned_worktree_directories", lambda _repo: [])
+    monkeypatch.setattr(
+        cleanup, "_git_maintenance", lambda _repo, *, apply: {"ok": True}
+    )
+    monkeypatch.setattr(cleanup, "sweep_review_temp_orphans", lambda: {"errors": 0})
+    monkeypatch.setattr(
+        cleanup,
+        "sweep_tmp_leaks",
+        lambda apply=False: {
+            "errors": 0,
+            "roots_reaped": 0,
+            "bytes_freed": 0,
+            "candidates": 0,
+            "skipped_live": 0,
+        },
+    )
+
+    result = cleanup._repo_result(repo, apply=False)
+
+    assert result["fetch"]["ok"] is True
+    assert spec in (result["fetch_refspecs"] or {}).get("pruned", [])
+    assert spec not in _fetch_refspecs(repo)
+    fetched = _git(repo, "fetch", "origin", check=False)
+    assert fetched.returncode == 0, fetched.stderr or fetched.stdout
+
+
+def test_cli_json_heals_stale_refspec(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _narrow_clone(tmp_path)
+    spec = _add_stale_refspec(repo, "agy/infra-6977-runner")
+
+    rc = fetch_refspecs.main(["--repo-root", str(repo), "--json"])
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert spec in report["pruned"]
+    assert spec not in _fetch_refspecs(repo)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #7121. Narrow clones that accumulate per-branch `remote.origin.fetch` refspecs hard-fail every `git fetch` / `git pull` after those remote heads are deleted. Hygiene now drops the matching fetch refspec when it deletes a merged/closed origin head, and a preflight reconciles configured refspecs against live remote heads.

This is a normal PR against `main` (not merge-queue).

## Changes

- Add `scripts/hygiene/fetch_refspecs.py`: drop/reconcile/dedup fetch refspecs, keep the canonical `main` refspec, and add per-branch specs idempotently.
- Hook the helper into scheduled Git hygiene: reconcile before the first fetch, drop the matching spec when an origin head is deleted, and re-reconcile before the post-origin prune fetch.
- Tests: fixture clone with a refspec pointing at a deleted head; fetch succeeds after the cleaner/guard. Also covers idempotent add, dedup, live-spec keep, offline ls-remote fail-closed, and the scheduled preflight.

## Testing

- [x] `python3 -m pytest tests/hygiene/test_fetch_refspecs.py tests/orchestration/test_scheduled_worktree_cleanup.py tests/hygiene/test_root_entry_guard.py` — 38 + 13 passed locally
- [ ] Website builds without errors (`cd site && npm run build`) — not applicable
- [ ] Ukrainian text reviewed for naturalness — not applicable

## Related Issues

Fixes #7121

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad8a9c95-29e2-4426-94ec-014e508957e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad8a9c95-29e2-4426-94ec-014e508957e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

