### PR TITLE
ops: fleet agent eyes digester + charter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ site/public/atlas/
 
 # Logs
 logs/
+# Fleet session digest artifacts (local-only). Script + charter stay tracked.
+# See docs/ops/fleet-agent-eyes.md and scripts/ops/digest_codex_rollout.py.
+logs/agent-digests/
 .runtime/
 *.log
 npm-debug.log*

--- a/docs/ops/fleet-agent-eyes.md
+++ b/docs/ops/fleet-agent-eyes.md
@@ -54,7 +54,7 @@ python3 scripts/ops/digest_codex_rollout.py
 | `DIGEST_REPO` | `~/projects/learn-ukrainian` |
 | `DIGEST_MAX` | `12` |
 
-Behavior: glob `**/rollout-*.jsonl` and `**/*.jsonl`, sort mtime newest first (rollout name is tie-break only — do not rank an old Codex rollout over a newer Claude/other jsonl), tail last 500 lines, keep material keywords, drop AGENTS.md / cold_start / rules-load noise, write `logs/agent-digests/<label>-latest.md`, refresh `logs/agent-digests/index.md`, print the output path plus `bytes= sources= label=`.
+Behavior: glob `**/rollout-*.jsonl` and `**/*.jsonl`, apply a size floor, sort mtime newest first (rollout name is tie-break only — do not rank an old Codex rollout over a newer Claude/other jsonl), cap at `DIGEST_MAX`, tail last 500 lines, keep material keywords, drop AGENTS.md / cold_start / rules-load noise, write `logs/agent-digests/<label>-latest.md`, refresh `logs/agent-digests/index.md`, print the output path plus `bytes= sources= label=`.
 
 Those files are local artifacts. They are gitignored and must not be committed.
 

--- a/docs/ops/fleet-agent-eyes.md
+++ b/docs/ops/fleet-agent-eyes.md
@@ -54,7 +54,7 @@ python3 scripts/ops/digest_codex_rollout.py
 | `DIGEST_REPO` | `~/projects/learn-ukrainian` |
 | `DIGEST_MAX` | `12` |
 
-Behavior: glob `**/rollout-*.jsonl` and `**/*.jsonl`, prefer `rollout-*`, tail last 500 lines, keep material keywords, drop AGENTS.md / cold_start / rules-load noise, write `logs/agent-digests/<label>-latest.md`, refresh `logs/agent-digests/index.md`, print the output path plus `bytes= sources= label=`.
+Behavior: glob `**/rollout-*.jsonl` and `**/*.jsonl`, sort mtime newest first (rollout name is tie-break only — do not rank an old Codex rollout over a newer Claude/other jsonl), tail last 500 lines, keep material keywords, drop AGENTS.md / cold_start / rules-load noise, write `logs/agent-digests/<label>-latest.md`, refresh `logs/agent-digests/index.md`, print the output path plus `bytes= sources= label=`.
 
 Those files are local artifacts. They are gitignored and must not be committed.
 

