### PR TITLE
fix(fleet): share one open-PR identity probe between reaper and hygiene gate

### DIFF
--- a/scripts/fleet/hramatka_hygiene_check.py
+++ b/scripts/fleet/hramatka_hygiene_check.py
@@ -10,7 +10,10 @@ filesystem — this is PR-4 of the stream-hygiene package
 (`conversation_7b6241377cd44c7ea5265da5c85efb5c`); it does not implement or
 import the PR-2 scope gate (`hramatka_scope_gate.py`) or the PR-3 reaper
 (`post_task_reap.py`) bodies, by design, so this gate has no hard dependency
-on either PR's merge order.
+on either PR's merge order.  The one deliberate exception is the shared
+open-PR identity probe (`scripts/fleet/pr_identity.py`, #7127): a leaf module
+that imports neither this gate nor the reaper, so both callers express the
+PR-identity binding once without any import cycle.
 
 Usage:
   .venv/bin/python -m scripts.fleet.hramatka_hygiene_check
@@ -39,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.common.repo_root import main_checkout_root
+from scripts.fleet import pr_identity
 
 REPO_ROOT = main_checkout_root(Path(__file__).resolve().parents[2])
 
@@ -213,83 +217,24 @@ def _branch_has_open_pr(
 ) -> bool:
     """Return True only when ``branch`` provably has an OPEN same-repo PR.
 
-    Mirrors the PR-3 reaper's retention rule (``post_task_reap`` retains a
-    bound worktree whose branch still has an open PR) without importing it,
-    per this module's deliberate no-hard-dependency design.
-
-    Fail-closed for this gate, which is the opposite direction from the
-    reaper: ANY doubt returns False and the worktree stays counted.  The gate
-    must never hand out a verified-clean handoff on a guess.  Concretely,
-    every one of these counts the worktree rather than excusing it:
-
-    * no branch identity (a detached worktree);
-    * ``gh`` missing, timing out, or exiting non-zero;
-    * output that is not JSON, or not a JSON list;
-    * a list containing anything that is not an object (``[null]``);
-    * a row missing/!= ``state == "OPEN"``;
-    * a row whose ``headRefName`` is not exactly this branch;
-    * a cross-repository (fork) head;
-    * a row without a positive integer ``number``.
-
-    A single malformed row poisons the whole answer -- a partially
-    understood response is an unknown, and unknowns do not exempt.
-
-    Deliberately NOT required: that the PR head OID equals the local
-    worktree HEAD.  A worktree legitimately sits ahead of or behind its
-    pushed PR head, so demanding equality would recreate the unpassable-gate
-    bug this change fixes, in a new form.  Branch identity plus a same-repo
-    head is the binding that answers the actual question -- is this worktree
-    still serving an open PR?
+    PR identity binding lives in one shared probe (scripts.fleet.pr_identity,
+    #7127) — the same binding post_task_reap's reaper uses — so this gate and
+    the reaper cannot drift apart again.  This caller keeps the gate's
+    fail-closed direction, which is the opposite direction from the reaper:
+    ANY unknown (no branch identity, gh failure, malformed row such as
+    ``[{}]``, fork head, mismatched branch) returns False and the worktree
+    stays counted.  The gate must never hand out a verified-clean handoff on
+    a guess.
     """
     if not branch:
         return False
-    try:
-        proc = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--head",
-                branch,
-                "--state",
-                "open",
-                "--json",
-                "number,state,headRefName,isCrossRepository",
-            ],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    if proc.returncode != 0:
-        return False
-    try:
-        rows = json.loads(proc.stdout or "[]")
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(rows, list):
-        return False
-
-    matched = False
-    for row in rows:
-        if not isinstance(row, dict):
-            return False
-        number = row.get("number")
-        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
-            return False
-        if row.get("state") != "OPEN":
-            return False
-        if row.get("isCrossRepository") is not False:
-            return False
-        if row.get("headRefName") != branch:
-            return False
-        matched = True
-    return matched
+    has_open_pr, _error = pr_identity.probe_open_pr_for_branch(
+        repo_root=repo_root,
+        repo=repo,
+        branch=branch,
+        timeout=timeout,
+    )
+    return has_open_pr is True
 
 
 def _is_under_dispatch_worktrees(path: Path, dispatch_root: Path) -> bool:

