### PR TITLE
docs(phase3): Cycle 007 compile-throughput resume design

### DIFF
--- a/docs/projects/open-model-data/cycle007-evidence-compile-throughput.md
+++ b/docs/projects/open-model-data/cycle007-evidence-compile-throughput.md
@@ -1,0 +1,264 @@
+# Cycle 007 evidence-compile throughput (design)
+
+Status: draft design plus inert scaffolding. Not authorized to change a live
+Foundry compile. Not a frozen amendment.
+
+This document is text-free: counts, hashes, tool names, and pass/fail facts
+only. It does not name hosts, addresses, or private row content.
+
+Parent stream: Phase 3 recovery issue `#6375`. Frozen Cycle 007 contract:
+`batch_state/phase3-cycle007-source-grounded-amendment-v1.md`.
+
+## Recommendation
+
+Ship **option A first**: durable resume after a sealed packet prefix. Keep
+packet compilation serial and keep the frozen query plan unchanged.
+
+Option A is the only change that removes the multi-day restart cost. The
+current compiler can already take a long clean run; the dominant loss is
+that every stop discards staging and returns to packet 1 of 204.
+
+Do **not** activate A, B, or C against an in-flight compile. A later
+activation PR may land only after that 204 seals or a clean stop, and only
+after the addendum path in [Amendment and review](#amendment-and-review).
+
+## Confirmed current parallelism
+
+Read of
+`scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py` and
+the text-free runner
+`batch_state/phase3-compile-cycle007-evidence-v1.py` on the reviewed main
+head used for this design:
+
+| Layer | What actually runs | What the name sounds like |
+| --- | --- | --- |
+| Packet loop | Serial `for` over packets `1..N` inside `compile_sidecar_bundle` | Packet-parallel |
+| Row loop | Serial `for` over rows inside `compile_packet_sidecar` | — |
+| Per-row channels | Sequential Sources calls in `compile_row_evidence` | Amendment step 5 "always-on parallel path" |
+| MCP client | One `LocalMcpSourcesClient` / one `RealMcpToolTransport` / one session | N workers |
+| Install | Fresh staging directory, validate all sidecars, then atomic claim of `output_dir` | Resume |
+| Runner | Starts one reviewed Sources process, compiles, refuses if `output` exists | Checkpoint |
+
+The amendment phrase "always-on parallel path" is a **coverage** rule: style
+guide, Antonenko prose, UA-GEC, and heritage run for every row and are not
+gated on a VESUM miss. It is not a concurrency rule. Those calls are issued
+one after another on one synchronous client.
+
+`RealMcpToolTransport` owns one background asyncio loop and one MCP session.
+`call_tool` waits for that session. `LocalMcpSourcesClient._call_text`
+mutates the ordered-call commitment without a lock. One client is therefore
+single-threaded at the wire.
+
+The public manifest stores `mcp_transport_attestation`, including
+`tool_call_count` and `ordered_call_commitment_sha256`. That commitment is a
+process-global hash chain over `(ordinal, tool, arguments_sha256,
+response_sha256)`. Any resume or fan-out that drops, reorders, or interleaves
+calls changes the public manifest even when every sidecar body stays the
+same.
+
+`CODE_HASHES` binds `compiler_sha256` to the whole compiler module. Editing
+that file changes every sidecar and the controller canary binding. This
+scaffolding therefore lives in a **new** module and does not import-cycle
+into the compiler or the runner.
+
+Frozen real-mode denominator, unchanged by this design: `REAL_PACKET_COUNT =
+204`, `REAL_ROW_COUNT = 10159`.
+
+## Ranked options
+
+### A. Durable resume after sealed packet N (do this)
+
+**User-visible outcome.** A stopped compile continues at packet `N+1` when
+packets `1..N` are already validated, sealed, and identity-bound. Packet
+`N+1` that did not finish is discarded, never resumed mid-row.
+
+**Why it is first.** Foundry already observed a 60-packet prefix discarded
+with the destination left at `0/204`. Serial MCP cost is real; throwing away
+a sealed prefix is the part that turns one long run into several.
+
+**Smallest safe shape.**
+
+1. Keep `output_dir` refuse-if-exists and the final atomic install.
+2. Replace *ephemeral* staging (`mkdtemp` + delete on any failure) with a
+   durable sibling staging directory, mode `0700`, files mode `0600`.
+3. After each packet: `validate_sidecar`, atomic write `sidecar-NNNN.json`,
+   fsync, write a text-free progress receipt.
+4. Progress receipt fields are a closed set: schema, `text_free`, cycle id,
+   sealed count, next index, target `204`/`10159`, last sidecar hashes,
+   identity hash, running serial call-chain, tool counts. No paths, no row
+   text, no tool payloads.
+5. On start: if durable staging is empty, begin at packet 1. If a prefix
+   `1..N` exists, re-validate identity and bindings, replay the persisted
+   call-chain, continue at `N+1`. A gap, leftover foreign file, or identity
+   drift fails closed.
+6. Incomplete `mkstemp` sidecar leftovers are deleted and not counted.
+7. After packet 204, assemble the same manifest shape as today, validate it,
+   atomically install into `output_dir`, then remove staging.
+
+**Sidecar bytes.** `compile_packet_sidecar` is already independent per
+packet given the same server identity and rows. A resumed serial run with
+the *same* compiler module SHA can emit the same sidecar files as a clean
+run. A compiler-module edit cannot resume a prefix sealed by a different
+`compiler_sha256`.
+
+**Public manifest.** Keep today's attestation schema by persisting the
+serial call-chain after each sealed packet and continuing ordinals. Do not
+rebuild attestation from "this process only" or the resumed manifest will
+not match a never-interrupted serial compile.
+
+**Contract touch.** Compiler commentary currently calls this "amendment
+step 14": the whole bundle is staged and validated before anything is
+installed, and failure deletes only that staging directory. Durable
+prefix-seal is a material change to that install/custody rule. It does
+**not** change the query plan, tokenizer, channels, evidence-ID recipe, or
+the `204`/`10159` denominator.
+
+**Risks.** Partial last packet must never be treated as sealed. Identity
+drift (compiler, Sources server, `sources.db`, `vesum.db`) must fail
+closed rather than mix prefixes. Staging must stay operator-private
+(`0700`/`0600`) and off public surfaces. Disk accounting must count sealed
+sidecars plus one in-progress atomic temp, which is the estimator Foundry
+already uses.
+
+### B. Bounded packet-parallel with N Sources clients (later)
+
+**User-visible outcome.** Up to N packets compile at once, each with its
+own `LocalMcpSourcesClient` / `RealMcpToolTransport`. Sidecar `packet_index`
+order in the manifest stays `1..204`.
+
+**Why it is second.** It can cut a *clean* run, but it does not save a
+restart unless A exists. It also cannot preserve the current process-global
+`ordered_call_commitment_sha256` without serializing the wire, which
+defeats the fan-out.
+
+**Contract-safe constraints if later authorized.**
+
+- Query plan, evidence IDs, and per-packet sidecar bodies stay serial-equivalent.
+- N new clients, not one shared client (the current client is not
+  thread-safe).
+- Prefer proving N sessions against one reviewed Sources process *or* N
+  loopback processes bound to the same reviewed code/data identity. The
+  Sources DB helper caches one process-global SQLite connection
+  (`check_same_thread=False`). Concurrent `asyncio.to_thread` use of that
+  singleton is not a proven read-parallel contract. A public concurrency
+  canary is a precondition, not an afterthought.
+- Bound N fail-closed (scaffolding default is `1`; a request for `N>1` is
+  `packet_workers_not_authorized` until an addendum says otherwise).
+- Attestation must become a sorted per-packet composition, or B changes
+  the public manifest schema. That is an amendment-visible change.
+
+**Risks.** SQLite/FTS contention, memory of N in-flight sidecars, disk
+temp amplification, non-deterministic call order, and mixed identity if
+workers attach to different endpoints. Higher CF surface than A.
+
+### C. Other low-risk throughput (supporting, not a substitute)
+
+Ranked under A, and none of these replace sealed-prefix resume:
+
+1. **Text-free sealed-count pulse from durable staging** — operational
+   visibility only. Already possible as counts/hashes. Does not save work
+   unless A persists the files.
+2. **Keep one Sources process for the whole compile** — the runner already
+   does this. Do not start/stop per packet.
+3. **Process-local form cache** — amendment pre-call language already
+   mentions deterministic cache reuse, but today's public attestation is
+   an ordered *call* chain. Caching would drop `tool_call_count` and
+   change `ordered_call_commitment_sha256`. Safe only after attestation is
+   packet-composed (same addendum family as B) or after cache hits are
+   folded into the chain with a closed, reviewed record type. Do not
+   silently skip MCP calls.
+4. **Intra-row channel overlap** — same client-safety and attestation-order
+   problems as B, smaller payoff than packet-parallel.
+5. **Do not pull a new compiler SHA onto a live run** — `CODE_HASHES` and
+   the controller canary bind the compiler file. A mid-run checkout of an
+   activation commit cannot resume the prefix it interrupted.
+
+C items 1–2 need no amendment. C item 3 needs the same attestation review
+as B. C item 5 is a hard operational rule.
+
+## Amendment and review
+
+Frozen, do-not-edit artifact:
+
+- path: `batch_state/phase3-cycle007-source-grounded-amendment-v1.md`
+- SHA-256: `4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0`
+
+Controller, Gemini/Grok runners, adjudication, and completion tooling all
+bind that exact hash. Rewriting the frozen file is out of scope.
+
+The frozen amendment already requires:
+
+- exact `204` packets / `10159` rows
+- text-free public receipts
+- no network fallback during compile
+- fail-closed missing/conflicting evidence
+- no mid-run validator, taxonomy, source-hierarchy, or custody change
+  inside a live run
+- pre-call proof that the compiler produced `204` sidecars / `10159` rows
+
+It does not authorize durable prefix-seal or packet-parallel workers.
+
+### What needs a new addendum
+
+| Change | New addendum? | Review seats |
+| --- | --- | --- |
+| Inert scaffolding + this design | No. Not executable. | Ordinary CF code review of the PR |
+| A: durable sealed-prefix resume, persist serial call-chain, keep sidecar bytes | Yes. Changes step-14 install/custody. | Scope/circularity + CF exact-head. Ukrainian source-authority only if a reviewer claims the query plan moved (it must not). |
+| B: N clients / composed attestation | Yes, separate from A. | Scope/circularity + CF. Public Sources concurrency canary. |
+| C.3 process-local MCP skip cache | Yes, unless the addendum already redefined attestation. | Same as B |
+| C.1–C.2 operational pulse / one server | No | None beyond current text-free pulse rules |
+
+### Draft addendum (not frozen, not executable)
+
+Working title: Cycle 007 compile-throughput addendum (resume-only).
+
+Intended bindings, to be hashed only after the review seats approve the
+exact bytes:
+
+- Parent amendment SHA-256 remains
+  `4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0`.
+- Query plan, tokenizer, compound parser, channels, evidence-ID recipe,
+  residual taxonomy, and `204`/`10159` are unchanged.
+- Compiler may persist validated `sidecar-NNNN.json` files and one
+  text-free progress receipt in a durable private staging directory.
+- Resume is authorized only for a consecutive sealed prefix whose
+  `code_hashes` and Sources identity match the running compiler.
+- Mid-packet state is discarded.
+- Final `output_dir` install stays atomic and refuse-if-exists.
+- Public `mcp_transport_attestation` stays schema
+  `phase3_cycle007_mcp_transport_attestation_v1` and is the serial
+  continuation of the persisted call-chain.
+- Packet-parallel workers remain unauthorized.
+- Activation against a compile already in flight under another
+  `compiler_sha256` is forbidden.
+
+Until those bytes are frozen and the seats above approve them, the helpers
+in `phase3_cycle007_evidence_compile_throughput.py` must stay unwired.
+
+## Smallest PR path
+
+1. **This PR (draft, this commit family).** Design document, inert
+   helpers, synthetic tests. Compiler, runner, controller, and frozen
+   amendment files are untouched, so `compiler_sha256` and the amendment
+   hash stay put for the live run.
+2. **After the current 204 seals or a clean stop.** Freeze the resume-only
+   addendum SHA. Scope/circularity review of those exact bytes. CF
+   exact-head review of the activation diff.
+3. **Activation PR.** Wire `compile_sidecar_bundle` / the text-free runner
+   to durable staging + resume. Default remains fail-closed if identity
+   drifts. Still serial packets. Still one Sources client.
+4. **Optional later PR.** B, only with a composed-attestation addendum and
+   a public concurrency canary.
+
+Success for this PR: a clear recommendation (A), a contract-safe resume
+shape that preserves text-free Cycle 007 bindings, and tests that prove
+the helpers fail closed without activating production compile.
+
+## Non-goals
+
+- Touching live metal, restarting Foundry, or starting a second compiler.
+- Editing the frozen amendment file.
+- Changing `compile_sidecar_bundle`, `compile_cycle007_package`, or the
+  compile runner in this PR.
+- Packet-parallel activation.
+- Labeling. Labeling stays off until a later START after evidence seals.

--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_compile_throughput.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_compile_throughput.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Inert Cycle 007 evidence-compile throughput helpers.
+
+These helpers are scaffolding for a reviewed resume addendum. They are not
+imported by ``phase3_cycle007_evidence_compiler`` or
+``batch_state/phase3-compile-cycle007-evidence-v1.py``. Calling them does
+not compile evidence, start Sources, or install a sidecar bundle.
+
+Public surfaces stay text-free: counts, hashes, tool names, and closed
+failure codes only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compiler as compiler
+from scripts.projects.open_model_data import phase3_cycle007_evidence_contract as contract
+
+ACTIVATION_STATE = "scaffolding_only"
+PROGRESS_SCHEMA_VERSION = "phase3_cycle007_compile_progress_v1"
+EVALUATION_CYCLE_ID = compiler.EVALUATION_CYCLE_ID
+CALL_CHAIN_SEED = "phase3-cycle007-mcp-tool-call-chain-v1"
+SIDECAR_NAME_RE = re.compile(r"sidecar-(\d{4})\.json\Z")
+TEMP_SIDECAR_NAME_RE = re.compile(r"\.sidecar-\d{4}\.json\.")
+PRODUCTION_PACKET_WORKERS = 1
+MAX_REVIEWED_PACKET_WORKERS = 4
+
+PROGRESS_REQUIRED_KEYS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "text_free",
+        "evaluation_cycle_id",
+        "activation_state",
+        "sealed_packet_count",
+        "next_packet_index",
+        "target_packet_count",
+        "target_row_count",
+        "last_sealed_sidecar_sha256",
+        "last_sealed_sidecar_id",
+        "identity_sha256",
+        "ordered_call_commitment_sha256",
+        "tool_call_count",
+        "counts_by_tool",
+        "progress_sha256",
+    }
+)
+PRIVATE_PROGRESS_KEYS: frozenset[str] = frozenset(
+    {
+        "query",
+        "row_identity",
+        "locator",
+        "negative_reason",
+        "retrieval_payloads",
+        "source_text",
+        "unit_id",
+        "path",
+        "endpoint",
+        "host",
+    }
+)
+_IDENTITY_COMPARE_KEYS: tuple[str, ...] = (
+    "tokenizer_id",
+    "tokenizer_version",
+    "code_hashes",
+    "server_code_sha256",
+    "sources_db_sha256",
+    "vesum_db_sha256",
+)
+
+
+class ThroughputScaffoldingError(ValueError):
+    """Closed, text-free helper failure."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def initial_call_commitment() -> str:
+    """Return the same call-chain seed ``LocalMcpSourcesClient`` starts from."""
+    return contract.sha256_text(CALL_CHAIN_SEED)
+
+
+def identity_sha256(expected_identity: Mapping[str, Any]) -> str:
+    missing = [key for key in _IDENTITY_COMPARE_KEYS if key not in expected_identity]
+    if missing:
+        raise ThroughputScaffoldingError("identity_incomplete")
+    return contract.sha256_value({key: expected_identity[key] for key in _IDENTITY_COMPARE_KEYS})
+
+
+def sidecar_filename(packet_index: int) -> str:
+    if not isinstance(packet_index, int) or isinstance(packet_index, bool) or packet_index < 1:
+        raise ThroughputScaffoldingError("packet_index_invalid")
+    return f"sidecar-{packet_index:04d}.json"
+
+
+def bound_packet_workers(requested: int, *, authorized: bool = False) -> int:
+    """Fail closed unless packet-parallel workers are explicitly authorized.
+
+    Production wiring is serial (``requested == 1``). Option B remains off
+    until a reviewed addendum sets ``authorized=True`` and a later PR
+    actually starts N clients.
+    """
+    if not isinstance(requested, int) or isinstance(requested, bool):
+        raise ThroughputScaffoldingError("packet_workers_out_of_range")
+    if requested < 1 or requested > MAX_REVIEWED_PACKET_WORKERS:
+        raise ThroughputScaffoldingError("packet_workers_out_of_range")
+    if requested != PRODUCTION_PACKET_WORKERS and not authorized:
+        raise ThroughputScaffoldingError("packet_workers_not_authorized")
+    return requested
+
+
+def extend_serial_call_commitment(
+    prior_commitment: str,
+    calls: Sequence[Mapping[str, Any]],
+    *,
+    starting_ordinal: int,
+) -> tuple[str, int]:
+    """Continue the compiler's ordered MCP call-chain without issuing calls."""
+    if not _is_sha256(prior_commitment):
+        raise ThroughputScaffoldingError("call_commitment_invalid")
+    if not isinstance(starting_ordinal, int) or isinstance(starting_ordinal, bool) or starting_ordinal < 1:
+        raise ThroughputScaffoldingError("call_ordinal_invalid")
+    commitment = prior_commitment
+    ordinal = starting_ordinal
+    for raw_call in calls:
+        if not isinstance(raw_call, Mapping):
+            raise ThroughputScaffoldingError("call_record_invalid")
+        tool = raw_call.get("tool")
+        arguments_sha256 = raw_call.get("arguments_sha256")
+        response_sha256 = raw_call.get("response_sha256")
+        if not isinstance(tool, str) or not tool:
+            raise ThroughputScaffoldingError("call_record_invalid")
+        if not _is_sha256(arguments_sha256) or not _is_sha256(response_sha256):
+            raise ThroughputScaffoldingError("call_record_invalid")
+        call = {
+            "ordinal": ordinal,
+            "tool": tool,
+            "arguments_sha256": arguments_sha256,
+            "response_sha256": response_sha256,
+        }
+        commitment = contract.sha256_text(commitment + "\n" + contract.canonical_json(call))
+        ordinal += 1
+    return commitment, ordinal
+
+
+def build_progress_receipt(
+    *,
+    sealed_packet_count: int,
+    target_packet_count: int = compiler.REAL_PACKET_COUNT,
+    target_row_count: int = compiler.REAL_ROW_COUNT,
+    last_sealed_sidecar_sha256: str | None,
+    last_sealed_sidecar_id: str | None,
+    expected_identity: Mapping[str, Any],
+    ordered_call_commitment_sha256: str,
+    tool_call_count: int,
+    counts_by_tool: Mapping[str, int],
+) -> dict[str, Any]:
+    """Build a text-free sealed-prefix receipt. Does not write it."""
+    _require_count(sealed_packet_count, "sealed_packet_count")
+    _require_count(target_packet_count, "target_packet_count", minimum=1)
+    _require_count(target_row_count, "target_row_count", minimum=1)
+    if sealed_packet_count > target_packet_count:
+        raise ThroughputScaffoldingError("sealed_prefix_overflow")
+    next_packet_index = sealed_packet_count + 1
+    if sealed_packet_count == 0:
+        if last_sealed_sidecar_sha256 is not None or last_sealed_sidecar_id is not None:
+            raise ThroughputScaffoldingError("progress_last_sidecar_invalid")
+    else:
+        if not _is_sha256(last_sealed_sidecar_sha256):
+            raise ThroughputScaffoldingError("progress_last_sidecar_invalid")
+        if not isinstance(last_sealed_sidecar_id, str) or not last_sealed_sidecar_id.startswith("cycle007_sidecar:"):
+            raise ThroughputScaffoldingError("progress_last_sidecar_invalid")
+    if not _is_sha256(ordered_call_commitment_sha256):
+        raise ThroughputScaffoldingError("call_commitment_invalid")
+    _require_count(tool_call_count, "tool_call_count")
+    if any(not isinstance(name, str) or not name for name in counts_by_tool):
+        raise ThroughputScaffoldingError("tool_counts_invalid")
+    if any(not isinstance(count, int) or isinstance(count, bool) or count < 0 for count in counts_by_tool.values()):
+        raise ThroughputScaffoldingError("tool_counts_invalid")
+    if sum(counts_by_tool.values()) != tool_call_count:
+        raise ThroughputScaffoldingError("tool_counts_invalid")
+
+    receipt = {
+        "schema_version": PROGRESS_SCHEMA_VERSION,
+        "text_free": True,
+        "evaluation_cycle_id": EVALUATION_CYCLE_ID,
+        "activation_state": ACTIVATION_STATE,
+        "sealed_packet_count": sealed_packet_count,
+        "next_packet_index": next_packet_index,
+        "target_packet_count": target_packet_count,
+        "target_row_count": target_row_count,
+        "last_sealed_sidecar_sha256": last_sealed_sidecar_sha256,
+        "last_sealed_sidecar_id": last_sealed_sidecar_id,
+        "identity_sha256": identity_sha256(expected_identity),
+        "ordered_call_commitment_sha256": ordered_call_commitment_sha256,
+        "tool_call_count": tool_call_count,
+        "counts_by_tool": dict(sorted(counts_by_tool.items())),
+    }
+    _reject_private_progress_keys(receipt)
+    receipt["progress_sha256"] = contract.sha256_value(receipt)
+    return receipt
+
+
+def validate_progress_receipt(
+    receipt: Mapping[str, Any],
+    expected_identity: Mapping[str, Any],
+    *,
+    sealed_packet_count: int | None = None,
+    last_sealed_sidecar_sha256: str | None = None,
+) -> None:
+    if not isinstance(receipt, Mapping) or set(receipt) != PROGRESS_REQUIRED_KEYS:
+        raise ThroughputScaffoldingError("progress_shape_invalid")
+    _reject_private_progress_keys(receipt)
+    if receipt.get("schema_version") != PROGRESS_SCHEMA_VERSION:
+        raise ThroughputScaffoldingError("progress_schema_drift")
+    if receipt.get("text_free") is not True:
+        raise ThroughputScaffoldingError("progress_not_text_free")
+    if receipt.get("evaluation_cycle_id") != EVALUATION_CYCLE_ID:
+        raise ThroughputScaffoldingError("progress_cycle_drift")
+    if receipt.get("activation_state") != ACTIVATION_STATE:
+        raise ThroughputScaffoldingError("progress_activation_drift")
+    unsigned = {key: value for key, value in receipt.items() if key != "progress_sha256"}
+    if receipt.get("progress_sha256") != contract.sha256_value(unsigned):
+        raise ThroughputScaffoldingError("progress_hash_drift")
+    if receipt.get("identity_sha256") != identity_sha256(expected_identity):
+        raise ThroughputScaffoldingError("identity_drift")
+    if sealed_packet_count is not None and receipt.get("sealed_packet_count") != sealed_packet_count:
+        raise ThroughputScaffoldingError("progress_prefix_mismatch")
+    if (
+        last_sealed_sidecar_sha256 is not None
+        and receipt.get("last_sealed_sidecar_sha256") != last_sealed_sidecar_sha256
+    ):
+        raise ThroughputScaffoldingError("progress_last_sidecar_mismatch")
+    expected_next = int(receipt["sealed_packet_count"]) + 1
+    if receipt.get("next_packet_index") != expected_next:
+        raise ThroughputScaffoldingError("progress_next_index_mismatch")
+
+
+def discard_incomplete_sidecar_temps(staging_dir: Path) -> int:
+    """Remove compiler ``mkstemp`` leftovers. Never deletes a sealed sidecar."""
+    if not staging_dir.is_dir() or staging_dir.is_symlink():
+        raise ThroughputScaffoldingError("staging_unavailable")
+    removed = 0
+    for path in sorted(staging_dir.iterdir()):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if TEMP_SIDECAR_NAME_RE.search(path.name) is None:
+            continue
+        path.unlink()
+        removed += 1
+    return removed
+
+
+def list_sealed_sidecar_indexes(staging_dir: Path) -> list[int]:
+    if not staging_dir.is_dir() or staging_dir.is_symlink():
+        raise ThroughputScaffoldingError("staging_unavailable")
+    indexes: list[int] = []
+    for path in sorted(staging_dir.iterdir()):
+        if path.is_symlink():
+            raise ThroughputScaffoldingError("staging_symlink")
+        match = SIDECAR_NAME_RE.fullmatch(path.name)
+        if match is None:
+            if path.name == "progress.json" or TEMP_SIDECAR_NAME_RE.search(path.name):
+                continue
+            raise ThroughputScaffoldingError("staging_foreign_file")
+        if not path.is_file():
+            raise ThroughputScaffoldingError("staging_foreign_file")
+        indexes.append(int(match.group(1)))
+    return indexes
+
+
+def assert_consecutive_prefix(indexes: Sequence[int]) -> int:
+    if not indexes:
+        return 0
+    expected = list(range(1, len(indexes) + 1))
+    if list(indexes) != expected:
+        raise ThroughputScaffoldingError("sealed_prefix_gap")
+    return indexes[-1]
+
+
+def load_sidecar(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ThroughputScaffoldingError("sidecar_unreadable")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ThroughputScaffoldingError("sidecar_unreadable") from exc
+    if not isinstance(payload, dict):
+        raise ThroughputScaffoldingError("sidecar_shape_invalid")
+    return payload
+
+
+def assert_sidecar_identity(
+    sidecar: Mapping[str, Any], expected_identity: Mapping[str, Any], packet_index: int
+) -> None:
+    if sidecar.get("packet_index") != packet_index:
+        raise ThroughputScaffoldingError("sidecar_index_mismatch")
+    if sidecar.get("evaluation_cycle_id") != EVALUATION_CYCLE_ID:
+        raise ThroughputScaffoldingError("sidecar_cycle_drift")
+    for key in _IDENTITY_COMPARE_KEYS:
+        if sidecar.get(key) != expected_identity.get(key):
+            raise ThroughputScaffoldingError("identity_drift")
+
+
+def resume_next_packet_index(
+    staging_dir: Path,
+    expected_identity: Mapping[str, Any],
+    *,
+    progress: Mapping[str, Any] | None = None,
+    target_packet_count: int = compiler.REAL_PACKET_COUNT,
+) -> int:
+    """Return the next packet index for a durable sealed prefix.
+
+    ``1`` means start fresh. ``N+1`` means packets ``1..N`` already sealed.
+    Does not compile the next packet and does not install ``output_dir``.
+    """
+    if not staging_dir.exists():
+        if progress is not None:
+            raise ThroughputScaffoldingError("progress_without_staging")
+        return 1
+    discard_incomplete_sidecar_temps(staging_dir)
+    indexes = list_sealed_sidecar_indexes(staging_dir)
+    sealed = assert_consecutive_prefix(indexes)
+    last_sha256: str | None = None
+    last_sidecar_id: str | None = None
+    for packet_index in indexes:
+        path = staging_dir / sidecar_filename(packet_index)
+        sidecar = load_sidecar(path)
+        assert_sidecar_identity(sidecar, expected_identity, packet_index)
+        last_sha256 = contract.sha256_bytes(path.read_bytes())
+        last_sidecar_id = str(sidecar.get("sidecar_id"))
+    if progress is not None:
+        validate_progress_receipt(
+            progress,
+            expected_identity,
+            sealed_packet_count=sealed,
+            last_sealed_sidecar_sha256=last_sha256,
+        )
+        if progress.get("target_packet_count") != target_packet_count:
+            raise ThroughputScaffoldingError("progress_target_drift")
+        if last_sidecar_id is not None and progress.get("last_sealed_sidecar_id") != last_sidecar_id:
+            raise ThroughputScaffoldingError("progress_last_sidecar_mismatch")
+    if sealed > target_packet_count:
+        raise ThroughputScaffoldingError("sealed_prefix_overflow")
+    return sealed + 1
+
+
+def production_wiring_is_inactive() -> bool:
+    """True when the frozen compiler and runner do not import this module."""
+    compiler_text = Path(compiler.__file__).read_text(encoding="utf-8")
+    runner_path = compiler.ROOT / "batch_state" / "phase3-compile-cycle007-evidence-v1.py"
+    runner_text = runner_path.read_text(encoding="utf-8")
+    marker = "phase3_cycle007_evidence_compile_throughput"
+    return marker not in compiler_text and marker not in runner_text
+
+
+def packet_loop_is_serial() -> bool:
+    """True when ``compile_sidecar_bundle`` still walks packets in a for-loop."""
+    text = Path(compiler.__file__).read_text(encoding="utf-8")
+    return "for packet_index, (rows, residual_lane, packet_binding) in enumerate(" in text
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _require_count(value: Any, _label: str, *, minimum: int = 0) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise ThroughputScaffoldingError("count_invalid")
+
+
+def _reject_private_progress_keys(receipt: Mapping[str, Any]) -> None:
+    if PRIVATE_PROGRESS_KEYS & set(receipt):
+        raise ThroughputScaffoldingError("progress_not_text_free")
+
+
+def write_private_json(path: Path, payload: Mapping[str, Any]) -> str:
+    """Atomic mode-0600 write for tests. Not a production installer."""
+    encoded = (contract.canonical_json(payload) + "\n").encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True, mode=compiler.PRIVATE_DIR_MODE)
+    os.chmod(path.parent, compiler.PRIVATE_DIR_MODE)
+    return compiler._atomic_write_private(path, encoded)
+
+
+def assert_private_modes(root: Path) -> None:
+    if stat.S_IMODE(root.stat().st_mode) != compiler.PRIVATE_DIR_MODE:
+        raise ThroughputScaffoldingError("staging_mode_drift")
+    for path in sorted(root.rglob("*")):
+        expected = compiler.PRIVATE_DIR_MODE if path.is_dir() else compiler.PRIVATE_FILE_MODE
+        if stat.S_IMODE(path.stat().st_mode) != expected:
+            raise ThroughputScaffoldingError("staging_mode_drift")

