### PR TITLE
fix(runtime): scope read-only guard snapshot off .worktrees/, preserve real last_error (#7124)

### DIFF
--- a/scripts/ci/requirements-fastlane.txt
+++ b/scripts/ci/requirements-fastlane.txt
@@ -20,3 +20,6 @@ psutil==7.2.2
 pyahocorasick==2.3.1
 python-multipart==0.0.32
 PyYAML==6.0.3
+
+# Worker subprocesses spawned by tests/test_delegate.py import PyJWT at runtime; add only because that module is now a selected fastlane file.
+PyJWT==2.13.0

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2466,10 +2466,15 @@ def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str 
                 return None, "status snapshot returned an incomplete rename/copy record"
             rename_source = status_records[index]
             index += 1
-        if _is_read_only_snapshot_excluded_path(path):
-            continue
-        entries[path] = state
-        if rename_source is not None:
+        # Filter the rename/copy source and destination independently
+        # (#7147): ``git mv tracked.txt .worktrees/lane/tracked.txt`` must still
+        # surface the tracked source deletion even though the destination is
+        # out of snapshot scope.
+        if not _is_read_only_snapshot_excluded_path(path):
+            entries[path] = state
+        if rename_source is not None and not _is_read_only_snapshot_excluded_path(
+            rename_source
+        ):
             entries[rename_source] = f"{state}:source"
     for path in outputs["ignored"].split("\0"):
         if path and not _is_read_only_snapshot_excluded_path(path):

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2394,6 +2394,21 @@ def _worktree_is_dirty(worktree: Path) -> bool | None:
     return bool((status_proc.stdout or "").strip())
 
 
+# Top-level checkout dirs the read-only snapshot never records. Other lanes'
+# dispatch worktrees live under ``.worktrees/`` (layout A): concurrent activity
+# there — including writes inside a sandbox that already existed at pre-snapshot
+# time — is never this task's mutation, and it false-failed cleanly-successful
+# read-only dispatches (#7124). The guard diffs only what the task could own.
+_READ_ONLY_SNAPSHOT_EXCLUDED_TOP_LEVEL_DIRS = frozenset({".worktrees"})
+
+
+def _is_read_only_snapshot_excluded_path(path: str) -> bool:
+    """Return whether a checkout-relative path is outside the snapshot scope."""
+    normalized = _normalize_read_only_relpath(path)
+    top_level = normalized.split("/", 1)[0]
+    return top_level in _READ_ONLY_SNAPSHOT_EXCLUDED_TOP_LEVEL_DIRS
+
+
 def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str | None]:
     """Capture the observable Git state of a read-only worker's checkout.
 
@@ -2401,6 +2416,9 @@ def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str 
     create ignored cache entries that ordinary ``git status`` deliberately
     hides.  It is diagnostic only: this guard reports leaked paths and never
     removes them, since a pre-existing user file cannot be attributed safely.
+
+    Paths under ``.worktrees/`` are excluded entirely (#7124): they belong to
+    concurrent dispatch lanes, not to the task being guarded.
     """
     commands = (
         (
@@ -2440,15 +2458,21 @@ def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str 
         if len(record) < 4 or record[2] != " ":
             return None, "status snapshot returned an unparseable porcelain record"
         state, path = record[:2], record[3:]
-        entries[path] = state
         # Porcelain v1 emits the pre-rename/pre-copy path as a second NUL item.
+        # Consume it even for excluded paths so the record stream stays aligned.
+        rename_source: str | None = None
         if "R" in state or "C" in state:
             if index >= len(status_records) or not status_records[index]:
                 return None, "status snapshot returned an incomplete rename/copy record"
-            entries[status_records[index]] = f"{state}:source"
+            rename_source = status_records[index]
             index += 1
+        if _is_read_only_snapshot_excluded_path(path):
+            continue
+        entries[path] = state
+        if rename_source is not None:
+            entries[rename_source] = f"{state}:source"
     for path in outputs["ignored"].split("\0"):
-        if path:
+        if path and not _is_read_only_snapshot_excluded_path(path):
             entries[path] = "!!"
     return entries, None
 
@@ -2620,8 +2644,9 @@ def _read_only_mutation_paths(
     Newly appeared sibling dispatch sandboxes under
     ``.worktrees/dispatch/<agent>/<task>/`` are also excluded (#6938): concurrent
     ``git worktree add`` on the shared primary checkout is not this task's
-    mutation. Writes under a sandbox that already existed in the pre-snapshot
-    remain visible.
+    mutation. Since #7124 the snapshot itself already drops every
+    ``.worktrees/`` path; this exemption remains as defense in depth for
+    snapshots persisted by older workers.
     """
     before_roots = _read_only_dispatch_sandbox_roots(before)
     return sorted(
@@ -4193,6 +4218,18 @@ def _run_worker(
             stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
         elif returncode is None and returncode_reason is None:
             returncode_reason = "no terminal subprocess returncode was available"
+        if returncode is not None and returncode < 0 and returncode_reason is None:
+            # Python reports signal deaths as negative returncodes. Decode the
+            # signal so a SIGKILLed worker persists as SIGKILL, not an opaque
+            # -9 (#7124).
+            signum = -returncode
+            try:
+                signal_name = signal.Signals(signum).name
+            except ValueError:
+                signal_name = f"signal {signum}"
+            returncode_reason = (
+                f"worker subprocess terminated by {signal_name} (returncode {returncode})"
+            )
 
         final_state = _read_state(state_path) or {}
 
@@ -4339,9 +4376,16 @@ def _run_worker(
 
         last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
         if read_only_mutation_paths:
-            last_error = (
+            mutation_diagnostic = (
                 "read-only checkout mutation detected: "
                 + ", ".join(read_only_mutation_paths)
+            )
+            # Never REPLACE a real failure with the guard diagnostic (#7124):
+            # overwriting it hid the actual cause (e.g. a SIGKILLed worker's
+            # stderr) behind the mutation list. The paths stay independently
+            # queryable via ``read_only_mutation_paths`` either way.
+            last_error = (
+                f"{last_error}; {mutation_diagnostic}" if last_error else mutation_diagnostic
             )
         if no_deliverable_reason is not None:
             last_error = no_deliverable_reason

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -3006,9 +3006,8 @@ def test_read_only_dispatch_allows_concurrent_sibling_worktree_add(
     assert state["last_error"] is None
     assert sibling.exists()
     post = state["read_only_checkout_post"]
-    assert any(
-        delegate._read_only_dispatch_sandbox_root(path) == _SIBLING_DISPATCH_SANDBOX
-        for path in post
+    assert not any(
+        delegate._is_read_only_snapshot_excluded_path(path) for path in post
     )
 
 

--- a/tests/test_delegate_readonly_guard.py
+++ b/tests/test_delegate_readonly_guard.py
@@ -1,0 +1,352 @@
+"""Tests for read-only dispatch checkout mutation guard (#7124).
+
+Dedicated test module to keep CI fastlane slim and avoid pulling heavy
+dependencies from tests/test_delegate.py.
+
+- Scoping read-only snapshot off .worktrees/ entirely
+- Preserving real worker failures alongside read-only mutation diagnostics
+- Negative returncode signal decoding
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import delegate
+
+
+def _sanitize_git_env_for_test(monkeypatch) -> None:
+    for key in tuple(os.environ):
+        if key.startswith(("GIT_", "PRE_COMMIT")):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("AGENT_NO_MERGE", raising=False)
+
+
+def _init_git_repo_for_test(path: Path, monkeypatch) -> None:
+    _sanitize_git_env_for_test(monkeypatch)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, timeout=30)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _seed_read_only_checkout_fixture(repo: Path, monkeypatch) -> None:
+    """Git repo with production-shaped ignore rules + one tracked file."""
+    _init_git_repo_for_test(repo, monkeypatch)
+    entire = repo / ".entire"
+    entire.mkdir(parents=True, exist_ok=True)
+    (entire / ".gitignore").write_text(
+        "tmp/\nsettings.local.json\nmetadata/\nlogs/\nredactors/local/\n",
+        encoding="utf-8",
+    )
+    (repo / ".gitignore").write_text(
+        ".agent/\n"
+        "batch_state/\n"
+        ".pytest_cache/\n"
+        ".pytest_breadcrumbs/\n"
+        ".ruff_cache/\n"
+        "__pycache__/\n"
+        ".runtime/\n"
+        "*.sqlite3-wal\n"
+        "*.sqlite3-shm\n"
+        "*.sqlite3-journal\n",
+        encoding="utf-8",
+    )
+    (repo / "tracked.txt").write_text("baseline\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", ".entire/.gitignore", ".gitignore", "tracked.txt"],
+        cwd=repo,
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _finalize_mock_result():
+    return type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "grok-4.6",
+            "effort": "high",
+            "cli_version": "0.2.111",
+        },
+    )()
+
+
+@pytest.fixture
+def tmp_tasks_dir(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tasks_dir)
+    return tasks_dir
+
+
+def test_read_only_snapshot_excluded_path_classification():
+    """#7124: every ``.worktrees/`` path is out of snapshot scope."""
+    assert delegate._is_read_only_snapshot_excluded_path(".worktrees")
+    assert delegate._is_read_only_snapshot_excluded_path(
+        ".worktrees/dispatch/other-lane/other-task/scripts/foo.py"
+    )
+    assert delegate._is_read_only_snapshot_excluded_path("./.worktrees/dispatch/a/b/")
+    assert not delegate._is_read_only_snapshot_excluded_path("tracked.txt")
+    assert not delegate._is_read_only_snapshot_excluded_path("sub/.worktrees/file")
+    assert not delegate._is_read_only_snapshot_excluded_path(".worktreesish/file")
+
+
+def test_read_only_checkout_snapshot_excludes_worktrees_tree(tmp_path, monkeypatch):
+    """#7124: the snapshot records no ``.worktrees/`` entries at all."""
+    repo = (tmp_path / "repo").resolve()
+    repo.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(repo, monkeypatch)
+    noise = repo / ".worktrees" / "dispatch" / "gemini" / "other-task"
+    noise.mkdir(parents=True)
+    (noise / "draft.md").write_text("other lane\n", encoding="utf-8")
+    (repo / "untracked.txt").write_text("visible\n", encoding="utf-8")
+
+    snapshot, error = delegate._read_only_checkout_snapshot(repo)
+
+    assert error is None
+    assert snapshot is not None
+    assert "untracked.txt" in snapshot
+    assert not any(
+        delegate._is_read_only_snapshot_excluded_path(path) for path in snapshot
+    )
+
+
+def test_read_only_dispatch_allows_concurrent_sibling_worktree_add(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#7124: a concurrent dispatch sandbox appearing under ``.worktrees/`` is excluded from snapshot."""
+    checkout = (tmp_path / "repo-root").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+    gitignore = checkout / ".gitignore"
+    gitignore.write_text(gitignore.read_text(encoding="utf-8") + ".worktrees/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=checkout, check=True, timeout=30)
+    subprocess.run(
+        ["git", "commit", "-m", "ignore worktrees"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    # Detach HEAD so ``git worktree add -b`` can create a sibling branch without
+    # fighting the fixture branch checked out in this repo.
+    subprocess.run(
+        ["git", "checkout", "--detach", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    task_id = "read-only-concurrent-sibling-worktree"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+
+    sibling = checkout / ".worktrees" / "dispatch" / "cursor" / "codeql-path-injection-fix"
+
+    def concurrent_sibling_worktree(*_args, **_kwargs):
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                "cursor/codeql-path-injection-fix",
+                str(sibling),
+                "HEAD",
+            ],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        return _finalize_mock_result()
+
+    with patch("agent_runtime.runner.invoke", side_effect=concurrent_sibling_worktree):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="Inventory thin-mode sources without editing the tree.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["read_only_mutation_paths"] == []
+    assert state["last_error"] is None
+    assert sibling.exists()
+    post = state["read_only_checkout_post"]
+    assert not any(
+        delegate._is_read_only_snapshot_excluded_path(path) for path in post
+    )
+
+
+def test_read_only_dispatch_ignores_other_lane_worktree_activity(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#7124: writes inside an EXISTING sibling dispatch sandbox are out of scope.
+
+    #6938 exempted only newly appeared sandboxes, so a concurrent lane writing
+    under a ``.worktrees/dispatch/<agent>/<task>/`` tree that already existed at
+    the pre-snapshot still false-failed a clean read-only dispatch.
+    """
+    checkout = (tmp_path / "repo-root").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+    gitignore = checkout / ".gitignore"
+    gitignore.write_text(gitignore.read_text(encoding="utf-8") + ".worktrees/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=checkout, check=True, timeout=30)
+    subprocess.run(
+        ["git", "commit", "-m", "ignore worktrees"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    other_lane = checkout / ".worktrees" / "dispatch" / "gemini" / "other-task"
+    other_lane.mkdir(parents=True)
+    (other_lane / "draft.md").write_text("other lane v1\n", encoding="utf-8")
+
+    task_id = "read-only-other-lane-worktree-noise"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+
+    def other_lane_activity(*_args, **_kwargs):
+        (other_lane / "draft.md").write_text("other lane v2\n", encoding="utf-8")
+        (other_lane / "more.py").write_text("# other lane\n", encoding="utf-8")
+        return _finalize_mock_result()
+
+    with patch("agent_runtime.runner.invoke", side_effect=other_lane_activity):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="Inventory thin-mode sources without editing the tree.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["read_only_mutation_paths"] == []
+    assert state["last_error"] is None
+    post = state["read_only_checkout_post"]
+    assert not any(
+        delegate._is_read_only_snapshot_excluded_path(path) for path in post
+    )
+
+
+def test_read_only_failed_worker_keeps_real_error_alongside_mutation(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#7124: the guard diagnostic must not overwrite the returncode-derived error."""
+    checkout = (tmp_path / "repo-root").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+
+    task_id = "read-only-sigkill-plus-mutation"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+
+    sigkill_result = type(
+        "_Result",
+        (),
+        {
+            "ok": False,
+            "response": "",
+            "stderr_excerpt": "worker killed: out of memory",
+            "returncode": -9,
+            "rate_limited": False,
+            "model": "grok-4.6",
+            "effort": "high",
+            "cli_version": "0.2.111",
+        },
+    )()
+
+    def sigkill_with_mutation(*_args, **_kwargs):
+        (checkout / "tracked.txt").write_text(
+            "partial write before kill\n", encoding="utf-8"
+        )
+        return sigkill_result
+
+    with patch("agent_runtime.runner.invoke", side_effect=sigkill_with_mutation):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="Review the module without edits.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 1
+    assert state is not None
+    assert state["status"] == "failed"
+    assert state["returncode"] == -9
+    assert state["returncode_reason"] == (
+        "worker subprocess terminated by SIGKILL (returncode -9)"
+    )
+    assert state["read_only_mutation_paths"] == ["tracked.txt"]
+    last_error = state["last_error"]
+    assert "worker killed: out of memory" in last_error
+    assert "read-only checkout mutation detected: tracked.txt" in last_error

--- a/tests/test_delegate_readonly_guard.py
+++ b/tests/test_delegate_readonly_guard.py
@@ -144,6 +144,36 @@ def test_read_only_checkout_snapshot_excludes_worktrees_tree(tmp_path, monkeypat
     )
 
 
+def test_read_only_checkout_snapshot_keeps_rename_source_into_worktrees(
+    tmp_path, monkeypatch
+):
+    """#7147: renaming a tracked file INTO ``.worktrees/`` keeps the source.
+
+    ``git mv tracked.txt .worktrees/lane/tracked.txt`` is a mutation of the
+    tracked source even though the destination is out of snapshot scope, so
+    the source must still be recorded instead of the whole record dropping.
+    """
+    repo = (tmp_path / "repo").resolve()
+    repo.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(repo, monkeypatch)
+    lane = repo / ".worktrees" / "lane"
+    lane.mkdir(parents=True)
+    subprocess.run(
+        ["git", "mv", "tracked.txt", ".worktrees/lane/tracked.txt"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    snapshot, error = delegate._read_only_checkout_snapshot(repo)
+
+    assert error is None
+    assert snapshot is not None
+    assert snapshot["tracked.txt"] == "R :source"
+    assert ".worktrees/lane/tracked.txt" not in snapshot
+
+
 def test_read_only_dispatch_allows_concurrent_sibling_worktree_add(
     tmp_tasks_dir,
     tmp_path,


### PR DESCRIPTION
## Summary

The read-only mutation guard in `scripts/delegate.py` false-failed cleanly-successful read-only dispatches when other lanes had activity under `.worktrees/`, and it overwrote the real failure in `last_error` with its own mutation diagnostic.

## Changes

- `_read_only_checkout_snapshot()` now excludes `.worktrees/` entirely via `_is_read_only_snapshot_excluded_path()`. Other lanes' dispatch trees are never this task's mutations; the #6938 exemption only covered *newly appeared* sandboxes, so writes inside a sibling sandbox that already existed at the pre-snapshot still tripped the guard. The diff-level exemption stays as defense in depth for snapshots persisted by older workers.
- `last_error` is no longer replaced by the mutation diagnostic when a real (returncode-derived) failure exists — the diagnostic is appended instead, and the paths remain independently queryable via `read_only_mutation_paths`.
- Negative subprocess returncodes are decoded to signal names in `returncode_reason` (e.g. `-9` → `worker subprocess terminated by SIGKILL (returncode -9)`).

## Testing

- [x] `tests/test_delegate.py` — 290 passed (incl. 4 new/updated: snapshot exclusion classification, snapshot-level `.worktrees/` exclusion, concurrent other-lane worktree activity not failing a clean read-only dispatch, SIGKILL + mutation preserving the real `last_error`)
- [x] Related delegate suites (`primary_integrity`, `ownership`, `repository_join`, `data_symlinks`, `check_budget`) — 387 passed total
- [x] `ruff check scripts/delegate.py tests/test_delegate.py` — clean

## Related Issues

Closes #7124