--- a/docs/ops/fleet-agent-eyes.md
+++ b/docs/ops/fleet-agent-eyes.md
@@ -1,0 +1,78 @@
+# Fleet agent eyes
+
+**Status:** CTO LOCKED 2026-08-23  
+**Audience:** Watch Desk, SRE hosts, CTO, ITSEC  
+**Scope:** Token-cheap fleet session awareness. Public repo only — no infra IPs, SSH hosts, or private topology.
+
+This charter is the standing watch order. It does not authorize new architecture, a new control plane, or loading raw session bodies into watcher models.
+
+## Purpose
+
+Keep a human or coordinator seat aware of live fleet work without spending frontier tokens on raw Codex/Claude/Gemini rollouts. Authoritative state stays where it already lives: Monitor leases, GitHub, Fleet Comms, and the body-free Entire projection. Shell digests are a cheap tail, not a memory system.
+
+## Ladder (use in this order)
+
+1. **Monitor / leases** — occupancy, observer presence, and lease rows. Live work is what Monitor says is live.
+2. **GitHub + Fleet pulses** — issues, PRs, CI, and Fleet Comms receipts. Disposition and review state are here.
+3. **Entire (non-authoritative, ADR-018)** — first `GET /api/ops/entire-context/status` and `GET /api/ops/entire-context/search` on Monitor, then the local `entire_context` CLI (`status`, one bounded `search`). Native Entire only after a green private preflight. Never `--raw-transcript`. Entire locates; it does not own task state.
+4. **Shell digests** — `scripts/ops/digest_codex_rollout.py` keyword extract from jsonl tails. No LLM.
+5. **Screen last** — attach to a live terminal only when the four cheaper rungs are insufficient.
+
+Do not skip to a lower rung because a higher rung is quieter than expected. Absence of a pulse is not proof of idle.
+
+## Hard rules
+
+- **Never load raw rollouts into watcher models.** Tails stay on disk; models see the keyword digest or a verified Entire locator, not `rollout-*.jsonl`.
+- **Entire-before-digest.** Run ladder step 3 before step 4 on any non-trivial watch. Digest is the fallback when Entire/Monitor already said the cheap facts.
+- **No Grok Bot full-session ingest.** Grok Bot is coordinator / external QA observer only. It must not be fed full session transcripts, rollout files, or digest dumps as a standing corpus.
+- **Standing watches live on Watch Desk.** Heavy AI stays on VPS / Codex / substitute implement seats. The coordinator does not become a second orchestrator by ingesting sessions.
+- **OPSEC.** Public tree and public PRs contain no host coordinates, SSH aliases, raw IPs, or private topology. Local digest files are gitignored artifacts.
+
+## Owners
+
+| Role | Owns |
+| --- | --- |
+| **Watch Desk** | Standing watches. Reads Monitor, pulses, Entire locators, then digests. Does not ingest raw rollouts. |
+| **SRE** | Runs the digester on hosts. Env, cron/systemd (or equivalent), disk hygiene for `logs/agent-digests/`. |
+| **CTO** | This script and this charter. Changes require a new lock, not a silent edit. |
+| **ITSEC** | OPSEC: no IPs, SSH hosts, private topology, or session-body export into public or watcher-model context. |
+
+## Shell digest
+
+Keyword extract only. No LLM. Runnable as a script:
+
+```bash
+DIGEST_LABEL=local \
+DIGEST_REPO="$HOME/projects/learn-ukrainian" \
+python3 scripts/ops/digest_codex_rollout.py
+```
+
+| Env | Default |
+| --- | --- |
+| `DIGEST_LABEL` | `local` |
+| `DIGEST_ROOTS` | `~/.codex/sessions:~/.claude/projects:~/.gemini/tmp:~/.config/gemini` |
+| `DIGEST_REPO` | `~/projects/learn-ukrainian` |
+| `DIGEST_MAX` | `12` |
+
+Behavior: glob `**/rollout-*.jsonl` and `**/*.jsonl`, prefer `rollout-*`, tail last 500 lines, keep material keywords, drop AGENTS.md / cold_start / rules-load noise, write `logs/agent-digests/<label>-latest.md`, refresh `logs/agent-digests/index.md`, print the output path plus `bytes= sources= label=`.
+
+Those files are local artifacts. They are gitignored and must not be committed.
+
+## Acceptance checklist
+
+Use this before calling a watch or a digest change done:
+
+- [ ] Digest is keyword extract only (no LLM, no raw-rollout paste into a watcher model).
+- [ ] `logs/agent-digests/` remains untracked; script and this charter stay tracked.
+- [ ] Output contains no infra IPs, SSH hosts, or private topology.
+- [ ] Entire-before-digest: Monitor `/api/ops/entire-context` and `entire_context` CLI were consulted before the shell digest on a non-trivial watch.
+- [ ] Native Entire, if used, followed the private preflight; `--raw-transcript` was not used; ADR-018 remains non-authoritative.
+- [ ] Grok Bot did not ingest a full session, rollout, or digest corpus. It coordinates only.
+- [ ] Standing watch is on Watch Desk; heavy generation/review stayed on VPS / Codex / substitute seats.
+
+## Non-goals
+
+- Not a Foundry, Sources, occupancy, or private-infra change.
+- Not a replacement for Monitor leases, Fleet Comms, GitHub, or formal review.
+- Not Entire-as-memory and not a public checkpoint export.
+- Not permission to wire Grok Bot (or any watcher model) to session tails.

--- a/scripts/ops/digest_codex_rollout.py
+++ b/scripts/ops/digest_codex_rollout.py
@@ -23,9 +23,10 @@ import json
 import os
 import re
 from collections import deque
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 DEFAULT_LABEL = "local"
 DEFAULT_REPO = Path.home() / "projects" / "learn-ukrainian"
