### PR TITLE
perf(ci): parallelize pytest shard planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,19 @@ name: CI
 
 # CI Gate reboot (#5762) made every required job unconditional after the prior
 # paths-filtered control plane caused four consecutive gate failures. #5744
-# restores the proven pytest topology: one deterministic planner, four
+# restores the proven pytest topology: four deterministic,
 # duration-balanced file shards, and JUnit reconstruction inside CI Gate.
 #
 # Two-tier merge-queue cutover (#6943 stage 2): one workflow, two events.
 # pull_request tier (light): ruff + fastlane + contracts + frontend.
-# merge_group / push / workflow_dispatch tier (full): light PLUS planner +
-# four shards + coverage floor. CI Gate remains the sole required context,
+# merge_group / push / workflow_dispatch tier (full): light PLUS planner
+# contract, four shards, and coverage floor. CI Gate remains the sole required context,
 # reports on both events, and fail-closes on missing/skipped required deps.
 #
 # Third class (#7018): docs_skills — decided by scripts/ci/landing_class.py on
 # merge_group / push / workflow_dispatch (NOT GitHub paths:/paths-ignore).
 # Allowlist-only diffs (shared skills + docs/**/*.md + repo-root *.md) take
-# no-op success on pytest-plan / python shards / coverage-floor / Gate
+# no-op success on the planner contract / python shards / coverage-floor / Gate
 # verify-artifacts so CI Gate still sees success, never skipped (#5762).
 # Any off-allowlist path or classifier error → full suite (fail closed).
 # The full tier still never path-filters pytest collection for product code.
@@ -122,17 +122,59 @@ jobs:
             echo "class=full" >> "${GITHUB_OUTPUT}"
           fi
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.classify.outputs.class != 'docs_skills'
+        with:
+          python-version-file: '.python-version'
+
+      - name: Restore successful-main pytest duration dataset
+        if: steps.classify.outputs.class != 'docs_skills'
+        id: pytest-duration-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-artifacts/pytest-durations.json
+          key: pytest-shard-durations-v1-main-${{ github.sha }}
+          restore-keys: |
+            pytest-shard-durations-v1-main-
+
+      - name: Freeze immutable pytest duration snapshot
+        if: steps.classify.outputs.class != 'docs_skills'
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          CACHE_PRIMARY_KEY: pytest-shard-durations-v1-main-${{ github.sha }}
+          CACHE_MATCHED_KEY: ${{ steps.pytest-duration-cache.outputs.cache-matched-key || '' }}
+          CACHE_HIT: ${{ steps.pytest-duration-cache.outputs.cache-hit || 'false' }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/pytest_shards.py snapshot \
+            --durations ci-artifacts/pytest-durations.json \
+            --output ci-artifacts/pytest-duration-snapshot.json \
+            --source-sha "$EVENT_SHA" \
+            --cache-primary-key "$CACHE_PRIMARY_KEY" \
+            --cache-matched-key "$CACHE_MATCHED_KEY" \
+            --cache-hit "$CACHE_HIT"
+
+      - name: Upload immutable pytest duration snapshot
+        if: steps.classify.outputs.class != 'docs_skills'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-duration-snapshot
+          path: ci-artifacts/pytest-duration-snapshot.json
+          if-no-files-found: error
+          retention-days: 1
+
   # ---------------------------------------------------------------------
-  # 1. pytest-plan — collect once, then produce all four LPT file plans from
-  #    one duration dataset restored from a successful main run (#5744).
+  # 1. pytest-plan — validate the immutable planner input and schema without
+  #    collecting tests. The four shards collect and plan independently after
+  #    landing-class, so this job is not on their critical path (#7141).
   #    Full tier only (merge_group / push / workflow_dispatch).
   #    docs_skills (#7018): no-op success (job still runs; never skipped).
   # ---------------------------------------------------------------------
   pytest-plan:
-    name: Pytest plan
+    name: Pytest plan contract
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     needs: [landing-class]
     permissions:
       contents: read
@@ -141,90 +183,29 @@ jobs:
         if: needs.landing-class.outputs.class == 'docs_skills'
         run: echo "landing-class=docs_skills; pytest-plan no-op success (#7018)"
 
-      # Default checkout is the event SHA: for merge_group that is the
-      # merge-group commit (never the PR head). Do not override with
-      # pull_request.head.sha — that would test a stale tree.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: needs.landing-class.outputs.class != 'docs_skills'
         with:
           python-version-file: '.python-version'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Download immutable pytest duration snapshot
         if: needs.landing-class.outputs.class != 'docs_skills'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          name: pytest-duration-snapshot
+          path: ci-artifacts
 
-      - name: Restore Atlas lexicon manifest cache
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        id: atlas-manifest-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+      - name: Validate planner contract without collection
         if: needs.landing-class.outputs.class != 'docs_skills'
         run: |
-          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
-
-      - name: Install planner dependencies
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        run: |
-          set -euo pipefail
-          python -m venv .venv
-          # The planner collects `not atlas_release and not slow`: retain the
-          # offline ukrainian_word_stress trie, but never install the live
-          # Stanza/torch stack for a selection that excludes its tests.
-          grep -viE '^(torch|torchvision|open_clip_torch|stanza)==' requirements-lock.txt \
-            > "${RUNNER_TEMP}/requirements-ci.txt"
-          # Bounded retry absorbs transient PyPI blips (#7002).
-          for attempt in 1 2 3; do
-            echo "planner pip install attempt ${attempt}/3"
-            if .venv/bin/python -m pip install --upgrade pip \
-              && .venv/bin/python -m pip install --no-deps -r "${RUNNER_TEMP}/requirements-ci.txt" \
-              && .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0; then
-              exit 0
-            fi
-            case "${attempt}" in
-              1) sleep 10 ;;
-              2) sleep 30 ;;
-            esac
-          done
-          echo "::error::Install planner dependencies failed after 3 attempts" >&2
-          exit 1
-
-      - name: Restore successful-main pytest duration dataset
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ci-artifacts/pytest-durations.json
-          key: pytest-shard-durations-v1-main-${{ github.sha }}
-          restore-keys: |
-            pytest-shard-durations-v1-main-
-
-      - name: Plan all duration-balanced pytest shards
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        run: |
-          .venv/bin/python scripts/ci/pytest_shards.py plan \
-            --durations ci-artifacts/pytest-durations.json \
-            --output-dir ci-artifacts/plans
-
-      - name: Upload pytest plans
-        if: needs.landing-class.outputs.class != 'docs_skills'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pytest-plans
-          path: ci-artifacts/plans/
-          if-no-files-found: error
-          retention-days: 1
+          python scripts/ci/pytest_shards.py validate-snapshot \
+            --snapshot ci-artifacts/pytest-duration-snapshot.json \
+            --expected-source-sha "$GITHUB_SHA"
 
   # ---------------------------------------------------------------------
   # 2. pytest-fastlane — direct changed-test signal, independent of the full