--- a/scripts/fleet/post_task_reap.py
+++ b/scripts/fleet/post_task_reap.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.common.repo_root import main_checkout_root
+from scripts.fleet import pr_identity
 from scripts.orchestration import reap_worktrees, reaper_lifecycle
 from scripts.path_safety import assert_delete_target
 
@@ -500,16 +501,23 @@ def _no_open_pr_for_branch(
 ) -> tuple[bool, str | None]:
     """Return (no_open_pr, failure) for the branch that owns the bound tree.
 
-    Reuses the canonical reaper's candidate derivation so detached and
-    dispatch-layout worktrees are checked under the same branch names that the
-    canonical path would have probed.  A probe error is fail-closed.
+    PR identity binding lives in one shared probe (scripts.fleet.pr_identity,
+    #7127) — the same binding hramatka_hygiene_check uses — so the reaper and
+    the closeout gate cannot drift apart again.  This caller keeps only its
+    fail-closed direction: an unknown answer retains the worktree instead of
+    deleting it.
     """
     if not branch:
         return False, "no branch identity to probe for an open PR"
-    prs, error = reap_worktrees._query_pr_states(repo_root, branch)
-    if error is not None:
+    repo = pr_identity.resolve_repo_slug(repo_root)
+    has_open_pr, error = pr_identity.probe_open_pr_for_branch(
+        repo_root=repo_root,
+        repo=repo,
+        branch=branch,
+    )
+    if has_open_pr is None:
         return False, f"PR guard unavailable; {error}"
