### PR TITLE
feat(fleet): caveman lite skill + ACP toolless vs toolful plan/review layers

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -29,6 +29,20 @@ that skill). Do not reintroduce claims Sol rejected (see §Plane modes).
 at the **onboarding contract** for ownership and experimental ACPX scope; this rule does
 **not** duplicate mutable model pins, effort ladders, or a hard-coded live plane mode.
 
+## Communication & execution layers (do not conflate)
+
+| Layer | Role |
+| --- | --- |
+| Fleet-comms | Durable authority for queues, receipts, jobs |
+| ACP / ACPX | Toolless provider transport for ordinary inter-agent asks/discuss only |
+| Toolful native / `delegate.py` | Plan, create, review, design, implementation |
+| Caveman | Optional output-style compression (lite default); never persisted GitHub/curriculum text |
+
+- ACP / ACPX are **toolless**. Use them only for inter-agent communication (state transfer). Do **not** use `ask-*` ACP/ACPX for plan, create, review, or design tasks.
+- For plan, create, review, and design, use **toolful** native or `delegate.py` seats (claude/codex/kimi/glm/opencode/agy).
+- Explicit: `ask-* --type review` over ACP is **not** the review-of-record path when the reviewer needs to read the tree. Review of record = toolful seat + verdict posted on the PR.
+- Caveman is **style**, not transport. Default intensity: **lite** (drop filler/hedging, keep articles and full sentences). Never use it as a substitute for fleet-comms durable state, and never caveman persisted artifacts (commits, PR/issue bodies, curriculum, runbooks, review-of-record text posted on GitHub).
+
 ## Two halves (do not conflate)
 
 | Half | Status | Surfaces |

--- a/agents_extensions/shared/skills/caveman/SKILL.md
+++ b/agents_extensions/shared/skills/caveman/SKILL.md
@@ -2,7 +2,7 @@
 name: caveman
 description: >
   Ultra-compressed communication mode. Cuts output tokens 65% (measured) by speaking like caveman
-  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  while keeping full technical accuracy. Supports intensity levels: lite (this repo default), full, ultra,
   wenyan-lite, wenyan-full, wenyan-ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
@@ -10,7 +10,7 @@ description: >
 
 ## Project Overlay (learn-ukrainian fleet policy)
 
-- **Default intensity for this repo:** **lite** (drop filler/hedging, keep articles and full sentences). Operator readability > ultra grunt.
+- **Default intensity for this repo:** **lite** (drop filler/hedging, keep articles and full sentences). Operator readability > ultra grunt. This overlay overrides the vendored `Default: full` and the frontmatter `(default)` tag below.
 - **Caveman is style, not transport.** Never use it as a substitute for fleet-comms durable state.
 - **Never caveman persisted artifacts:** commits, PR/issue bodies, curriculum, runbooks, review-of-record text posted on GitHub. Those stay normal English. Matches vendor "Boundaries".
 - **Session chat / inter-agent ACP bodies** may use lite caveman.
@@ -23,7 +23,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 Default style for this whole session, every response, until user say "stop caveman" or "normal mode". Keep terse on long sessions no filler drift.
 
-Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
+Default for this repo: **lite** (overrides vendor full). Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
 
 ## Rules
 

--- a/agents_extensions/shared/skills/caveman/SKILL.md
+++ b/agents_extensions/shared/skills/caveman/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts output tokens 65% (measured) by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+## Project Overlay (learn-ukrainian fleet policy)
+
+- **Default intensity for this repo:** **lite** (drop filler/hedging, keep articles and full sentences). Operator readability > ultra grunt.
+- **Caveman is style, not transport.** Never use it as a substitute for fleet-comms durable state.
+- **Never caveman persisted artifacts:** commits, PR/issue bodies, curriculum, runbooks, review-of-record text posted on GitHub. Those stay normal English. Matches vendor "Boundaries".
+- **Session chat / inter-agent ACP bodies** may use lite caveman.
+
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+Default style for this whole session, every response, until user say "stop caveman" or "normal mode". Keep terse on long sessions no filler drift.
+
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Never drop not/never/no/only/except flip meaning worse than any token saved. Numbers, units exact.
+
+Never ADD word to sound caveman. Compression only style never grow output. No inserted pronoun or copula to fake broken grammar: "when it not" cost one token more than "when not" and say same thing. Keep correct verb form when correct form cost same "sees" one token, "see" one token, so mangle buy nothing and read worse. Same rule as abbreviations and arrows: if caveman phrasing not shorter than plain phrasing, use plain.
+
+Tool calls: fire direct. No preamble, plan, or progress note before or between calls. After result: next call direct or final answer never announce next call. Text before call only to clarify, warn security/irreversible, or resolve ambiguity.
+
+Preserve user's dominant language exactly reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Every emitted line in that language openings, pre-tool status lines, all not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim unless user explicitly ask for translation.
+
+'Drop articles' = article languages only. Where small markers carry case/role (particles, postpositions), keep them grammar, not filler; compress politeness/filler instead.
+
+Answer directly in this style. Skip "caveman mode on", "me caveman think", "Caveman:" prefix or recap redundant with the reply itself. No normal answer plus caveman duplicate. User ask what mode is → say so plainly.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction chars, not tokens. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
+- wenyan-ultra: "新參照則重繪。useMemo 包之。"
+
+Example "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool reuse open DB connections. No per-request handshake."
+- wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
+- wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+Classical chars = wenyan modes only. Never swap a word to a classical char to shrink at non-wenyan levels.
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example shows FORMAT only write warning in session language, not example's.
+
+Example destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Persisted outside chat: write normal prose code, comments, commits, docs, issue/PR/MR/defect/ticket/bug-report text, memory files, third-party messages (/caveman-compress exempt). "Open a defect" or "file a bug" mean the same as "open issue": body go to other humans, so body normal English. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -327,7 +327,9 @@ action. Read and apply every `unread` or `read-but-not-live-consumed` entry, the
 ### 6. Cross-family review gate (load-bearing — discussion ≠ review)
 
 A review of record is **independent and cross-family** (outside the author's model
-family; never self-review, never same-family). CF, design, and plan use toolful seats (`delegate.py` or native harnesses); ACP is toolless intercomm only, and caveman lite is style (never persisted review text).
+family; never self-review, never same-family).
+
+- **Execution and comms layers:** CF, design, and plan use toolful seats (`delegate.py` or native harnesses); ACP is toolless intercomm only, and caveman lite is style (never persisted review text).
 
 **Shielded formal CF is RETIRED (operator 2026-08-07).** Do **not** run
 `review-pr` / sealed `lu-review-*` / `shielded-reviews` clones — the CLI fails

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -327,7 +327,7 @@ action. Read and apply every `unread` or `read-but-not-live-consumed` entry, the
 ### 6. Cross-family review gate (load-bearing — discussion ≠ review)
 
 A review of record is **independent and cross-family** (outside the author's model
-family; never self-review, never same-family).
+family; never self-review, never same-family). CF, design, and plan use toolful seats (`delegate.py` or native harnesses); ACP is toolless intercomm only, and caveman lite is style (never persisted review text).
 
 **Shielded formal CF is RETIRED (operator 2026-08-07).** Do **not** run
 `review-pr` / sealed `lu-review-*` / `shielded-reviews` clones — the CLI fails