@@ -395,11 +376,12 @@ jobs:
           exit "$status"
 
   # ---------------------------------------------------------------------
-  # 3. python — execute the planner's four unconditional test partitions.
+  # 3. python — collect and execute four unconditional test partitions.
   # ---------------------------------------------------------------------
   # The selection still never consults changed files: every collected test runs
-  # exactly once. Four parallel jobs are the topology that completed under the
-  # #5776 hang investigation; one xdist session did not.
+  # exactly once. Each shard makes the same deterministic plan from one frozen
+  # duration snapshot; four parallel jobs are the topology that completed under
+  # the #5776 hang investigation; one xdist session did not.
   # docs_skills (#7018): no-op success (job still runs; never skipped).
   python:
     name: Python (pytest) [${{ matrix.shard }}/4]
@@ -410,7 +392,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
-    needs: [pytest-plan, landing-class]
+    needs: [landing-class]
     permissions:
       contents: read
     steps:
@@ -437,6 +419,13 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      - name: Download immutable pytest duration snapshot
+        if: needs.landing-class.outputs.class != 'docs_skills'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pytest-duration-snapshot
+          path: ci-artifacts
 
       - name: Restore Atlas lexicon manifest cache
         if: needs.landing-class.outputs.class != 'docs_skills'
@@ -505,14 +494,17 @@ jobs:
           path: ~/.cache/pip
           key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-no-live-ml
 
-      - name: Download the single planner's shard plans
+      - name: Collect and plan this pytest shard locally
         if: needs.landing-class.outputs.class != 'docs_skills'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pytest-plans
-          path: ci-artifacts/plans
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/ci/pytest_shards.py plan-shard \
+            --snapshot ci-artifacts/pytest-duration-snapshot.json \
+            --shard-id "$SHARD" \
+            --expected-source-sha "$GITHUB_SHA" \
+            --output-dir ci-artifacts
 
-      # The playground probe is deliberately excluded from the planner's bulk
+      # The playground probe is deliberately excluded from the bulk
       # collection and is run serially on shard 1. It is a named isolation
       # exception, never a changed-file filter; all other collected tests run
       # through the file-grouped LPT plan exactly once.
@@ -535,8 +527,6 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p ci-artifacts
-          cp "ci-artifacts/plans/pytest-shard-${SHARD}/plan.json" ci-artifacts/plan.json
-          cp "ci-artifacts/plans/pytest-shard-${SHARD}/test-nodeids.txt" ci-artifacts/test-nodeids.txt
           if grep -q '^tests/agent_runtime/test_acp_text_agent.py::' ci-artifacts/test-nodeids.txt; then
             # npm registry blips (#7002; Stanza provision idiom).
             for attempt in 1 2 3; do
@@ -559,7 +549,9 @@ jobs:
             cov_args="--cov=scripts --cov-report="
           fi
           # shellcheck disable=SC2086  # cov_args is a deliberate word-split argument list
-          .venv/bin/python scripts/ci/pytest_shards.py run --nodeids ci-artifacts/test-nodeids.txt -- \
+          .venv/bin/python scripts/ci/pytest_shards.py run \
+            --nodeids ci-artifacts/test-nodeids.txt \
+            --execution-receipt ci-artifacts/execution.json -- \
             -n auto --dist=loadfile --strict-markers --timeout=120 --timeout-method=thread \
             -m 'not atlas_release and not slow' \
             --junitxml=ci-artifacts/main-junit.xml --durations=0 $cov_args \
@@ -1465,7 +1457,7 @@ jobs:
       - name: Docs/skills-only — skip shard artifact verify (no-op success)
         if: github.event_name != 'pull_request' && needs.landing-class.outputs.class == 'docs_skills'
         run: echo "landing-class=docs_skills; CI Gate verify-artifacts no-op success (#7018)"
-      - name: Download pytest plans and JUnit results
+      - name: Download pytest shard plans and JUnit results
         if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1473,7 +1465,12 @@ jobs:
           path: ci-artifacts
       - name: Verify pytest shard completeness
         if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
-        run: python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir ci-artifacts
+        run: |
+          python scripts/ci/pytest_shards.py verify-artifacts \
+            --artifact-dir ci-artifacts \
+            --expected-source-sha "$GITHUB_SHA" \
+            --require-plan-metadata \
+            --require-execution-receipt
       - name: Fail unless every event-required job succeeded
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,8 @@ jobs:
 
       - name: Collect and plan this pytest shard locally
         if: needs.landing-class.outputs.class != 'docs_skills'
+        env:
+          SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
           .venv/bin/python scripts/ci/pytest_shards.py plan-shard \

--- a/docs/runbooks/ci-gate.md
+++ b/docs/runbooks/ci-gate.md
@@ -13,15 +13,21 @@ an operational guard, not a change to `ci.yml`'s job graph or `CI Gate` needs.
 - **pull_request (light tier):** `ruff`, `pytest-fastlane`, `contracts`,
   `frontend`. Planner / four shards / coverage floor are intentionally skipped.
 - **merge_group / push / workflow_dispatch (full tier):** the light set plus
-  `pytest-plan`, all four `python` shards, and `coverage-floor`. Skipped ≠
-  success on this tier.
+  the `pytest-plan` contract, all four `python` shards, and `coverage-floor`.
+  Skipped ≠ success on this tier. `landing-class` freezes one immutable
+  duration snapshot; each Python shard collects the required selection and
+  computes its own file-grouped LPT plan in parallel. CI Gate verifies the
+  source/selection/snapshot metadata, exact node-ID receipts, JUnit counts,
+  and complete four-shard partition.
 
 Aggregation is `scripts/ci/gate_required_results.py` (fail-closed on missing,
 failed, cancelled, or unexpectedly skipped required jobs). The fastlane's
 changed-file selection is only an early signal: it never selects, skips, or
-replaces the full-suite shard plan on the full tier. The workflow remains the
-authoritative job composition; this runbook deliberately does not duplicate
-its YAML.
+replaces the full-suite shard plan on the full tier. The planner contract does
+not collect tests and is not a shard dependency; its result validates the
+immutable snapshot and planner schema while Gate remains authoritative for
+actual planning and execution. The workflow remains the authoritative job
+composition; this runbook deliberately does not duplicate its YAML.
 
 The contracts job's BIO preparation validation is load-bearing. In particular,
 an active BIO hold must continue to fail closed (`PREPARATION_HOLD_ACTIVE`),

--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Plan and verify duration-balanced pytest shards for the CI Gate.
 
-The planner collects the selected suite exactly once, groups every selected
+Each full-tier shard collects the selected suite locally, groups every selected
 node ID by test file, then uses deterministic longest-processing-time (LPT)
-assignment.  Workers execute only the planner-produced node-ID list; CI Gate
-reconstructs and verifies the complete partition from their JUnit artifacts.
+assignment.  The collection and assignment run in parallel across the matrix;
+CI Gate reconstructs and verifies the complete partition from the shard
+artifacts.  ``write_plans`` remains available for offline tooling that wants
+all four plans in one directory.
 
 Required selection (stage-1 slow-split): the identical mark expression
