### PR TITLE
feat(api): enumerate dual opaque hosts and add idle/occupant glance to occupancy (#7139)

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -543,16 +543,25 @@ function renderOccupancy(data) {
     if (!host || typeof host !== 'object') continue;
     const hostId = short(host.host_id);
     const occupants = listValue(host.occupants);
+    const idleState = host.idle_or_empty ? 'idle' : 'active';
+    let utilText = '—';
+    if (host.status !== 'unavailable') {
+      const parts = [];
+      if (host.mem && host.mem.pct != null) parts.push(`RAM ${host.mem.pct}%`);
+      if (host.disk && host.disk.pct != null) parts.push(`Disk ${host.disk.pct}%`);
+      if (Array.isArray(host.loadavg) && host.loadavg.length) parts.push(`Load ${host.loadavg[0]}`);
+      if (parts.length) utilText = parts.join(' · ');
+    }
     if (!occupants.length) {
-      rows.push(`<tr><td class="mono">${escapeHtml(hostId)}</td><td>${pill(host.status)}</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td></tr>`);
+      rows.push(`<tr><td class="mono">${escapeHtml(hostId)}</td><td>${pill(host.status)}</td><td>${pill(idleState)}</td><td class="muted">${escapeHtml(utilText)}</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td></tr>`);
       continue;
     }
     occupants.forEach(item => {
-      rows.push(`<tr><td class="mono">${escapeHtml(hostId)}</td><td>${pill(host.status)}</td><td>${escapeHtml(short(item.kind))}</td><td class="mono">${escapeHtml(short(item.agent))}</td><td class="mono">${escapeHtml(short(item.task_id))}</td><td class="mono">${escapeHtml(short(item.epic))}</td><td>${pill(item.status)}</td></tr>`);
+      rows.push(`<tr><td class="mono">${escapeHtml(hostId)}</td><td>${pill(host.status)}</td><td>${pill(idleState)}</td><td class="muted">${escapeHtml(utilText)}</td><td>${escapeHtml(short(item.kind))}</td><td class="mono">${escapeHtml(short(item.agent))}</td><td class="mono">${escapeHtml(short(item.task_id))}</td><td class="mono">${escapeHtml(short(item.epic))}</td><td>${pill(item.status)}</td></tr>`);
     });
   }
   document.getElementById('occupancy-content').innerHTML = table(
-    ['Host', 'Probe', 'Kind', 'Agent', 'Task', 'Epic', 'Status'],
+    ['Host', 'Probe', 'Burn', 'Utilization', 'Kind', 'Agent', 'Task', 'Epic', 'Status'],
     rows,
     'No occupancy occupants. Observer heartbeats appear under cloud-observer.',
   );

--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -543,7 +543,7 @@ function renderOccupancy(data) {
     if (!host || typeof host !== 'object') continue;
     const hostId = short(host.host_id);
     const occupants = listValue(host.occupants);
-    const idleState = host.idle_or_empty ? 'idle' : 'active';
+    const idleState = host.status === 'unavailable' ? 'unknown' : (host.idle_or_empty ? 'idle' : 'active');
     let utilText = '—';
     if (host.status !== 'unavailable') {
       const parts = [];

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -237,9 +237,9 @@ Standard HTTP status codes: `404` for missing resources, `500` for server errors
 
 ### `GET /api/occupancy[?host_id=x][&fresh=true]`
 
-Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). Host keys are opaque `host_id` values from `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Without that map the `hosts` object is empty — canonical aliases are never used as JSON keys.
+Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). The payload always enumerates both opaque hosts `host-teacher` and `host-job` (and any additional mapped hosts). Host mappings are configured via `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Unmapped default hosts return `status: "unavailable"` with `idle_or_empty: true`. Canonical aliases are never used as JSON keys.
 
-Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service | observer`. Observer heartbeats (`POST /api/observer/presence`) appear under `host_id` `cloud-observer` (no CPU/RAM metrics, no SSH identity). Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
+Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service | observer`. Each host entry includes `occupant_count`, `ai_seats` (active agent seats), and `idle_or_empty` (boolean indicating near-zero burn). Observer heartbeats (`POST /api/observer/presence`) appear under `host_id` `cloud-observer` (no CPU/RAM metrics, no SSH identity). Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
 
 On a running event loop, a missing or expired cache entry and `fresh=true` wait for the shared load probe before responding. A successful sample younger than 30s is `fresh`. Refresh starts at 15s so a live heartbeat does not wait until the window expires; while that probe runs, the same sample stays `fresh` for 15s past the window. Cached metrics between 45 and 300 seconds old may still be returned as `stale` while a refresh runs.
 
@@ -263,6 +263,17 @@ curl -s http://localhost:8765/api/occupancy | python3 -m json.tool
       "status": "fresh",
       "observed_at": "2026-08-19T12:00:00Z",
       "age_seconds": 1.5,
+      "occupants": [
+        {
+          "kind": "job",
+          "agent": null,
+          "task_id": "example-job",
+          "epic": "atlas"
+        }
+      ],
+      "occupant_count": 1,
+      "ai_seats": [],
+      "idle_or_empty": false,
       "cpu_count": 4,
       "loadavg": [0.15, 0.22, 0.18],
       "mem": {
@@ -274,15 +285,7 @@ curl -s http://localhost:8765/api/occupancy | python3 -m json.tool
         "available_bytes": 53687091200,
         "total_bytes": 107374182400,
         "pct": 50.0
-      },
-      "occupants": [
-        {
-          "kind": "job",
-          "agent": null,
-          "task_id": "example-job",
-          "epic": "atlas"
-        }
-      ]
+      }
     },
     "host-teacher": {
       "host_id": "host-teacher",
@@ -290,7 +293,10 @@ curl -s http://localhost:8765/api/occupancy | python3 -m json.tool
       "error": "unreachable",
       "observed_at": "2026-08-19T12:00:00Z",
       "age_seconds": 0.0,
-      "occupants": []
+      "occupants": [],
+      "occupant_count": 0,
+      "ai_seats": [],
+      "idle_or_empty": true
     }
   }
 }

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -237,7 +237,7 @@ Standard HTTP status codes: `404` for missing resources, `500` for server errors
 
 ### `GET /api/occupancy[?host_id=x][&fresh=true]`
 
-Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). The payload always enumerates both opaque hosts `host-teacher` and `host-job` (and any additional mapped hosts). Host mappings are configured via `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Unmapped default hosts return `status: "unavailable"` with `idle_or_empty: true`. Canonical aliases are never used as JSON keys.
+Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). The payload always enumerates both opaque hosts `host-teacher` and `host-job` (and any additional mapped hosts). Host mappings are configured via `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Unmapped default hosts return `status: "unavailable"` with `idle_or_empty: false` — unreachable burn is unknown, not proven idle. Canonical aliases are never used as JSON keys.
 
 Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service | observer`. Each host entry includes `occupant_count`, `ai_seats` (active agent seats), and `idle_or_empty` (boolean indicating near-zero burn). Observer heartbeats (`POST /api/observer/presence`) appear under `host_id` `cloud-observer` (no CPU/RAM metrics, no SSH identity). Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
 
@@ -296,7 +296,7 @@ curl -s http://localhost:8765/api/occupancy | python3 -m json.tool
       "occupants": [],
       "occupant_count": 0,
       "ai_seats": [],
-      "idle_or_empty": true
+      "idle_or_empty": false
     }
   }
 }

--- a/scripts/api/occupancy.py
+++ b/scripts/api/occupancy.py
@@ -123,7 +123,8 @@ def _is_idle_or_empty(
     if occupants and not all(o.get("kind") == "observer" and o.get("status") == "idle" for o in occupants):
         return False
     if status == "unavailable":
-        return True
+        # Unreachable burn is unknown, not proven idle.
+        return False
     if load_entry:
         job_unit = load_entry.get("job_unit")
         if isinstance(job_unit, dict) and int(job_unit.get("active_count") or 0) > 0:

--- a/scripts/api/occupancy.py
+++ b/scripts/api/occupancy.py
@@ -29,6 +29,18 @@ OCCUPANCY_SCHEMA = "monitor-occupancy.v1"
 _LOAD_METRIC_KEYS = ("cpu_count", "loadavg", "mem", "disk")
 
 
+DEFAULT_HOST_IDS = ("host-teacher", "host-job")
+
+
+def _unavailable_load_entry() -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "error": "unreachable",
+        "observed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "age_seconds": 0.0,
+    }
+
+
 def parse_host_id_map(raw: str | None = None) -> dict[str, str]:
     """Parse ``canonical=opaque`` pairs. Drop anything that is not opaque."""
     text = (raw if raw is not None else os.environ.get("MONITOR_OCCUPANCY_HOST_IDS", "")).strip()
@@ -103,14 +115,53 @@ def _merge_occupants(*groups: list[dict[str, str | None]]) -> list[dict[str, str
     return merged
 
 
-def _shape_host(host_id: str, load_entry: dict[str, Any], occupants: list[dict[str, str | None]]) -> dict[str, Any]:
+def _is_idle_or_empty(
+    status: str,
+    occupants: list[dict[str, str | None]],
+    load_entry: dict[str, Any] | None = None,
+) -> bool:
+    if occupants:
+        if not all(o.get("kind") == "observer" and o.get("status") == "idle" for o in occupants):
+            return False
+    if status == "unavailable":
+        return True
+    if load_entry:
+        job_unit = load_entry.get("job_unit")
+        if isinstance(job_unit, dict) and int(job_unit.get("active_count") or 0) > 0:
+            return False
+        loadavg = load_entry.get("loadavg")
+        if isinstance(loadavg, list) and loadavg:
+            try:
+                load1 = float(loadavg[0])
+                if load1 >= 1.0:
+                    return False
+            except (TypeError, ValueError, IndexError):
+                pass
+    return True
+
+
+def _shape_host(
+    host_id: str,
+    load_entry: dict[str, Any],
+    occupants: list[dict[str, str | None]],
+) -> dict[str, Any]:
     status = str(load_entry.get("status") or "unavailable")
+    valid_status = status if status in {"fresh", "stale", "unavailable"} else "unavailable"
+    ai_seats: list[str] = []
+    for o in occupants:
+        agent = o.get("agent")
+        if agent and agent not in ai_seats:
+            ai_seats.append(str(agent))
+    idle = _is_idle_or_empty(valid_status, occupants, load_entry)
     shaped: dict[str, Any] = {
         "host_id": host_id,
-        "status": status if status in {"fresh", "stale", "unavailable"} else "unavailable",
+        "status": valid_status,
         "observed_at": load_entry.get("observed_at"),
         "age_seconds": load_entry.get("age_seconds", 0.0),
         "occupants": occupants,
+        "occupant_count": len(occupants),
+        "ai_seats": ai_seats,
+        "idle_or_empty": idle,
     }
     if shaped["status"] == "unavailable":
         shaped["error"] = "unreachable"
@@ -137,12 +188,21 @@ def _occupants_from_observers() -> list[dict[str, str | None]]:
 
 
 def _shape_cloud_observer(occupants: list[dict[str, str | None]]) -> dict[str, Any]:
+    ai_seats: list[str] = []
+    for o in occupants:
+        agent = o.get("agent")
+        if agent and agent not in ai_seats:
+            ai_seats.append(str(agent))
+    idle = (not occupants) or all(o.get("status") == "idle" for o in occupants)
     return {
         "host_id": CLOUD_OBSERVER_HOST_ID,
         "status": "fresh",
         "observed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "age_seconds": 0.0,
         "occupants": occupants,
+        "occupant_count": len(occupants),
+        "ai_seats": ai_seats,
+        "idle_or_empty": idle,
     }
 
 
@@ -156,20 +216,26 @@ def _attach_cloud_observer(payload: dict[str, Any], host_id: str | None) -> dict
     return payload
 
 
-def _selected_hosts(host_id: str | None) -> dict[str, str]:
+def _selected_hosts(host_id: str | None) -> dict[str, str | None]:
     if host_id == CLOUD_OBSERVER_HOST_ID:
         return {}
 
     mapping = parse_host_id_map()
-    if not mapping:
-        return {}
-
     reverse = {opaque: canonical for canonical, opaque in mapping.items()}
     if host_id is not None:
-        if host_id not in reverse:
-            raise HTTPException(status_code=400, detail="unknown host_id")
-        return {host_id: reverse[host_id]}
-    return {opaque: canonical for canonical, opaque in mapping.items()}
+        if host_id in reverse:
+            return {host_id: reverse[host_id]}
+        if host_id in DEFAULT_HOST_IDS:
+            return {host_id: None}
+        raise HTTPException(status_code=400, detail="unknown host_id")
+
+    selected: dict[str, str | None] = {}
+    for default_id in DEFAULT_HOST_IDS:
+        selected[default_id] = reverse.get(default_id)
+    for opaque, canonical in reverse.items():
+        if opaque not in selected:
+            selected[opaque] = canonical
+    return selected
 
 
 def _empty_payload() -> dict[str, Any]:
@@ -180,14 +246,20 @@ def _empty_payload() -> dict[str, Any]:
     }
 
 
-def _payload_from_entries(selected: dict[str, str], load_entries: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _payload_from_entries(
+    selected: dict[str, str | None],
+    load_entries: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
     hosts: dict[str, Any] = {}
     for opaque, canonical in selected.items():
-        load_entry = load_entries[canonical]
-        occupants = _merge_occupants(
-            _occupants_from_registry(canonical),
-            _occupants_from_job_unit(canonical, load_entry),
-        )
+        load_entry = load_entries.get(opaque) or _unavailable_load_entry()
+        if canonical is not None:
+            occupants = _merge_occupants(
+                _occupants_from_registry(canonical),
+                _occupants_from_job_unit(canonical, load_entry),
+            )
+        else:
+            occupants = []
         hosts[opaque] = _shape_host(opaque, load_entry, occupants)
 
     return {
@@ -203,7 +275,12 @@ def occupancy_payload(*, host_id: str | None = None, fresh: bool = False) -> dic
     if not selected:
         return _attach_cloud_observer(_empty_payload(), host_id)
 
-    load_entries = {canonical: load_mod._get_host_load_entry(canonical, fresh=fresh) for canonical in selected.values()}
+    load_entries: dict[str, dict[str, Any]] = {}
+    for opaque, canonical in selected.items():
+        if canonical is None:
+            load_entries[opaque] = _unavailable_load_entry()
+        else:
+            load_entries[opaque] = load_mod._get_host_load_entry(canonical, fresh=fresh)
     return _attach_cloud_observer(_payload_from_entries(selected, load_entries), host_id)
 
 
@@ -212,10 +289,17 @@ async def _occupancy_payload_async(*, host_id: str | None = None, fresh: bool = 
     if not selected:
         return _attach_cloud_observer(_empty_payload(), host_id)
 
-    entries = await asyncio.gather(
-        *(load_mod._get_host_load_entry_async(canonical, fresh=fresh) for canonical in selected.values())
-    )
-    load_entries = dict(zip(selected.values(), entries, strict=True))
+    tasks = []
+    keys = []
+    for opaque, canonical in selected.items():
+        keys.append(opaque)
+        if canonical is None:
+            tasks.append(asyncio.sleep(0, result=_unavailable_load_entry()))
+        else:
+            tasks.append(load_mod._get_host_load_entry_async(canonical, fresh=fresh))
+
+    entries = await asyncio.gather(*tasks)
+    load_entries = dict(zip(keys, entries, strict=True))
     return _attach_cloud_observer(_payload_from_entries(selected, load_entries), host_id)
 
 

--- a/scripts/api/occupancy.py
+++ b/scripts/api/occupancy.py
@@ -120,9 +120,8 @@ def _is_idle_or_empty(
     occupants: list[dict[str, str | None]],
     load_entry: dict[str, Any] | None = None,
 ) -> bool:
-    if occupants:
-        if not all(o.get("kind") == "observer" and o.get("status") == "idle" for o in occupants):
-            return False
+    if occupants and not all(o.get("kind") == "observer" and o.get("status") == "idle" for o in occupants):
+        return False
     if status == "unavailable":
         return True
     if load_entry:

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -64,7 +64,7 @@ def _warm_load(fake: atlas_job.FakeHostAdapter) -> None:
     load_mod.set_host_load_cache("teach-box", fake.host_load("teach-box"))
 
 
-def test_occupancy_empty_without_opaque_map(tmp_path, monkeypatch) -> None:
+def test_occupancy_enumerates_both_default_hosts_without_opaque_map(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
     monkeypatch.delenv("MONITOR_OCCUPANCY_HOST_IDS", raising=False)
     fake = atlas_job.FakeHostAdapter()
@@ -75,7 +75,18 @@ def test_occupancy_empty_without_opaque_map(tmp_path, monkeypatch) -> None:
         assert resp.status_code == 200
         data = resp.json()
         assert data["schema"] == "monitor-occupancy.v1"
-        assert data["hosts"] == {}
+        assert sorted(data["hosts"].keys()) == ["host-job", "host-teacher"]
+        for host_id in ("host-job", "host-teacher"):
+            entry = data["hosts"][host_id]
+            assert entry["host_id"] == host_id
+            assert entry["status"] == "unavailable"
+            assert entry["error"] == "unreachable"
+            assert entry["idle_or_empty"] is True
+            assert entry["occupants"] == []
+            assert entry["occupant_count"] == 0
+            assert entry["ai_seats"] == []
+            assert "cpu_count" not in entry
+            assert "mem" not in entry
         text = resp.text
         for alias in _ALIAS_LEAKS:
             assert alias not in text
@@ -105,6 +116,10 @@ def test_occupancy_shape_uses_placeholders(tmp_path, monkeypatch) -> None:
             assert "mem" in host
             assert "disk" in host
             assert isinstance(host["occupants"], list)
+            assert isinstance(host["occupant_count"], int)
+            assert isinstance(host["ai_seats"], list)
+            assert isinstance(host["idle_or_empty"], bool)
+            assert host["idle_or_empty"] is True
             assert "error" not in host
         text = json.dumps(data)
         assert _IP.findall(text) == []
@@ -421,3 +436,111 @@ def test_safe_summary_drops_paths_secrets_and_aliases() -> None:
         "status": "working",
     }
     assert "summary" not in occupant
+
+
+def test_occupancy_dual_host_partial_map(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", "job-box=host-job")
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        load_mod.clear_host_load_cache()
+        load_mod.set_host_load_cache("job-box", fake.host_load("job-box"))
+        resp = client.get("/api/occupancy")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert sorted(data["hosts"].keys()) == ["host-job", "host-teacher"]
+        assert data["hosts"]["host-job"]["status"] == "fresh"
+        assert data["hosts"]["host-job"]["cpu_count"] == 4
+        assert data["hosts"]["host-teacher"]["status"] == "unavailable"
+        assert data["hosts"]["host-teacher"]["error"] == "unreachable"
+        assert data["hosts"]["host-teacher"]["idle_or_empty"] is True
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
+def test_occupancy_idle_or_empty_flag_transitions(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        # Case 1: Low load, no occupants -> idle_or_empty is True
+        load_mod.clear_host_load_cache()
+        idle_load = fake.host_load("job-box")
+        idle_load["loadavg"] = [0.10, 0.15, 0.12]
+        idle_load["job_unit"] = {"active_count": 0, "job_id": None, "state": None}
+        load_mod.set_host_load_cache("job-box", idle_load)
+        resp = client.get("/api/occupancy?host_id=host-job")
+        assert resp.status_code == 200
+        assert resp.json()["hosts"]["host-job"]["idle_or_empty"] is True
+
+        # Case 2: High CPU load (>= 1.0) -> idle_or_empty is False
+        load_mod.clear_host_load_cache()
+        busy_load = fake.host_load("job-box")
+        busy_load["loadavg"] = [2.50, 1.80, 1.20]
+        load_mod.set_host_load_cache("job-box", busy_load)
+        resp = client.get("/api/occupancy?host_id=host-job")
+        assert resp.status_code == 200
+        assert resp.json()["hosts"]["host-job"]["idle_or_empty"] is False
+
+        # Case 3: Active job_unit -> idle_or_empty is False
+        load_mod.clear_host_load_cache()
+        active_unit_load = fake.host_load("job-box")
+        active_unit_load["loadavg"] = [0.10, 0.10, 0.10]
+        active_unit_load["job_unit"] = {"active_count": 1, "job_id": "unit-job", "state": "running"}
+        load_mod.set_host_load_cache("job-box", active_unit_load)
+        resp = client.get("/api/occupancy?host_id=host-job")
+        assert resp.status_code == 200
+        assert resp.json()["hosts"]["host-job"]["idle_or_empty"] is False
+
+        # Case 4: Occupant in registry -> idle_or_empty is False
+        load_mod.clear_host_load_cache()
+        load_mod.set_host_load_cache("job-box", idle_load)
+        plan = _plan()
+        atlas_job.save_registry(
+            {
+                "id": plan["id"],
+                "state": "running",
+                "host": "job-box",
+                "kind": "reenrich",
+                "unit": atlas_job.unit_name(plan["id"]),
+                "workdir": atlas_job.work_dir_for(plan["id"], plan),
+                "result_sink": "git",
+                "issue": plan["issue"],
+                "plan": plan,
+                "agent": "gemini",
+            }
+        )
+        resp = client.get("/api/occupancy?host_id=host-job")
+        assert resp.status_code == 200
+        host_entry = resp.json()["hosts"]["host-job"]
+        assert host_entry["idle_or_empty"] is False
+        assert host_entry["occupant_count"] == 1
+        assert host_entry["ai_seats"] == ["gemini"]
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
+def test_occupancy_unmapped_default_host_query(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.delenv("MONITOR_OCCUPANCY_HOST_IDS", raising=False)
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        resp = client.get("/api/occupancy?host_id=host-teacher")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert list(data["hosts"].keys()) == ["host-teacher"]
+        teacher = data["hosts"]["host-teacher"]
+        assert teacher["host_id"] == "host-teacher"
+        assert teacher["status"] == "unavailable"
+        assert teacher["error"] == "unreachable"
+        assert teacher["idle_or_empty"] is True
+        assert teacher["occupant_count"] == 0
+        assert teacher["ai_seats"] == []
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -81,7 +81,7 @@ def test_occupancy_enumerates_both_default_hosts_without_opaque_map(tmp_path, mo
             assert entry["host_id"] == host_id
             assert entry["status"] == "unavailable"
             assert entry["error"] == "unreachable"
-            assert entry["idle_or_empty"] is True
+            assert entry["idle_or_empty"] is False
             assert entry["occupants"] == []
             assert entry["occupant_count"] == 0
             assert entry["ai_seats"] == []
@@ -203,6 +203,7 @@ def test_occupancy_unavailable_has_no_metrics_or_ssh_text(tmp_path, monkeypatch)
         dead = data["hosts"]["host-teacher"]
         assert dead["status"] == "unavailable"
         assert dead["error"] == "unreachable"
+        assert dead["idle_or_empty"] is False
         assert "cpu_count" not in dead
         assert "mem" not in dead
         assert "ssh" not in json.dumps(dead).lower()
@@ -450,7 +451,7 @@ def test_occupancy_dual_host_partial_map(tmp_path, monkeypatch) -> None:
         assert data["hosts"]["host-job"]["cpu_count"] == 4
         assert data["hosts"]["host-teacher"]["status"] == "unavailable"
         assert data["hosts"]["host-teacher"]["error"] == "unreachable"
-        assert data["hosts"]["host-teacher"]["idle_or_empty"] is True
+        assert data["hosts"]["host-teacher"]["idle_or_empty"] is False
     finally:
         atlas_job.set_host_adapter(None)
         load_mod.clear_host_load_cache()
@@ -534,7 +535,7 @@ def test_occupancy_unmapped_default_host_query(tmp_path, monkeypatch) -> None:
         assert teacher["host_id"] == "host-teacher"
         assert teacher["status"] == "unavailable"
         assert teacher["error"] == "unreachable"
-        assert teacher["idle_or_empty"] is True
+        assert teacher["idle_or_empty"] is False
         assert teacher["occupant_count"] == 0
         assert teacher["ai_seats"] == []
     finally:

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -312,9 +312,7 @@ def test_occupancy_stale_while_revalidate_reuse(tmp_path, monkeypatch) -> None:
         load_mod.clear_host_load_cache()
 
 
-def test_occupancy_heartbeat_boundary_stays_fresh_while_probe_runs(
-    tmp_path, monkeypatch
-) -> None:
+def test_occupancy_heartbeat_boundary_stays_fresh_while_probe_runs(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
     monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
     fake = atlas_job.FakeHostAdapter()
@@ -356,9 +354,7 @@ def test_occupancy_heartbeat_boundary_stays_fresh_while_probe_runs(
 
 
 def test_parse_host_id_map_drops_non_opaque_values() -> None:
-    parsed = parse_host_id_map(
-        "job-box=host-job,teach-box=atlas-runner,bad=1.2.3.4,also=vps,ok=host-teacher"
-    )
+    parsed = parse_host_id_map("job-box=host-job,teach-box=atlas-runner,bad=1.2.3.4,also=vps,ok=host-teacher")
     assert parsed == {"job-box": "host-job", "ok": "host-teacher"}
     assert not _opaque_host_id("atlas-runner")
     assert not _opaque_host_id("hramatka")

--- a/tests/test_fleet_occupancy_idle_contract.py
+++ b/tests/test_fleet_occupancy_idle_contract.py
@@ -1,0 +1,39 @@
+"""UI contract: unavailable occupancy hosts render unknown, never idle (#7139)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FLEET_HTML = ROOT / "dashboards" / "fleet.html"
+
+
+def _idle_state_expression(html: str) -> str:
+    match = re.search(r"const idleState = (?P<expr>[^;]+);", html)
+    assert match is not None, "renderOccupancy must derive an idleState label"
+    return match.group("expr").strip()
+
+
+def test_unavailable_host_burn_pill_is_unknown_never_idle() -> None:
+    html = FLEET_HTML.read_text(encoding="utf-8")
+    expr = _idle_state_expression(html)
+
+    # The unavailable branch short-circuits first and maps to 'unknown'.
+    assert expr.startswith("host.status === 'unavailable' ? 'unknown' :"), expr
+
+    # 'idle' is only reachable in the non-unavailable fallback branch.
+    fallback = expr.split(":", 1)[1]
+    assert "'idle'" in fallback
+    assert "idle_or_empty" in fallback
+
+    # The unavailable branch never produces an idle label.
+    unavailable_branch = expr.split("?", 1)[1].split(":", 1)[0]
+    assert "'idle'" not in unavailable_branch
+    assert unavailable_branch.strip() == "'unknown'"
+
+    # Both occupancy row templates actually render the derived label as a pill.
+    assert html.count("pill(idleState)") == 2
+
+    # Utilization metrics stay hidden for unavailable hosts.
+    assert "if (host.status !== 'unavailable') {" in html


### PR DESCRIPTION
## Summary
Implements a focused slice of #7139:
- Extends `GET /api/occupancy` (`scripts/api/occupancy.py`) so the payload always enumerates both opaque hosts `host-teacher` and `host-job` (and any additional mapped hosts) alongside existing utilization metrics (load, RAM, disk).
- Adds `idle_or_empty` boolean flag per host indicating near-zero AI/service burn so idle hosts are surfaced clearly.
- Adds `occupant_count` and `ai_seats` list for a quick glance at active AI agent seats on each host.
- Enhances the Monitor Fleet dashboard (`dashboards/fleet.html`) Host Occupancy panel to display the burn status (`idle` / `active`) and utilization metrics glance.
- Updates documentation in `docs/MONITOR-API.md`.
- Adds and adjusts focused tests in `tests/api/test_occupancy.py`.

## OPSEC Compliance
Public API and UI strings use opaque host IDs only (`host-teacher`, `host-job`, `cloud-observer`). No IP addresses, SSH aliases, tunnel maps, or local filesystem paths.

## Testing
- Ran test suite with `.venv/bin/python -m pytest tests/api/test_occupancy.py` (all 14 passed).
- Verified trailer with `.venv/bin/python scripts/audit/lint_agent_trailer.py`.