### PR TITLE
feat(api): show driver and Foundry burn on occupancy glance (#7139)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -239,7 +239,14 @@ Standard HTTP status codes: `404` for missing resources, `500` for server errors
 
 Opaque host occupancy for drivers. Reuses the atlas-jobs load cache (no second probe board). The payload always enumerates both opaque hosts `host-teacher` and `host-job` (and any additional mapped hosts). Host mappings are configured via `MONITOR_OCCUPANCY_HOST_IDS` (`canonical=opaque-id,...`). Unmapped default hosts return `status: "unavailable"` with `idle_or_empty: false` — unreachable burn is unknown, not proven idle. Canonical aliases are never used as JSON keys.
 
-Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service | observer`. Each host entry includes `occupant_count`, `ai_seats` (active agent seats), and `idle_or_empty` (boolean indicating near-zero burn). Observer heartbeats (`POST /api/observer/presence`) appear under `host_id` `cloud-observer` (no CPU/RAM metrics, no SSH identity). Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics.
+Occupants are `{kind, agent, task_id, epic}` with `kind` in `driver | worker | job | service | observer`. Each host entry includes `occupant_count`, `ai_seats` (active agent seats), and `idle_or_empty` (boolean indicating near-zero burn). Sources, in order:
+
+- atlas-job registry rows in `running` / `queued` / `submitted` / `needs_finalize`
+- the cached load `job_unit` when a unit is active
+- local session-stream epic-driver leases (active, unexpired). Attached to `MONITOR_OCCUPANCY_DRIVER_HOST_ID` when that value is an enumerated opaque host, otherwise to the opaque id of `ATLAS_JOB_SELF_HOST` when that token is mapped. Remote tmux seats are not scraped.
+- optional occupancy markers (`MONITOR_OCCUPANCY_MARKERS` file or directory, else `.agent/occupancy/markers` on the live checkout). Foundry / evidence-compiler (or any service) can publish `{kind, agent, task_id, epic, host_id}` with an `expires_at`. `idle_or_empty` stays false while those occupants are active.
+
+Observer heartbeats (`POST /api/observer/presence`) appear under `host_id` `cloud-observer` (no CPU/RAM metrics, no SSH identity). Unreachable probes return `"status": "unavailable"` and `"error": "unreachable"` with no SSH/error text and no load metrics. Unavailable hosts still report `idle_or_empty: false` (burn unknown).
 
 On a running event loop, a missing or expired cache entry and `fresh=true` wait for the shared load probe before responding. A successful sample younger than 30s is `fresh`. Refresh starts at 15s so a live heartbeat does not wait until the window expires; while that probe runs, the same sample stays `fresh` for 15s past the window. Cached metrics between 45 and 300 seconds old may still be returned as `stale` while a refresh runs.
 

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -8,7 +8,10 @@ Services bind `127.0.0.1` only. Reach them from another machine with an SSH
 tunnel; set `MONITOR_INSTANCE_ID` in the environment so `/api/health`
 distinguishes hosts. For `GET /api/occupancy`, set `MONITOR_OCCUPANCY_HOST_IDS`
 to comma-separated `canonical=opaque-id` pairs (opaque values only, e.g.
-`host-job`). Do not put addresses or SSH hostnames in the occupancy JSON.
+`host-job`). Optional local seats: `ATLAS_JOB_SELF_HOST` or
+`MONITOR_OCCUPANCY_DRIVER_HOST_ID` attaches session-stream driver leases;
+`MONITOR_OCCUPANCY_MARKERS` publishes Foundry/compiler heartbeats. Do not put
+addresses or SSH hostnames in the occupancy JSON.
 
 Units are **Linux-native `Type=simple`** processes. Do not wrap
 `./services.sh start` in `Type=oneshot RemainAfterExit=yes`: that is

--- a/scripts/api/occupancy.py
+++ b/scripts/api/occupancy.py
@@ -2,8 +2,10 @@
 
 Sibling of ``GET /api/atlas-jobs/load`` — one occupancy board, no second probe
 path. Canonical SSH aliases never appear as JSON keys. Map them with
-``MONITOR_OCCUPANCY_HOST_IDS`` (``alias=opaque-id,...``). Observer heartbeats
-from ``POST /api/observer/presence`` appear under ``cloud-observer``.
+``MONITOR_OCCUPANCY_HOST_IDS`` (``alias=opaque-id,...``). Occupants come from
+the atlas-job registry, the cached job unit, local session-stream driver
+leases, and optional occupancy markers. Observer heartbeats from
+``POST /api/observer/presence`` appear under ``cloud-observer``.
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ from fastapi.responses import JSONResponse
 
 from scripts.api import atlas_jobs_router as load_mod
 from scripts.api.observer_presence import list_live
+from scripts.api.occupancy_local import occupants_from_markers, occupants_from_session_streams
 from scripts.api.occupancy_sanitize import CLOUD_OBSERVER_HOST_ID
 from scripts.api.occupancy_sanitize import occupant as _occupant
 from scripts.api.occupancy_sanitize import opaque_host_id as _opaque_host_id
@@ -251,15 +254,22 @@ def _payload_from_entries(
     load_entries: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     hosts: dict[str, Any] = {}
+    mapping = parse_host_id_map()
     for opaque, canonical in selected.items():
         load_entry = load_entries.get(opaque) or _unavailable_load_entry()
+        groups: list[list[dict[str, str | None]]] = []
         if canonical is not None:
-            occupants = _merge_occupants(
-                _occupants_from_registry(canonical),
-                _occupants_from_job_unit(canonical, load_entry),
+            groups.append(_occupants_from_registry(canonical))
+            groups.append(_occupants_from_job_unit(canonical, load_entry))
+        groups.append(
+            occupants_from_session_streams(
+                host_id=opaque,
+                mapping=mapping,
+                selected=selected,
             )
-        else:
-            occupants = []
+        )
+        groups.append(occupants_from_markers(host_id=opaque))
+        occupants = _merge_occupants(*groups)
         hosts[opaque] = _shape_host(opaque, load_entry, occupants)
 
     return {

--- a/scripts/api/occupancy_local.py
+++ b/scripts/api/occupancy_local.py
@@ -1,0 +1,378 @@
+"""Local durable occupancy seats: session-stream leases and optional markers.
+
+These sources never probe a remote host. They read the Monitor checkout's
+session-stream DB (same path as ``/api/session-streams``) and an optional
+marker file or directory. Opaque ``host_id`` values only; paths stay off the
+JSON wire.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import parse_timestamp
+from scripts.api.occupancy_sanitize import occupant as _occupant
+from scripts.api.occupancy_sanitize import opaque_host_id as _opaque_host_id
+from scripts.api.occupancy_sanitize import safe_field as _safe_field
+from scripts.api.session_streams_router import _db_path as session_streams_db_path
+from scripts.api.session_streams_router import _repo_root
+from scripts.lexicon.runner import atlas_job
+
+ENV_DRIVER_HOST_ID = "MONITOR_OCCUPANCY_DRIVER_HOST_ID"
+ENV_MARKERS = "MONITOR_OCCUPANCY_MARKERS"
+ENV_FOUNDRY_HOST_ID = "MONITOR_OCCUPANCY_FOUNDRY_HOST_ID"
+MARKERS_SCHEMA = "monitor-occupancy-markers.v1"
+MARKER_KINDS = frozenset({"driver", "worker", "job", "service"})
+DEFAULT_MARKER_TTL_S = 15 * 60
+_MARKERS_REL = Path(".agent") / "occupancy" / "markers"
+
+
+def markers_root() -> Path:
+    raw = os.environ.get(ENV_MARKERS, "").strip()
+    if raw:
+        return Path(raw)
+    return _repo_root() / _MARKERS_REL
+
+
+def self_host_opaque_ids(mapping: dict[str, str]) -> set[str]:
+    """Opaque ids whose canonical token is this process (no remote guess)."""
+    claimed: set[str] = set()
+    for canonical, opaque in mapping.items():
+        if atlas_job.is_self_host(canonical) and _opaque_host_id(opaque):
+            claimed.add(opaque)
+    return claimed
+
+
+def driver_seat_host_id(mapping: dict[str, str], selected: dict[str, str | None]) -> str | None:
+    """Opaque host that may claim local session-stream driver seats."""
+    explicit = os.environ.get(ENV_DRIVER_HOST_ID, "").strip().lower()
+    if explicit:
+        return explicit if _opaque_host_id(explicit) and explicit in selected else None
+    claimed = self_host_opaque_ids(mapping) & set(selected)
+    if len(claimed) == 1:
+        return next(iter(claimed))
+    return None
+
+
+def _parse_when(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return parse_timestamp(value.strip())
+    except ValueError:
+        return None
+
+
+def _epic_from_stream(stream_id: str) -> str | None:
+    if not stream_id.startswith("epic:"):
+        return None
+    number = stream_id.removeprefix("epic:")
+    return number if number.isdigit() else None
+
+
+def occupants_from_session_streams(
+    *,
+    host_id: str,
+    mapping: dict[str, str],
+    selected: dict[str, str | None],
+    db_path: Path | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, str | None]]:
+    """Active epic-driver leases attached to one opaque host."""
+    if driver_seat_host_id(mapping, selected) != host_id:
+        return []
+    path = session_streams_db_path() if db_path is None else db_path
+    if not path.is_file():
+        return []
+    clock = now or datetime.now(UTC)
+    try:
+        database = SessionStreamDatabase(path)
+        with database.connect(read_only=True) as conn:
+            rows = conn.execute(
+                """
+                SELECT l.stream_id, l.holder_agent, l.holder_task_id, l.expires_at
+                FROM stream_leases AS l
+                JOIN sessions AS s ON s.stream_id = l.stream_id
+                    AND s.session_id = l.session_id
+                WHERE l.state = 'active'
+                  AND s.state IN ('open', 'rolling')
+                """
+            ).fetchall()
+    except (OSError, sqlite3.Error, ValueError):
+        return []
+
+    occupants: list[dict[str, str | None]] = []
+    seen: set[tuple[str, str]] = set()
+    for row in rows:
+        try:
+            expires_at = parse_timestamp(str(row["expires_at"]))
+        except (KeyError, ValueError):
+            continue
+        if expires_at <= clock:
+            continue
+        stream_id = str(row["stream_id"] or "")
+        epic = _epic_from_stream(stream_id)
+        if epic is None:
+            continue
+        task_id = _safe_field(row["holder_task_id"], role="task_id") or f"epic-{epic}"
+        occupant = _occupant(
+            kind="driver",
+            agent=row["holder_agent"],
+            task_id=task_id,
+            epic=epic,
+        )
+        if occupant is None:
+            continue
+        key = (occupant["kind"], occupant["task_id"] or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        occupants.append(occupant)
+    return occupants
+
+
+def _marker_fresh(payload: dict[str, Any], *, now: datetime) -> bool:
+    expires = _parse_when(payload.get("expires_at"))
+    if expires is not None:
+        return expires > now
+    updated = _parse_when(payload.get("updated_at"))
+    if updated is None:
+        return True
+    return (now - updated).total_seconds() <= DEFAULT_MARKER_TTL_S
+
+
+def _occupant_from_marker(
+    payload: dict[str, Any],
+    *,
+    host_id: str,
+    now: datetime,
+) -> dict[str, str | None] | None:
+    if not isinstance(payload, dict):
+        return None
+    marker_host = str(payload.get("host_id") or "").strip().lower()
+    if marker_host != host_id or not _opaque_host_id(marker_host):
+        return None
+    kind = str(payload.get("kind") or "").strip()
+    if kind not in MARKER_KINDS:
+        return None
+    if not _marker_fresh(payload, now=now):
+        return None
+    return _occupant(
+        kind=kind,
+        agent=payload.get("agent"),
+        task_id=payload.get("task_id"),
+        epic=payload.get("epic"),
+    )
+
+
+def _iter_marker_payloads(root: Path) -> Iterator[dict[str, Any]]:
+    if root.is_file():
+        candidates = [root]
+    elif root.is_dir():
+        candidates = sorted(path for path in root.iterdir() if path.is_file() and path.suffix == ".json")
+    else:
+        return
+    for path in candidates:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeError):
+            continue
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict):
+                    yield item
+            continue
+        if not isinstance(raw, dict):
+            continue
+        occupants = raw.get("occupants")
+        if isinstance(occupants, list):
+            for item in occupants:
+                if isinstance(item, dict):
+                    yield item
+            continue
+        yield raw
+
+
+def occupants_from_markers(
+    *,
+    host_id: str,
+    root: Path | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, str | None]]:
+    """Optional Foundry/compiler (or other service) heartbeats for one host."""
+    path = markers_root() if root is None else root
+    clock = now or datetime.now(UTC)
+    occupants: list[dict[str, str | None]] = []
+    seen: set[tuple[str, str]] = set()
+    try:
+        payloads = _iter_marker_payloads(path)
+    except OSError:
+        return []
+    for payload in payloads:
+        occupant = _occupant_from_marker(payload, host_id=host_id, now=clock)
+        if occupant is None:
+            continue
+        key = (occupant["kind"], occupant["task_id"] or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        occupants.append(occupant)
+    return occupants
+
+
+def _marker_filename(kind: str, task_id: str) -> str:
+    return f"{kind}-{task_id}.json"
+
+
+def write_marker(
+    *,
+    kind: str,
+    task_id: str,
+    host_id: str,
+    agent: str | None = None,
+    epic: str | None = None,
+    path: Path | None = None,
+    ttl_seconds: int = DEFAULT_MARKER_TTL_S,
+    now: datetime | None = None,
+) -> Path | None:
+    """Write one sanitized marker. Returns None when the row cannot be published."""
+    if kind not in MARKER_KINDS or not _opaque_host_id(host_id):
+        return None
+    occupant = _occupant(kind=kind, agent=agent, task_id=task_id, epic=epic)
+    if occupant is None:
+        return None
+    clock = now or datetime.now(UTC)
+    expires = clock + timedelta(seconds=max(1, int(ttl_seconds)))
+    payload = {
+        "schema": MARKERS_SCHEMA,
+        "kind": occupant["kind"],
+        "agent": occupant["agent"],
+        "task_id": occupant["task_id"],
+        "epic": occupant["epic"],
+        "host_id": host_id,
+        "updated_at": clock.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires.isoformat().replace("+00:00", "Z"),
+    }
+    dest = markers_root() if path is None else path
+    try:
+        as_file = dest.suffix == ".json" and not dest.is_dir()
+        if as_file:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            return dest
+        dest.mkdir(parents=True, exist_ok=True)
+        target = dest / _marker_filename(str(occupant["kind"]), str(occupant["task_id"]))
+        target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return target
+    except OSError:
+        return None
+
+
+def clear_marker(*, kind: str, task_id: str, path: Path | None = None) -> None:
+    dest = markers_root() if path is None else path
+    try:
+        if dest.is_file():
+            dest.unlink()
+            return
+        if dest.is_dir():
+            target = dest / _marker_filename(kind, task_id)
+            if target.is_file():
+                target.unlink()
+    except OSError:
+        return
+
+
+@contextmanager
+def occupancy_marker_scope(
+    *,
+    kind: str,
+    task_id: str,
+    host_id: str | None = None,
+    agent: str | None = None,
+    epic: str | None = None,
+    path: Path | None = None,
+    ttl_seconds: int = DEFAULT_MARKER_TTL_S,
+) -> Iterator[Path | None]:
+    """Publish a marker for the life of a Foundry/compiler run. No-op if unconfigured."""
+    resolved_host = (host_id or os.environ.get(ENV_FOUNDRY_HOST_ID, "")).strip().lower()
+    dest = path
+    if dest is None and not os.environ.get(ENV_MARKERS, "").strip():
+        yield None
+        return
+    if not resolved_host or not _opaque_host_id(resolved_host):
+        yield None
+        return
+    written = write_marker(
+        kind=kind,
+        task_id=task_id,
+        host_id=resolved_host,
+        agent=agent,
+        epic=epic,
+        path=dest,
+        ttl_seconds=ttl_seconds,
+    )
+    try:
+        yield written
+    finally:
+        if written is not None:
+            clear_marker(kind=kind, task_id=task_id, path=dest or written)
+
+
+def foundry_marker_host_id(mapping: dict[str, str]) -> str | None:
+    explicit = os.environ.get(ENV_FOUNDRY_HOST_ID, "").strip().lower()
+    if explicit and _opaque_host_id(explicit):
+        return explicit
+    claimed = self_host_opaque_ids(mapping)
+    if len(claimed) == 1:
+        return next(iter(claimed))
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Publish or clear a sanitized occupancy marker (opaque host_id only).")
+    sub = parser.add_subparsers(dest="command", required=True)
+    heartbeat = sub.add_parser("heartbeat", help="write one marker")
+    heartbeat.add_argument("--kind", required=True)
+    heartbeat.add_argument("--task-id", required=True)
+    heartbeat.add_argument("--host-id", required=True)
+    heartbeat.add_argument("--agent")
+    heartbeat.add_argument("--epic")
+    heartbeat.add_argument("--ttl-seconds", type=int, default=DEFAULT_MARKER_TTL_S)
+    clear = sub.add_parser("clear", help="remove one marker")
+    clear.add_argument("--kind", required=True)
+    clear.add_argument("--task-id", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "heartbeat":
+        written = write_marker(
+            kind=args.kind,
+            task_id=args.task_id,
+            host_id=args.host_id,
+            agent=args.agent,
+            epic=args.epic,
+            ttl_seconds=args.ttl_seconds,
+        )
+        if written is None:
+            print("occupancy-marker: refused", flush=True)
+            return 2
+        print(f"occupancy-marker: kind={args.kind} task_id={args.task_id} host_id={args.host_id}")
+        return 0
+    clear_marker(kind=args.kind, task_id=args.task_id)
+    print(f"occupancy-marker: cleared kind={args.kind} task_id={args.task_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -886,7 +886,7 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "exact",
         "http",
         "Opaque host occupancy: load fields plus occupants {kind, agent, task_id, epic}; observer heartbeats appear under host_id cloud-observer.",
-        "In-process atlas-jobs load cache plus local atlas-jobs registry; host keys from MONITOR_OCCUPANCY_HOST_IDS; in-process observer presence store for cloud-observer.",
+        "In-process atlas-jobs load cache plus local atlas-jobs registry, local session-stream driver leases, and optional occupancy markers; host keys from MONITOR_OCCUPANCY_HOST_IDS; in-process observer presence store for cloud-observer.",
         "Stale-while-revalidate via the existing load cache (fresh <=30s, stale <=300s); observer rows TTL 15 minutes; never probes SSH on the request path.",
         ("operators", "dispatch", "tests", "qa-engineer", "grok-bot"),
         "Reuses GET /api/atlas-jobs/load cache; does not add a second probe board. Observer presence is not a RAM lease.",

--- a/scripts/projects/open_model_data/foundry_cli.py
+++ b/scripts/projects/open_model_data/foundry_cli.py
@@ -910,16 +910,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "prepare":
-            result = prepare(
-                input_path=args.input,
-                output_dir=args.output_dir,
-                max_records=args.max_records,
-                evaluation_artifacts=tuple(args.evaluation_artifact),
-                tokenizer_path=args.tokenizer_path,
-                tokenizer_identifier=args.tokenizer_identifier,
-                tokenizer_revision=args.tokenizer_revision,
-                cost_path=args.cost_config,
-            )
+            from scripts.api.occupancy_local import occupancy_marker_scope
+
+            with occupancy_marker_scope(
+                kind="service",
+                agent="foundry",
+                task_id="ukrainian-data-foundry",
+                epic="foundry",
+            ):
+                result = prepare(
+                    input_path=args.input,
+                    output_dir=args.output_dir,
+                    max_records=args.max_records,
+                    evaluation_artifacts=tuple(args.evaluation_artifact),
+                    tokenizer_path=args.tokenizer_path,
+                    tokenizer_identifier=args.tokenizer_identifier,
+                    tokenizer_revision=args.tokenizer_revision,
+                    cost_path=args.cost_config,
+                )
             print(canonical_json(result.receipt))
         else:
             print(canonical_json(verify(args.output_dir)))

--- a/tests/api/test_occupancy.py
+++ b/tests/api/test_occupancy.py
@@ -6,6 +6,7 @@ import json
 import re
 import threading
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -38,6 +39,18 @@ def _clear_observer_presence() -> None:
 @pytest.fixture(autouse=True)
 def _non_operational_run_root(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_local_occupants(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MONITOR_OCCUPANCY_MARKERS", str(tmp_path / "no-markers"))
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+    monkeypatch.delenv("MONITOR_OCCUPANCY_FOUNDRY_HOST_ID", raising=False)
+    monkeypatch.delenv("ATLAS_JOB_SELF_HOST", raising=False)
+    monkeypatch.setattr(
+        "scripts.api.occupancy_local.session_streams_db_path",
+        lambda: tmp_path / "missing-session-streams.sqlite3",
+    )
 
 
 def _plan(**overrides: object) -> dict:

--- a/tests/api/test_occupancy_local.py
+++ b/tests/api/test_occupancy_local.py
@@ -1,0 +1,243 @@
+"""Unit tests for local occupancy seats (session streams + markers)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import LeaseHolder
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+from scripts.api.occupancy_local import (
+    clear_marker,
+    driver_seat_host_id,
+    occupancy_marker_scope,
+    occupants_from_markers,
+    occupants_from_session_streams,
+    write_marker,
+)
+
+
+def _open_lease(
+    db_path: Path,
+    *,
+    stream_id: str = "epic:7139",
+    agent: str = "claude",
+    task_id: str = "infra-drive",
+    ttl_seconds: int = 600,
+) -> None:
+    store = SessionStreamStore(SessionStreamDatabase(db_path))
+    store.open_session(
+        stream_id=stream_id,
+        holder=LeaseHolder(
+            agent=agent,
+            harness="claude-code",
+            instance_id="runtime-1",
+            process_id=41001,
+            task_id=task_id,
+        ),
+        lineage_id="lineage-occupancy",
+        ttl_seconds=ttl_seconds,
+        session_id="session-occupancy",
+        lease_id="lease-occupancy",
+    )
+
+
+def test_driver_seat_host_id_uses_explicit_opaque_then_self_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    mapping = {"teach-box": "host-teacher", "job-box": "host-job"}
+    selected = {"host-teacher": "teach-box", "host-job": "job-box"}
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+    monkeypatch.delenv("ATLAS_JOB_SELF_HOST", raising=False)
+    assert driver_seat_host_id(mapping, selected) is None
+
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "teach-box")
+    assert driver_seat_host_id(mapping, selected) == "host-teacher"
+
+    monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "host-job")
+    assert driver_seat_host_id(mapping, selected) == "host-job"
+
+    monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "atlas-runner")
+    assert driver_seat_host_id(mapping, selected) is None
+
+
+def test_occupants_from_session_streams_reads_active_lease_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "session-streams.sqlite3"
+    _open_lease(db_path)
+    mapping = {"teach-box": "host-teacher"}
+    selected = {"host-teacher": "teach-box", "host-job": "job-box"}
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "teach-box")
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+
+    teacher = occupants_from_session_streams(
+        host_id="host-teacher",
+        mapping=mapping,
+        selected=selected,
+        db_path=db_path,
+    )
+    assert teacher == [{"kind": "driver", "agent": "claude", "task_id": "infra-drive", "epic": "7139"}]
+    assert (
+        occupants_from_session_streams(
+            host_id="host-job",
+            mapping=mapping,
+            selected=selected,
+            db_path=db_path,
+        )
+        == []
+    )
+
+
+def test_occupants_from_session_streams_skips_expired_and_broken_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mapping = {"teach-box": "host-teacher"}
+    selected = {"host-teacher": "teach-box"}
+    monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "host-teacher")
+
+    expired = tmp_path / "expired.sqlite3"
+    _open_lease(expired, ttl_seconds=1)
+    later = datetime.now(UTC) + timedelta(seconds=5)
+    assert (
+        occupants_from_session_streams(
+            host_id="host-teacher",
+            mapping=mapping,
+            selected=selected,
+            db_path=expired,
+            now=later,
+        )
+        == []
+    )
+
+    broken = tmp_path / "broken.sqlite3"
+    broken.write_text("not-a-database", encoding="utf-8")
+    assert (
+        occupants_from_session_streams(
+            host_id="host-teacher",
+            mapping=mapping,
+            selected=selected,
+            db_path=broken,
+        )
+        == []
+    )
+    assert (
+        occupants_from_session_streams(
+            host_id="host-teacher",
+            mapping=mapping,
+            selected=selected,
+            db_path=tmp_path / "missing.sqlite3",
+        )
+        == []
+    )
+
+
+def test_occupants_from_session_streams_falls_back_when_task_id_is_unsafe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "session-streams.sqlite3"
+    _open_lease(db_path, agent="claude", task_id="atlas-runner-reenrich-3")
+    monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "host-teacher")
+    occupants = occupants_from_session_streams(
+        host_id="host-teacher",
+        mapping={"teach-box": "host-teacher"},
+        selected={"host-teacher": "teach-box"},
+        db_path=db_path,
+    )
+    assert occupants == [{"kind": "driver", "agent": "claude", "task_id": "epic-7139", "epic": "7139"}]
+
+
+def test_marker_round_trip_and_expiry(tmp_path: Path) -> None:
+    markers = tmp_path / "markers"
+    written = write_marker(
+        kind="service",
+        agent="foundry",
+        task_id="evidence-compiler",
+        epic="7102",
+        host_id="host-teacher",
+        path=markers,
+        ttl_seconds=60,
+    )
+    assert written is not None
+    assert written.parent == markers
+    assert occupants_from_markers(host_id="host-teacher", root=markers) == [
+        {
+            "kind": "service",
+            "agent": "foundry",
+            "task_id": "evidence-compiler",
+            "epic": "7102",
+        }
+    ]
+    assert occupants_from_markers(host_id="host-job", root=markers) == []
+
+    stale_time = datetime.now(UTC) + timedelta(minutes=30)
+    assert occupants_from_markers(host_id="host-teacher", root=markers, now=stale_time) == []
+
+    clear_marker(kind="service", task_id="evidence-compiler", path=markers)
+    assert occupants_from_markers(host_id="host-teacher", root=markers) == []
+
+
+def test_marker_rejects_leaks_and_observer_kind(tmp_path: Path) -> None:
+    markers = tmp_path / "markers"
+    assert (
+        write_marker(
+            kind="service",
+            agent="foundry",
+            task_id="evidence-compiler",
+            host_id="atlas-runner",
+            path=markers,
+        )
+        is None
+    )
+    assert (
+        write_marker(
+            kind="service",
+            agent="foundry",
+            task_id="atlas-runner-job",
+            host_id="host-teacher",
+            path=markers,
+        )
+        is None
+    )
+    leaked = markers / "leaked.json"
+    leaked.parent.mkdir(parents=True)
+    leaked.write_text(
+        '{"kind":"service","agent":"foundry","task_id":"ok","host_id":"host-teacher","epic":"not/a-token"}',
+        encoding="utf-8",
+    )
+    assert occupants_from_markers(host_id="host-teacher", root=markers) == [
+        {"kind": "service", "agent": "foundry", "task_id": "ok", "epic": None}
+    ]
+    observer = markers / "observer.json"
+    observer.write_text(
+        '{"kind":"observer","agent":"cursor","task_id":"7061","host_id":"host-teacher"}',
+        encoding="utf-8",
+    )
+    kinds = {row["kind"] for row in occupants_from_markers(host_id="host-teacher", root=markers)}
+    assert "observer" not in kinds
+
+
+def test_occupancy_marker_scope_is_opt_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MONITOR_OCCUPANCY_MARKERS", raising=False)
+    monkeypatch.delenv("MONITOR_OCCUPANCY_FOUNDRY_HOST_ID", raising=False)
+    with occupancy_marker_scope(
+        kind="service",
+        task_id="ukrainian-data-foundry",
+        agent="foundry",
+        epic="foundry",
+        host_id="host-teacher",
+    ) as written:
+        assert written is None
+
+    monkeypatch.setenv("MONITOR_OCCUPANCY_MARKERS", str(tmp_path / "markers"))
+    with occupancy_marker_scope(
+        kind="service",
+        task_id="ukrainian-data-foundry",
+        agent="foundry",
+        epic="foundry",
+        host_id="host-teacher",
+    ) as written:
+        assert written is not None
+        assert occupants_from_markers(host_id="host-teacher", root=tmp_path / "markers")
+    assert occupants_from_markers(host_id="host-teacher", root=tmp_path / "markers") == []

--- a/tests/api/test_occupancy_seats.py
+++ b/tests/api/test_occupancy_seats.py
@@ -1,0 +1,199 @@
+"""API tests for occupancy seats beyond the atlas-job registry (#7139)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import LeaseHolder
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+from scripts.api import atlas_jobs_router as load_mod
+from scripts.api.occupancy import router as occupancy_router
+from scripts.api.occupancy_local import write_marker
+from scripts.lexicon.runner import atlas_job
+
+_IP = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
+_ALIAS_LEAKS = ("atlas-runner", "hramatka", "vps")
+_PLACEHOLDER_MAP = "job-box=host-job,teach-box=host-teacher"
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(occupancy_router, prefix="/api/occupancy")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_local_occupants(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_RUN_ROOT", "/tmp/atlas-run-root")
+    monkeypatch.setenv("MONITOR_OCCUPANCY_MARKERS", str(tmp_path / "no-markers"))
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+    monkeypatch.delenv("MONITOR_OCCUPANCY_FOUNDRY_HOST_ID", raising=False)
+    monkeypatch.delenv("ATLAS_JOB_SELF_HOST", raising=False)
+    monkeypatch.setattr(
+        "scripts.api.occupancy_local.session_streams_db_path",
+        lambda: tmp_path / "missing-session-streams.sqlite3",
+    )
+
+
+def _open_driver_lease(db_path: Path, *, agent: str = "claude", task_id: str = "infra-drive") -> None:
+    store = SessionStreamStore(SessionStreamDatabase(db_path))
+    store.open_session(
+        stream_id="epic:7139",
+        holder=LeaseHolder(
+            agent=agent,
+            harness="claude-code",
+            instance_id="runtime-1",
+            process_id=41001,
+            task_id=task_id,
+        ),
+        lineage_id="lineage-occupancy",
+        ttl_seconds=600,
+        session_id="session-occupancy",
+        lease_id="lease-occupancy",
+    )
+
+
+def test_occupancy_session_stream_driver_keeps_low_load_host_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "teach-box")
+    db_path = tmp_path / "session-streams.sqlite3"
+    monkeypatch.setattr("scripts.api.occupancy_local.session_streams_db_path", lambda: db_path)
+    _open_driver_lease(db_path)
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        load_mod.clear_host_load_cache()
+        idle_load = fake.host_load("teach-box")
+        idle_load["loadavg"] = [0.10, 0.10, 0.10]
+        idle_load["job_unit"] = {"active_count": 0, "job_id": None, "state": None}
+        load_mod.set_host_load_cache("teach-box", idle_load)
+        load_mod.set_host_load_cache("job-box", fake.host_load("job-box"))
+        resp = _client().get("/api/occupancy?host_id=host-teacher")
+        assert resp.status_code == 200
+        host = resp.json()["hosts"]["host-teacher"]
+        assert host["idle_or_empty"] is False
+        assert host["occupants"] == [
+            {
+                "kind": "driver",
+                "agent": "claude",
+                "task_id": "infra-drive",
+                "epic": "7139",
+            }
+        ]
+        assert host["ai_seats"] == ["claude"]
+        text = resp.text
+        for alias in _ALIAS_LEAKS:
+            assert alias not in text
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
+def test_occupancy_driver_lease_without_host_claim_stays_idle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    db_path = tmp_path / "session-streams.sqlite3"
+    monkeypatch.setattr("scripts.api.occupancy_local.session_streams_db_path", lambda: db_path)
+    _open_driver_lease(db_path)
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        load_mod.clear_host_load_cache()
+        idle_load = fake.host_load("teach-box")
+        idle_load["loadavg"] = [0.10, 0.10, 0.10]
+        idle_load["job_unit"] = {"active_count": 0, "job_id": None, "state": None}
+        load_mod.set_host_load_cache("teach-box", idle_load)
+        load_mod.set_host_load_cache("job-box", fake.host_load("job-box"))
+        resp = _client().get("/api/occupancy?host_id=host-teacher")
+        assert resp.status_code == 200
+        host = resp.json()["hosts"]["host-teacher"]
+        assert host["occupants"] == []
+        assert host["idle_or_empty"] is True
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
+def test_occupancy_foundry_marker_keeps_low_load_host_busy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    markers = tmp_path / "markers"
+    monkeypatch.setenv("MONITOR_OCCUPANCY_MARKERS", str(markers))
+    written = write_marker(
+        kind="service",
+        agent="foundry",
+        task_id="evidence-compiler",
+        epic="7102",
+        host_id="host-teacher",
+        path=markers,
+    )
+    assert written is not None
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        load_mod.clear_host_load_cache()
+        idle_load = fake.host_load("teach-box")
+        idle_load["loadavg"] = [0.20, 0.20, 0.20]
+        idle_load["job_unit"] = {"active_count": 0, "job_id": None, "state": None}
+        load_mod.set_host_load_cache("teach-box", idle_load)
+        load_mod.set_host_load_cache("job-box", fake.host_load("job-box"))
+        resp = _client().get("/api/occupancy?host_id=host-teacher")
+        assert resp.status_code == 200
+        host = resp.json()["hosts"]["host-teacher"]
+        assert host["idle_or_empty"] is False
+        assert host["occupants"] == [
+            {
+                "kind": "service",
+                "agent": "foundry",
+                "task_id": "evidence-compiler",
+                "epic": "7102",
+            }
+        ]
+        assert host["ai_seats"] == ["foundry"]
+        text = json.dumps(host)
+        assert _IP.findall(text) == []
+        for alias in _ALIAS_LEAKS:
+            assert alias not in text
+        assert "/home/" not in text
+        assert "ssh" not in text.lower()
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()
+
+
+def test_occupancy_marker_on_unavailable_host_is_not_idle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_JOB_REGISTRY", str(tmp_path))
+    monkeypatch.delenv("MONITOR_OCCUPANCY_HOST_IDS", raising=False)
+    markers = tmp_path / "markers"
+    monkeypatch.setenv("MONITOR_OCCUPANCY_MARKERS", str(markers))
+    write_marker(
+        kind="service",
+        agent="foundry",
+        task_id="evidence-compiler",
+        epic="7102",
+        host_id="host-teacher",
+        path=markers,
+    )
+    fake = atlas_job.FakeHostAdapter()
+    atlas_job.set_host_adapter(fake)
+    try:
+        resp = _client().get("/api/occupancy?host_id=host-teacher")
+        assert resp.status_code == 200
+        host = resp.json()["hosts"]["host-teacher"]
+        assert host["status"] == "unavailable"
+        assert host["idle_or_empty"] is False
+        assert host["occupant_count"] == 1
+        assert host["occupants"][0]["kind"] == "service"
+    finally:
+        atlas_job.set_host_adapter(None)
+        load_mod.clear_host_load_cache()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GET /api/occupancy` no longer treats a host as empty just because the atlas-job registry is quiet. Epic-driver seats and Foundry/compiler burn now appear as occupants, so `idle_or_empty` stays false while that work is live (including when load1 &lt; 1.0). Unavailable hosts still report unknown burn (`idle_or_empty: false`).

Hardware util (load / mem / disk) is unchanged.

## Changes

- Keep atlas-job registry + cached `job_unit` occupants
- Attach local session-stream epic-driver leases (`kind=driver`) to `MONITOR_OCCUPANCY_DRIVER_HOST_ID` or the mapped `ATLAS_JOB_SELF_HOST` opaque id — no remote seat scrape
- Read optional occupancy markers (`MONITOR_OCCUPANCY_MARKERS`, else `.agent/occupancy/markers`) so Foundry / evidence-compiler can publish `{kind, agent, task_id, epic, host_id}`
- Foundry CLI `prepare` publishes a marker when that env is set; helper: `python -m scripts.api.occupancy_local heartbeat|clear`
- OPSEC: opaque `host_id` only; sanitizer still drops aliases, addresses, and path-shaped fields

## Testing

- [x] `python -m pytest tests/api/test_occupancy.py tests/api/test_occupancy_local.py tests/api/test_occupancy_seats.py tests/test_fleet_occupancy_idle_contract.py tests/test_open_model_foundry_cli.py`
- [ ] Website builds without errors (`cd site && npm run build`) — not touched
- [ ] Ukrainian text reviewed for naturalness — not touched

## Related Issues

Refs #7139. This PR leaves #7139 open (paid-lane “which subscription burns where” and live deploy/restart remain residual).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b2ac51f-56cb-4ad7-942d-9c7f0db3aa86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b2ac51f-56cb-4ad7-942d-9c7f0db3aa86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

