### PR TITLE
fix(transport): reject path-shaped ACP task tokens

### DIFF
--- a/scripts/ai_agent_bridge/_acp_execution.py
+++ b/scripts/ai_agent_bridge/_acp_execution.py
@@ -32,6 +32,17 @@ class AcpExecutionWorkspaceError(RuntimeError):
     """ACP could not obtain or release its isolated execution cwd."""
 
 
+def _execution_label(task_id: str) -> str:
+    """Return a bounded directory label, rejecting transport-shaped debris."""
+    raw = task_id.strip()
+    if not raw or raw.startswith("-") or "{" in raw or "}" in raw:
+        raise AcpExecutionWorkspaceError("unsafe_acp_execution_task_id")
+    label = _SAFE_TASK.sub("-", raw).strip("-._")[:32]
+    if not label or label.startswith("-") or label in {".", ".."}:
+        raise AcpExecutionWorkspaceError("unsafe_acp_execution_task_id")
+    return label
+
+
 def _git_binary() -> str:
     binary = shutil.which("git")
     if binary is None:
@@ -59,6 +70,11 @@ def acp_execution_cwd(repo_root: Path, *, task_id: str) -> Iterator[Path]:
     unique detached worktree with no checkout, so the runtime gains only the
     Git/worktree identity required by ACP admission—not another source copy.
     """
+    # Validate before any mkdir/worktree operation.  ACP/opencode stdout is an
+    # NDJSON event stream; a wiring or quoting fault must fail closed instead
+    # of turning a raw event line, JSON fragment, or flag-shaped token into a
+    # filesystem segment (#6863).
+    label = _execution_label(task_id)
     resolved = repo_root.resolve()
     path_class = classify_repo_path(resolved, cwd=resolved)
     if path_class in {"dispatch_worktree", "other_worktree"}:
@@ -68,7 +84,6 @@ def acp_execution_cwd(repo_root: Path, *, task_id: str) -> Iterator[Path]:
         raise AcpExecutionWorkspaceError("acp_repo_root_must_be_a_registered_checkout")
 
     main_root = resolve_main_root(resolved)
-    label = _SAFE_TASK.sub("-", task_id).strip("-._")[:32] or "task"
     workspace = main_root / ".worktrees" / "dispatch" / "acp" / f"runtime-{label}-{uuid.uuid4().hex[:10]}"
     workspace.parent.mkdir(parents=True, exist_ok=True)
     created = False

--- a/tests/ai_agent_bridge/test_acp_execution.py
+++ b/tests/ai_agent_bridge/test_acp_execution.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from scripts.ai_agent_bridge._acp_execution import acp_execution_cwd
+import pytest
+
+from scripts.ai_agent_bridge._acp_execution import (
+    AcpExecutionWorkspaceError,
+    acp_execution_cwd,
+)
 from scripts.guardrails.worktree_containment import classify_repo_path
 
 
@@ -47,3 +52,30 @@ def test_primary_root_call_uses_and_removes_detached_no_checkout_worktree(
     assert not workspace.exists()
     listed = _git(primary, "worktree", "list", "--porcelain").stdout
     assert str(workspace) not in listed
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "-rf",
+        '{"type":"tool","part":{"tool":"bash"}}',
+        'prompt"}}',
+    ],
+)
+def test_transport_fragment_task_id_is_rejected_before_directory_creation(
+    tmp_path: Path,
+    token: str,
+) -> None:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-b", "main")
+
+    with pytest.raises(
+        AcpExecutionWorkspaceError,
+        match="unsafe_acp_execution_task_id",
+    ):
+        with acp_execution_cwd(primary, task_id=token):
+            raise AssertionError("unsafe task id reached the ACP execution body")
+
+    assert not (primary / ".worktrees").exists()
+    assert not (primary / token).exists()


### PR DESCRIPTION
## Summary

- fail closed before ACP execution workspace creation when the task identifier looks like an option or ACP/opencode NDJSON debris
- keep the existing bounded label normalization for ordinary task identifiers
- cover the literal -rf token, a complete tool event line, and a trailing JSON fragment; each must leave no workspace or same-named directory

## Root-cause scope

A bounded audit did not recover the retired Aug-13 bridge-ask creator. Current ACPX transport streams NDJSON on stdout and passes no output path. This PR therefore hardens the live ACP compatibility boundary that converts transport task metadata into a worktree directory segment. It complements the existing plane-root anchor and root-entry alert from #6866.

No automatic sweeper is included because the leaked directories are forensic evidence and flag-shaped deletion targets are unsafe to remove heuristically.

## Verification

- 68 passed: ACP execution and ask-contract suites
- ruff: clean on both changed files
- mutation check: removing the suspicious-token rejection makes all three new cases fail
- root hygiene strict scan: clean

Fixes #6863