-``not atlas_release and not slow`` is applied on the planner, every shard
-worker invocation path that re-collects, fastlane, and coverage inputs.
+``not atlas_release and not slow`` is applied on every shard collection and
+worker invocation path, fastlane, and coverage inputs.
 ``pyproject.toml`` ``addopts`` keeps ``-m 'not atlas_release'`` only — never
 put ``not slow`` in global addopts (nightly would inherit it).
 """
@@ -18,6 +20,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import re
 import statistics
 import sys
@@ -39,9 +42,23 @@ COMMON_ARGS = (
     REQUIRED_MARKEXPR,
     "--strict-markers",
 )
+PLANNER_SCHEMA_VERSION = 2
+DURATION_SNAPSHOT_SCHEMA_VERSION = 1
 _DURATION_LINE = re.compile(r"^\s*(?P<seconds>\d+(?:\.\d+)?)s\s+(?:call|setup|teardown)\s+(?P<nodeid>\S+)")
 _DATASET_VERSION = 1
 _P95_HISTORY_LIMIT = 40
+
+
+def _canonical_digest(value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _duration_digest(durations: dict[str, float]) -> str:
+    return _canonical_digest(durations)
+
+
+SELECTION_DIGEST = _canonical_digest(COMMON_ARGS)
 
 
 def _digest(nodeids: Iterable[str]) -> str:
@@ -55,6 +72,26 @@ def _read_json(path: Path) -> Any:
 def _write_json(path: Path, value: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _normalise_durations(source: Any, *, label: str, strict: bool = False) -> dict[str, float]:
+    if not isinstance(source, dict):
+        raise ValueError(f"duration file {label} has invalid node_durations")
+    durations: dict[str, float] = {}
+    for nodeid, duration in source.items():
+        valid = (
+            isinstance(nodeid, str)
+            and isinstance(duration, (int, float))
+            and not isinstance(duration, bool)
+            and math.isfinite(float(duration))
+            and float(duration) > 0
+        )
+        if not valid:
+            if strict:
+                raise ValueError(f"duration file {label} contains an invalid timing")
+            continue
+        durations[nodeid] = float(duration)
+    return durations
 
 
 class _NodeidCollector:
@@ -88,13 +125,77 @@ def load_durations(path: Path | None) -> dict[str, float]:
     if not isinstance(raw, dict):
         raise ValueError(f"duration file {path} must be a JSON object")
     source = raw.get("node_durations", raw)
-    if not isinstance(source, dict):
-        raise ValueError(f"duration file {path} has invalid node_durations")
-    return {
-        nodeid: float(duration)
-        for nodeid, duration in source.items()
-        if isinstance(nodeid, str) and isinstance(duration, (int, float)) and duration > 0
+    return _normalise_durations(source, label=str(path))
+
+
+def write_duration_snapshot(
+    *,
+    durations_path: Path | None,
+    output: Path,
+    source_sha: str,
+    cache_primary_key: str,
+    cache_matched_key: str | None,
+    cache_hit: str,
+) -> None:
+    """Freeze one duration input for every shard in this CI event."""
+    durations = load_durations(durations_path)
+    mode = "cache" if durations else "median-fallback"
+    primary_key = cache_primary_key.strip() or "unspecified"
+    matched_key = (cache_matched_key or "").strip()
+    snapshot = {
+        "cache_hit": cache_hit.strip().lower() == "true",
+        "duration_cache_key": matched_key or (primary_key if mode == "cache" else "none"),
+        "duration_cache_matched_key": matched_key or None,
+        "duration_cache_primary_key": primary_key,
+        "duration_mode": mode,
+        "duration_snapshot_digest": _duration_digest(durations),
+        "node_durations": durations,
+        "planner_schema_version": PLANNER_SCHEMA_VERSION,
+        "schema_version": DURATION_SNAPSHOT_SCHEMA_VERSION,
+        "selection_digest": SELECTION_DIGEST,
+        "source_sha": source_sha.strip(),
     }
+    if not snapshot["source_sha"]:
+        raise ValueError("duration snapshot source_sha must not be empty")
+    _write_json(output, snapshot)
+
+
+def load_duration_snapshot(path: Path, *, expected_source_sha: str | None = None) -> dict[str, Any]:
+    """Load and validate the immutable duration snapshot shared by all shards."""
+    raw = _read_json(path)
+    if not isinstance(raw, dict) or raw.get("schema_version") != DURATION_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError(f"duration snapshot {path} has an unsupported schema")
+    if raw.get("planner_schema_version") != PLANNER_SCHEMA_VERSION:
+        raise ValueError(f"duration snapshot {path} has an unsupported planner schema")
+    if raw.get("selection_digest") != SELECTION_DIGEST:
+        raise ValueError(f"duration snapshot {path} has a selection digest mismatch")
+    source_sha = raw.get("source_sha")
+    if not isinstance(source_sha, str) or not source_sha.strip():
+        raise ValueError(f"duration snapshot {path} has no source SHA")
+    if expected_source_sha is not None and source_sha != expected_source_sha.strip():
+        raise ValueError(f"duration snapshot source SHA {source_sha!r} does not match {expected_source_sha!r}")
+    durations = _normalise_durations(raw.get("node_durations"), label=str(path), strict=True)
+    if raw.get("duration_snapshot_digest") != _duration_digest(durations):
+        raise ValueError(f"duration snapshot {path} has a duration digest mismatch")
+    mode = raw.get("duration_mode")
+    if mode not in {"cache", "median-fallback"}:
+        raise ValueError(f"duration snapshot {path} has an invalid duration mode")
+    cache_key = raw.get("duration_cache_key")
+    if not isinstance(cache_key, str) or not cache_key:
+        raise ValueError(f"duration snapshot {path} has no duration cache identity")
+    return {**raw, "node_durations": durations}
+
+
+def validate_duration_snapshot(path: Path, *, expected_source_sha: str | None = None) -> None:
+    """Validate the fast planner-contract input without collecting tests."""
+    snapshot = load_duration_snapshot(path, expected_source_sha=expected_source_sha)
+    print(
+        "validated pytest duration snapshot: "
+        f"source_sha={snapshot['source_sha']} "
+        f"mode={snapshot['duration_mode']} "
+        f"timings={len(snapshot['node_durations'])} "
+        f"digest={snapshot['duration_snapshot_digest']}"
+    )
 
 
 def _file_nodeids(nodeids: Sequence[str]) -> dict[str, list[str]]:
@@ -134,6 +235,51 @@ def assign_shards(nodeids: Sequence[str], shard_count: int, durations: dict[str,
     return shard_groups
 
 
+def _plan_payload(
+    *,
+    nodeids: Sequence[str],
+    assigned: Sequence[str],
+    weights: dict[str, float],
+    shard_id: int,
+    shard_count: int,
+    snapshot: dict[str, Any] | None,
+) -> dict[str, Any]:
+    metadata = snapshot or {
+        "duration_cache_key": "offline",
+        "duration_mode": "local",
+        "duration_snapshot_digest": _duration_digest({}),
+        "planner_schema_version": PLANNER_SCHEMA_VERSION,
+        "selection_digest": SELECTION_DIGEST,
+        "source_sha": "offline",
+    }
+    assigned_files = sorted({nodeid.split("::", 1)[0] for nodeid in assigned})
+    return {
+        "assigned_digest": _digest(assigned),
+        "assigned_nodeids": list(assigned),
+        "collected_count": len(nodeids),
+        "collected_digest": _digest(nodeids),
+        "duration_cache_key": metadata["duration_cache_key"],
+        "duration_mode": metadata["duration_mode"],
+        "duration_snapshot_digest": metadata["duration_snapshot_digest"],
+        "estimated_seconds": sum(weights[filename] for filename in assigned_files),
+        "grouping": "file",
+        "markexpr": REQUIRED_MARKEXPR,
+        "planner_schema_version": metadata["planner_schema_version"],
+        "selection_digest": metadata["selection_digest"],
+        "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
+        "shard_count": shard_count,
+        "shard_id": shard_id,
+        "source_sha": metadata["source_sha"],
+        "partition_mode": "lpt-durations",
+    }
+
+
+def _write_plan_outputs(output_dir: Path, plan: dict[str, Any]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "test-nodeids.txt").write_text("\n".join(plan["assigned_nodeids"]) + "\n", encoding="utf-8")
+    _write_json(output_dir / "plan.json", plan)
+
+
 def assert_set_integrity(nodeids: Sequence[str], shards: Sequence[Sequence[str]]) -> None:
     """Fail closed unless shard union equals the fast collection exactly.
 
