### PR TITLE
feat(occupancy): Mac GUI observer presence for Cursor IDE and Codex UI (#7104)

### DIFF
--- a/docs/runbooks/cursor-driver.md
+++ b/docs/runbooks/cursor-driver.md
@@ -14,7 +14,7 @@ Cursor is a first-class worker and orchestrator seat in the fleet roster. Promot
 .venv/bin/python -m scripts.orchestration.observer_heartbeat \
   --agent cursor --task-id <issue-or-task> --epic <epic> --status working
 ```
-- **GUI Cursor IDE = Human Supervision Only:** GUI Cursor chat is interactive human supervision and inspection. It is **not** a second driver protocol, does not claim autonomous stream leases, and does not run an unmonitored alternate orchestration loop.
+- **GUI Cursor IDE = Human Supervision Only:** GUI Cursor chat is interactive human supervision and inspection. It is **not** a second driver protocol, does not claim autonomous stream leases, and does not run an unmonitored alternate orchestration loop. Idle GUI supervision heartbeats automatically via the Mac observer LaunchAgent (`scripts/orchestration/install_mac_observer_launchd.py`, #7104).
 
 ## Identity Contract & Attestation
 

--- a/docs/runbooks/launchd-inventory.md
+++ b/docs/runbooks/launchd-inventory.md
@@ -96,6 +96,26 @@ dispatch worktree.
   render|install|status|uninstall`.
 - Reference: [Archived thread cleanup](archived-thread-cleanup.md).
 
+### `com.learn-ukrainian.mac-observer-heartbeat`
+
+- Purpose: Heartbeats live Mac GUI sessions (Cursor IDE and Codex UI) to
+  `POST /api/observer/presence` over the loopback Monitor tunnel so
+  occupancy shows supervision seats under `cloud-observer` without claiming
+  stream leases (#7104).
+- Program: `/bin/bash --noprofile --norc
+  scripts/orchestration/run_mac_observer_heartbeat.sh --repo-root <primary
+  checkout>`. The wrapper execs the primary `.venv/bin/python` with
+  `scripts/orchestration/observer_heartbeat.py --mac-gui`. `Program` must stay
+  `/bin/bash` so a venv rebuild cannot invalidate launchd LWCR (exit 78; #6937, #6941).
+- Schedule: at load and every 8 minutes (`StartInterval=480`), well within
+  the 15-minute presence TTL.
+- Delete authority: none. It posts loopback presence only.
+- Logs: `~/.codex/mac-observer/logs/` — outside the repository.
+- Manage: `.venv/bin/python
+  scripts/orchestration/install_mac_observer_launchd.py
+  render|install|status|uninstall`.
+- Reference: [Cursor driver](cursor-driver.md) and #7104.
+
 ## Invariants
 
 - Logs and receipts of scheduled jobs must live outside the repository so

--- a/packaging/launchd/README.md
+++ b/packaging/launchd/README.md
@@ -1,0 +1,17 @@
+# macOS LaunchAgent templates (loopback observer heartbeat)
+
+Templates and installers for macOS LaunchAgents.
+
+## `com.learn-ukrainian.mac-observer-heartbeat`
+
+Supervises background observer presence heartbeats for live Mac GUI sessions (Cursor IDE and Codex UI).
+When Cursor or Codex GUI apps are active, sends periodic heartbeats to `POST /api/observer/presence`
+over the loopback monitor tunnel (`http://127.0.0.1:8765`), keeping their presence alive under `cloud-observer`
+in `/api/occupancy` with `status=idle` and TTL ≤15m.
+
+To install or manage:
+```bash
+.venv/bin/python scripts/orchestration/install_mac_observer_launchd.py install
+.venv/bin/python scripts/orchestration/install_mac_observer_launchd.py status
+.venv/bin/python scripts/orchestration/install_mac_observer_launchd.py uninstall
+```

--- a/scripts/orchestration/install_mac_observer_launchd.py
+++ b/scripts/orchestration/install_mac_observer_launchd.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Install the Mac GUI observer presence heartbeat LaunchAgent on macOS (#7104)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+LABEL = "com.learn-ukrainian.mac-observer-heartbeat"
+DEFAULT_INTERVAL_MINUTES = 8
+LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# launchd binds LWCR to ProgramArguments[0]. /bin/bash is Apple-signed and
+# survives a primary .venv rebuild; pointing Program at .venv/bin/python
+# is what produced exit 78 after the 2026-08-15 uv rewrite (#6937, #6941).
+STABLE_PROGRAM = "/bin/bash"
+WRAPPER_NAME = "run_mac_observer_heartbeat.sh"
+
+
+class LaunchdError(RuntimeError):
+    """The requested launchd state could not be verified."""
+
+
+def default_repo_root() -> Path:
+    """Return the checkout containing this installer."""
+    return Path(__file__).resolve().parents[2]
+
+
+def default_home() -> Path:
+    """Return the current user's home without consulting shell expansion."""
+    return Path.home()
+
+
+def plist_path(home: Path) -> Path:
+    """Return the per-user LaunchAgent path."""
+    return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def state_dir(home: Path) -> Path:
+    """Return the durable logs and state directory outside the checkout."""
+    return home / ".codex" / "mac-observer"
+
+
+def wrapper_path(repo_root: Path) -> Path:
+    """Return the stable bash wrapper launchd executes."""
+    return repo_root / "scripts" / "orchestration" / WRAPPER_NAME
+
+
+def build_plist(
+    *,
+    repo_root: Path,
+    home: Path,
+    interval_minutes: int,
+) -> dict[str, Any]:
+    runtime = state_dir(home)
+    return {
+        "Label": LABEL,
+        "EnvironmentVariables": {"PATH": LAUNCHD_PATH},
+        "LowPriorityIO": True,
+        "ProcessType": "Background",
+        "ProgramArguments": [
+            STABLE_PROGRAM,
+            "--noprofile",
+            "--norc",
+            str(wrapper_path(repo_root)),
+            "--repo-root",
+            str(repo_root),
+        ],
+        "RunAtLoad": True,
+        "StandardErrorPath": str(runtime / "logs" / "stderr.log"),
+        "StandardOutPath": str(runtime / "logs" / "stdout.log"),
+        "StartInterval": interval_minutes * 60,
+        "WorkingDirectory": str(repo_root),
+    }
+
+
+def render_plist(
+    *,
+    repo_root: Path,
+    home: Path,
+    interval_minutes: int,
+) -> bytes:
+    """Render a stable XML plist for inspection and tests."""
+    return plistlib.dumps(
+        build_plist(
+            repo_root=repo_root,
+            home=home,
+            interval_minutes=interval_minutes,
+        ),
+        fmt=plistlib.FMT_XML,
+        sort_keys=True,
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        descriptor = os.open(path, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError:
+        pass
+
+
+def atomic_write(path: Path, content: bytes, *, mode: int = 0o600) -> bool:
+    """Atomically replace path and report whether its contents changed."""
+    if path.is_file() and path.read_bytes() == content:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, mode)
+        os.replace(temporary_path, path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return True
+
+
+def _launchctl(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["/bin/launchctl", *command],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise LaunchdError("/bin/launchctl is unavailable; macOS is required") from exc
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _service_target() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _loaded_readback() -> subprocess.CompletedProcess[str]:
+    return _launchctl(["print", _service_target()])
+
+
+def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdError:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    return LaunchdError(f"launchctl {action} failed: {detail}")
+
+
+def _validate_runtime(repo_root: Path, *, require_interpreter: bool = False) -> None:
+    if not (repo_root / ".git").is_dir() and not (repo_root / ".git").is_file():
+        raise LaunchdError(f"repository root is missing .git: {repo_root}")
+    if require_interpreter:
+        interpreter = repo_root / ".venv" / "bin" / "python"
+        if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+            raise LaunchdError(f"required interpreter is missing: {interpreter}")
+        heartbeat_script = repo_root / "scripts" / "orchestration" / "observer_heartbeat.py"
+        if not heartbeat_script.is_file():
+            raise LaunchdError(f"observer heartbeat script is missing: {heartbeat_script}")
+        wrapper = wrapper_path(repo_root)
+        if not wrapper.is_file():
+            raise LaunchdError(f"heartbeat wrapper is missing: {wrapper}")
+        if not os.access(STABLE_PROGRAM, os.X_OK):
+            raise LaunchdError(f"stable launchd program is missing: {STABLE_PROGRAM}")
+
+
+def install(
+    *,
+    repo_root: Path,
+    home: Path,
+    interval_minutes: int,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    _validate_runtime(repo_root, require_interpreter=True)
+    destination = plist_path(home)
+    content = render_plist(
+        repo_root=repo_root,
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+    runtime = state_dir(home)
+    logs_dir = runtime / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(logs_dir, 0o700)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    before = _loaded_readback()
+    was_loaded = before.returncode == 0
+    changed = not destination.is_file() or destination.read_bytes() != content
+    if changed and was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+
+    wrote_plist = atomic_write(destination, content)
+    if changed or not was_loaded:
+        bootstrap = _launchctl(["bootstrap", _domain(), str(destination)])
+        if bootstrap.returncode != 0:
+            raise _failure("bootstrap", bootstrap)
+
+    readback = _loaded_readback()
+    if readback.returncode != 0:
+        raise _failure("print", readback)
+    return {
+        "action": "install",
+        "changed": changed,
+        "interval_minutes": interval_minutes,
+        "label": LABEL,
+        "loaded": True,
+        "plist_path": str(destination),
+        "repo_root": str(repo_root),
+        "wrote_plist": wrote_plist,
+    }
+
+
+def _valid_persisted_plist(
+    payload: Any,
+    *,
+    repo_root: Path,
+    home: Path,
+    interval_minutes: int,
+) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    arguments = payload.get("ProgramArguments")
+    if not isinstance(arguments, list) or len(arguments) < 5:
+        return False
+    if arguments[0] != STABLE_PROGRAM:
+        return False
+    if any(".venv/bin/python" in str(arg) for arg in arguments):
+        return False
+    return payload == build_plist(
+        repo_root=repo_root,
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+
+
+def status(
+    *,
+    repo_root: Path,
+    home: Path,
+    interval_minutes: int,
+) -> tuple[dict[str, Any], int]:
+    destination = plist_path(home)
+    loaded = _loaded_readback().returncode == 0
+    persisted: Any = None
+    parse_error = None
+    if destination.is_file():
+        try:
+            persisted = plistlib.loads(destination.read_bytes())
+        except Exception as exc:
+            parse_error = str(exc)
+    valid = _valid_persisted_plist(
+        persisted,
+        repo_root=repo_root.resolve(),
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+    result = {
+        "action": "status",
+        "installed": destination.is_file(),
+        "interval_minutes": interval_minutes,
+        "label": LABEL,
+        "loaded": loaded,
+        "parse_error": parse_error,
+        "plist_path": str(destination),
+        "valid_plist": valid,
+    }
+    return result, 0 if loaded and valid else 1
+
+
+def uninstall(*, home: Path) -> dict[str, Any]:
+    destination = plist_path(home)
+    was_loaded = _loaded_readback().returncode == 0
+    if was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+    destination.unlink(missing_ok=True)
+    return {
+        "action": "uninstall",
+        "label": LABEL,
+        "loaded": False,
+        "plist_path": str(destination),
+        "preserved_state_dir": str(state_dir(home)),
+    }
+
+
+def positive_interval(value: str) -> int:
+    try:
+        interval = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("interval must be a positive integer") from exc
+    if interval <= 0:
+        raise argparse.ArgumentTypeError("interval must be a positive integer")
+    return interval
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=default_repo_root())
+    parser.add_argument("--home", type=Path, default=default_home())
+    parser.add_argument(
+        "--interval-minutes",
+        type=positive_interval,
+        default=DEFAULT_INTERVAL_MINUTES,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("render")
+    subparsers.add_parser("install")
+    subparsers.add_parser("status")
+    subparsers.add_parser("uninstall")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.expanduser().resolve()
+    home = args.home.expanduser().resolve()
+    if args.command == "render":
+        print(
+            render_plist(
+                repo_root=repo_root,
+                home=home,
+                interval_minutes=args.interval_minutes,
+            ).decode("utf-8"),
+            end="",
+        )
+        return 0
+    if args.command == "install":
+        result = install(
+            repo_root=repo_root,
+            home=home,
+            interval_minutes=args.interval_minutes,
+        )
+        return_code = 0
+    elif args.command == "status":
+        result, return_code = status(
+            repo_root=repo_root,
+            home=home,
+            interval_minutes=args.interval_minutes,
+        )
+    else:
+        result = uninstall(home=home)
+        return_code = 0
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return return_code
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except LaunchdError as exc:
+        print(json.dumps({"error": str(exc), "label": LABEL}, sort_keys=True))
+        raise SystemExit(2) from None

--- a/scripts/orchestration/observer_heartbeat.py
+++ b/scripts/orchestration/observer_heartbeat.py
@@ -10,14 +10,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Callable, Sequence
 from typing import Any
 from urllib.parse import urlparse
 
 DEFAULT_MONITOR = "http://127.0.0.1:8765"
-ALLOWED_AGENTS = frozenset({"grok-bot", "qa-engineer", "cursor"})
+ALLOWED_AGENTS = frozenset({"grok-bot", "qa-engineer", "cursor", "codex"})
 ALLOWED_STATUSES = frozenset({"working", "blocked", "idle"})
 RENEW_AFTER_S = 8 * 60
 
@@ -95,25 +97,166 @@ def post_observer_presence(
     }
 
 
+def is_gui_process_for_agent(agent: str, command_line: str) -> bool:
+    """Return True if command_line indicates a running GUI process for agent."""
+    cmd = command_line.strip()
+    if not cmd:
+        return False
+    if agent == "cursor":
+        if "Cursor.app" in cmd:
+            return True
+        basename = cmd.rsplit("/", 1)[-1]
+        return basename in {"Cursor", "Cursor Helper"} or basename.startswith("Cursor Helper ")
+    if agent == "codex":
+        if "Codex.app" in cmd:
+            return True
+        basename = cmd.rsplit("/", 1)[-1]
+        return basename in {"Codex", "Codex Helper", "codex-ui"} or basename.startswith("Codex Helper ")
+    return False
+
+
+def _list_running_processes(runner: Callable[[], Sequence[str]] | None = None) -> list[str]:
+    if runner is not None:
+        return list(runner())
+    try:
+        proc = subprocess.run(
+            ["/bin/ps", "-ax", "-o", "comm"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            return []
+        return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+
+def detect_mac_gui_session(
+    agent: str,
+    *,
+    process_lines: Sequence[str] | None = None,
+    runner: Callable[[], Sequence[str]] | None = None,
+) -> bool:
+    """Detect whether a Mac GUI session is alive for agent without claiming a lease."""
+    if agent not in ALLOWED_AGENTS:
+        raise HeartbeatError("unknown observer agent")
+    lines = process_lines if process_lines is not None else _list_running_processes(runner)
+    return any(is_gui_process_for_agent(agent, line) for line in lines)
+
+
+def detect_live_gui_agents(
+    *,
+    process_lines: Sequence[str] | None = None,
+    runner: Callable[[], Sequence[str]] | None = None,
+) -> list[str]:
+    """Detect which allowed GUI observer agents are currently running."""
+    lines = process_lines if process_lines is not None else _list_running_processes(runner)
+    found: list[str] = []
+    for agent in ("cursor", "codex"):
+        if any(is_gui_process_for_agent(agent, line) for line in lines):
+            found.append(agent)
+    return found
+
+
+def sweep_mac_gui_presence(
+    *,
+    base: str | None = None,
+    opener: Any = None,
+    process_lines: Sequence[str] | None = None,
+    runner: Callable[[], Sequence[str]] | None = None,
+    cursor_task_id: str = "cursor-gui",
+    codex_task_id: str = "codex-gui",
+    status: str = "idle",
+) -> list[dict[str, Any]]:
+    """Detect live Mac GUI sessions and post observer heartbeat with status=idle.
+
+    If a GUI is not running, no heartbeat is posted (omitted).
+    """
+    live_agents = detect_live_gui_agents(process_lines=process_lines, runner=runner)
+    task_map = {
+        "cursor": cursor_task_id,
+        "codex": codex_task_id,
+    }
+    results: list[dict[str, Any]] = []
+    for agent in live_agents:
+        task_id = task_map.get(agent, f"{agent}-gui")
+        row = post_observer_presence(
+            agent=agent,
+            task_id=task_id,
+            status=status,
+            summary=f"{agent} mac gui observer heartbeat",
+            base=base,
+            opener=opener,
+        )
+        results.append(row)
+    return results
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Post loopback observer presence (#7075).")
-    parser.add_argument("--agent", required=True)
-    parser.add_argument("--task-id", required=True)
-    parser.add_argument("--status", default="working")
+    parser = argparse.ArgumentParser(description="Post loopback observer presence (#7075, #7104).")
+    parser.add_argument("--agent")
+    parser.add_argument("--task-id")
+    parser.add_argument("--status")
     parser.add_argument("--epic")
     parser.add_argument("--summary")
+    parser.add_argument(
+        "--mac-gui",
+        action="store_true",
+        help="Detect running Mac GUI sessions (Cursor/Codex) and post idle heartbeats",
+    )
+    parser.add_argument("--cursor-task-id", default="cursor-gui")
+    parser.add_argument("--codex-task-id", default="codex-gui")
+    parser.add_argument("--repo-root", help=argparse.SUPPRESS)
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    opener: Any = None,
+    process_lines: Sequence[str] | None = None,
+    runner: Callable[[], Sequence[str]] | None = None,
+) -> int:
     args = build_parser().parse_args(argv)
+    if args.mac_gui:
+        status = args.status if args.status is not None else "idle"
+        try:
+            results = sweep_mac_gui_presence(
+                opener=opener,
+                process_lines=process_lines,
+                runner=runner,
+                cursor_task_id=args.cursor_task_id,
+                codex_task_id=args.codex_task_id,
+                status=status,
+            )
+        except HeartbeatError as exc:
+            print(f"observer-heartbeat: {exc}", file=sys.stderr)
+            return 2
+        except Exception:
+            print("observer-heartbeat: monitor unreachable", file=sys.stderr)
+            return 1
+        if not results:
+            print("observer-heartbeat: no live mac gui sessions detected")
+            return 0
+        for row in results:
+            print(f"observer-heartbeat: agent={row['agent']} task_id={row['task_id']} status={row['status']}")
+        return 0
+
+    if not args.agent or not args.task_id:
+        print("observer-heartbeat: --agent and --task-id are required (or use --mac-gui)", file=sys.stderr)
+        return 2
+
+    status = args.status if args.status is not None else "working"
     try:
         post_observer_presence(
             agent=args.agent,
             task_id=args.task_id,
-            status=args.status,
+            status=status,
             epic=args.epic,
             summary=args.summary,
+            opener=opener,
         )
     except HeartbeatError as exc:
         print(f"observer-heartbeat: {exc}", file=sys.stderr)
@@ -121,7 +264,7 @@ def main(argv: list[str] | None = None) -> int:
     except Exception:
         print("observer-heartbeat: monitor unreachable", file=sys.stderr)
         return 1
-    print(f"observer-heartbeat: agent={args.agent} task_id={args.task_id} status={args.status}")
+    print(f"observer-heartbeat: agent={args.agent} task_id={args.task_id} status={status}")
     return 0
 
 

--- a/scripts/orchestration/run_mac_observer_heartbeat.sh
+++ b/scripts/orchestration/run_mac_observer_heartbeat.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# launchd binds LWCR to ProgramArguments[0]. That must stay /bin/bash
+# (Apple-signed). Never put .venv/bin/python there: a venv rebuild
+# replaces the binary and launchd then fails with
+# "Unable to get updated LWCR ... error 0x3 - No such process" (exit 78).
+set -euo pipefail
+
+primary=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--repo-root" ]]; then
+    primary="${args[$((i + 1))]:-}"
+    break
+  fi
+done
+
+if [[ -z "${primary}" ]]; then
+  echo "mac-observer-heartbeat: missing --repo-root (primary checkout)" >&2
+  exit 78
+fi
+
+python="${primary}/.venv/bin/python"
+script="$(cd "$(dirname "$0")" && pwd)/observer_heartbeat.py"
+
+if [[ ! -x "${python}" ]]; then
+  echo "mac-observer-heartbeat: missing interpreter: ${python}" >&2
+  exit 78
+fi
+if [[ ! -f "${script}" ]]; then
+  echo "mac-observer-heartbeat: missing script: ${script}" >&2
+  exit 78
+fi
+
+exec "${python}" "${script}" --mac-gui "$@"

--- a/tests/orchestration/test_install_mac_observer_launchd.py
+++ b/tests/orchestration/test_install_mac_observer_launchd.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.orchestration import install_mac_observer_launchd as launchd
+
+
+def test_rendered_plist_runs_mac_observer_periodically(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+
+    payload = plistlib.loads(
+        launchd.render_plist(
+            repo_root=repo,
+            home=home,
+            interval_minutes=8,
+        )
+    )
+
+    assert payload["Label"] == launchd.LABEL
+    assert payload["StartInterval"] == 480
+    assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"][0] == launchd.STABLE_PROGRAM
+    assert payload["ProgramArguments"] == [
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        str(repo / "scripts" / "orchestration" / "run_mac_observer_heartbeat.sh"),
+        "--repo-root",
+        str(repo),
+    ]
+    assert "/opt/homebrew/bin" in payload["EnvironmentVariables"]["PATH"]
+    assert not any(".venv/bin/python" in part for part in payload["ProgramArguments"])
+    assert payload["StandardOutPath"] == str(home / ".codex" / "mac-observer" / "logs" / "stdout.log")
+    assert payload["StandardErrorPath"] == str(home / ".codex" / "mac-observer" / "logs" / "stderr.log")
+
+
+def test_status_rejects_modified_program_arguments(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+    payload["ProgramArguments"] = ["/bin/sh", "-c", "echo unsafe"]
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result, return_code = launchd.status(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+
+    assert return_code == 1
+    assert result["loaded"] is True
+    assert result["valid_plist"] is False
+
+
+def test_install_is_verified_and_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    (repo / ".git").mkdir(parents=True)
+    interpreter = repo / ".venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    script = repo / "scripts" / "orchestration" / "observer_heartbeat.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# heartbeat\n", encoding="utf-8")
+    wrapper = repo / "scripts" / "orchestration" / "run_mac_observer_heartbeat.sh"
+    wrapper.write_text("#!/bin/bash\n", encoding="utf-8")
+
+    loaded_states = iter(
+        [
+            SimpleNamespace(returncode=1, stdout="", stderr="not loaded"),
+            SimpleNamespace(returncode=0, stdout="loaded", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: next(loaded_states))
+    launchctl_calls: list[list[str]] = []
+
+    def fake_launchctl(command: list[str]) -> SimpleNamespace:
+        launchctl_calls.append(list(command))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(launchd, "_launchctl", fake_launchctl)
+
+    first = launchd.install(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+
+    assert first["changed"] is True
+    assert first["loaded"] is True
+    assert launchctl_calls == [
+        [
+            "bootstrap",
+            launchd._domain(),
+            str(launchd.plist_path(home)),
+        ]
+    ]
+    expected = launchd.render_plist(
+        repo_root=repo.resolve(),
+        home=home,
+        interval_minutes=8,
+    )
+    assert launchd.plist_path(home).read_bytes() == expected
+
+    monkeypatch.setattr(
+        launchd,
+        "_loaded_readback",
+        lambda: SimpleNamespace(returncode=0, stdout="loaded", stderr=""),
+    )
+    launchctl_calls.clear()
+
+    second = launchd.install(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+
+    assert second["changed"] is False
+    assert second["wrote_plist"] is False
+    assert launchctl_calls == []
+
+
+def test_uninstall_removes_plist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    destination.write_text("plist", encoding="utf-8")
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "not loaded"
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result = launchd.uninstall(home=home)
+
+    assert result["loaded"] is False
+    assert not destination.exists()
+
+
+def test_status_rejects_venv_python_as_program(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mutation-check: putting .venv/bin/python back in Program must fail status."""
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+    payload["ProgramArguments"][0] = str(repo / ".venv" / "bin" / "python")
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result, return_code = launchd.status(
+        repo_root=repo,
+        home=home,
+        interval_minutes=8,
+    )
+
+    assert return_code == 1
+    assert result["valid_plist"] is False
+    assert result["loaded"] is True
+
+
+def test_positive_interval_validation() -> None:
+    assert launchd.positive_interval("8") == 8
+    with pytest.raises(Exception, match="positive integer"):
+        launchd.positive_interval("0")
+    with pytest.raises(Exception, match="positive integer"):
+        launchd.positive_interval("-2")
+    with pytest.raises(Exception, match="positive integer"):
+        launchd.positive_interval("abc")

--- a/tests/orchestration/test_observer_heartbeat.py
+++ b/tests/orchestration/test_observer_heartbeat.py
@@ -79,7 +79,7 @@ def test_post_observer_presence_posts_cursor_payload() -> None:
 def test_post_observer_presence_does_not_echo_response_text() -> None:
     def opener(request: object, timeout: int = 0) -> _FakeResponse:
         del request, timeout
-        return _FakeResponse({"agent": "atlas-runner", "task_id": "see 10.0.0.1", "status": "working"})
+        return _FakeResponse({"agent": "atlas-runner", "task_id": "see unexpected-data", "status": "working"})
 
     row = post_observer_presence(agent="cursor", task_id="7075", opener=opener)
     assert row == {"agent": "cursor", "task_id": "7075", "status": "working", "host_id": None}
@@ -130,3 +130,202 @@ def test_main_timeout_is_unreachable(monkeypatch: pytest.MonkeyPatch, capsys: py
     assert "monitor unreachable" in err
     assert "Traceback" not in err
     assert "stalled" not in err
+
+
+def test_post_observer_presence_posts_codex_payload() -> None:
+    captured: dict[str, object] = {}
+
+    def opener(request: object, timeout: int = 0) -> _FakeResponse:
+        del timeout
+        captured["url"] = getattr(request, "full_url", None)
+        captured["body"] = json.loads(getattr(request, "data", b"{}").decode("utf-8"))
+        return _FakeResponse(
+            {
+                "agent": "codex",
+                "task_id": "7104",
+                "status": "idle",
+                "host_id": "cloud-observer",
+            }
+        )
+
+    row = post_observer_presence(
+        agent="codex",
+        task_id="7104",
+        status="idle",
+        epic="7073",
+        summary="codex ui mac observer heartbeat",
+        opener=opener,
+    )
+    assert captured["url"] == "http://127.0.0.1:8765/api/observer/presence"
+    assert captured["body"] == {
+        "agent": "codex",
+        "kind": "observer",
+        "task_id": "7104",
+        "status": "idle",
+        "epic": "7073",
+        "summary": "codex ui mac observer heartbeat",
+    }
+    assert row["agent"] == "codex"
+    assert row["task_id"] == "7104"
+    assert row["status"] == "idle"
+    assert row["host_id"] == "cloud-observer"
+
+
+def test_post_observer_presence_rejects_unknown_agent_fail_closed() -> None:
+    for unknown in ("claude", "gemini", "atlas-runner", "hramatka", "custom"):
+        with pytest.raises(HeartbeatError, match="unknown observer agent"):
+            post_observer_presence(agent=unknown, task_id="7104")
+
+
+def test_post_observer_presence_rejects_invalid_status() -> None:
+    for invalid in ("running", "done", "active", "offline", "unknown"):
+        with pytest.raises(HeartbeatError, match="invalid status"):
+            post_observer_presence(agent="cursor", task_id="7104", status=invalid)
+
+
+def test_main_rejects_unknown_agent_fail_closed(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--agent", "claude", "--task-id", "7104"]) == 2
+    err = capsys.readouterr().err
+    assert "unknown observer agent" in err
+
+
+def test_main_missing_required_args_fail_closed(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert "--agent and --task-id are required" in err
+
+
+def test_detect_mac_gui_session_cursor_and_codex() -> None:
+    from scripts.orchestration.observer_heartbeat import (
+        detect_live_gui_agents,
+        detect_mac_gui_session,
+        is_gui_process_for_agent,
+    )
+
+    cursor_processes = [
+        "/Applications/Cursor.app/Contents/MacOS/Cursor",
+        "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app/Contents/MacOS/Cursor Helper (Renderer)",
+        "/usr/bin/bash",
+    ]
+    codex_processes = [
+        "/Applications/Codex.app/Contents/MacOS/Codex",
+        "/Applications/Codex.app/Contents/Frameworks/Codex Helper.app/Contents/MacOS/Codex Helper",
+        "/usr/bin/python",
+    ]
+    both_processes = cursor_processes + codex_processes
+    neither_processes = ["/usr/bin/bash", "/usr/bin/python", "/usr/bin/git", "node"]
+
+    assert detect_mac_gui_session("cursor", process_lines=cursor_processes) is True
+    assert detect_mac_gui_session("codex", process_lines=cursor_processes) is False
+
+    assert detect_mac_gui_session("codex", process_lines=codex_processes) is True
+    assert detect_mac_gui_session("cursor", process_lines=codex_processes) is False
+
+    assert detect_live_gui_agents(process_lines=both_processes) == ["cursor", "codex"]
+    assert detect_live_gui_agents(process_lines=neither_processes) == []
+
+    # Direct process pattern unit checks
+    assert is_gui_process_for_agent("cursor", "/Applications/Cursor.app/Contents/MacOS/Cursor") is True
+    assert is_gui_process_for_agent("cursor", "Cursor") is True
+    assert is_gui_process_for_agent("cursor", "Cursor Helper") is True
+    assert is_gui_process_for_agent("cursor", "python scripts/orchestration/observer_heartbeat.py") is False
+
+    assert is_gui_process_for_agent("codex", "/Applications/Codex.app/Contents/MacOS/Codex") is True
+    assert is_gui_process_for_agent("codex", "Codex") is True
+    assert is_gui_process_for_agent("codex", "codex-ui") is True
+    assert is_gui_process_for_agent("codex", "codex exec") is False
+
+
+def test_detect_mac_gui_session_rejects_unknown_agent() -> None:
+    from scripts.orchestration.observer_heartbeat import detect_mac_gui_session
+
+    with pytest.raises(HeartbeatError, match="unknown observer agent"):
+        detect_mac_gui_session("claude", process_lines=[])
+
+
+def test_sweep_mac_gui_presence() -> None:
+    from scripts.orchestration.observer_heartbeat import sweep_mac_gui_presence
+
+    posted_bodies: list[dict[str, object]] = []
+
+    def opener(request: object, timeout: int = 0) -> _FakeResponse:
+        del timeout
+        body = json.loads(getattr(request, "data", b"{}").decode("utf-8"))
+        posted_bodies.append(body)
+        return _FakeResponse(
+            {
+                "agent": body["agent"],
+                "task_id": body["task_id"],
+                "status": body["status"],
+                "host_id": "cloud-observer",
+            }
+        )
+
+    # When both Cursor and Codex are running
+    lines = [
+        "/Applications/Cursor.app/Contents/MacOS/Cursor",
+        "/Applications/Codex.app/Contents/MacOS/Codex",
+    ]
+    results = sweep_mac_gui_presence(
+        opener=opener,
+        process_lines=lines,
+        cursor_task_id="cursor-gui",
+        codex_task_id="codex-gui",
+        status="idle",
+    )
+    assert len(results) == 2
+    assert {r["agent"] for r in results} == {"cursor", "codex"}
+    assert {b["agent"] for b in posted_bodies} == {"cursor", "codex"}
+    for b in posted_bodies:
+        assert b["status"] == "idle"
+
+    # When neither is running -> omits heartbeats
+    posted_bodies.clear()
+    results_empty = sweep_mac_gui_presence(
+        opener=opener,
+        process_lines=["/usr/bin/bash"],
+    )
+    assert results_empty == []
+    assert posted_bodies == []
+
+
+def test_main_mac_gui_mode_posts_idle_for_running_gui(capsys: pytest.CaptureFixture[str]) -> None:
+    posted: list[dict[str, object]] = []
+
+    def opener(request: object, timeout: int = 0) -> _FakeResponse:
+        del timeout
+        body = json.loads(getattr(request, "data", b"{}").decode("utf-8"))
+        posted.append(body)
+        return _FakeResponse(
+            {
+                "agent": body["agent"],
+                "task_id": body["task_id"],
+                "status": body["status"],
+                "host_id": "cloud-observer",
+            }
+        )
+
+    lines = ["/Applications/Cursor.app/Contents/MacOS/Cursor"]
+    rc = main(["--mac-gui"], opener=opener, process_lines=lines)
+    assert rc == 0
+    assert len(posted) == 1
+    assert posted[0]["agent"] == "cursor"
+    assert posted[0]["task_id"] == "cursor-gui"
+    assert posted[0]["status"] == "idle"
+    out = capsys.readouterr().out
+    assert "agent=cursor task_id=cursor-gui status=idle" in out
+
+
+def test_main_mac_gui_mode_noop_when_not_running(capsys: pytest.CaptureFixture[str]) -> None:
+    posted: list[dict[str, object]] = []
+
+    def opener(request: object, timeout: int = 0) -> _FakeResponse:
+        del timeout
+        posted.append({})
+        return _FakeResponse({})
+
+    rc = main(["--mac-gui"], opener=opener, process_lines=["/usr/bin/bash"])
+    assert rc == 0
+    assert posted == []
+    out = capsys.readouterr().out
+    assert "no live mac gui sessions detected" in out


### PR DESCRIPTION
## Summary

Remaining #7104 after #7105 (API allowlist). Mac GUI Cursor IDE and Codex UI sessions heartbeat `POST /api/observer/presence` over Monitor loopback so occupancy can show them under `cloud-observer` without a RAM lease.

- `codex` added to `observer_heartbeat.py` ALLOWED_AGENTS (API already allowed it)
- GUI process detection without stream leases
- LaunchAgent installer; operator installs on the Mac (this VPS cannot run launchd)
- Tests for allowlist, loopback URL, GUI detection, installer

OPSEC: loopback URL only; no hostnames/IPs/paths in payloads.

Refs #7104 #6943 #7105

## Test plan

- [x] pytest `tests/orchestration/test_observer_heartbeat.py` `tests/orchestration/test_install_mac_observer_launchd.py`
- [ ] Toolful cross-family review (not ACP)
- [ ] Operator install LaunchAgent on Mac after merge

X-Agent: agy/7104-mac-observer-heartbeat-v1