-    return all(pr.state != "OPEN" for pr in prs), None
+    return not has_open_pr, None
 
 
 def _reap_terminal_without_pr(

--- a/scripts/fleet/pr_identity.py
+++ b/scripts/fleet/pr_identity.py
@@ -1,0 +1,182 @@
+"""The one shared open-PR identity probe for worktree-retention callers (#7127).
+
+``post_task_reap._no_open_pr_for_branch`` (the reaper) and
+``hramatka_hygiene_check._branch_has_open_pr`` (the closeout gate) both answer
+"does this branch still have an open PR?" for the same dispatch worktrees, and
+they must not drift apart again — #7126 found them already disagreeing on
+malformed rows.  This module expresses the PR-identity binding exactly once:
+
+* an explicit ``--repo`` scope, never gh's cwd fallback;
+* ``state == "OPEN"``;
+* exact ``headRefName`` equality with the probed branch;
+* a non-fork (same-repository) head;
+* a positive integer ``number``.
+
+A row that fails any clause makes the WHOLE answer unknown: a partially
+understood response never proves absence.  Unknowns come back as
+``(None, reason)`` so each caller keeps its own fail-closed direction — the
+reaper retains, the gate still counts.  This probe never chooses for them.
+
+Deliberately NOT required: that the PR head OID equals the local worktree
+HEAD.  A worktree legitimately sits ahead of or behind its pushed PR head, so
+demanding equality would recreate an unpassable gate.  Branch identity plus a
+same-repo head is the binding that answers the actual question — is this
+worktree still serving an open PR?
+
+This module is a leaf: it imports nothing from either caller, so neither
+module body can form an import cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+DEFAULT_PROBE_TIMEOUT_SECONDS = 30.0
+_REPO_SLUG_TIMEOUT_SECONDS = 15.0
+
+# Same isolation contract as the reaper modules: gh/git must resolve nothing
+# from a stray GIT_* environment pointing at an unrelated checkout.
+_GIT_ENV_DENYLIST = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+}
+
+# Same remote-URL grammar as scripts/delegate.py::_GITHUB_REMOTE_PATTERNS.
+_GITHUB_REMOTE_PATTERNS = (
+    re.compile(r"^https?://(?:[^/@\s]+@)?github\.com/([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE),
+    re.compile(r"^ssh://git@github\.com/([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE),
+    re.compile(r"^git@github\.com:([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE),
+    re.compile(r"^git://github\.com/([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE),
+)
+
+
+def _sanitized_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _GIT_ENV_DENYLIST and not key.startswith("PRE_COMMIT")
+    }
+
+
+def _run_gh(cmd: list[str], *, cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=_sanitized_env(),
+    )
+
+
+def resolve_repo_slug(repo_root: Path) -> str | None:
+    """Return ``owner/repo`` for the checkout's ``remote.origin.url``, else None.
+
+    Local git-config read only — no network, no gh.  A caller that cannot prove
+    the repository identity must treat the open-PR answer as unknown, never
+    fall back to gh's cwd-based repository resolution.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=_REPO_SLUG_TIMEOUT_SECONDS,
+            check=False,
+            env=_sanitized_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    url = (proc.stdout or "").strip()
+    if not url:
+        return None
+    for pattern in _GITHUB_REMOTE_PATTERNS:
+        match = pattern.match(url)
+        if match:
+            return f"{match.group(1)}/{match.group(2)}"
+    return None
+
+
+def probe_open_pr_for_branch(
+    *,
+    repo_root: Path,
+    repo: str | None,
+    branch: str | None,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> tuple[bool | None, str | None]:
+    """Return ``(has_open_pr, error)`` for ``branch`` in one explicit repository.
+
+    ``True``  — GitHub provably reports at least one OPEN PR bound to this
+                 exact branch (same repo, non-fork head, positive number).
+    ``False`` — GitHub provably reports none.
+    ``None``  — unknown; ``error`` carries the structural reason.  Error
+                 strings never echo gh stderr so they can land in reports.
+
+    Callers choose their own fail-closed direction for ``None``; this probe
+    never guesses in either direction.
+    """
+    if not branch:
+        return None, "no branch identity to probe for an open PR"
+    if not repo:
+        return None, "no explicit repository identity bound to this checkout"
+    try:
+        proc = _run_gh(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number,state,headRefName,isCrossRepository",
+            ],
+            cwd=repo_root,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return None, f"gh pr list timed out after {exc.timeout}s"
+    except OSError as exc:
+        return None, f"gh pr list failed to run: {exc}"
+    if proc.returncode != 0:
+        return None, f"gh pr list failed (exit {proc.returncode})"
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None, "gh pr list returned invalid JSON"
+    if not isinstance(rows, list):
+        return None, "gh pr list returned a non-list payload"
+
+    matched = False
+    for row in rows:
+        if not isinstance(row, dict):
+            return None, "gh pr list returned a malformed row (not an object)"
+        number = row.get("number")
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            return None, "gh pr list returned a row without a usable PR number"
+        if row.get("state") != "OPEN":
+            return None, "gh pr list returned a row whose state is not OPEN"
+        if row.get("isCrossRepository") is not False:
+            return None, "gh pr list returned a cross-repository (fork) row"
+        if row.get("headRefName") != branch:
+            return None, "gh pr list returned a row bound to a different branch"
+        matched = True
+    return matched, None

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1931,18 +1931,37 @@ def test_query_pr_states_accepts_every_real_gh_state(monkeypatch, state) -> None
 @pytest.mark.parametrize(
     ("label", "payload", "expect_deletion_allowed"),
     [
-        ("incomplete row", '[{"state": "CLOSED"}]', False),
-        ("bogus enum", '[{"state": "WAT", "number": 1}]', False),
+        ("incomplete row", "[{}]", False),
+        (
+            "bogus enum",
+            '[{"state": "WAT", "number": 1, "headRefName": "some/branch", "isCrossRepository": false}]',
+            False,
+        ),
+        (
+            "non-open row under an open-state query",
+            '[{"state": "CLOSED", "number": 1, "headRefName": "some/branch", "isCrossRepository": false}]',
+            False,
+        ),
         ("genuinely empty", "[]", True),
-        ("valid closed", '[{"state": "CLOSED", "number": 1}]', True),
-        ("valid merged", '[{"state": "MERGED", "number": 1}]', True),
-        ("valid open", '[{"state": "OPEN", "number": 1}]', False),
+        (
+            "valid open",
+            '[{"state": "OPEN", "number": 1, "headRefName": "some/branch", "isCrossRepository": false}]',
+            False,
+        ),
     ],
 )
 def test_post_task_reap_deletion_authorization_end_to_end(monkeypatch, label, payload, expect_deletion_allowed) -> None:
     """The destructive authorization itself: ambiguity retains, and a real
-    answer still permits reaping."""
-    monkeypatch.setattr(rw, "_run", lambda *_a, **_k: _gh_stdout(payload))
+    answer still permits reaping.
+
+    #7127: the authorization now flows through the one shared PR-identity
+    probe (scripts.fleet.pr_identity), so the gh boundary faked here is the
+    probe's, not reap_worktrees'.  A CLOSED row would be a contract violation
+    for the probe's ``--state open`` query and is treated as unknown (retain);
+    the branch whose PRs are all closed/merged is answered by ``[]`` instead.
+    """
+    monkeypatch.setattr(post_task_reap.pr_identity, "resolve_repo_slug", lambda _root: "octo/fleet")
+    monkeypatch.setattr(post_task_reap.pr_identity, "_run_gh", lambda *_a, **_k: _gh_stdout(payload))
 
     no_open_pr, _guard_error = post_task_reap._no_open_pr_for_branch(
         repo_root=Path("/nonexistent"), branch="some/branch"

--- a/tests/test_fleet_hramatka_hygiene_check.py
+++ b/tests/test_fleet_hramatka_hygiene_check.py
@@ -385,7 +385,9 @@ def _probe_with(monkeypatch, result: Any) -> bool:
             raise result
         return result
 
-    monkeypatch.setattr(hygiene.subprocess, "run", _fake_run)
+    # The gate's gh access now lives in the shared probe (#7127); patch the
+    # probe's subprocess boundary, not this module's own subprocess module.
+    monkeypatch.setattr(hygiene.pr_identity, "_run_gh", _fake_run)
     return hygiene._branch_has_open_pr(Path("/nonexistent"), "kimi/some-task")
 
 
@@ -473,7 +475,7 @@ def test_probe_queries_an_explicit_repository(monkeypatch) -> None:
         seen["cmd"] = cmd
         return _gh_result("[]")
 
-    monkeypatch.setattr(hygiene.subprocess, "run", _fake_run)
+    monkeypatch.setattr(hygiene.pr_identity, "_run_gh", _fake_run)
     hygiene._branch_has_open_pr(Path("/nonexistent"), "kimi/some-task")
 
     cmd = seen["cmd"]

--- a/tests/test_fleet_post_task_reap.py
+++ b/tests/test_fleet_post_task_reap.py
@@ -60,6 +60,17 @@ def hermetic_reap(monkeypatch, tmp_path):
 
     monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", merged_pr)
 
+    # Shared-probe control (#7127): the bound checkout resolves to a GitHub
+    # repository and provably has no OPEN PR, unless a test overrides it.
+    monkeypatch.setattr(
+        post_task_reap.pr_identity, "resolve_repo_slug", lambda _root: "octo/hermetic"
+    )
+    monkeypatch.setattr(
+        post_task_reap.pr_identity,
+        "probe_open_pr_for_branch",
+        lambda **_kwargs: (False, None),
+    )
+
     return repo_root, tasks_dir
 
 
@@ -319,12 +330,43 @@ def test_no_pr_open_pr_retain(hermetic_reap, monkeypatch):
     def open_pr(_repo: Path, _branch: str | None):
         return [post_task_reap.reap_worktrees.PullRequestState(9, "OPEN", "deadbeef")], None
 
+    # The canonical path declines on the OPEN PR; the shared probe (#7127)
+    # must independently confirm it for the no-PR fallback.
     monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", open_pr)
+    monkeypatch.setattr(
+        post_task_reap.pr_identity,
+        "probe_open_pr_for_branch",
+        lambda **_kwargs: (True, None),
+    )
 
     report = post_task_reap.post_task_reap("open-pr-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
 
     assert report["main_worktree"]["action"] == "retained"
     assert "open PR" in report["main_worktree"]["reason"]
+    assert worktree.exists()
+
+
+def test_no_pr_probe_unknown_retain(hermetic_reap, monkeypatch):
+    """An unknown shared-probe answer (malformed gh row, outage, …) is
+    fail-closed: the no-PR fallback must retain, never delete on a guess."""
+    repo_root, tasks_dir = hermetic_reap
+    worktree = _add_dispatch_worktree(repo_root, "kimi", "pr-unknown-task")
+    _write_task_state(tasks_dir, "pr-unknown-task", "done", worktree)
+
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_query_pr_states", _no_pr_states)
+    # Force the no-PR fallback (which consults the shared probe) by failing the
+    # canonical Class-A settled-dispatch activity probe, as in the dry-run test.
+    monkeypatch.setattr(post_task_reap.reap_worktrees, "_active_task_ids", lambda: None)
+    monkeypatch.setattr(
+        post_task_reap.pr_identity,
+        "probe_open_pr_for_branch",
+        lambda **_kwargs: (None, "gh pr list returned a malformed row (not an object)"),
+    )
+
+    report = post_task_reap.post_task_reap("pr-unknown-task", tasks_dir=tasks_dir, repo_root=repo_root, apply=True)
+
+    assert report["main_worktree"]["action"] == "retained"
+    assert "PR guard unavailable" in report["main_worktree"]["reason"]
     assert worktree.exists()
 
 

--- a/tests/test_fleet_pr_identity.py
+++ b/tests/test_fleet_pr_identity.py
@@ -1,0 +1,346 @@
+"""Hermetic tests for scripts.fleet.pr_identity — the one shared open-PR probe.
+
+No live `gh` or network calls: the gh subprocess boundary is always faked, and
+git runs only against throwaway repos under tmp_path.  Includes the #7127
+identity-agreement contract: for the SAME gh answer, the reaper
+(``post_task_reap._no_open_pr_for_branch``) and the gate
+(``hramatka_hygiene_check._branch_has_open_pr``) must derive from one binding
+and differ only in their fail-closed direction.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from scripts.fleet import hramatka_hygiene_check as hygiene
+from scripts.fleet import post_task_reap, pr_identity
+
+BRANCH = "kimi/some-task"
+REPO = "octo/fleet"
+
+_OPEN_ROW = {
+    "number": 7127,
+    "state": "OPEN",
+    "headRefName": BRANCH,
+    "isCrossRepository": False,
+}
+
+
+def _gh_result(stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+# --- probe tri-state semantics ----------------------------------------------
+
+
+def _probe_with(monkeypatch, result: Any):
+    def _fake_run(*_args: Any, **_kwargs: Any):
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(pr_identity, "_run_gh", _fake_run)
+    return pr_identity.probe_open_pr_for_branch(
+        repo_root=Path("/nonexistent"),
+        repo=REPO,
+        branch=BRANCH,
+    )
+
+
+def test_probe_true_only_for_a_well_formed_open_same_repo_row(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, _gh_result(json.dumps([_OPEN_ROW]))) == (True, None)
+
+
+def test_probe_false_for_a_provably_empty_answer(monkeypatch) -> None:
+    assert _probe_with(monkeypatch, _gh_result("[]")) == (False, None)
+
+
+def test_probe_empty_stdout_means_empty_list_not_unknown(monkeypatch) -> None:
+    """Both prior implementations read empty stdout as []; keep that precedent."""
+    assert _probe_with(monkeypatch, _gh_result("")) == (False, None)
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("null body", "null"),
+        ("object not list", "{}"),
+        ("null row", "[null]"),
+        ("empty row", "[{}]"),
+        ("row is a string", '["open"]'),
+        ("malformed json", "not json"),
+    ],
+)
+def test_probe_reports_untrusted_payloads_as_unknown(monkeypatch, label: str, payload: str) -> None:
+    """`[{}]` and `[null]` are successful-but-untrusted shapes: a partially
+    understood response is an unknown, and unknowns never prove absence."""
+    has_open, error = _probe_with(monkeypatch, _gh_result(payload))
+    assert has_open is None, label
+    assert error, label
+
+
+@pytest.mark.parametrize(
+    ("label", "row"),
+    [
+        ("closed state", {**_OPEN_ROW, "state": "CLOSED"}),
+        ("merged state", {**_OPEN_ROW, "state": "MERGED"}),
+        ("state missing", {k: v for k, v in _OPEN_ROW.items() if k != "state"}),
+        ("fork head", {**_OPEN_ROW, "isCrossRepository": True}),
+        ("cross-repo unknown", {k: v for k, v in _OPEN_ROW.items() if k != "isCrossRepository"}),
+        ("different branch", {**_OPEN_ROW, "headRefName": "kimi/other-task"}),
+        ("head missing", {k: v for k, v in _OPEN_ROW.items() if k != "headRefName"}),
+        ("number missing", {k: v for k, v in _OPEN_ROW.items() if k != "number"}),
+        ("number not int", {**_OPEN_ROW, "number": "7127"}),
+        ("number bool", {**_OPEN_ROW, "number": True}),
+        ("number non-positive", {**_OPEN_ROW, "number": 0}),
+    ],
+)
+def test_probe_reports_rows_that_do_not_bind_to_this_branch_as_unknown(
+    monkeypatch, label: str, row
+) -> None:
+    """A same-named branch on a fork, or after a rename, must not read as
+    proven-absent either: every unbound row makes the answer unknown."""
+    has_open, error = _probe_with(monkeypatch, _gh_result(json.dumps([row])))
+    assert has_open is None, label
+    assert error, label
+
+
+def test_probe_one_bad_row_poisons_a_good_one(monkeypatch) -> None:
+    has_open, error = _probe_with(monkeypatch, _gh_result(json.dumps([_OPEN_ROW, {}])))
+    assert has_open is None
+    assert error
+
+
+def test_probe_reports_nonzero_exit_as_unknown(monkeypatch) -> None:
+    has_open, error = _probe_with(monkeypatch, _gh_result(json.dumps([_OPEN_ROW]), returncode=1))
+    assert has_open is None
+    assert error
+    # OPSEC: the failure stays structural; gh stderr never lands in reports.
+    assert "stderr" not in error
+
+
+def test_probe_reports_timeout_as_unknown(monkeypatch) -> None:
+    has_open, error = _probe_with(monkeypatch, subprocess.TimeoutExpired(cmd="gh", timeout=1))
+    assert has_open is None
+    assert error
+
+
+def test_probe_reports_missing_gh_as_unknown(monkeypatch) -> None:
+    has_open, error = _probe_with(monkeypatch, OSError("gh missing"))
+    assert has_open is None
+    assert error
+
+
+def test_probe_refuses_to_run_without_branch_or_repo(monkeypatch) -> None:
+    called: list[Any] = []
+
+    def _fail_run(*_args: Any, **_kwargs: Any):
+        called.append(1)
+        raise AssertionError("gh must not run without an explicit identity")
+
+    monkeypatch.setattr(pr_identity, "_run_gh", _fail_run)
+
+    has_open, error = pr_identity.probe_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), repo=REPO, branch=None
+    )
+    assert has_open is None
+    assert "branch" in error
+
+    has_open, error = pr_identity.probe_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), repo=None, branch=BRANCH
+    )
+    assert has_open is None
+    assert "repository" in error
+
+    assert called == []
+
+
+def test_probe_binds_the_query_to_the_explicit_identity(monkeypatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake_run(cmd: list[str], **_kwargs: Any):
+        seen["cmd"] = cmd
+        return _gh_result("[]")
+
+    monkeypatch.setattr(pr_identity, "_run_gh", _fake_run)
+    pr_identity.probe_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), repo=REPO, branch=BRANCH
+    )
+
+    cmd = seen["cmd"]
+    assert cmd[:3] == ["gh", "pr", "list"]
+    assert cmd[cmd.index("--repo") + 1] == REPO
+    assert cmd[cmd.index("--head") + 1] == BRANCH
+    assert cmd[cmd.index("--state") + 1] == "open"
+    assert cmd[cmd.index("--json") + 1] == "number,state,headRefName,isCrossRepository"
+
+
+# --- resolve_repo_slug --------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=True, timeout=30)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/octo/fleet.git", "octo/fleet"),
+        ("https://github.com/octo/fleet", "octo/fleet"),
+        ("git@github.com:octo/fleet.git", "octo/fleet"),
+        ("ssh://git@github.com/octo/fleet.git", "octo/fleet"),
+        ("/tmp/hermetic-origin.git", None),
+        ("https://gitlab.com/octo/fleet.git", None),
+    ],
+)
+def test_resolve_repo_slug_parses_github_remotes(tmp_path, url: str, expected: str | None) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["git", "init"], cwd=repo)
+    _git(["git", "remote", "add", "origin", url], cwd=repo)
+
+    assert pr_identity.resolve_repo_slug(repo) == expected
+
+
+def test_resolve_repo_slug_fails_closed_without_a_checkout(tmp_path) -> None:
+    assert pr_identity.resolve_repo_slug(tmp_path / "missing") is None
+
+
+# --- identity agreement: one probe, two fail-closed directions (#7127) -------
+
+
+def test_both_callers_consult_the_one_shared_probe_module() -> None:
+    assert post_task_reap.pr_identity is hygiene.pr_identity is pr_identity
+
+
+@pytest.mark.parametrize(
+    ("probe_answer", "gate_expected", "reaper_no_open_expected", "reaper_error_expected"),
+    [
+        ((True, None), True, False, None),
+        ((False, None), False, True, None),
+        ((None, "gh pr list failed (exit 1)"), False, False, "PR guard unavailable"),
+    ],
+)
+def test_directions_fail_closed_per_caller(
+    monkeypatch, probe_answer, gate_expected: bool, reaper_no_open_expected: bool, reaper_error_expected
+) -> None:
+    """The probe's answer maps onto each caller's own fail-closed direction:
+    only a PROVEN absence permits the reaper to proceed; the gate exempts a
+    worktree only on a PROVEN open PR."""
+    monkeypatch.setattr(pr_identity, "resolve_repo_slug", lambda _root: REPO)
+    monkeypatch.setattr(pr_identity, "probe_open_pr_for_branch", lambda **_kwargs: probe_answer)
+
+    assert hygiene._branch_has_open_pr(Path("/nonexistent"), BRANCH) is gate_expected
+
+    no_open, error = post_task_reap._no_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), branch=BRANCH
+    )
+    assert no_open is reaper_no_open_expected
+    if reaper_error_expected is None:
+        assert error is None
+    else:
+        assert reaper_error_expected in error
+
+
+def test_reaper_treats_unresolvable_repository_identity_as_unknown(monkeypatch) -> None:
+    monkeypatch.setattr(pr_identity, "resolve_repo_slug", lambda _root: None)
+
+    no_open, error = post_task_reap._no_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), branch=BRANCH
+    )
+
+    assert no_open is False
+    assert "PR guard unavailable" in error
+    assert "no explicit repository" in error
+
+
+def _drive_both_over_one_gh_answer(monkeypatch, result: Any):
+    """Run the REAL reaper and gate predicates over ONE shared gh answer."""
+    def _fake_run(*_args: Any, **_kwargs: Any):
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(pr_identity, "_run_gh", _fake_run)
+    monkeypatch.setattr(pr_identity, "resolve_repo_slug", lambda _root: REPO)
+
+    gate_has_open = hygiene._branch_has_open_pr(Path("/nonexistent"), BRANCH)
+    reaper_no_open, reaper_error = post_task_reap._no_open_pr_for_branch(
+        repo_root=Path("/nonexistent"), branch=BRANCH
+    )
+    return gate_has_open, reaper_no_open, reaper_error
+
+
+@pytest.mark.parametrize(
+    ("label", "payload", "outcome"),
+    [
+        ("open row", json.dumps([_OPEN_ROW]), "proven_open"),
+        ("empty list", "[]", "proven_absent"),
+        ("empty row", "[{}]", "unknown"),
+        ("null row", "[null]", "unknown"),
+        ("non-list", "{}", "unknown"),
+        ("malformed json", "not json", "unknown"),
+    ],
+)
+def test_identity_agreement_on_one_gh_answer(monkeypatch, label: str, payload: str, outcome: str) -> None:
+    """The #7127 contract: both predicates derive from one binding.  A proven
+    open PR exempts (gate) and retains (reaper); a proven absence is the ONLY
+    answer under which the reaper may proceed; everything else — including
+    malformed `{}` rows — fails closed in BOTH directions at once."""
+    gate_has_open, reaper_no_open, reaper_error = _drive_both_over_one_gh_answer(
+        monkeypatch, _gh_result(payload)
+    )
+
+    if outcome == "proven_open":
+        assert gate_has_open is True, label
+        assert reaper_no_open is False, label
+        assert reaper_error is None, label
+    elif outcome == "proven_absent":
+        assert gate_has_open is False, label
+        assert reaper_no_open is True, label
+        assert reaper_error is None, label
+    else:
+        assert gate_has_open is False, label
+        assert reaper_no_open is False, label
+        assert "PR guard unavailable" in (reaper_error or ""), label
+
+
+def test_identity_agreement_on_transport_failures(monkeypatch) -> None:
+    for failure in (
+        _gh_result("[]", returncode=1),
+        subprocess.TimeoutExpired(cmd="gh", timeout=1),
+        OSError("gh missing"),
+    ):
+        gate_has_open, reaper_no_open, reaper_error = _drive_both_over_one_gh_answer(
+            monkeypatch, failure
+        )
+        assert gate_has_open is False
+        assert reaper_no_open is False
+        assert "PR guard unavailable" in (reaper_error or "")
+
+
+def test_each_caller_binds_its_own_explicit_repository(monkeypatch) -> None:
+    """The gate pins the public repo; the reaper binds the checkout's own
+    origin.  Both flow into the probe's --repo scope, never gh's cwd guess."""
+    seen: list[dict[str, Any]] = []
+
+    def _fake_probe(**kwargs: Any):
+        seen.append(kwargs)
+        return False, None
+
+    monkeypatch.setattr(pr_identity, "probe_open_pr_for_branch", _fake_probe)
+    monkeypatch.setattr(pr_identity, "resolve_repo_slug", lambda _root: REPO)
+
+    hygiene._branch_has_open_pr(Path("/nonexistent"), BRANCH)
+    post_task_reap._no_open_pr_for_branch(repo_root=Path("/nonexistent"), branch=BRANCH)
+
+    assert [call["repo"] for call in seen] == [hygiene.PUBLIC_REPOSITORY, REPO]
+    assert all(call["branch"] == BRANCH for call in seen)