@@ -169,25 +315,47 @@ def write_plans(*, durations_path: Path | None, output_dir: Path, shard_count: i
     weights = _file_weights(nodeids, durations)
     for shard_id, assigned in enumerate(shards, start=1):
         shard_dir = output_dir / f"pytest-shard-{shard_id}"
-        shard_dir.mkdir(parents=True, exist_ok=True)
-        (shard_dir / "test-nodeids.txt").write_text("\n".join(assigned) + "\n", encoding="utf-8")
-        assigned_files = sorted({nodeid.split("::", 1)[0] for nodeid in assigned})
-        _write_json(
-            shard_dir / "plan.json",
-            {
-                "assigned_digest": _digest(assigned),
-                "assigned_nodeids": assigned,
-                "collected_count": len(nodeids),
-                "collected_digest": _digest(nodeids),
-                "estimated_seconds": sum(weights[filename] for filename in assigned_files),
-                "grouping": "file",
-                "markexpr": REQUIRED_MARKEXPR,
-                "partition_mode": "lpt-durations",
-                "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
-                "shard_count": shard_count,
-                "shard_id": shard_id,
-            },
+        _write_plan_outputs(
+            shard_dir,
+            _plan_payload(
+                nodeids=nodeids,
+                assigned=assigned,
+                weights=weights,
+                shard_id=shard_id,
+                shard_count=shard_count,
+                snapshot=None,
+            ),
         )
+
+
+def write_shard_plan(
+    *,
+    snapshot_path: Path,
+    output_dir: Path,
+    shard_id: int,
+    shard_count: int = SHARD_COUNT,
+    expected_source_sha: str | None = None,
+) -> None:
+    """Collect and materialize one shard's deterministic plan."""
+    if shard_id < 1 or shard_id > shard_count:
+        raise ValueError(f"shard_id must be between 1 and {shard_count}")
+    snapshot = load_duration_snapshot(snapshot_path, expected_source_sha=expected_source_sha)
+    nodeids = collect_nodeids()
+    durations = snapshot["node_durations"]
+    shards = assign_shards(nodeids, shard_count, durations)
+    assert_set_integrity(nodeids, shards)
+    weights = _file_weights(nodeids, durations)
+    _write_plan_outputs(
+        output_dir,
+        _plan_payload(
+            nodeids=nodeids,
+            assigned=shards[shard_id - 1],
+            weights=weights,
+            shard_id=shard_id,
+            shard_count=shard_count,
+            snapshot=snapshot,
+        ),
+    )
 
 
 def _junit_count(path: Path) -> int:
@@ -197,21 +365,32 @@ def _junit_count(path: Path) -> int:
     return sum(int(suite.attrib.get("tests", "0")) for suite in root.iter("testsuite"))
 
 
-def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
+def verify_artifacts(
+    artifact_dir: Path,
+    shard_count: int,
+    *,
+    expected_source_sha: str | None = None,
+    require_plan_metadata: bool = False,
+    require_execution_receipt: bool = False,
+) -> None:
     """Fail closed unless plan, execution count, and partition all agree."""
     plans: list[dict[str, Any]] = []
     for shard_id in range(1, shard_count + 1):
         shard_dir = artifact_dir / f"pytest-shard-{shard_id}"
         plan_path = shard_dir / "plan.json"
+        nodeids_path = shard_dir / "test-nodeids.txt"
         main_junit = shard_dir / "main-junit.xml"
-        if not plan_path.exists() or not main_junit.exists():
-            raise RuntimeError(f"missing plan or main JUnit artifact for shard {shard_id}")
+        if not plan_path.exists() or not nodeids_path.exists() or not main_junit.exists():
+            raise RuntimeError(f"missing plan, node-ID, or main JUnit artifact for shard {shard_id}")
         plan = _read_json(plan_path)
         if plan.get("shard_id") != shard_id or plan.get("shard_count") != shard_count:
             raise RuntimeError(f"invalid shard identity in {plan_path}")
         assigned = plan.get("assigned_nodeids")
         if not isinstance(assigned, list) or not all(isinstance(nodeid, str) for nodeid in assigned):
             raise RuntimeError(f"invalid assigned node IDs in {plan_path}")
+        listed = [line.strip() for line in nodeids_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        if listed != assigned:
+            raise RuntimeError(f"test-nodeids.txt does not match plan.json in shard {shard_id}")
         if not assigned:
             raise RuntimeError(f"empty shard {shard_id} collapses the required gate")
         if _digest(assigned) != plan.get("assigned_digest"):
@@ -224,6 +403,37 @@ def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
             )
         if _junit_count(main_junit) != len(assigned):
             raise RuntimeError(f"main JUnit count does not match plan for shard {shard_id}")
+        if expected_source_sha is not None and plan.get("source_sha") != expected_source_sha.strip():
+            raise RuntimeError(f"source SHA does not match the event SHA for shard {shard_id}")
+        if require_plan_metadata:
+            for field in (
+                "duration_cache_key",
+                "duration_mode",
+                "duration_snapshot_digest",
+                "planner_schema_version",
+                "selection_digest",
+                "source_sha",
+            ):
+                if field not in plan:
+                    raise RuntimeError(f"plan {plan_path} is missing required field {field}")
+            if plan["planner_schema_version"] != PLANNER_SCHEMA_VERSION:
+                raise RuntimeError(f"unsupported planner schema in {plan_path}")
+            if plan["selection_digest"] != SELECTION_DIGEST:
+                raise RuntimeError(f"selection digest mismatch in {plan_path}")
+        if require_execution_receipt:
+            receipt_path = shard_dir / "execution.json"
+            if not receipt_path.exists():
+                raise RuntimeError(f"missing execution receipt for shard {shard_id}")
+            receipt = _read_json(receipt_path)
+            if receipt.get("planned_nodeids") != assigned:
+                raise RuntimeError(f"execution receipt plan mismatch for shard {shard_id}")
+            reported = receipt.get("reported_nodeids")
+            if not isinstance(reported, list) or set(reported) != set(assigned) or len(reported) != len(assigned):
+                raise RuntimeError(f"execution receipt does not cover the assigned set for shard {shard_id}")
+            if receipt.get("reported_count") != len(assigned) or receipt.get("reported_digest") != _digest(reported):
+                raise RuntimeError(f"execution receipt count or digest mismatch for shard {shard_id}")
+            if receipt.get("pytest_exit_code") != 0:
+                raise RuntimeError(f"pytest execution receipt is not green for shard {shard_id}")
         serial = plan.get("serial_nodeids")
         if shard_id == 1:
             playground_junit = shard_dir / "playground-junit.xml"
@@ -246,6 +456,10 @@ def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
         raise RuntimeError("a serial test was also assigned to a parallel shard")
     if len(assigned) != counts.pop() or _digest(assigned) != digests.pop():
         raise RuntimeError("shards do not form a complete partition of the collected selection")
+    if require_plan_metadata:
+        for field in ("source_sha", "duration_snapshot_digest", "duration_cache_key", "duration_mode"):
+            if len({plan[field] for plan in plans}) != 1:
+                raise RuntimeError(f"shards disagree about {field}")
 
 
 def parse_durations(log_paths: Sequence[Path]) -> dict[str, float]:
@@ -296,8 +510,39 @@ def publish_durations(*, log_paths: Sequence[Path], previous: Path | None, outpu
     )
 
 
-def run_nodeids(nodeids_path: Path, pytest_args: Sequence[str]) -> int:
-    """Invoke pytest with a planner-produced node-ID list (not shell @file)."""
+class _ExecutionRecorder:
+    def __init__(self) -> None:
+        self.reported_nodeids: set[str] = set()
+
+    def pytest_runtest_logreport(self, report: Any) -> None:
+        self.reported_nodeids.add(report.nodeid)
+
+
+def _write_execution_receipt(
+    path: Path,
+    *,
+    planned_nodeids: Sequence[str],
+    reported_nodeids: Iterable[str],
+    pytest_exit_code: int,
+) -> None:
+    reported = sorted(set(reported_nodeids))
+    _write_json(
+        path,
+        {
+            "planned_count": len(planned_nodeids),
+            "planned_digest": _digest(planned_nodeids),
+            "planned_nodeids": list(planned_nodeids),
+            "pytest_exit_code": pytest_exit_code,
+            "reported_count": len(reported),
+            "reported_digest": _digest(reported),
+            "reported_nodeids": reported,
+            "schema_version": 1,
+        },
+    )
+
+
+def run_nodeids(nodeids_path: Path, pytest_args: Sequence[str], receipt_path: Path | None = None) -> int:
+    """Invoke pytest with a shard-produced node-ID list (not shell @file)."""
     import pytest
 
     if __package__ in (None, ""):
@@ -318,27 +563,72 @@ def run_nodeids(nodeids_path: Path, pytest_args: Sequence[str]) -> int:
     # inside xdist workers, so a hang in the controller or a full worker pipe
     # is otherwise silent until the job's timeout-minutes cancels it.
     with StallWatcher.from_env():
-        return int(pytest.main([*args, *nodeids]))
+        if receipt_path is None:
+            return int(pytest.main([*args, *nodeids]))
+        recorder = _ExecutionRecorder()
+        exit_code = int(pytest.main([*args, *nodeids], plugins=[recorder]))
+        _write_execution_receipt(
+            receipt_path,
+            planned_nodeids=nodeids,
+            reported_nodeids=recorder.reported_nodeids,
+            pytest_exit_code=exit_code,
+        )
+        return exit_code
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    commands = parser.add_subparsers(dest="command", required=True)
-    plan = commands.add_parser("plan")
-    plan.add_argument("--durations", type=Path)
-    plan.add_argument("--output-dir", type=Path, required=True)
-    plan.add_argument("--shard-count", type=int, default=SHARD_COUNT)
-    verify = commands.add_parser("verify-artifacts")
-    verify.add_argument("--artifact-dir", type=Path, required=True)
-    verify.add_argument("--shard-count", type=int, default=SHARD_COUNT)
-    publish = commands.add_parser("publish-durations")
-    publish.add_argument("--log", type=Path, action="append", required=True)
-    publish.add_argument("--previous", type=Path)
-    publish.add_argument("--output", type=Path, required=True)
-    publish.add_argument("--summary", type=Path, required=True)
-    run = commands.add_parser("run")
-    run.add_argument("--nodeids", type=Path, required=True)
-    run.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    formatter = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan, execute, and verify the CI Gate's deterministic pytest shard partition.\n"
+            "Use it for full-tier CI evidence and local planner/partition tests; it does not replace pytest itself."
+        ),
+        formatter_class=formatter,
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/ci/pytest_shards.py plan-shard --snapshot ci-artifacts/pytest-duration-snapshot.json --shard-id 1 --output-dir ci-artifacts\n"
+            "  .venv/bin/python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir ci-artifacts --expected-source-sha $GITHUB_SHA --require-plan-metadata --require-execution-receipt\n"
+            "Outputs: shard plans, node-ID lists, execution receipts, and validation errors; no databases or remote state.\n"
+            "Exit codes: 0 means the requested operation passed; 1 means an input, partition, or test failed; 2 means CLI usage failed.\n"
+            "Related: .github/workflows/ci.yml, tests/test_ci_shard_partition.py, and docs/runbooks/ci-gate.md."
+        ),
+    )
+    commands = parser.add_subparsers(dest="command", required=True, title="commands")
+    plan = commands.add_parser("plan", help="Materialize all shard plans in one directory for offline use.", description="Collect once and write all four offline LPT plans.", formatter_class=formatter)
+    plan.add_argument("--durations", type=Path, help="Optional JSON duration dataset; missing input uses median fallback.")
+    plan.add_argument("--output-dir", type=Path, required=True, help="Directory receiving pytest-shard-N/plan.json and test-nodeids.txt.")
+    plan.add_argument("--shard-count", type=int, default=SHARD_COUNT, help=f"Number of shards (default: {SHARD_COUNT}).")
+    snapshot = commands.add_parser("snapshot", help="Freeze one shared duration input for a CI event.", description="Normalize a cache restore into an immutable shard input snapshot.", formatter_class=formatter)
+    snapshot.add_argument("--durations", type=Path, help="Optional restored duration JSON; missing input selects median fallback.")
+    snapshot.add_argument("--output", type=Path, required=True, help="Output JSON snapshot path.")
+    snapshot.add_argument("--source-sha", required=True, help="Exact event tree SHA, normally GITHUB_SHA.")
+    snapshot.add_argument("--cache-primary-key", required=True, help="Requested cache key used for this event.")
+    snapshot.add_argument("--cache-matched-key", help="Matched restore key, when the cache action exposes one.")
+    snapshot.add_argument("--cache-hit", default="false", help="Exact cache-hit output (default: false).")
+    plan_shard = commands.add_parser("plan-shard", help="Collect and write one shard's plan locally.", description="Collect the required suite once and write one deterministic shard-local LPT plan.", formatter_class=formatter)
+    plan_shard.add_argument("--snapshot", type=Path, required=True, help="Immutable duration snapshot JSON shared by all shards.")
+    plan_shard.add_argument("--shard-id", type=int, required=True, help="1-based shard number, e.g. 1.")
+    plan_shard.add_argument("--output-dir", type=Path, required=True, help="Directory receiving plan.json and test-nodeids.txt.")
+    plan_shard.add_argument("--shard-count", type=int, default=SHARD_COUNT, help=f"Total shard count (default: {SHARD_COUNT}).")
+    plan_shard.add_argument("--expected-source-sha", help="Require the snapshot source SHA to equal this event SHA.")
+    validate = commands.add_parser("validate-snapshot", help="Validate the fast planner-contract snapshot without collection.", description="Check snapshot schema, planner version, selection digest, and source identity without collecting tests.", formatter_class=formatter)
+    validate.add_argument("--snapshot", type=Path, required=True, help="Immutable duration snapshot JSON to validate.")
+    validate.add_argument("--expected-source-sha", help="Require the snapshot source SHA to equal this event SHA.")
+    verify = commands.add_parser("verify-artifacts", help="Fail closed unless all shard evidence forms one complete partition.", description="Verify plans, node-ID lists, JUnit counts, and optional execution/provenance evidence.", formatter_class=formatter)
+    verify.add_argument("--artifact-dir", type=Path, required=True, help="Directory containing pytest-shard-1 through pytest-shard-N artifacts.")
+    verify.add_argument("--shard-count", type=int, default=SHARD_COUNT, help=f"Expected number of shards (default: {SHARD_COUNT}).")
+    verify.add_argument("--expected-source-sha", help="Require every plan source SHA to equal this event SHA.")
+    verify.add_argument("--require-plan-metadata", action="store_true", help="Require and cross-check immutable snapshot/planner metadata.")
+    verify.add_argument("--require-execution-receipt", action="store_true", help="Require each shard's reported execution node-ID receipt.")
+    publish = commands.add_parser("publish-durations", help="Publish successful-main test timings for later shard balancing.", description="Parse shard logs and write the rolling duration dataset.", formatter_class=formatter)
+    publish.add_argument("--log", type=Path, action="append", required=True, help="Pytest log path; repeat once per shard.")
+    publish.add_argument("--previous", type=Path, help="Prior duration dataset, if available.")
+    publish.add_argument("--output", type=Path, required=True, help="Output duration dataset JSON path.")
+    publish.add_argument("--summary", type=Path, required=True, help="Markdown summary output path.")
+    run = commands.add_parser("run", help="Run exactly the node IDs in a shard plan.", description="Execute a node-ID file with pytest and optionally record reported execution IDs.", formatter_class=formatter)
+    run.add_argument("--nodeids", type=Path, required=True, help="Newline-delimited planned node-ID file.")
+    run.add_argument("--execution-receipt", type=Path, help="Optional JSON receipt path recording planned and reported node IDs.")
+    run.add_argument("pytest_args", nargs=argparse.REMAINDER, help="Arguments passed to pytest after `--`, e.g. -- -q --junitxml=main-junit.xml.")
     return parser
 
 