--- a/tests/test_phase3_cycle007_evidence_compile_throughput.py
+++ b/tests/test_phase3_cycle007_evidence_compile_throughput.py
@@ -1,0 +1,207 @@
+"""Synthetic tests for inert Cycle 007 compile-throughput scaffolding.
+
+No private packet text, no network, no Foundry activation. Production
+compiler and runner stay unwired.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compiler as compiler
+from scripts.projects.open_model_data import phase3_cycle007_evidence_contract as contract
+
+_COMPILER_TEST_PATH = Path(__file__).with_name("test_phase3_cycle007_evidence_compiler.py")
+_SPEC = importlib.util.spec_from_file_location("cycle007_compiler_test_helpers", _COMPILER_TEST_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_COMPILER_TESTS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_COMPILER_TESTS)
+SyntheticSourcesClient = _COMPILER_TESTS.SyntheticSourcesClient
+_row = _COMPILER_TESTS._row
+
+
+def _expected_identity(client: SyntheticSourcesClient) -> dict[str, object]:
+    identity = client.server_identity()
+    return {
+        "tokenizer_id": compiler.TOKENIZER_ID,
+        "tokenizer_version": compiler.TOKENIZER_VERSION,
+        "code_hashes": compiler.CODE_HASHES,
+        "server_code_sha256": identity["server_code_sha256"],
+        "sources_db_sha256": identity["sources_db_sha256"],
+        "vesum_db_sha256": identity["vesum_db_sha256"],
+    }
+
+
+def _seal_packet(staging: Path, packet_index: int, client: SyntheticSourcesClient) -> dict[str, object]:
+    sidecar = compiler.compile_packet_sidecar(packet_index, [_row(f"unit-{packet_index}")], client)
+    path = staging / throughput.sidecar_filename(packet_index)
+    digest = throughput.write_private_json(path, sidecar)
+    return {"sidecar": sidecar, "sha256": digest, "path": path}
+
+
+def test_production_compiler_and_runner_stay_unwired_and_serial() -> None:
+    assert throughput.production_wiring_is_inactive() is True
+    assert throughput.packet_loop_is_serial() is True
+    assert throughput.bound_packet_workers(1) == 1
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="packet_workers_not_authorized"):
+        throughput.bound_packet_workers(2)
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="packet_workers_out_of_range"):
+        throughput.bound_packet_workers(0)
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="packet_workers_out_of_range"):
+        throughput.bound_packet_workers(throughput.MAX_REVIEWED_PACKET_WORKERS + 1)
+    assert throughput.bound_packet_workers(2, authorized=True) == 2
+
+
+def test_empty_or_missing_staging_resumes_at_packet_one(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    missing = tmp_path / "absent"
+    assert throughput.resume_next_packet_index(missing, expected) == 1
+
+    staging = tmp_path / "staging"
+    staging.mkdir(mode=0o700)
+    assert throughput.resume_next_packet_index(staging, expected) == 1
+
+
+def test_sealed_prefix_resumes_after_last_validated_packet(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    staging = tmp_path / "staging"
+    first = _seal_packet(staging, 1, client)
+    second = _seal_packet(staging, 2, client)
+    throughput.assert_private_modes(staging)
+
+    progress = throughput.build_progress_receipt(
+        sealed_packet_count=2,
+        target_packet_count=4,
+        target_row_count=4,
+        last_sealed_sidecar_sha256=str(second["sha256"]),
+        last_sealed_sidecar_id=str(second["sidecar"]["sidecar_id"]),
+        expected_identity=expected,
+        ordered_call_commitment_sha256=throughput.initial_call_commitment(),
+        tool_call_count=0,
+        counts_by_tool={},
+    )
+    dumped = contract.canonical_json(progress)
+    assert "unit-1" not in dumped
+    assert "Привіт" not in dumped
+    assert progress["text_free"] is True
+    assert progress["activation_state"] == "scaffolding_only"
+    assert set(progress) == throughput.PROGRESS_REQUIRED_KEYS
+
+    assert throughput.resume_next_packet_index(staging, expected, progress=progress, target_packet_count=4) == 3
+    assert first["sidecar"]["packet_index"] == 1
+
+
+def test_gap_identity_drift_and_foreign_files_fail_closed(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    staging = tmp_path / "staging"
+    _seal_packet(staging, 1, client)
+    _seal_packet(staging, 3, client)
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="sealed_prefix_gap"):
+        throughput.resume_next_packet_index(staging, expected)
+
+    clean = tmp_path / "clean"
+    _seal_packet(clean, 1, client)
+    drifted = dict(expected)
+    drifted["sources_db_sha256"] = "d" * 64
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="identity_drift"):
+        throughput.resume_next_packet_index(clean, drifted)
+
+    (clean / "notes.txt").write_text("x", encoding="utf-8")
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="staging_foreign_file"):
+        throughput.resume_next_packet_index(clean, expected)
+
+
+def test_incomplete_temp_sidecar_is_discarded_and_not_counted(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    staging = tmp_path / "staging"
+    _seal_packet(staging, 1, client)
+    leftover = staging / ".sidecar-0002.json.partial"
+    leftover.write_text("{", encoding="utf-8")
+
+    assert throughput.resume_next_packet_index(staging, expected) == 2
+    assert leftover.exists() is False
+    assert (staging / "sidecar-0001.json").is_file()
+
+
+def test_progress_receipt_rejects_private_keys_and_hash_drift() -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    receipt = throughput.build_progress_receipt(
+        sealed_packet_count=0,
+        last_sealed_sidecar_sha256=None,
+        last_sealed_sidecar_id=None,
+        expected_identity=expected,
+        ordered_call_commitment_sha256=throughput.initial_call_commitment(),
+        tool_call_count=0,
+        counts_by_tool={},
+    )
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="progress_not_text_free"):
+        throughput._reject_private_progress_keys({**receipt, "unit_id": "unit-1"})
+
+    tampered = dict(receipt)
+    tampered["sealed_packet_count"] = 1
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="progress_hash_drift"):
+        throughput.validate_progress_receipt(tampered, expected)
+
+
+def test_progress_mismatch_against_sealed_bytes_fails_closed(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    expected = _expected_identity(client)
+    staging = tmp_path / "staging"
+    sealed = _seal_packet(staging, 1, client)
+    progress = throughput.build_progress_receipt(
+        sealed_packet_count=1,
+        target_packet_count=4,
+        target_row_count=4,
+        last_sealed_sidecar_sha256="a" * 64,
+        last_sealed_sidecar_id=str(sealed["sidecar"]["sidecar_id"]),
+        expected_identity=expected,
+        ordered_call_commitment_sha256=throughput.initial_call_commitment(),
+        tool_call_count=0,
+        counts_by_tool={},
+    )
+    with pytest.raises(throughput.ThroughputScaffoldingError, match="progress_last_sidecar_mismatch"):
+        throughput.resume_next_packet_index(staging, expected, progress=progress, target_packet_count=4)
+
+
+def test_serial_call_chain_matches_local_sources_client_recipe() -> None:
+    first = {
+        "tool": "verify_words",
+        "arguments_sha256": contract.sha256_value({"words": ["a"]}),
+        "response_sha256": contract.sha256_text("found:1"),
+    }
+    second = {
+        "tool": "check_modern_form",
+        "arguments_sha256": contract.sha256_value({"word": "a"}),
+        "response_sha256": contract.sha256_text("{}"),
+    }
+    direct, next_ordinal = throughput.extend_serial_call_commitment(
+        throughput.initial_call_commitment(),
+        [first, second],
+        starting_ordinal=1,
+    )
+    stepwise, mid = throughput.extend_serial_call_commitment(
+        throughput.initial_call_commitment(),
+        [first],
+        starting_ordinal=1,
+    )
+    resumed, final_ordinal = throughput.extend_serial_call_commitment(stepwise, [second], starting_ordinal=mid)
+    assert direct == resumed
+    assert next_ordinal == final_ordinal == 3
+    assert len(direct) == 64
+
+
+def test_compile_sidecar_bundle_still_refuses_existing_output(tmp_path: Path) -> None:
+    client = SyntheticSourcesClient()
+    output_dir = tmp_path / "sidecars"
+    compiler.compile_sidecar_bundle([[_row("unit-1")]], client, output_dir)
+    with pytest.raises(contract.EvidenceContractError):
+        compiler.compile_sidecar_bundle([[_row("unit-1")]], client, output_dir)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Draft design for cutting Cycle 007 evidence-compile wall-clock without breaking the text-free 204/10159 binding. Confirms current parallelism, ranks contract-safe options, and lands inert scaffolding only.

This PR does not activate resume or packet-parallel workers. It does not edit the frozen compiler, runner, or amendment file. It does not touch live Foundry.

## Recommendation

**Option A first:** durable resume after a sealed packet prefix. Packets stay serial. The frozen query plan stays unchanged.

The amendment phrase "always-on parallel path" is per-row channel coverage, not concurrency. `compile_sidecar_bundle` walks packets in a for-loop on one Sources client. Staging is discarded on any stop, which is why a full restart returns to 0/204.

## Changes

- Design: `docs/projects/open-model-data/cycle007-evidence-compile-throughput.md`
- Inert helpers: `scripts/projects/open_model_data/phase3_cycle007_evidence_compile_throughput.py` (not imported by the compiler or compile runner)
- Synthetic tests for sealed-prefix resume, gap/identity fail-closed, text-free progress receipts, serial call-chain continuation, and `N>1` workers unauthorized

## Amendment / CF

Frozen amendment SHA-256 remains `4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0`. Do not rewrite that file.

- This scaffolding PR: ordinary CF code review only
- Activating A later: new addendum (install/custody / persisted serial call-chain) + scope/circularity + CF exact-head. Not against an in-flight compile.
- Option B (N clients): separate addendum plus a public Sources concurrency canary

## Testing

- [x] `python3 -m pytest tests/test_phase3_cycle007_evidence_compile_throughput.py` — 9 passed
- [x] `python3 -m ruff check` on the new Python files
- [ ] Modules pass audit (`scripts/audit_module.py`) — not a curriculum-module change
- [ ] Website builds without errors (`cd site && npm run build`) — docs-only, not required here
- [ ] Ukrainian text reviewed for naturalness — no Ukrainian product text

## Related Issues

Refs #6375

This PR leaves #6375 open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-752487b4-dd38-4f99-9753-29d489303cf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-752487b4-dd38-4f99-9753-29d489303cf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