@@ -313,7 +314,7 @@ def write_digest(
     digest_dir = repo / "logs" / "agent-digests"
     digest_dir.mkdir(parents=True, exist_ok=True)
     sources = collect_sources(roots, limit)
-    generated = datetime.now(timezone.utc)
+    generated = datetime.now(UTC)
     body = render_digest(label=label, sources=sources, generated=generated)
     output = digest_dir / f"{label}-latest.md"
     output.write_text(body, encoding="utf-8")

--- a/scripts/ops/digest_codex_rollout.py
+++ b/scripts/ops/digest_codex_rollout.py
@@ -136,43 +136,32 @@ def env_roots(environ: dict[str, str] | None = None) -> list[Path]:
     return [path.expanduser() for path in DEFAULT_ROOTS]
 
 
-def _mtime(path: Path) -> float:
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
-
-
 def collect_sources(roots: Iterable[Path], limit: int) -> list[Path]:
-    """Collect jsonl tails, preferring ``rollout-*.jsonl`` over generic jsonl."""
-    rollouts: list[Path] = []
-    others: list[Path] = []
+    """Collect jsonl tails, newest mtime first; rollout name is tie-break only."""
+    found: list[Path] = []
     seen: set[Path] = set()
 
     for root in roots:
         if not root.is_dir():
             continue
         try:
-            rollout_hits = list(root.rglob("rollout-*.jsonl"))
-            all_hits = list(root.rglob("*.jsonl"))
+            hits = list(root.rglob("rollout-*.jsonl")) + list(root.rglob("*.jsonl"))
         except OSError:
             continue
-        for path in rollout_hits:
-            resolved = path.resolve()
-            if resolved in seen or not path.is_file():
+        for path in hits:
+            try:
+                resolved = path.resolve()
+                if resolved in seen or not path.is_file():
+                    continue
+                path.stat()
+            except OSError:
                 continue
             seen.add(resolved)
-            rollouts.append(path)
-        for path in all_hits:
-            resolved = path.resolve()
-            if resolved in seen or not path.is_file():
-                continue
-            seen.add(resolved)
-            others.append(path)
+            found.append(path)
 
-    rollouts.sort(key=_mtime, reverse=True)
-    others.sort(key=_mtime, reverse=True)
-    return (rollouts + others)[:limit]
+    # mtime newest first; rollout-* wins only when timestamps tie.
+    found.sort(key=lambda p: (-p.stat().st_mtime, 0 if "rollout-" in p.name else 1))
+    return found[:limit]
 
 
 def tail_lines(path: Path, count: int = TAIL_LINES) -> list[str]:

--- a/scripts/ops/digest_codex_rollout.py
+++ b/scripts/ops/digest_codex_rollout.py
@@ -30,6 +30,7 @@ from typing import Any, Iterable
 DEFAULT_LABEL = "local"
 DEFAULT_REPO = Path.home() / "projects" / "learn-ukrainian"
 DEFAULT_MAX = 12
+MIN_SOURCE_BYTES = 64
 TAIL_LINES = 500
 SNIPPET_LIMIT = 16
 SNIPPET_CHARS = 220
@@ -153,7 +154,8 @@ def collect_sources(roots: Iterable[Path], limit: int) -> list[Path]:
                 resolved = path.resolve()
                 if resolved in seen or not path.is_file():
                     continue
-                path.stat()
+                if path.stat().st_size < MIN_SOURCE_BYTES:
+                    continue
             except OSError:
                 continue
             seen.add(resolved)

--- a/scripts/ops/digest_codex_rollout.py
+++ b/scripts/ops/digest_codex_rollout.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Fleet session digester — keyword extract from Codex/Claude jsonl tails.
+
+No LLM. Token-cheap local artifact for Watch Desk / SRE hosts.
+See docs/ops/fleet-agent-eyes.md.
+
+Env:
+  DIGEST_LABEL  output label (default: local)
+  DIGEST_ROOTS  colon-separated session roots
+  DIGEST_REPO   repo root for logs/agent-digests/ (default: ~/projects/learn-ukrainian)
+  DIGEST_MAX    max source files (default: 12)
+
+Writes:
+  logs/agent-digests/<label>-latest.md
+  logs/agent-digests/index.md
+
+Prints the output path plus ``bytes= sources= label=``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_LABEL = "local"
+DEFAULT_REPO = Path.home() / "projects" / "learn-ukrainian"
+DEFAULT_MAX = 12
+TAIL_LINES = 500
+SNIPPET_LIMIT = 16
+SNIPPET_CHARS = 220
+
+DEFAULT_ROOTS = (
+    Path.home() / ".codex" / "sessions",
+    Path.home() / ".claude" / "projects",
+    Path.home() / ".gemini" / "tmp",
+    Path.home() / ".config" / "gemini",
+)
+
+# Material watch terms: blockers, failures, review/merge, fleet ops.
+_MATERIAL_RE = re.compile(
+    r"(?i)\b(?:"
+    r"error|errors|fail(?:ed|ure|ing)?|exception|traceback|"
+    r"blocked|blocker|stall(?:ed|ing)?|hung|hang(?:ing)?|timeout|"
+    r"conflict|rejected|denied|panic|crash|abort(?:ed)?"
+    r"|lease|occupancy|dispatch|worktree|"
+    r"waiting|stuck|unable|cannot|"
+    r"merge|review|pytest|github"
+    r")\b|"
+    r"#\d{2,}\b|"
+    r"\bPR\s*#?\d+\b|"
+    r"\bci\b",
+)
+
+# Session-start / rules-load noise that burns tokens without watch value.
+_NOISE_RE = re.compile(
+    r"(?i)(?:AGENTS\.md|CLAUDE\.md|GEMINI\.md|CODEX\.md|MEMORY\.md|"
+    r"cold[_-]?start|cursor_cold_start|/api/rules|"
+    r"operator-expectations|non-negotiable-rules|"
+    r"SessionStart|loading rules|ruleset digest)",
+)
+
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6_RE = re.compile(r"\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}\b", re.IGNORECASE)
+_USER_HOST_RE = re.compile(r"\b[\w.-]+@[\w.-]+\b")
+_SSH_HINT_RE = re.compile(r"(?i)\b(?:ssh|scp)\s+\S+")
+_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+_TEXT_KEYS = frozenset(
+    {
+        "text",
+        "content",
+        "message",
+        "error",
+        "stderr",
+        "stdout",
+        "reason",
+        "detail",
+        "summary",
+        "output",
+        "prompt",
+        "result",
+    }
+)
+_SKIP_KEYS = frozenset(
+    {
+        "id",
+        "session_id",
+        "cwd",
+        "path",
+        "filepath",
+        "home",
+        "hostname",
+        "host",
+        "ip",
+        "address",
+    }
+)
+
+
+def env_label(environ: dict[str, str] | None = None) -> str:
+    env = os.environ if environ is None else environ
+    raw = (env.get("DIGEST_LABEL") or DEFAULT_LABEL).strip() or DEFAULT_LABEL
+    if not _LABEL_RE.fullmatch(raw):
+        raise SystemExit(f"DIGEST_LABEL must match {_LABEL_RE.pattern}: {raw!r}")
+    return raw
+
+
+def env_max(environ: dict[str, str] | None = None) -> int:
+    env = os.environ if environ is None else environ
+    raw = (env.get("DIGEST_MAX") or str(DEFAULT_MAX)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"DIGEST_MAX must be an integer: {raw!r}") from exc
+    if value < 1 or value > 100:
+        raise SystemExit("DIGEST_MAX must be between 1 and 100")
+    return value
+
+
+def env_repo(environ: dict[str, str] | None = None) -> Path:
+    env = os.environ if environ is None else environ
+    raw = (env.get("DIGEST_REPO") or str(DEFAULT_REPO)).strip()
+    return Path(raw).expanduser()
+
+
+def env_roots(environ: dict[str, str] | None = None) -> list[Path]:
+    env = os.environ if environ is None else environ
+    raw = (env.get("DIGEST_ROOTS") or "").strip()
+    if raw:
+        return [Path(part).expanduser() for part in raw.split(":") if part.strip()]
+    return [path.expanduser() for path in DEFAULT_ROOTS]
+
+
+def _mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def collect_sources(roots: Iterable[Path], limit: int) -> list[Path]:
+    """Collect jsonl tails, preferring ``rollout-*.jsonl`` over generic jsonl."""
+    rollouts: list[Path] = []
+    others: list[Path] = []
+    seen: set[Path] = set()
+
+    for root in roots:
+        if not root.is_dir():
+            continue
+        try:
+            rollout_hits = list(root.rglob("rollout-*.jsonl"))
+            all_hits = list(root.rglob("*.jsonl"))
+        except OSError:
+            continue
+        for path in rollout_hits:
+            resolved = path.resolve()
+            if resolved in seen or not path.is_file():
+                continue
+            seen.add(resolved)
+            rollouts.append(path)
+        for path in all_hits:
+            resolved = path.resolve()
+            if resolved in seen or not path.is_file():
+                continue
+            seen.add(resolved)
+            others.append(path)
+
+    rollouts.sort(key=_mtime, reverse=True)
+    others.sort(key=_mtime, reverse=True)
+    return (rollouts + others)[:limit]
+
+
+def tail_lines(path: Path, count: int = TAIL_LINES) -> list[str]:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            return list(deque(handle, maxlen=count))
+    except OSError:
+        return []
+
+
+def _walk_strings(value: Any, key: str | None = None) -> Iterable[str]:
+    if key is not None and key.lower() in _SKIP_KEYS:
+        return
+    if isinstance(value, str):
+        if key is None or key.lower() in _TEXT_KEYS or len(value) >= 24:
+            yield value
+        return
+    if isinstance(value, dict):
+        for child_key, child in value.items():
+            yield from _walk_strings(child, str(child_key))
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _walk_strings(item, key)
+
+
+def strings_from_line(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped:
+        return []
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return [stripped]
+    if isinstance(payload, (dict, list, str)):
+        return [item for item in _walk_strings(payload) if item.strip()]
+    return []
+
+
+def redact_opsec(text: str) -> str:
+    """Strip IPs, user@host, and ssh command remnants from local snippets."""
+    text = _IPV4_RE.sub("[redacted-ip]", text)
+    text = _IPV6_RE.sub("[redacted-ip]", text)
+    text = _USER_HOST_RE.sub("[redacted-host]", text)
+    text = _SSH_HINT_RE.sub("[redacted-ssh]", text)
+    return text
+
+
+def is_noise(text: str) -> bool:
+    return bool(_NOISE_RE.search(text))
+
+
+def is_material(text: str) -> bool:
+    return bool(_MATERIAL_RE.search(text))
+
+
+def extract_snippets(lines: Iterable[str], limit: int = SNIPPET_LIMIT) -> list[str]:
+    snippets: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        for raw in strings_from_line(line):
+            if is_noise(raw) or not is_material(raw):
+                continue
+            cleaned = " ".join(redact_opsec(raw).split())
+            if len(cleaned) > SNIPPET_CHARS:
+                cleaned = cleaned[: SNIPPET_CHARS - 1].rstrip() + "…"
+            if not cleaned or cleaned in seen:
+                continue
+            seen.add(cleaned)
+            snippets.append(cleaned)
+            if len(snippets) >= limit:
+                return snippets
+    return snippets
+
+
+def source_label(path: Path) -> str:
+    """Short display name: last three parts, no home/host topology."""
+    return "/".join(path.parts[-3:])
+
+
+def render_digest(
+    *,
+    label: str,
+    sources: list[Path],
+    generated: datetime,
+) -> str:
+    rows: list[str] = [
+        f"# Fleet session digest — {label}",
+        "",
+        f"Generated: {generated.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+        f"Sources: {len(sources)}",
+        "Method: keyword extract (no LLM)",
+        "Ladder: shell digest (step 4). Prefer Monitor, GitHub+Fleet pulses, and Entire first.",
+        "",
+    ]
+    if not sources:
+        rows.append("No session jsonl sources found under configured roots.")
+        rows.append("")
+        return "\n".join(rows)
+
+    for path in sources:
+        rows.append(f"## {source_label(path)}")
+        rows.append("")
+        snippets = extract_snippets(tail_lines(path))
+        if snippets:
+            for snippet in snippets:
+                rows.append(f"- {snippet}")
+        else:
+            rows.append("- (no material keyword hits in last 500 lines)")
+        rows.append("")
+    return "\n".join(rows)
+
+
+def render_index(digest_dir: Path, generated: datetime) -> str:
+    rows = [
+        "# Agent session digests",
+        "",
+        "Local artifacts. Do not commit. Charter: `docs/ops/fleet-agent-eyes.md`.",
+        "",
+        f"Refreshed: {generated.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+        "",
+        "| Label | File | Bytes |",
+        "| --- | --- | ---: |",
+    ]
+    latest = sorted(digest_dir.glob("*-latest.md"))
+    if not latest:
+        rows.append("| — | — | 0 |")
+    else:
+        for path in latest:
+            label = path.name.removesuffix("-latest.md")
+            try:
+                size = path.stat().st_size
+            except OSError:
+                size = 0
+            rows.append(f"| {label} | {path.name} | {size} |")
+    rows.append("")
+    return "\n".join(rows)
+
+
+def write_digest(
+    *,
+    label: str,
+    repo: Path,
+    roots: list[Path],
+    limit: int,
+) -> tuple[Path, int, int]:
+    digest_dir = repo / "logs" / "agent-digests"
+    digest_dir.mkdir(parents=True, exist_ok=True)
+    sources = collect_sources(roots, limit)
+    generated = datetime.now(timezone.utc)
+    body = render_digest(label=label, sources=sources, generated=generated)
+    output = digest_dir / f"{label}-latest.md"
+    output.write_text(body, encoding="utf-8")
+    index = digest_dir / "index.md"
+    index.write_text(render_index(digest_dir, generated), encoding="utf-8")
+    return output, output.stat().st_size, len(sources)
+
+
+def main() -> int:
+    label = env_label()
+    repo = env_repo()
+    roots = env_roots()
+    limit = env_max()
+    output, size, sources = write_digest(label=label, repo=repo, roots=roots, limit=limit)
+    print(output)
+    print(f"bytes={size} sources={sources} label={label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_digest_codex_rollout.py
+++ b/tests/test_digest_codex_rollout.py
@@ -1,0 +1,142 @@
+"""Tests for the token-cheap fleet session digester."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO / "scripts" / "ops" / "digest_codex_rollout.py"
+
+spec = importlib.util.spec_from_file_location("digest_codex_rollout_under_test", MODULE_PATH)
+assert spec and spec.loader
+digest = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(digest)
+
+
+def _write_jsonl(path: Path, rows: list[object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for row in rows:
+        if isinstance(row, str):
+            lines.append(row)
+        else:
+            lines.append(json.dumps(row))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class DigestCodexRolloutTests(unittest.TestCase):
+    def test_prefers_rollout_jsonl_over_generic(self) -> None:
+        root = Path(self._tmp()) / "sessions"
+        generic = root / "other.jsonl"
+        rollout = root / "2026" / "08" / "23" / "rollout-abc.jsonl"
+        _write_jsonl(generic, [{"text": "generic failed merge"}])
+        _write_jsonl(rollout, [{"text": "rollout blocked on review"}])
+        generic.write_text(
+            generic.read_text(encoding="utf-8") + '{"text":"newer generic error"}\n',
+            encoding="utf-8",
+        )
+        sources = digest.collect_sources([root], limit=1)
+        self.assertEqual(sources, [rollout])
+
+    def test_noise_filter_drops_agents_md_and_cold_start(self) -> None:
+        lines = [
+            '{"text":"Reading AGENTS.md before work"}',
+            '{"text":"cursor_cold_start fetched /api/rules"}',
+            '{"text":"pytest failed on digest filter"}',
+        ]
+        self.assertEqual(digest.extract_snippets(lines), ["pytest failed on digest filter"])
+
+    def test_redacts_ip_and_user_host(self) -> None:
+        text = digest.redact_opsec("blocked ssh deploy@internal-node on 203.0.113.50")
+        self.assertNotIn("203.0.113.50", text)
+        self.assertNotIn("deploy@internal-node", text)
+        self.assertIn("[redacted-ip]", text)
+        self.assertTrue("[redacted-host]" in text or "[redacted-ssh]" in text)
+
+    def test_write_digest_and_index(self) -> None:
+        tmp = Path(self._tmp())
+        root = tmp / "codex"
+        repo = tmp / "repo"
+        rollout = root / "sessions" / "rollout-watch.jsonl"
+        _write_jsonl(
+            rollout,
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "lease expired; dispatch stuck"}]
+                    },
+                },
+                {"text": "Loading CLAUDE.md and MEMORY.md"},
+            ],
+        )
+        env = {
+            "DIGEST_LABEL": "watchdesk",
+            "DIGEST_ROOTS": str(root),
+            "DIGEST_REPO": str(repo),
+            "DIGEST_MAX": "12",
+        }
+        old = {key: os.environ.get(key) for key in env}
+        os.environ.update(env)
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertEqual(digest.main(), 0)
+        finally:
+            for key, value in old.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        latest = repo / "logs" / "agent-digests" / "watchdesk-latest.md"
+        out = buf.getvalue().strip().splitlines()
+        self.assertEqual(out[0], str(latest))
+        self.assertEqual(out[1], f"bytes={latest.stat().st_size} sources=1 label=watchdesk")
+
+        body = latest.read_text(encoding="utf-8")
+        self.assertIn("lease expired; dispatch stuck", body)
+        self.assertNotIn("CLAUDE.md", body)
+        self.assertIn("keyword extract (no LLM)", body)
+
+        index = (repo / "logs" / "agent-digests" / "index.md").read_text(encoding="utf-8")
+        self.assertIn("watchdesk", index)
+        self.assertIn("watchdesk-latest.md", index)
+
+    def test_default_roots_and_env_helpers(self) -> None:
+        keys = ("DIGEST_LABEL", "DIGEST_ROOTS", "DIGEST_REPO", "DIGEST_MAX")
+        old = {key: os.environ.pop(key, None) for key in keys}
+        try:
+            self.assertEqual(digest.env_label(), "local")
+            self.assertEqual(digest.env_max(), 12)
+            self.assertEqual(digest.env_repo(), Path.home() / "projects" / "learn-ukrainian")
+            self.assertEqual(
+                digest.env_roots(),
+                [
+                    Path.home() / ".codex" / "sessions",
+                    Path.home() / ".claude" / "projects",
+                    Path.home() / ".gemini" / "tmp",
+                    Path.home() / ".config" / "gemini",
+                ],
+            )
+        finally:
+            for key, value in old.items():
+                if value is not None:
+                    os.environ[key] = value
+
+    def _tmp(self) -> str:
+        import tempfile
+
+        handle = tempfile.TemporaryDirectory()
+        self.addCleanup(handle.cleanup)
+        return handle.name
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_digest_codex_rollout.py
+++ b/tests/test_digest_codex_rollout.py
@@ -31,16 +31,28 @@ def _write_jsonl(path: Path, rows: list[object]) -> None:
 
 
 class DigestCodexRolloutTests(unittest.TestCase):
-    def test_prefers_rollout_jsonl_over_generic(self) -> None:
+    def test_mtime_first_newer_claude_beats_old_rollout(self) -> None:
         root = Path(self._tmp()) / "sessions"
-        generic = root / "other.jsonl"
-        rollout = root / "2026" / "08" / "23" / "rollout-abc.jsonl"
-        _write_jsonl(generic, [{"text": "generic failed merge"}])
+        claude = root / "claude-session.jsonl"
+        rollout = root / "2026" / "08" / "21" / "rollout-abc.jsonl"
         _write_jsonl(rollout, [{"text": "rollout blocked on review"}])
-        generic.write_text(
-            generic.read_text(encoding="utf-8") + '{"text":"newer generic error"}\n',
-            encoding="utf-8",
-        )
+        _write_jsonl(claude, [{"text": "claude failed merge"}])
+        older = 1_724_220_000  # 2026-08-21-ish
+        newer = older + 172_800
+        os.utime(rollout, (older, older))
+        os.utime(claude, (newer, newer))
+        sources = digest.collect_sources([root], limit=1)
+        self.assertEqual(sources, [claude])
+
+    def test_rollout_name_is_mtime_tie_break_only(self) -> None:
+        root = Path(self._tmp()) / "sessions"
+        claude = root / "claude-session.jsonl"
+        rollout = root / "rollout-abc.jsonl"
+        _write_jsonl(claude, [{"text": "claude failed merge"}])
+        _write_jsonl(rollout, [{"text": "rollout blocked on review"}])
+        stamp = 1_724_400_000
+        os.utime(claude, (stamp, stamp))
+        os.utime(rollout, (stamp, stamp))
         sources = digest.collect_sources([root], limit=1)
         self.assertEqual(sources, [rollout])
 

--- a/tests/test_digest_codex_rollout.py
+++ b/tests/test_digest_codex_rollout.py
@@ -31,25 +31,26 @@ def _write_jsonl(path: Path, rows: list[object]) -> None:
 
 
 class DigestCodexRolloutTests(unittest.TestCase):
-    def test_mtime_first_newer_claude_beats_old_rollout(self) -> None:
+    def test_prefers_newer_generic_jsonl_over_older_rollout(self) -> None:
+        """Newer Claude/other jsonl beats an older Codex rollout-* (not name-first)."""
         root = Path(self._tmp()) / "sessions"
-        claude = root / "claude-session.jsonl"
+        generic = root / "other.jsonl"
         rollout = root / "2026" / "08" / "21" / "rollout-abc.jsonl"
-        _write_jsonl(rollout, [{"text": "rollout blocked on review"}])
-        _write_jsonl(claude, [{"text": "claude failed merge"}])
+        _write_jsonl(rollout, [{"text": "rollout blocked on review — stale Aug-21 Codex tail"}])
+        _write_jsonl(generic, [{"text": "generic failed merge — newer Claude session jsonl"}])
         older = 1_724_220_000  # 2026-08-21-ish
         newer = older + 172_800
         os.utime(rollout, (older, older))
-        os.utime(claude, (newer, newer))
+        os.utime(generic, (newer, newer))
         sources = digest.collect_sources([root], limit=1)
-        self.assertEqual(sources, [claude])
+        self.assertEqual(sources, [generic])
 
     def test_rollout_name_is_mtime_tie_break_only(self) -> None:
         root = Path(self._tmp()) / "sessions"
         claude = root / "claude-session.jsonl"
         rollout = root / "rollout-abc.jsonl"
-        _write_jsonl(claude, [{"text": "claude failed merge"}])
-        _write_jsonl(rollout, [{"text": "rollout blocked on review"}])
+        _write_jsonl(claude, [{"text": "claude failed merge — same-mtime generic jsonl"}])
+        _write_jsonl(rollout, [{"text": "rollout blocked on review — same-mtime Codex tail"}])
         stamp = 1_724_400_000
         os.utime(claude, (stamp, stamp))
         os.utime(rollout, (stamp, stamp))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Token-cheap fleet session eyes for the public repo: a keyword-only jsonl tail digester and the CTO-locked watch ladder (2026-08-23). No LLM. No infra IPs, SSH hosts, or private topology.

**Merge-blocking sort fix:** `collect_sources` now ranks by **mtime newest first** (size floor + `DIGEST_MAX` limit). `rollout-*` is a same-mtime tie-break only. An older Codex rollout no longer hides a newer Claude/other jsonl (the Aug-21 stale writer-digest bug). `test_prefers_rollout_jsonl_over_generic` is gone; replaced by `test_prefers_newer_generic_jsonl_over_older_rollout`. OPSEC redaction tests remain.

## Changes

- Add `scripts/ops/digest_codex_rollout.py` — env-driven (`DIGEST_LABEL`, `DIGEST_ROOTS`, `DIGEST_REPO`, `DIGEST_MAX`) material-keyword extract from Codex/Claude jsonl tails (mtime-first, last 500 lines, noise filter for `AGENTS.md` / `cold_start` / rules load). Writes `logs/agent-digests/<label>-latest.md`, refreshes `index.md`, prints `bytes= sources= label=`.
- Add `docs/ops/fleet-agent-eyes.md` — locked ladder (Monitor/leases → GitHub+Fleet pulses → Entire via Monitor `/api/ops/entire-context` then `entire_context` CLI; native Entire after preflight; never `--raw-transcript`; ADR-018 non-authoritative → shell digests → screen last), owners, and acceptance checklist. Notes mtime-first source selection.
- Ignore `logs/agent-digests/` in `.gitignore`. Digest outputs are **local artifacts and must not be committed**. The script and charter stay tracked.
- Tests: newer generic jsonl beats older `rollout-*`; rollout name is tie-break only; OPSEC redaction kept.

## Testing

- [x] `python3 -m unittest tests.test_digest_codex_rollout -v` (6 tests)
- [x] Smoke: `DIGEST_ROOTS`/`DIGEST_REPO` temp dirs → output path + `bytes=` `sources=` `label=`
- [x] `python3 scripts/audit/lint_opsec_leaks.py --staged` — zero leaks
- [ ] Modules pass audit (`scripts/audit_module.py`) — N/A (ops tooling, no curriculum)
- [ ] Website builds without errors (`cd site && npm run build`) — N/A
- [ ] Ukrainian text reviewed for naturalness — N/A

## Related Issues

No closing issue reference. This is a standalone public-repo ops addition. Digests remain gitignored local artifacts; this PR contains no host coordinates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f606133-3a84-44ed-a9b5-08d4b5d73929?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f606133-3a84-44ed-a9b5-08d4b5d73929&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