@@ -493,6 +493,7 @@ stores are read-only migration/projection inputs, not a live write target.
   handoff-status` / `handoff-claim` (#5530).
 - **Sealed formal CF is retired** — CF is the direct `ask-<lane>` + PR-post flow in §6,
   not `review-pr` / sealed `lu-review-*`.
+- **ACP provider transport:** ACP is toolless intercomm only (state transfer / ordinary asks/discuss); CF, design, and plan use toolful seats (`delegate.py` or native harnesses), and caveman lite is style.
 - **Never** flip the plane, enable retention apply, or invent a competing comms design
   from this skill — those remain the infra lane's gated actions, even post-cutover.
 

--- a/docs/runbooks/agent-seat-onboarding.md
+++ b/docs/runbooks/agent-seat-onboarding.md
@@ -59,6 +59,18 @@ and the narrowly allowlisted dual paths.
 | **Entire context recall** | Optional automatic body-free discovery plus preflight-gated private native session search/explain/recap | Task state, live discussion, terminal receipts, source code authority, rollover, Monitor state, or formal review |
 | **Buzz** | **Explicitly deferred** | Anything in this rollout — relay-as-authority conflicts with the current authority model |
 
+### Caveman output-style skill
+
+Shared skill `agents_extensions/shared/skills/caveman/` — default intensity **lite**
+(drop filler/hedging; keep articles and full sentences). `npm run agents:deploy`
+(`scripts/deploy_prompts.sh`) rsyncs it to `.claude/skills/caveman`, `.codex/skills/caveman`,
+the `.agent` overlay, `.agents/skills/caveman`, and `.gemini/skills/caveman`. Never hand-edit
+those deploy copies. Caveman is **style only** — never persisted artifacts (commits, PR/issue
+bodies, curriculum, runbooks, review-of-record text on GitHub) and never a substitute for
+fleet-comms durable state. Cursor, Kimi, GLM, and OpenCode consume it through the **host
+harness** skill tree of the CLI that actually launches them (same rule as Entire capture), not
+a model-named extra copy.
+
 ### Entire recall onboarding matrix
 
 Capture belongs to the **host harness**, not to a model label. The same model


### PR DESCRIPTION
## Summary

- Adds `agents_extensions/shared/skills/caveman/SKILL.md` vendored from upstream (MIT) with learn-ukrainian project overlay:
  - Default intensity: `lite` (drop filler/hedging, keep articles and full sentences)
  - Caveman is communication style, not transport; never substitutes for fleet-comms durable state
  - Never used on persisted artifacts (commits, PR/issue bodies, curriculum, runbooks, review-of-record text)
  - Session chat / inter-agent ACP bodies may use lite caveman
- Updates `agents_extensions/shared/rules/fleet-comms-coordination.md` with communication and execution layering table clarifying:
  - Fleet-comms = Durable authority for queues, receipts, jobs
  - ACP / ACPX = Toolless provider transport for ordinary inter-agent asks/discuss only (state transfer)
  - Toolful native / `delegate.py` seats = Plan, create, review, design, implementation
  - Caveman = Optional output-style compression (lite default)
  - Explicit rule: `ask-* --type review` over ACP is not the review-of-record path when reviewer needs to inspect the tree; review of record requires a toolful seat + PR verdict
- Updates `agents_extensions/shared/skills/drive-epic/SKILL.md` (§6 CF gate and Fleet-comms state) with pointers that CF/design/plan uses toolful seats, ACP is toolless intercomm only, and caveman lite is style.

Refs #6943