@@ -347,12 +637,37 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if args.command == "plan":
             write_plans(durations_path=args.durations, output_dir=args.output_dir, shard_count=args.shard_count)
+        elif args.command == "snapshot":
+            write_duration_snapshot(
+                durations_path=args.durations,
+                output=args.output,
+                source_sha=args.source_sha,
+                cache_primary_key=args.cache_primary_key,
+                cache_matched_key=args.cache_matched_key,
+                cache_hit=args.cache_hit,
+            )
+        elif args.command == "plan-shard":
+            write_shard_plan(
+                snapshot_path=args.snapshot,
+                output_dir=args.output_dir,
+                shard_id=args.shard_id,
+                shard_count=args.shard_count,
+                expected_source_sha=args.expected_source_sha,
+            )
+        elif args.command == "validate-snapshot":
+            validate_duration_snapshot(args.snapshot, expected_source_sha=args.expected_source_sha)
         elif args.command == "verify-artifacts":
-            verify_artifacts(args.artifact_dir, args.shard_count)
+            verify_artifacts(
+                args.artifact_dir,
+                args.shard_count,
+                expected_source_sha=args.expected_source_sha,
+                require_plan_metadata=args.require_plan_metadata,
+                require_execution_receipt=args.require_execution_receipt,
+            )
         elif args.command == "publish-durations":
             publish_durations(log_paths=args.log, previous=args.previous, output=args.output, summary=args.summary)
         elif args.command == "run":