### PR DESCRIPTION
## Summary

Closes #7127.

Two modules independently answered *"does this branch still have an open PR?"* — the reaper's `_no_open_pr_for_branch()` (delegating to `reap_worktrees._query_pr_states()`) and the gate's `_branch_has_open_pr()` (#7126) — and they already disagreed on malformed rows. This extracts **one dependency-safe PR-identity probe** both callers now share.

## The shared probe

New leaf module `scripts/fleet/pr_identity.py` (imports neither caller, so no import cycle into either module body — verified by a test). It expresses the identity binding exactly once:

- explicit `--repo` scope (never gh's cwd fallback);
- `state == "OPEN"`;
- exact `headRefName` equality with the probed branch;
- non-fork (same-repository) head;
- positive integer `number`.

It returns a tri-state: `True` (provably open), `False` (provably none), `None` (unknown + structural reason; gh stderr is never echoed). A single malformed row — e.g. `[{}]` — poisons the whole answer to unknown.

## Per-caller fail-closed directions (unchanged, by design)

| probe answer | reaper `_no_open_pr_for_branch` | gate `_branch_has_open_pr` |
|---|---|---|
| proven open | retain | exempt (not counted) |
| proven absent | may proceed | counted |
| unknown | **retain (never delete)** | **still counted (never passes)** |

The reaper now also binds the repository explicitly, resolved from the checkout's `remote.origin.url`; an unresolvable slug is an unknown, which retains.

## Tests

- `tests/test_fleet_pr_identity.py` (new): probe tri-state semantics incl. `[{}]`/`[null]`/non-list/transport failures; command-shape binding (`--repo`/`--head`/`--state open`); repo-slug resolution; **identity-agreement tests** driving the real reaper and gate predicates over one shared gh answer, plus the direction matrix and per-caller explicit-repo pinning.
- `tests/test_fleet_post_task_reap.py`: hermetic fixture controls the shared probe; new unknown-retains fallback test; open-PR test drives probe + canonical path independently.
- `tests/test_fleet_hramatka_hygiene_check.py`: probe tests now patch the probe's gh boundary.
- `tests/orchestration/test_reap_worktrees.py`: the #7126 deletion-authorization end-to-end test re-driven through the probe's gh boundary, same contract (ambiguity retains, proven-absent permits).

## Verification

- `pytest tests/test_fleet_pr_identity.py tests/test_fleet_post_task_reap.py tests/test_fleet_hramatka_hygiene_check.py tests/orchestration/test_reap_worktrees.py tests/orchestration/test_scheduled_worktree_cleanup.py` — **257 passed**
- `ruff check scripts/` + touched test files — clean

`reap_worktrees._query_pr_states` itself and the scheduled cleanup are untouched.