### PR TITLE
fix(ci): bound Contracts secret/OPSEC scans to validated commit ranges (#7141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,14 +744,31 @@ jobs:
       - name: Check internal IDs are not published
         run: .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
+      - name: Resolve secret scan commit scope (#7141)
+        id: secret-scan-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || '' }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          PUSH_AFTER_SHA: ${{ github.event.after || '' }}
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/ci/secret_scan_scope.py
+
       - name: Gate scrubbed public identifiers and teacher-cloze answers
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          OPSEC_RANGE: ${{ steps.secret-scan-scope.outputs.opsec_range }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             .venv/bin/python scripts/audit/lint_opsec_leaks.py \
               "${PR_BASE_SHA}...${PR_HEAD_SHA}" --public-identifiers
+          elif [ -n "$OPSEC_RANGE" ]; then
+            .venv/bin/python scripts/audit/lint_opsec_leaks.py \
+              --commit-range "$OPSEC_RANGE" --public-identifiers
           else
             .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
           fi
@@ -983,6 +1000,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 1
@@ -995,6 +1014,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 2
@@ -1007,6 +1028,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Fail if TruffleHog exhausted retries

--- a/scripts/audit/lint_opsec_leaks.py
+++ b/scripts/audit/lint_opsec_leaks.py
@@ -252,12 +252,64 @@ def run_git_nul_separated(cmd: list[str]) -> list[str]:
     return decoded
 
 
+def run_git_lines(cmd: list[str]) -> list[str]:
+    """Run a git command whose output is one record per line."""
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT, check=True)
+    return [line for line in res.stdout.splitlines() if line]
+
+
 def get_diff_range_head(diff_range: str) -> str:
     """Return the revision containing files at the right side of a git range."""
     for separator in ("...", ".."):
         if separator in diff_range:
             return diff_range.rsplit(separator, 1)[1]
     return "HEAD"
+
+
+def get_files_changed_in_commit_range(
+    commit_range: str,
+    *,
+    apply_infrastructure_skips: bool = True,
+) -> tuple[list[str], str, str]:
+    """Return the union of paths touched by every commit in ``commit_range``.
+
+    A tree diff can omit a path changed and then reverted by a later queued
+    commit.  Landing scans must retain the union of the constituent PR
+    surfaces, so collect each commit's changed paths and read the resulting
+    tree at the range head exactly once.
+    """
+    commits = run_git_lines(["git", "rev-list", commit_range])
+    paths: list[str] = []
+    for commit in commits:
+        paths.extend(
+            run_git_nul_separated(
+                [
+                    "git",
+                    "diff-tree",
+                    "--root",
+                    "-r",
+                    "-m",
+                    "--no-commit-id",
+                    "--no-renames",
+                    "--name-only",
+                    "--diff-filter=ACMRT",
+                    "-z",
+                    commit,
+                ]
+            )
+        )
+    head = get_diff_range_head(commit_range)
+    head_paths = set(
+        run_git_nul_separated(["git", "ls-tree", "-rz", "--name-only", head])
+    )
+    return (
+        filter_rel_paths(
+            sorted(set(paths) & head_paths),
+            apply_infrastructure_skips=apply_infrastructure_skips,
+        ),
+        f"git commit range ({commit_range})",
+        head,
+    )
 
 
 def get_files_to_check(
@@ -352,6 +404,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--staged", action="store_true", help="Inspect staged git index blobs")
     parser.add_argument("--all", action="store_true", help="Explicitly scan all tracked files in repo")
     parser.add_argument(
+        "--commit-range",
+        help="Scan the union of paths changed by every commit in a range",
+    )
+    parser.add_argument(
         "--public-identifiers",
         action="store_true",
         help="Scan learner-facing files for scrubbed personal identifiers only",
@@ -364,14 +420,27 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.public_identifiers and (args.staged or args.all):
         parser.error("--public-identifiers cannot be combined with --staged or --all")
+    if args.commit_range and (args.diff_range or args.staged or args.all):
+        parser.error("--commit-range cannot be combined with a diff range, --staged, or --all")
+    if args.commit_range and not args.public_identifiers:
+        parser.error("--commit-range requires --public-identifiers")
     if args.revision and not args.public_identifiers:
         parser.error("--revision requires --public-identifiers")
-    if args.revision and args.diff_range:
-        parser.error("--revision cannot be combined with a diff range")
+    if args.revision and (args.diff_range or args.commit_range):
+        parser.error("--revision cannot be combined with a diff range or --commit-range")
 
     try:
         if args.public_identifiers:
-            if args.diff_range:
+            if args.commit_range:
+                changed_paths, diff_mode, rev_target = get_files_changed_in_commit_range(
+                    args.commit_range,
+                    apply_infrastructure_skips=False,
+                )
+                rel_paths = [
+                    path for path in changed_paths if is_public_personal_identifier_path(path)
+                ]
+                mode_str = f"changed learner-facing files (--public-identifiers; {diff_mode})"
+            elif args.diff_range:
                 changed_paths, diff_mode, rev_target = get_files_to_check(
                     args.diff_range, apply_infrastructure_skips=False
                 )

--- a/scripts/ci/secret_scan_scope.py
+++ b/scripts/ci/secret_scan_scope.py
@@ -1,0 +1,177 @@
+"""Resolve bounded secret-scan ranges for landing events.
+
+GitHub's TruffleHog action has built-in range handling for ``push`` and
+``pull_request``, but not ``merge_group``.  This resolver supplies explicit
+base/head values for merge-queue and main-push runs, and deliberately selects
+the action's full-history path when a safe range cannot be established.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+_ZERO_SHA = "0" * 40
+_SCOPED_EVENTS = frozenset({"merge_group", "push"})
+
+
+@dataclass(frozen=True, slots=True)
+class ScanScope:
+    """Values consumed by the TruffleHog action and the OPSEC linter."""
+
+    trufflehog_base: str
+    trufflehog_head: str
+    opsec_range: str
+    mode: str
+    reason: str
+
+
+def _full_scan_scope(reason: str) -> ScanScope:
+    """Keep the current full scan, including for an empty push payload."""
+
+    # A non-empty head keeps the action in its explicit BASE/HEAD path.  An
+    # empty BASE then means the same full-history scan as the action's current
+    # merge_group fallback, while avoiding its push ``commits == []`` early
+    # exit.
+    return ScanScope(
+        trufflehog_base="",
+        trufflehog_head="HEAD",
+        opsec_range="",
+        mode="full-fallback",
+        reason=reason,
+    )
+
+
+def _normalize_sha(value: str, label: str) -> tuple[str | None, str | None]:
+    raw = value.strip()
+    if not raw:
+        return None, f"missing-{label}-sha"
+    if raw == _ZERO_SHA:
+        return None, f"zero-{label}-sha"
+    if not _SHA_RE.fullmatch(raw):
+        return None, f"invalid-{label}-sha"
+    return raw.lower(), None
+
+
+def _commit_exists(repo_root: Path, sha: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def _is_ancestor(repo_root: Path, base_sha: str, head_sha: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", base_sha, head_sha],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def resolve_scan_scope(
+    event_name: str,
+    *,
+    merge_group_base_sha: str = "",
+    merge_group_head_sha: str = "",
+    push_before_sha: str = "",
+    push_after_sha: str = "",
+    repo_root: Path | None = None,
+) -> ScanScope:
+    """Return a validated landing range or an explicit full-scan fallback.
+
+    ``merge_group.base_sha`` is the queue branch's parent and
+    ``merge_group.head_sha`` is the merge-group commit.  For a main push, the
+    event's ``before`` and ``after`` SHAs define the pushed range.  Both forms
+    are accepted only when the commits exist locally and the base is an
+    ancestor of the head; this rejects empty, first-run, force-push, and
+    malformed ranges without ever turning a scan into a skip.
+    """
+
+    event = event_name.strip()
+    if event not in _SCOPED_EVENTS:
+        return ScanScope("", "", "", "unchanged", "event-not-scoped")
+
+    if event == "merge_group":
+        raw_base, raw_head = merge_group_base_sha, merge_group_head_sha
+    else:
+        raw_base, raw_head = push_before_sha, push_after_sha
+
+    base_sha, error = _normalize_sha(raw_base, "base")
+    if error:
+        return _full_scan_scope(error)
+    head_sha, error = _normalize_sha(raw_head, "head")
+    if error:
+        return _full_scan_scope(error)
+    if base_sha is None or head_sha is None:
+        return _full_scan_scope("invalid-range")
+
+    if base_sha == head_sha:
+        return _full_scan_scope("empty-range")
+
+    root = repo_root or Path.cwd()
+    if not _commit_exists(root, base_sha):
+        return _full_scan_scope("unresolvable-base-sha")
+    if not _commit_exists(root, head_sha):
+        return _full_scan_scope("unresolvable-head-sha")
+    if not _is_ancestor(root, base_sha, head_sha):
+        return _full_scan_scope("base-not-ancestor")
+
+    return ScanScope(
+        trufflehog_base=base_sha,
+        trufflehog_head=head_sha,
+        opsec_range=f"{base_sha}..{head_sha}",
+        mode="scoped",
+        reason="validated-range",
+    )
+
+
+def _write_outputs(scope: ScanScope, output_path: Path | None) -> None:
+    lines = (
+        f"trufflehog_base={scope.trufflehog_base}",
+        f"trufflehog_head={scope.trufflehog_head}",
+        f"opsec_range={scope.opsec_range}",
+        f"mode={scope.mode}",
+        f"reason={scope.reason}",
+    )
+    if output_path is None:
+        for line in lines:
+            print(line)
+        return
+    with output_path.open("a", encoding="utf-8") as output:
+        for line in lines:
+            output.write(f"{line}\n")
+
+
+def main() -> int:
+    scope = resolve_scan_scope(
+        os.environ.get("EVENT_NAME", ""),
+        merge_group_base_sha=os.environ.get("MERGE_GROUP_BASE_SHA", ""),
+        merge_group_head_sha=os.environ.get("MERGE_GROUP_HEAD_SHA", ""),
+        push_before_sha=os.environ.get("PUSH_BEFORE_SHA", ""),
+        push_after_sha=os.environ.get("PUSH_AFTER_SHA", ""),
+    )
+    output = os.environ.get("GITHUB_OUTPUT")
+    _write_outputs(scope, Path(output) if output else None)
+    print(f"secret-scan-scope: mode={scope.mode} reason={scope.reason}")
+    if scope.opsec_range:
+        print(f"secret-scan-scope: range={scope.opsec_range}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -66,6 +66,22 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     assert "gate_required_results.py" in gate_steps
     assert "contains(needs.*.result, 'skipped')" not in gate_steps
 
+
+def test_contracts_bounds_landing_secret_and_opsec_scans() -> None:
+    workflow = _CI.read_text(encoding="utf-8")
+    assert "Resolve secret scan commit scope (#7141)" in workflow
+    assert "MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}" in workflow
+    assert "MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || '' }}" in workflow
+    assert "PUSH_BEFORE_SHA: ${{ github.event.before || '' }}" in workflow
+    assert "PUSH_AFTER_SHA: ${{ github.event.after || '' }}" in workflow
+    assert "base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}" in workflow
+    assert "head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}" in workflow
+    assert '--commit-range "$OPSEC_RANGE" --public-identifiers' in workflow
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in workflow
+    scope_index = workflow.index("Resolve secret scan commit scope (#7141)")
+    assert scope_index < workflow.index("Gate scrubbed public identifiers")
+    assert scope_index < workflow.index("TruffleHog secret scan (attempt 1)")
+
 def test_frontend_e2e_waits_for_ci_gate_success() -> None:
     e2e = _load(_CI)["jobs"]["frontend-e2e"]
     assert e2e["needs"] == ["ci-gate"]

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -194,7 +194,9 @@ def test_symmetric_diff_uses_its_head_for_blob_reads(monkeypatch):
 
 def test_commit_range_mode_keeps_union_of_touched_public_paths(monkeypatch, tmp_path):
     def git(*args: str) -> str:
-        return subprocess.check_output(["git", *args], cwd=tmp_path, text=True).strip()
+        return subprocess.check_output(
+            ["git", *args], cwd=tmp_path, text=True, timeout=30
+        ).strip()
 
     git("init", "--initial-branch=main")
     git("config", "user.email", "ci@example.com")

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from pathlib import Path
 
@@ -193,3 +194,39 @@ def test_symmetric_diff_uses_its_head_for_blob_reads(monkeypatch):
     assert paths == ["site/src/data/a.json"]
     assert mode == "git diff (base-sha...head-sha)"
     assert revision == "head-sha"
+
+
+def test_commit_range_mode_keeps_union_of_touched_public_paths(monkeypatch, tmp_path):
+    def git(*args: str) -> str:
+        return subprocess.check_output(["git", *args], cwd=tmp_path, text=True).strip()
+
+    git("init", "--initial-branch=main")
+    git("config", "user.email", "ci@example.com")
+    git("config", "user.name", "ci")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "base")
+    base = git("rev-parse", "HEAD")
+
+    public_path = tmp_path / "site/src/data/changed.json"
+    public_path.parent.mkdir(parents=True)
+    public_path.write_text("Alona\n", encoding="utf-8")
+    git("add", str(public_path.relative_to(tmp_path)))
+    git("commit", "-m", "introduce public path")
+
+    public_path.write_text("clean\n", encoding="utf-8")
+    git("commit", "-am", "revert public identifier")
+    head = git("rev-parse", "HEAD")
+
+    monkeypatch.setattr(opsec_linter, "REPO_ROOT", tmp_path)
+    scanned_paths: list[str] = []
+
+    def get_content(path: str, rev: str) -> str:
+        scanned_paths.append(path)
+        assert rev == head
+        return "clean content"
+
+    monkeypatch.setattr(opsec_linter, "get_git_content", get_content)
+
+    assert opsec_linter.main(["--commit-range", f"{base}..{head}", "--public-identifiers"]) == 0
+    assert scanned_paths == ["site/src/data/changed.json"]

--- a/tests/test_opsec_linter.py
+++ b/tests/test_opsec_linter.py
@@ -1,11 +1,7 @@
 import subprocess
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts/audit"))
-
-import lint_opsec_leaks as opsec_linter
-from lint_opsec_leaks import check_content
+from scripts.audit import lint_opsec_leaks as opsec_linter
+from scripts.audit.lint_opsec_leaks import check_content
 
 
 def test_f002_pkcs8_unqualified_private_key_detected():

--- a/tests/test_secret_scan_scope.py
+++ b/tests/test_secret_scan_scope.py
@@ -11,7 +11,9 @@ from scripts.ci.secret_scan_scope import resolve_scan_scope
 
 
 def _git(root: Path, *args: str) -> str:
-    return subprocess.check_output(["git", *args], cwd=root, text=True).strip()
+    return subprocess.check_output(
+        ["git", *args], cwd=root, text=True, timeout=30
+    ).strip()
 
 
 def _repo_with_range(root: Path) -> tuple[str, str, str]:
@@ -28,13 +30,14 @@ def _repo_with_range(root: Path) -> tuple[str, str, str]:
     head = _git(root, "rev-parse", "HEAD")
 
     empty_tree = subprocess.check_output(
-        ["git", "mktree"], cwd=root, input="", text=True
+        ["git", "mktree"], cwd=root, input="", text=True, timeout=30
     ).strip()
     unrelated = subprocess.check_output(
         ["git", "commit-tree", empty_tree],
         cwd=root,
         input="unrelated\n",
         text=True,
+        timeout=30,
     ).strip()
     return base, head, unrelated
 
@@ -57,6 +60,7 @@ def _repo_with_merge_group(root: Path) -> tuple[str, str]:
         cwd=root,
         input="merge group\n",
         text=True,
+        timeout=30,
     ).strip()
     return base, merge_group_head
 

--- a/tests/test_secret_scan_scope.py
+++ b/tests/test_secret_scan_scope.py
@@ -1,0 +1,162 @@
+"""Tests for bounded landing-event secret-scan ranges (#7141)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.secret_scan_scope import resolve_scan_scope
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=root, text=True).strip()
+
+
+def _repo_with_range(root: Path) -> tuple[str, str, str]:
+    _git(root, "init", "--initial-branch=main")
+    _git(root, "config", "user.email", "ci@example.com")
+    _git(root, "config", "user.name", "ci")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-m", "base")
+    base = _git(root, "rev-parse", "HEAD")
+
+    (root / "README.md").write_text("head\n", encoding="utf-8")
+    _git(root, "commit", "-am", "head")
+    head = _git(root, "rev-parse", "HEAD")
+
+    empty_tree = subprocess.check_output(
+        ["git", "mktree"], cwd=root, input="", text=True
+    ).strip()
+    unrelated = subprocess.check_output(
+        ["git", "commit-tree", empty_tree],
+        cwd=root,
+        input="unrelated\n",
+        text=True,
+    ).strip()
+    return base, head, unrelated
+
+
+def _repo_with_merge_group(root: Path) -> tuple[str, str]:
+    _git(root, "init", "--initial-branch=main")
+    _git(root, "config", "user.email", "ci@example.com")
+    _git(root, "config", "user.name", "ci")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-m", "base")
+    base = _git(root, "rev-parse", "HEAD")
+
+    (root / "README.md").write_text("queued\n", encoding="utf-8")
+    _git(root, "commit", "-am", "queued change")
+    queued_head = _git(root, "rev-parse", "HEAD")
+    tree = _git(root, "rev-parse", "HEAD^{tree}")
+    merge_group_head = subprocess.check_output(
+        ["git", "commit-tree", tree, "-p", base, "-p", queued_head],
+        cwd=root,
+        input="merge group\n",
+        text=True,
+    ).strip()
+    return base, merge_group_head
+
+
+def test_merge_group_uses_documented_base_and_head_range(tmp_path: Path) -> None:
+    base, head = _repo_with_merge_group(tmp_path)
+    event = {
+        "action": "checks_requested",
+        "merge_group": {
+            "base_ref": "refs/heads/main",
+            "base_sha": base,
+            "head_sha": head,
+        },
+    }
+
+    scope = resolve_scan_scope(
+        "merge_group",
+        merge_group_base_sha=event["merge_group"]["base_sha"],
+        merge_group_head_sha=event["merge_group"]["head_sha"],
+        repo_root=tmp_path,
+    )
+
+    assert scope.mode == "scoped"
+    assert scope.reason == "validated-range"
+    assert scope.trufflehog_base == base
+    assert scope.trufflehog_head == head
+    assert scope.opsec_range == f"{base}..{head}"
+
+
+def test_push_uses_event_before_and_after(tmp_path: Path) -> None:
+    base, head, _ = _repo_with_range(tmp_path)
+
+    scope = resolve_scan_scope(
+        "push",
+        push_before_sha=base,
+        push_after_sha=head,
+        repo_root=tmp_path,
+    )
+
+    assert scope.mode == "scoped"
+    assert scope.trufflehog_base == base
+    assert scope.trufflehog_head == head
+
+
+@pytest.mark.parametrize(
+    ("event_name", "base_field", "head_field", "reason"),
+    [
+        ("merge_group", "merge_group_base_sha", "merge_group_head_sha", "missing-base-sha"),
+        ("push", "push_before_sha", "push_after_sha", "zero-base-sha"),
+    ],
+)
+def test_unresolvable_landing_range_forces_full_scan(
+    tmp_path: Path,
+    event_name: str,
+    base_field: str,
+    head_field: str,
+    reason: str,
+) -> None:
+    _, head, _ = _repo_with_range(tmp_path)
+    values = {
+        base_field: "" if reason == "missing-base-sha" else "0" * 40,
+        head_field: head,
+        "repo_root": tmp_path,
+    }
+
+    scope = resolve_scan_scope(event_name, **values)
+
+    assert scope.mode == "full-fallback"
+    assert scope.reason == reason
+    assert scope.trufflehog_base == ""
+    assert scope.trufflehog_head == "HEAD"
+    assert scope.opsec_range == ""
+
+
+def test_force_push_and_equal_range_fail_closed_to_full_scan(tmp_path: Path) -> None:
+    base, head, unrelated = _repo_with_range(tmp_path)
+
+    forced = resolve_scan_scope(
+        "push",
+        push_before_sha=base,
+        push_after_sha=unrelated,
+        repo_root=tmp_path,
+    )
+    empty = resolve_scan_scope(
+        "merge_group",
+        merge_group_base_sha=head,
+        merge_group_head_sha=head,
+        repo_root=tmp_path,
+    )
+
+    assert forced.reason == "base-not-ancestor"
+    assert forced.trufflehog_head == "HEAD"
+    assert empty.reason == "empty-range"
+    assert empty.trufflehog_head == "HEAD"
+
+
+def test_pull_request_keeps_action_defaults_untouched(tmp_path: Path) -> None:
+    scope = resolve_scan_scope("pull_request", repo_root=tmp_path)
+
+    assert scope == resolve_scan_scope("workflow_dispatch", repo_root=tmp_path)
+    assert scope.trufflehog_base == ""
+    assert scope.trufflehog_head == ""
+    assert scope.opsec_range == ""


### PR DESCRIPTION
Wave B patch 3 (#7141): bound the Contracts job's TruffleHog + OPSEC scans to the commits actually being validated on merge_group/push, instead of full repository history.

Diagnosis basis (W1 report on #7141): the PR→merge_group doubling of Contracts (2.42m→5.14m) was 100% these two scans — TruffleHog full-history scanned 2.91GB / 778k chunks on merge_group for lack of commit bounds (+2.48m), and the OPSEC lint whole-repo scanned on non-PR events (+0.25m).

Design: fail-closed range resolver (underivable range ⇒ full scan, never skip); merge tier scans the union of the group's introduced commits; scan semantics otherwise unchanged; per GitHub merge_group event contract and TruffleHog's explicit base/head inputs.

Evidence (lane-reported): 112 targeted tests passed; actionlint + interpolation checks passed; ruff clean on touched files.

Expected effect vs frozen 2026-08-23 baseline: Contracts merge_group ~5.1m → ~2.4m (−2.7 runner-min per group; wall-clock relevant when contracts gates the group tail).

**Queue discipline: do NOT merge until #7165's post-merge evaluation completes** (one Wave B patch lands and is evaluated at a time — CTO rule on #7141).

Lane note: implemented by codex lane (task ci-waveb-w3-trufflehog); branch push relayed by orchestrator — worker token lacked the `workflow` scope (defect class tracked in #7166/#7168).