-            return run_nodeids(args.nodeids, args.pytest_args)
+            return run_nodeids(args.nodeids, args.pytest_args, receipt_path=args.execution_receipt)
     except (OSError, RuntimeError, ValueError, element_tree.ParseError) as error:
         print(f"pytest shard error: {error}", file=sys.stderr)
         return 1

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -58,7 +58,9 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     }
     assert jobs["pytest-plan"].get("if") == "github.event_name != 'pull_request'"
     assert jobs["python"].get("if") == "github.event_name != 'pull_request'"
+    assert jobs["python"]["needs"] == ["landing-class"]
     assert jobs["coverage-floor"].get("if") == "github.event_name != 'pull_request'"
+    assert "pytest-plans" not in _CI.read_text(encoding="utf-8")
     assert "ruff" in jobs
     gate_steps = "\n".join(
         step.get("name", "") + "\n" + str(step.get("run", "")) for step in jobs["ci-gate"]["steps"]

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -355,6 +355,19 @@ def test_ci_workflow_uses_shard_local_planner_and_ci_gate_verifier() -> None:
     assert nightly.splitlines()[0] == "name: Pytest slow nightly"
 
 
+def test_ci_shard_planner_declares_matrix_shard_env() -> None:
+    workflow = yaml.safe_load(
+        (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    )
+    planner_step = next(
+        step
+        for step in workflow["jobs"]["python"]["steps"]
+        if step.get("name") == "Collect and plan this pytest shard locally"
+    )
+
+    assert planner_step["env"]["SHARD"] == "${{ matrix.shard }}"
+
+
 def test_required_lanes_exclude_live_model_setup_and_fastlane_is_slim() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     workflow = yaml.safe_load((repo_root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -25,14 +25,21 @@ def _write_complete_artifacts(root: Path, selected: list[str]) -> None:
             "assigned_nodeids": [nodeid],
             "collected_count": len(selected),
             "collected_digest": digest,
+            "duration_cache_key": "cache-key",
+            "duration_mode": "cache",
+            "duration_snapshot_digest": "duration-digest",
             "grouping": "file",
             "markexpr": pytest_shards.REQUIRED_MARKEXPR,
             "partition_mode": "lpt-durations",
+            "planner_schema_version": pytest_shards.PLANNER_SCHEMA_VERSION,
+            "selection_digest": pytest_shards.SELECTION_DIGEST,
             "serial_nodeids": list(pytest_shards.SERIAL_TESTS) if shard_id == 1 else [],
             "shard_count": len(selected),
             "shard_id": shard_id,
+            "source_sha": "source-sha",
         }
         (shard / "plan.json").write_text(json.dumps(plan), encoding="utf-8")
+        (shard / "test-nodeids.txt").write_text(f"{nodeid}\n", encoding="utf-8")
         _write_junit(shard / "main-junit.xml", 1)
         if shard_id == 1:
             _write_junit(shard / "playground-junit.xml", len(pytest_shards.SERIAL_TESTS))
@@ -63,6 +70,26 @@ def test_assign_shards_is_complete_disjoint_balanced_and_file_grouped() -> None:
     assert any({"tests/test_heavy.py::test_a", "tests/test_heavy.py::test_b"}.issubset(shard) for shard in shards)
     totals = [sum(durations[nodeid] for nodeid in shard) for shard in shards]
     assert max(totals) - min(totals) == 4.0
+
+
+def test_assign_shards_is_invariant_to_collection_and_duration_map_order() -> None:
+    nodeids = [
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+        "tests/test_b.py::test_one",
+        "tests/test_c.py::test_one",
+    ]
+    durations = {
+        "tests/test_a.py::test_one": 8.0,
+        "tests/test_a.py::test_two": 2.0,
+        "tests/test_b.py::test_one": 6.0,
+        "tests/test_c.py::test_one": 4.0,
+    }
+
+    forward = pytest_shards.assign_shards(nodeids, 2, durations)
+    reversed_order = pytest_shards.assign_shards(list(reversed(nodeids)), 2, dict(reversed(list(durations.items()))))
+
+    assert [set(shard) for shard in forward] == [set(shard) for shard in reversed_order]
 
 
 def test_unknown_file_uses_median_known_file_weight() -> None:
@@ -106,11 +133,101 @@ def test_write_plans_collects_once_and_marks_duration_lpt(tmp_path: Path, monkey
     assert sorted(nodeid for plan in plans for nodeid in plan["assigned_nodeids"]) == selected
 
 
+def test_write_shard_plans_collect_independently_from_one_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(8)]
+    durations_path = tmp_path / "durations.json"
+    durations_path.write_text(
+        json.dumps({"node_durations": {nodeid: float(index + 1) for index, nodeid in enumerate(selected)}}),
+        encoding="utf-8",
+    )
+    snapshot_path = tmp_path / "snapshot.json"
+    pytest_shards.write_duration_snapshot(
+        durations_path=durations_path,
+        output=snapshot_path,
+        source_sha="event-sha",
+        cache_primary_key="cache-key",
+        cache_matched_key="cache-key",
+        cache_hit="true",
+    )
+    collected = 0
+
+    def fake_collect() -> list[str]:
+        nonlocal collected
+        collected += 1
+        return selected
+
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", fake_collect)
+    for shard_id in range(1, pytest_shards.SHARD_COUNT + 1):
+        pytest_shards.write_shard_plan(
+            snapshot_path=snapshot_path,
+            output_dir=tmp_path / f"shard-{shard_id}",
+            shard_id=shard_id,
+            expected_source_sha="event-sha",
+        )
+
+    assert collected == pytest_shards.SHARD_COUNT
+    plans = [
+        json.loads((tmp_path / f"shard-{shard_id}" / "plan.json").read_text(encoding="utf-8"))
+        for shard_id in range(1, pytest_shards.SHARD_COUNT + 1)
+    ]
+    expected = pytest_shards.assign_shards(
+        selected,
+        pytest_shards.SHARD_COUNT,
+        {nodeid: float(index + 1) for index, nodeid in enumerate(selected)},
+    )
+    assert [plan["assigned_nodeids"] for plan in plans] == expected
+    assert len({plan["collected_digest"] for plan in plans}) == 1
+    assert len({plan["duration_snapshot_digest"] for plan in plans}) == 1
+    assert sorted(nodeid for plan in plans for nodeid in plan["assigned_nodeids"]) == selected
+
+
 def test_verify_artifacts_accepts_complete_partition(tmp_path: Path) -> None:
     selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
     _write_complete_artifacts(tmp_path, selected)
 
     pytest_shards.verify_artifacts(tmp_path, 4)
+
+
+def test_verify_artifacts_requires_immutable_metadata_for_ci(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+    plan_path = tmp_path / "pytest-shard-2" / "plan.json"
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    plan["duration_snapshot_digest"] = "drifted"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="duration_snapshot_digest"):
+        pytest_shards.verify_artifacts(tmp_path, 4, require_plan_metadata=True)
+
+
+def test_verify_artifacts_requires_execution_receipts_for_ci(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+
+    with pytest.raises(RuntimeError, match="execution receipt"):
+        pytest_shards.verify_artifacts(tmp_path, 4, require_execution_receipt=True)
+
+
+def test_verify_artifacts_accepts_ci_metadata_and_execution_receipts(tmp_path: Path) -> None:
+    selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
+    _write_complete_artifacts(tmp_path, selected)
+    for shard_id, nodeid in enumerate(selected, start=1):
+        pytest_shards._write_execution_receipt(
+            tmp_path / f"pytest-shard-{shard_id}" / "execution.json",
+            planned_nodeids=[nodeid],
+            reported_nodeids=[nodeid],
+            pytest_exit_code=0,
+        )
+
+    pytest_shards.verify_artifacts(
+        tmp_path,
+        4,
+        expected_source_sha="source-sha",
+        require_plan_metadata=True,
+        require_execution_receipt=True,
+    )
 
 
 def test_verify_artifacts_rejects_mispartitioned_plan(tmp_path: Path) -> None:
@@ -123,7 +240,7 @@ def test_verify_artifacts_rejects_mispartitioned_plan(tmp_path: Path) -> None:
     plan_path.write_text(json.dumps(plan), encoding="utf-8")
     _write_junit(tmp_path / "pytest-shard-4" / "main-junit.xml", 0)
 
-    with pytest.raises(RuntimeError, match=r"empty shard|complete partition"):
+    with pytest.raises(RuntimeError, match=r"empty shard|complete partition|test-nodeids.txt"):
         pytest_shards.verify_artifacts(tmp_path, 4)
 
 
@@ -186,7 +303,31 @@ def test_run_nodeids_passes_exact_planner_output_to_pytest(tmp_path: Path, monke
     assert captured == [["-q", "--dist=loadfile", "tests/test_a.py::test_a", "tests/test_b.py::test_b"]]
 
 
-def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
+def test_run_nodeids_records_reported_execution_ids(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    nodeids = tmp_path / "nodeids.txt"
+    planned = ["tests/test_a.py::test_a", "tests/test_b.py::test_b"]
+    nodeids.write_text("\n".join(planned) + "\n", encoding="utf-8")
+    receipt = tmp_path / "execution.json"
+
+    import pytest as real_pytest
+
+    def fake_main(args: list[str], *, plugins: list[object]) -> int:
+        assert args[-2:] == planned
+        for nodeid in planned:
+            plugins[0].pytest_runtest_logreport(type("Report", (), {"nodeid": nodeid})())
+        return 0
+
+    monkeypatch.setattr(real_pytest, "main", fake_main)
+
+    assert pytest_shards.run_nodeids(nodeids, ["--", "-q"], receipt_path=receipt) == 0
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    assert data["planned_nodeids"] == planned
+    assert data["reported_nodeids"] == planned
+    assert data["reported_count"] == len(planned)
+    assert data["pytest_exit_code"] == 0
+
+
+def test_ci_workflow_uses_shard_local_planner_and_ci_gate_verifier() -> None:
     workflow = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     nightly = (
         Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pytest-slow-nightly.yml"
@@ -196,8 +337,10 @@ def test_ci_workflow_uses_single_planner_and_ci_gate_verifier() -> None:
     assert "pytest-fastlane:" in workflow
     assert "changed_tests.py" in workflow
     assert "timeout-minutes: 10" in workflow
-    assert "pytest_shards.py plan" in workflow
-    assert workflow.count("pytest_shards.py plan") == 1
+    assert "pytest_shards.py plan-shard" in workflow
+    assert "pytest_shards.py plan \\" not in workflow
+    assert "pytest-duration-snapshot" in workflow
+    assert "pytest-plans" not in workflow
     assert "pytest_shards.py verify-artifacts" in workflow
     assert "gate_required_results.py" in workflow
     assert "--dist=loadfile" in workflow
@@ -217,14 +360,18 @@ def test_required_lanes_exclude_live_model_setup_and_fastlane_is_slim() -> None:
     workflow = yaml.safe_load((repo_root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
 
-    planner_install = next(step for step in jobs["pytest-plan"]["steps"] if step.get("name") == "Install planner dependencies")
+    planner_steps = jobs["pytest-plan"]["steps"]
+    planner_validate = next(step for step in planner_steps if step.get("name") == "Validate planner contract without collection")
     shard_steps = jobs["python"]["steps"]
     shard_install = next(step for step in shard_steps if step.get("name") == "Install dependencies")
     fastlane_steps = jobs["pytest-fastlane"]["steps"]
     fastlane_install = next(step for step in fastlane_steps if step.get("name") == "Install slim fastlane test dependencies")
     fastlane_run = next(step for step in fastlane_steps if step.get("name") == "Run directly changed test modules")
 
-    for step in (planner_install, shard_install):
+    assert jobs["python"]["needs"] == ["landing-class"]
+    assert "validate-snapshot" in planner_validate["run"]
+    assert all("Install planner dependencies" not in str(step.get("name")) for step in planner_steps)
+    for step in (shard_install,):
         run = step["run"]
         assert "torch==2.13.0" not in run
         assert "download.pytorch.org" not in run


### PR DESCRIPTION
## Summary

Refs #7141.

This patch removes the full pytest collection/planning barrier from the merge_group and push shard path while keeping the existing four-shard topology and the `pytest-plan` job/Gate result contract.

- `landing-class` restores the successful-main duration dataset once and uploads one immutable, event-SHA-bound snapshot.
- Each `python` matrix shard depends only on `landing-class`, collects the exact existing selection locally, and independently computes the same deterministic file-grouped LPT plan from that snapshot.
- Each shard uploads `plan.json`, `test-nodeids.txt`, JUnit, and an execution receipt.
- CI Gate fail-closes on source/selection/snapshot metadata drift, node-list mismatch, JUnit mismatch, missing/duplicate/omitted node IDs, and non-green execution receipts.
- `pytest-plan` remains a full-tier job, but is now a lightweight snapshot/schema contract check; its job ID remains in Gate's expected-results wiring.
- `docs_skills` remains a no-op for snapshot, planner contract, shards, coverage, and artifact verification. `pytest-fastlane` remains independent. Pull-request fastlane semantics are unchanged.

## Wall-clock reasoning

Before: `pytest-plan` spent approximately 3.3–3.4 minutes collecting and materializing all four plans, and every shard waited for that job before starting. The current shard executions are approximately 7.1–7.5 minutes.

After: the plan job no longer performs collection or installs the planner-only dependency set. The four shards begin after `landing-class` and perform collection/planning concurrently with their existing checkout, runtime, and dependency setup. The planner's former ~3.3-minute barrier is therefore overlapped with shard startup rather than added before shard execution. The duration snapshot and deterministic LPT algorithm preserve today's balance target; CI evidence below records the observed spread.

## Design and rejected alternatives

Chosen: shard-local collection plus deterministic planning from one immutable duration snapshot. The plan metadata carries the event SHA, selection digest, planner schema, duration cache identity, duration snapshot digest, collection count/digest, and assigned digest. Gate compares those fields across all four shards and requires execution receipts.

Rejected:
- A centralized planner that still collects on one job: it preserves the merge-path barrier.
- A precomputed `main` manifest: it can be stale for the exact merge_group tree and would weaken merge-group semantics.
- Changed-test or reduced-shard selection: it would reduce full-tier coverage or threaten the existing balance.

## Evidence

Local, before CI:
- `115 passed in 4.82s` across shard partition, Gate, landing-class, queue-starvation, attribution, and Cursor Cloud verifier tests.
- Targeted Ruff passed for the changed Python/script test files.
- YAML/topology assertions, CLI help smoke, compile, and diff checks passed.
- Real local collection canary: `20,534` collected and assigned exactly once across four shard-local plans; common digest `c09ae3561d39571c1edd98bec3535cfdf1b634fff9b0afa50c6686d7da87e0c7`.

CI evidence will be added after the full-tier run: exact collected/executed counts, observed shard durations/spread, and green `ci-gate`.

Design review: Sol advisory seat approved the shard-local design with immutable snapshot, provenance, exact-receipt, and serial-playground guards. The normal ACP bridge was unavailable in this sparse worktree, so that advisory seat was substituted via the native fleet path; no architecture was advanced without the advisory GO.

No auto-merge is enabled; this PR is intentionally left for independent review and orchestrator-owned merge.