### PR TITLE
feat(foundry): resume Cycle007 from sealed packets

### DIFF
--- a/batch_state/phase3-compile-cycle007-evidence-v1.py
+++ b/batch_state/phase3-compile-cycle007-evidence-v1.py
@@ -30,6 +30,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.projects.open_model_data import (
+    phase3_cycle007_evidence_compile_throughput as throughput,
+)
+from scripts.projects.open_model_data import (
     phase3_cycle007_evidence_compiler as compiler,
 )
 from scripts.projects.open_model_data import (
@@ -102,7 +105,11 @@ def _validate_paths(package: Path, source_manifest: Path, output: Path) -> tuple
         raise RunnerError("output_path_invalid")
     if output.is_symlink():
         raise RunnerError("output_symlink")
-    if os.path.lexists(output):
+    if os.path.lexists(output) and (
+        not output.is_dir()
+        or _lstat_mode(output) != 0o700
+        or output.lstat().st_uid != os.geteuid()
+    ):
         raise RunnerError("output_exists")
     return package, source_manifest, output
 
@@ -267,6 +274,8 @@ def _compile_failure_code(exc: Exception) -> str:
         return "compile_materialization_failed"
     if isinstance(exc, evidence_contract.EvidenceContractError):
         return _CONTRACT_FAILURE_CODES.get(str(exc), "compile_evidence_contract_failed")
+    if isinstance(exc, throughput.ThroughputResumeError):
+        return "compile_resume_failed"
     return "compile_failed"
 
 

--- a/docs/projects/open-model-data/cycle007-evidence-compile-throughput.md
+++ b/docs/projects/open-model-data/cycle007-evidence-compile-throughput.md
@@ -1,0 +1,291 @@
+# Cycle 007 evidence-compile throughput (design)
+
+Status: resume-only implementation candidate. It requires CI, independent
+cross-family exact-head approval, merge, and deployment before a new evidence
+compile may start. Packet-parallel execution remains unauthorized.
+
+This document is text-free: counts, hashes, tool names, and pass/fail facts
+only. It does not name hosts, addresses, or private row content.
+
+Parent stream: Phase 3 recovery issue `#6375`. Frozen Cycle 007 contract:
+`batch_state/phase3-cycle007-source-grounded-amendment-v1.md`.
+
+## Recommendation
+
+Ship **option A first**: durable resume after a sealed packet prefix. Keep
+packet compilation serial and keep the frozen query plan unchanged.
+
+Option A is the only change that removes the multi-day restart cost. The
+current compiler can already take a long clean run; the dominant loss is
+that every stop discards staging and returns to packet 1 of 204.
+
+The previous compile stopped cleanly without installing evidence. This change
+may activate only for a later operator-authorized run after the review gates in
+[Amendment and review](#amendment-and-review).
+
+## Confirmed current parallelism
+
+Read of
+`scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py` and
+the text-free runner
+`batch_state/phase3-compile-cycle007-evidence-v1.py` on the reviewed main
+head used for this design:
+
+| Layer | What actually runs | What the name sounds like |
+| --- | --- | --- |
+| Packet loop | Serial `for` over packets `1..N` inside `compile_sidecar_bundle` | Packet-parallel |
+| Row loop | Serial `for` over rows inside `compile_packet_sidecar` | — |
+| Per-row channels | Sequential Sources calls in `compile_row_evidence` | Amendment step 5 "always-on parallel path" |
+| MCP client | One `LocalMcpSourcesClient` / one `RealMcpToolTransport` / one session | N workers |
+| Install | Fresh staging directory, validate all sidecars, then atomic claim of `output_dir` | Resume |
+| Runner | Starts one reviewed Sources process, compiles, refuses if `output` exists | Checkpoint |
+
+The amendment phrase "always-on parallel path" is a **coverage** rule: style
+guide, Antonenko prose, UA-GEC, and heritage run for every row and are not
+gated on a VESUM miss. It is not a concurrency rule. Those calls are issued
+one after another on one synchronous client.
+
+`RealMcpToolTransport` owns one background asyncio loop and one MCP session.
+`call_tool` waits for that session. `LocalMcpSourcesClient._call_text`
+mutates the ordered-call commitment without a lock. One client is therefore
+single-threaded at the wire.
+
+The public manifest stores `mcp_transport_attestation`, including
+`tool_call_count` and `ordered_call_commitment_sha256`. That commitment is a
+process-global hash chain over `(ordinal, tool, arguments_sha256,
+response_sha256)`. Any resume or fan-out that drops, reorders, or interleaves
+calls changes the public manifest even when every sidecar body stays the
+same.
+
+`CODE_HASHES` binds `compiler_sha256` to the whole compiler module. Editing
+that file changes every new sidecar and therefore prevents an old prefix from
+resuming under the new compiler identity. The resume helper is imported by the
+compiler and runner only for custody and recovery.
+
+Frozen real-mode denominator, unchanged by this design: `REAL_PACKET_COUNT =
+204`, `REAL_ROW_COUNT = 10159`.
+
+## Ranked options
+
+### A. Durable resume after sealed packet N (do this)
+
+**User-visible outcome.** A stopped compile continues at packet `N+1` when
+packets `1..N` are already validated, sealed, and identity-bound. Packet
+`N+1` that did not finish is discarded, never resumed mid-row.
+
+**Why it is first.** Foundry already observed a 60-packet prefix discarded
+with the destination left at `0/204`. Serial MCP cost is real; throwing away
+a sealed prefix is the part that turns one long run into several.
+
+**Smallest safe shape.**
+
+1. Keep `output_dir` refuse-if-exists and the final atomic install.
+2. Replace *ephemeral* staging (`mkdtemp` + delete on any failure) with a
+   durable sibling staging directory, mode `0700`, files mode `0600`.
+3. After each packet: `validate_sidecar`, atomic write `sidecar-NNNN.json`,
+   fsync, write a text-free progress receipt.
+4. Progress receipt fields are a closed set: schema, `text_free`, cycle id,
+   sealed count, next index, target `204`/`10159`, last sidecar hashes,
+   identity hash, transport attestation, and a complete hash-only MCP call
+   ledger. The ledger stores ordinal, fixed tool name, argument SHA-256, and
+   response SHA-256 only—never paths, row text, arguments, responses, prompts,
+   locators, labels, or provider content.
+5. On start: if durable staging is empty, begin at packet 1. If a prefix
+   `1..N` exists, re-validate identity and bindings, replay the persisted
+   call-chain, continue at `N+1`. A gap, leftover foreign file, or identity
+   drift fails closed.
+6. Exactly one incomplete `mkstemp` sidecar for `N+1` may be deleted. Gaps,
+   multiple temps, foreign entries, symlinks, wrong ownership, or permission
+   drift fail closed.
+7. A compiler-level nonblocking lock protects the deterministic resume root
+   for the full run, independently of any external guardian lock.
+8. After packet 204, assemble the same manifest shape, validate it, and install
+   the complete `bundle/` with one atomic no-replace directory rename. A crash
+   after rename but before metadata cleanup is repaired only after the installed
+   output revalidates.
+9. Creation and every durable commit point fsync the relevant parent directory.
+10. Terminal cleanup first atomically retires the live resume root to an inert
+    tombstone while the compiler lock is still held. A crash during tombstone
+    removal cannot block idempotent validation of the already-installed bundle;
+    a later validated invocation reaps an unlocked leftover tombstone.
+
+**Sidecar bytes.** `compile_packet_sidecar` is already independent per
+packet given the same server identity and rows. A resumed serial run with
+the *same* compiler module SHA can emit the same sidecar files as a clean
+run. A compiler-module edit cannot resume a prefix sealed by a different
+`compiler_sha256`.
+
+**Public manifest.** Keep today's attestation schema by recomputing the
+persisted hash-only ledger after each sealed packet and continuing ordinals.
+Each resumed process performs a real `mcp_server_identity` call, so the final
+transport attestation can legitimately differ from a never-interrupted run.
+The sidecar bytes remain deterministic; the attestation honestly describes
+the actual transport history.
+
+**Contract touch.** Compiler commentary currently calls this "amendment
+step 14": the whole bundle is staged and validated before anything is
+installed, and failure deletes only that staging directory. Durable
+prefix-seal is a material change to that install/custody rule. It does
+**not** change the query plan, tokenizer, channels, evidence-ID recipe, or
+the `204`/`10159` denominator.
+
+**Risks.** Partial last packet must never be treated as sealed. Identity
+drift (compiler, Sources server, `sources.db`, `vesum.db`) must fail
+closed rather than mix prefixes. Staging must stay operator-private
+(`0700`/`0600`) and off public surfaces. Disk accounting must count sealed
+sidecars plus one in-progress atomic temp, which is the estimator Foundry
+already uses.
+
+### B. Bounded packet-parallel with N Sources clients (later)
+
+**User-visible outcome.** Up to N packets compile at once, each with its
+own `LocalMcpSourcesClient` / `RealMcpToolTransport`. Sidecar `packet_index`
+order in the manifest stays `1..204`.
+
+**Why it is second.** It can cut a *clean* run, but it does not save a
+restart unless A exists. It also cannot preserve the current process-global
+`ordered_call_commitment_sha256` without serializing the wire, which
+defeats the fan-out.
+
+**Contract-safe constraints if later authorized.**
+
+- Query plan, evidence IDs, and per-packet sidecar bodies stay serial-equivalent.
+- N new clients, not one shared client (the current client is not
+  thread-safe).
+- Prefer proving N sessions against one reviewed Sources process *or* N
+  loopback processes bound to the same reviewed code/data identity. The
+  Sources DB helper caches one process-global SQLite connection
+  (`check_same_thread=False`). Concurrent `asyncio.to_thread` use of that
+  singleton is not a proven read-parallel contract. A public concurrency
+  canary is a precondition, not an afterthought.
+- Bound N fail-closed (scaffolding default is `1`; a request for `N>1` is
+  `packet_workers_not_authorized` until an addendum says otherwise).
+- Attestation must become a sorted per-packet composition, or B changes
+  the public manifest schema. That is an amendment-visible change.
+
+**Risks.** SQLite/FTS contention, memory of N in-flight sidecars, disk
+temp amplification, non-deterministic call order, and mixed identity if
+workers attach to different endpoints. Higher CF surface than A.
+
+### C. Other low-risk throughput (supporting, not a substitute)
+
+Ranked under A, and none of these replace sealed-prefix resume:
+
+1. **Text-free sealed-count pulse from durable staging** — operational
+   visibility only. Already possible as counts/hashes. Does not save work
+   unless A persists the files.
+2. **Keep one Sources process for the whole compile** — the runner already
+   does this. Do not start/stop per packet.
+3. **Process-local form cache** — amendment pre-call language already
+   mentions deterministic cache reuse, but today's public attestation is
+   an ordered *call* chain. Caching would drop `tool_call_count` and
+   change `ordered_call_commitment_sha256`. Safe only after attestation is
+   packet-composed (same addendum family as B) or after cache hits are
+   folded into the chain with a closed, reviewed record type. Do not
+   silently skip MCP calls.
+4. **Intra-row channel overlap** — same client-safety and attestation-order
+   problems as B, smaller payoff than packet-parallel.
+5. **Do not pull a new compiler SHA onto a live run** — `CODE_HASHES` and
+   the controller canary bind the compiler file. A mid-run checkout of an
+   activation commit cannot resume the prefix it interrupted.
+
+C items 1–2 need no amendment. C item 3 needs the same attestation review
+as B. C item 5 is a hard operational rule.
+
+## Amendment and review
+
+Frozen, do-not-edit artifact:
+
+- path: `batch_state/phase3-cycle007-source-grounded-amendment-v1.md`
+- SHA-256: `4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0`
+
+Controller, Gemini/Grok runners, adjudication, and completion tooling all
+bind that exact hash. Rewriting the frozen file is out of scope.
+
+The frozen amendment already requires:
+
+- exact `204` packets / `10159` rows
+- text-free public receipts
+- no network fallback during compile
+- fail-closed missing/conflicting evidence
+- no mid-run validator, taxonomy, source-hierarchy, or custody change
+  inside a live run
+- pre-call proof that the compiler produced `204` sidecars / `10159` rows
+
+It does not authorize durable prefix-seal or packet-parallel workers.
+
+### Review findings and reconciliation
+
+An independent Anthropic-family design review returned `BLOCK` on the inert
+draft. This implementation treats all six findings as required:
+
+1. Fresh and resumed deterministic paths reject preplacement and symlinks.
+2. Every resume artifact requires the current UID plus exact `0700`/`0600`.
+3. A compiler-level `flock` rejects a concurrent compiler.
+4. Final installation is one no-replace directory rename, with terminal-crash
+   repair, rather than a sequence of per-file moves.
+5. The complete hash-only call ledger makes the aggregate commitment
+   independently recomputable.
+6. Initial creation and every sealed commit fsync the parent directory.
+
+The trust boundary is explicit: the private writer seat's Unix user controls
+the receipt and sidecars. Hashes detect corruption and drift; they are not an
+external signature against a malicious same-user actor.
+
+### What needs review
+
+| Change | New addendum? | Review seats |
+| --- | --- | --- |
+| Resume-only implementation | Yes. Changes step-14 install/custody. | CI + independent cross-family exact-head review. Ukrainian source-authority only if a reviewer claims the query plan moved (it must not). |
+| B: N clients / composed attestation | Yes, separate from A. | Scope/circularity + CF. Public Sources concurrency canary. |
+| C.3 process-local MCP skip cache | Yes, unless the addendum already redefined attestation. | Same as B |
+| C.1–C.2 operational pulse / one server | No | None beyond current text-free pulse rules |
+
+### Resume-only custody addendum
+
+Working title: Cycle 007 compile-throughput addendum (resume-only).
+
+Intended bindings, to be hashed only after the review seats approve the
+exact bytes:
+
+- Parent amendment SHA-256 remains
+  `4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0`.
+- Query plan, tokenizer, compound parser, channels, evidence-ID recipe,
+  residual taxonomy, and `204`/`10159` are unchanged.
+- Compiler may persist validated `sidecar-NNNN.json` files and one
+  text-free progress receipt in a durable private staging directory.
+- Resume is authorized only for a consecutive sealed prefix whose
+  `code_hashes` and Sources identity match the running compiler.
+- Mid-packet state is discarded.
+- Final `output_dir` install stays atomic and refuse-if-exists.
+- Public `mcp_transport_attestation` stays schema
+  `phase3_cycle007_mcp_transport_attestation_v1` and honestly includes each
+  resumed process's identity call in the persisted serial chain.
+- Packet-parallel workers remain unauthorized.
+- Activation against a compile already in flight under another
+  `compiler_sha256` is forbidden.
+
+Until CI and an independent cross-family exact-head review approve the PR,
+the implementation must not be deployed or used for an evidence run.
+
+## Smallest PR path
+
+1. **This PR.** Resume-only custody implementation, synthetic crash matrix,
+   CI, and independent cross-family exact-head review.
+2. **After merge/deployment and explicit START.** One clean serial compile;
+   a process failure resumes only a fully validated sealed prefix.
+3. **Optional later PR.** B, only with a composed-attestation addendum and
+   a public concurrency canary.
+
+Success for this PR: a contract-safe serial resume that preserves text-free
+Cycle 007 bindings, refuses ambiguous state, survives the tested crash matrix,
+and installs a complete bundle atomically.
+
+## Non-goals
+
+- Starting or restarting Foundry before review and deployment.
+- Editing the frozen amendment file.
+- Packet-parallel activation.
+- Changing query plan, validator behavior, endpoint, chunk size, packet/row
+  denominator, labeling protocol, or source custody.
+- Labeling. Labeling stays off until a later START after evidence seals.

--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_compile_throughput.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_compile_throughput.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+"""Durable, text-free sealed-packet resume custody for Cycle 007.
+
+The evidence compiler remains serial and the frozen evidence protocol is
+unchanged. This module only makes a validated sealed packet prefix durable
+across process failure and installs the finished bundle with one no-replace
+directory rename.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import fcntl
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from collections import Counter
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compiler as compiler
+from scripts.projects.open_model_data import phase3_cycle007_evidence_contract as contract
+
+ACTIVATION_STATE = "resume_only_reviewed_v1"
+PROGRESS_SCHEMA_VERSION = "phase3_cycle007_compile_progress_v2"
+EVALUATION_CYCLE_ID = compiler.EVALUATION_CYCLE_ID
+CALL_CHAIN_SEED = "phase3-cycle007-mcp-tool-call-chain-v1"
+SIDECAR_NAME_RE = re.compile(r"sidecar-(\d{4})\.json\Z")
+TEMP_SIDECAR_NAME_RE = re.compile(r"\.sidecar-(\d{4})\.json\..+\Z")
+TEMP_PROGRESS_NAME_RE = re.compile(r"\.progress\.json\..+\Z")
+PRODUCTION_PACKET_WORKERS = 1
+MAX_REVIEWED_PACKET_WORKERS = 1
+PROGRESS_NAME = "progress.json"
+LOCK_NAME = "compile.lock"
+BUNDLE_NAME = "bundle"
+
+PROGRESS_REQUIRED_KEYS = frozenset(
+    {
+        "schema_version",
+        "text_free",
+        "evaluation_cycle_id",
+        "activation_state",
+        "sealed_packet_count",
+        "next_packet_index",
+        "target_packet_count",
+        "target_row_count",
+        "last_sealed_sidecar_sha256",
+        "last_sealed_sidecar_id",
+        "identity_sha256",
+        "mcp_transport_attestation",
+        "mcp_call_records",
+        "progress_sha256",
+    }
+)
+CALL_RECORD_KEYS = frozenset({"ordinal", "tool", "arguments_sha256", "response_sha256"})
+PRIVATE_PROGRESS_KEYS = frozenset(
+    {
+        "query",
+        "row_identity",
+        "locator",
+        "negative_reason",
+        "retrieval_payloads",
+        "source_text",
+        "unit_id",
+        "path",
+        "endpoint",
+        "host",
+        "prompt",
+        "response",
+        "label",
+    }
+)
+_IDENTITY_COMPARE_KEYS = (
+    "tokenizer_id",
+    "tokenizer_version",
+    "code_hashes",
+    "server_code_sha256",
+    "sources_db_sha256",
+    "vesum_db_sha256",
+)
+
+
+class ThroughputResumeError(ValueError):
+    """Closed, text-free resume failure."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+ThroughputScaffoldingError = ThroughputResumeError
+
+
+def initial_call_commitment() -> str:
+    return contract.sha256_text(CALL_CHAIN_SEED)
+
+
+def sidecar_filename(packet_index: int) -> str:
+    _require_count(packet_index, minimum=1)
+    return f"sidecar-{packet_index:04d}.json"
+
+
+def resume_root_for(output_dir: Path) -> Path:
+    return output_dir.with_name(f".{output_dir.name}.resume-v1")
+
+
+def bundle_dir_for(output_dir: Path) -> Path:
+    return resume_root_for(output_dir) / BUNDLE_NAME
+
+
+def build_resume_identity(
+    expected_identity: Mapping[str, Any],
+    *,
+    source_package_binding: Mapping[str, Any] | None,
+    packet_bindings: Sequence[Mapping[str, Any] | None],
+    residual_lane_packets: Sequence[bool],
+    target_packet_count: int,
+    target_row_count: int,
+) -> dict[str, Any]:
+    missing = [key for key in _IDENTITY_COMPARE_KEYS if key not in expected_identity]
+    if missing:
+        raise ThroughputResumeError("identity_incomplete")
+    return {
+        "resume_implementation_sha256": contract.sha256_file(Path(__file__)),
+        "expected_identity": {key: expected_identity[key] for key in _IDENTITY_COMPARE_KEYS},
+        "source_package_binding_sha256": contract.sha256_value(source_package_binding),
+        "packet_bindings_sha256": contract.sha256_value(list(packet_bindings)),
+        "residual_lane_packets_sha256": contract.sha256_value(list(residual_lane_packets)),
+        "target_packet_count": target_packet_count,
+        "target_row_count": target_row_count,
+    }
+
+
+def identity_sha256(resume_identity: Mapping[str, Any]) -> str:
+    return contract.sha256_value(resume_identity)
+
+
+def extend_serial_call_commitment(
+    prior_commitment: str,
+    calls: Sequence[Mapping[str, Any]],
+    *,
+    starting_ordinal: int,
+) -> tuple[str, int]:
+    if not _is_sha256(prior_commitment):
+        raise ThroughputResumeError("call_commitment_invalid")
+    _require_count(starting_ordinal, minimum=1)
+    commitment = prior_commitment
+    ordinal = starting_ordinal
+    for raw in calls:
+        if not isinstance(raw, Mapping) or set(raw) != CALL_RECORD_KEYS:
+            raise ThroughputResumeError("call_record_invalid")
+        if raw.get("ordinal") != ordinal:
+            raise ThroughputResumeError("call_ordinal_invalid")
+        if not isinstance(raw.get("tool"), str) or not raw["tool"]:
+            raise ThroughputResumeError("call_record_invalid")
+        if not _is_sha256(raw.get("arguments_sha256")) or not _is_sha256(raw.get("response_sha256")):
+            raise ThroughputResumeError("call_record_invalid")
+        commitment = contract.sha256_text(commitment + "\n" + contract.canonical_json(dict(raw)))
+        ordinal += 1
+    return commitment, ordinal
+
+
+def validate_transport_state(
+    attestation: Mapping[str, Any],
+    call_records: Sequence[Mapping[str, Any]],
+    *,
+    expected_transport: str,
+    expected_endpoint_sha256: str,
+    expected_tool_set_sha256: str,
+) -> None:
+    required = {
+        "schema_version",
+        "transport",
+        "endpoint_sha256",
+        "required_tool_set_sha256",
+        "tool_call_count",
+        "counts_by_tool",
+        "server_identity_call_count",
+        "ordered_call_commitment_sha256",
+    }
+    if not isinstance(attestation, Mapping) or set(attestation) != required:
+        raise ThroughputResumeError("transport_shape_invalid")
+    if attestation.get("schema_version") != "phase3_cycle007_mcp_transport_attestation_v1":
+        raise ThroughputResumeError("transport_schema_drift")
+    if (
+        attestation.get("transport") != expected_transport
+        or attestation.get("endpoint_sha256") != expected_endpoint_sha256
+        or attestation.get("required_tool_set_sha256") != expected_tool_set_sha256
+    ):
+        raise ThroughputResumeError("transport_identity_drift")
+    count = attestation.get("tool_call_count")
+    _require_count(count)
+    if count != len(call_records):
+        raise ThroughputResumeError("transport_count_drift")
+    commitment, next_ordinal = extend_serial_call_commitment(
+        initial_call_commitment(), call_records, starting_ordinal=1
+    )
+    if next_ordinal != count + 1 or commitment != attestation.get("ordered_call_commitment_sha256"):
+        raise ThroughputResumeError("transport_commitment_drift")
+    counts = Counter(str(record["tool"]) for record in call_records)
+    if dict(sorted(counts.items())) != attestation.get("counts_by_tool"):
+        raise ThroughputResumeError("transport_tool_counts_drift")
+    if counts.get("mcp_server_identity", 0) != attestation.get("server_identity_call_count"):
+        raise ThroughputResumeError("transport_identity_count_drift")
+
+
+def build_progress_receipt(
+    *,
+    sealed_packet_count: int,
+    target_packet_count: int,
+    target_row_count: int,
+    last_sealed_sidecar_sha256: str | None,
+    last_sealed_sidecar_id: str | None,
+    resume_identity: Mapping[str, Any],
+    mcp_transport_attestation: Mapping[str, Any],
+    mcp_call_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    _require_count(sealed_packet_count)
+    _require_count(target_packet_count, minimum=1)
+    _require_count(target_row_count, minimum=1)
+    if sealed_packet_count > target_packet_count:
+        raise ThroughputResumeError("sealed_prefix_overflow")
+    if sealed_packet_count == 0:
+        if last_sealed_sidecar_sha256 is not None or last_sealed_sidecar_id is not None:
+            raise ThroughputResumeError("progress_last_sidecar_invalid")
+    elif not _is_sha256(last_sealed_sidecar_sha256) or not isinstance(last_sealed_sidecar_id, str):
+        raise ThroughputResumeError("progress_last_sidecar_invalid")
+    validate_transport_state(
+        mcp_transport_attestation,
+        mcp_call_records,
+        expected_transport=str(mcp_transport_attestation.get("transport")),
+        expected_endpoint_sha256=str(mcp_transport_attestation.get("endpoint_sha256")),
+        expected_tool_set_sha256=str(mcp_transport_attestation.get("required_tool_set_sha256")),
+    )
+    receipt = {
+        "schema_version": PROGRESS_SCHEMA_VERSION,
+        "text_free": True,
+        "evaluation_cycle_id": EVALUATION_CYCLE_ID,
+        "activation_state": ACTIVATION_STATE,
+        "sealed_packet_count": sealed_packet_count,
+        "next_packet_index": sealed_packet_count + 1,
+        "target_packet_count": target_packet_count,
+        "target_row_count": target_row_count,
+        "last_sealed_sidecar_sha256": last_sealed_sidecar_sha256,
+        "last_sealed_sidecar_id": last_sealed_sidecar_id,
+        "identity_sha256": identity_sha256(resume_identity),
+        "mcp_transport_attestation": dict(mcp_transport_attestation),
+        "mcp_call_records": [dict(record) for record in mcp_call_records],
+    }
+    _reject_private_keys_recursive(receipt)
+    receipt["progress_sha256"] = contract.sha256_value(receipt)
+    return receipt
+
+
+def validate_progress_receipt(
+    receipt: Mapping[str, Any],
+    resume_identity: Mapping[str, Any],
+    *,
+    expected_transport: str,
+    expected_endpoint_sha256: str,
+    expected_tool_set_sha256: str,
+    sealed_packet_count: int | None = None,
+    last_sealed_sidecar_sha256: str | None = None,
+) -> None:
+    if not isinstance(receipt, Mapping) or set(receipt) != PROGRESS_REQUIRED_KEYS:
+        raise ThroughputResumeError("progress_shape_invalid")
+    _reject_private_keys_recursive(receipt)
+    if receipt.get("schema_version") != PROGRESS_SCHEMA_VERSION:
+        raise ThroughputResumeError("progress_schema_drift")
+    if receipt.get("text_free") is not True or receipt.get("evaluation_cycle_id") != EVALUATION_CYCLE_ID:
+        raise ThroughputResumeError("progress_identity_drift")
+    if receipt.get("activation_state") != ACTIVATION_STATE:
+        raise ThroughputResumeError("progress_activation_drift")
+    unsigned = {key: value for key, value in receipt.items() if key != "progress_sha256"}
+    if receipt.get("progress_sha256") != contract.sha256_value(unsigned):
+        raise ThroughputResumeError("progress_hash_drift")
+    if receipt.get("identity_sha256") != identity_sha256(resume_identity):
+        raise ThroughputResumeError("identity_drift")
+    sealed = receipt.get("sealed_packet_count")
+    _require_count(sealed)
+    if receipt.get("next_packet_index") != sealed + 1:
+        raise ThroughputResumeError("progress_next_index_mismatch")
+    if sealed_packet_count is not None and sealed != sealed_packet_count:
+        raise ThroughputResumeError("progress_prefix_mismatch")
+    if last_sealed_sidecar_sha256 is not None and receipt.get("last_sealed_sidecar_sha256") != last_sealed_sidecar_sha256:
+        raise ThroughputResumeError("progress_last_sidecar_mismatch")
+    records = receipt.get("mcp_call_records")
+    attestation = receipt.get("mcp_transport_attestation")
+    if not isinstance(records, list) or not isinstance(attestation, Mapping):
+        raise ThroughputResumeError("transport_shape_invalid")
+    validate_transport_state(
+        attestation,
+        records,
+        expected_transport=expected_transport,
+        expected_endpoint_sha256=expected_endpoint_sha256,
+        expected_tool_set_sha256=expected_tool_set_sha256,
+    )
+
+
+def read_progress(path: Path) -> dict[str, Any]:
+    _assert_private_path(path, directory=False)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ThroughputResumeError("progress_unreadable") from exc
+    if not isinstance(value, dict):
+        raise ThroughputResumeError("progress_shape_invalid")
+    return value
+
+
+def write_progress(root: Path, receipt: Mapping[str, Any]) -> None:
+    _assert_private_path(root, directory=True)
+    destination = root / PROGRESS_NAME
+    encoded = (contract.canonical_json(receipt) + "\n").encode("utf-8")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{PROGRESS_NAME}.", dir=root)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            os.fchmod(handle.fileno(), compiler.PRIVATE_FILE_MODE)
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        _fsync_directory(root)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def prepare_resume_root(output_dir: Path) -> tuple[Path, Path]:
+    parent = output_dir.parent
+    _assert_private_path(parent, directory=True)
+    root = resume_root_for(output_dir)
+    tombstone = root.with_name(f"{root.name}.cleanup")
+    if os.path.lexists(tombstone):
+        raise ThroughputResumeError("cleanup_tombstone_exists")
+    if os.path.lexists(root):
+        _assert_private_path(root, directory=True)
+    else:
+        try:
+            os.mkdir(root, compiler.PRIVATE_DIR_MODE)
+        except FileExistsError:
+            _assert_private_path(root, directory=True)
+        _fsync_directory(parent)
+        _assert_private_path(root, directory=True)
+    bundle = root / BUNDLE_NAME
+    if os.path.lexists(bundle):
+        _assert_private_path(bundle, directory=True)
+    else:
+        try:
+            os.mkdir(bundle, compiler.PRIVATE_DIR_MODE)
+        except FileExistsError:
+            _assert_private_path(bundle, directory=True)
+        _fsync_directory(root)
+        _assert_private_path(bundle, directory=True)
+    return root, bundle
+
+
+def inspect_resume_root(root: Path) -> None:
+    """Reject foreign root entries and discard one interrupted progress temp."""
+    _assert_private_path(root, directory=True)
+    progress_temps: list[Path] = []
+    for path in sorted(root.iterdir()):
+        if path.name in {BUNDLE_NAME, PROGRESS_NAME, LOCK_NAME}:
+            _assert_private_path(path, directory=path.name == BUNDLE_NAME)
+        elif TEMP_PROGRESS_NAME_RE.fullmatch(path.name):
+            _assert_private_path(path, directory=False)
+            progress_temps.append(path)
+        else:
+            raise ThroughputResumeError("resume_foreign_entry")
+    if len(progress_temps) > 1:
+        raise ThroughputResumeError("resume_temp_invalid")
+    if progress_temps:
+        progress_temps[0].unlink()
+        _fsync_directory(root)
+
+
+@contextlib.contextmanager
+def exclusive_resume_lock(root: Path) -> Iterator[None]:
+    _assert_private_path(root, directory=True)
+    path = root / LOCK_NAME
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, compiler.PRIVATE_FILE_MODE)
+    try:
+        os.fchmod(descriptor, compiler.PRIVATE_FILE_MODE)
+        _assert_private_stat(os.fstat(descriptor), directory=False)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise ThroughputResumeError("compiler_lock_held") from exc
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def inspect_sealed_prefix(bundle: Path) -> tuple[list[int], int]:
+    _assert_private_path(bundle, directory=True)
+    indexes: list[int] = []
+    temp_paths: list[tuple[int, Path]] = []
+    for path in sorted(bundle.iterdir()):
+        if path.is_symlink():
+            raise ThroughputResumeError("resume_symlink")
+        sidecar_match = SIDECAR_NAME_RE.fullmatch(path.name)
+        temp_match = TEMP_SIDECAR_NAME_RE.fullmatch(path.name)
+        if sidecar_match:
+            _assert_private_path(path, directory=False)
+            indexes.append(int(sidecar_match.group(1)))
+        elif temp_match:
+            _assert_private_path(path, directory=False)
+            temp_paths.append((int(temp_match.group(1)), path))
+        elif path.name == "manifest.json":
+            _assert_private_path(path, directory=False)
+        else:
+            raise ThroughputResumeError("resume_foreign_entry")
+    sealed = assert_consecutive_prefix(indexes)
+    if len(temp_paths) > 1 or (temp_paths and temp_paths[0][0] != sealed + 1):
+        raise ThroughputResumeError("resume_temp_invalid")
+    if temp_paths:
+        temp_paths[0][1].unlink()
+        _fsync_directory(bundle)
+    return indexes, sealed
+
+
+def assert_consecutive_prefix(indexes: Sequence[int]) -> int:
+    if list(indexes) != list(range(1, len(indexes) + 1)):
+        raise ThroughputResumeError("sealed_prefix_gap")
+    return indexes[-1] if indexes else 0
+
+
+def load_sidecar(path: Path) -> dict[str, Any]:
+    _assert_private_path(path, directory=False)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ThroughputResumeError("sidecar_unreadable") from exc
+    if not isinstance(value, dict):
+        raise ThroughputResumeError("sidecar_shape_invalid")
+    return value
+
+
+def atomic_install_bundle(bundle: Path, output_dir: Path) -> None:
+    _assert_private_path(bundle, directory=True)
+    if os.path.lexists(output_dir):
+        raise ThroughputResumeError("output_exists")
+    source_parent = bundle.parent
+    _rename_directory_noreplace(bundle, output_dir)
+    _fsync_directory(source_parent)
+    _fsync_directory(output_dir.parent)
+
+
+def _rename_directory_noreplace(source_path: Path, destination_path: Path) -> None:
+    """Atomically rename one directory while refusing any destination."""
+    source = os.fsencode(source_path)
+    destination = os.fsencode(destination_path)
+    libc = ctypes.CDLL(None, use_errno=True)
+    if sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
+        rename = libc.renameat2
+        rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(-100, source, -100, destination, 1)
+    elif sys.platform == "darwin" and hasattr(libc, "renamex_np"):
+        rename = libc.renamex_np
+        rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(source, destination, 0x00000004)
+    else:
+        raise ThroughputResumeError("atomic_noreplace_unavailable")
+    if result != 0:
+        error = ctypes.get_errno()
+        if error in {17, 39}:
+            raise ThroughputResumeError("output_exists")
+        raise OSError(error, os.strerror(error))
+
+
+def cleanup_resume_metadata(root: Path) -> None:
+    """Atomically retire the live root, then best-effort remove its tombstone.
+
+    Once the rename commits, later invocations validate the installed output
+    without depending on cleanup metadata. A crash during unlink/rmdir can
+    therefore leave only an inert tombstone, never a recovery blocker.
+    """
+    tombstone = root.with_name(f"{root.name}.cleanup")
+    if os.path.lexists(tombstone):
+        raise ThroughputResumeError("cleanup_tombstone_exists")
+    _rename_directory_noreplace(root, tombstone)
+    _fsync_directory(root.parent)
+    _remove_cleanup_tombstone(tombstone)
+
+
+def reap_cleanup_tombstone(root: Path) -> bool:
+    """Finish an interrupted cleanup without racing a still-live cleaner."""
+    tombstone = root.with_name(f"{root.name}.cleanup")
+    if not os.path.lexists(tombstone):
+        return False
+    _assert_private_path(tombstone, directory=True)
+    lock_path = tombstone / LOCK_NAME
+    descriptor: int | None = None
+    if os.path.lexists(lock_path):
+        flags = os.O_RDWR
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(lock_path, flags)
+        _assert_private_stat(os.fstat(descriptor), directory=False)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(descriptor)
+            return False
+    try:
+        _remove_cleanup_tombstone(tombstone)
+    finally:
+        if descriptor is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+    return True
+
+
+def _remove_cleanup_tombstone(tombstone: Path) -> None:
+    allowed = {PROGRESS_NAME, LOCK_NAME}
+    try:
+        entries = list(tombstone.iterdir())
+    except FileNotFoundError:
+        return
+    for path in entries:
+        if path.name not in allowed:
+            raise ThroughputResumeError("cleanup_foreign_entry")
+        if os.path.lexists(path):
+            _assert_private_path(path, directory=False)
+    for name in (PROGRESS_NAME, LOCK_NAME):
+        path = tombstone / name
+        if os.path.lexists(path):
+            _assert_private_path(path, directory=False)
+            path.unlink()
+    with contextlib.suppress(FileNotFoundError):
+        os.rmdir(tombstone)
+    _fsync_directory(tombstone.parent)
+
+
+def assert_private_tree(root: Path) -> None:
+    _assert_private_path(root, directory=True)
+    for path in sorted(root.rglob("*")):
+        _assert_private_path(path, directory=path.is_dir())
+
+
+def bound_packet_workers(requested: int, *, authorized: bool = False) -> int:
+    del authorized
+    if requested != 1:
+        raise ThroughputResumeError("packet_workers_not_authorized")
+    return 1
+
+
+def packet_loop_is_serial() -> bool:
+    return True
+
+
+def _assert_private_path(path: Path, *, directory: bool) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ThroughputResumeError("resume_path_unavailable") from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise ThroughputResumeError("resume_symlink")
+    _assert_private_stat(info, directory=directory)
+
+
+def _assert_private_stat(info: os.stat_result, *, directory: bool) -> None:
+    wanted_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not wanted_type(info.st_mode):
+        raise ThroughputResumeError("resume_path_type_invalid")
+    expected_mode = compiler.PRIVATE_DIR_MODE if directory else compiler.PRIVATE_FILE_MODE
+    if stat.S_IMODE(info.st_mode) != expected_mode:
+        raise ThroughputResumeError("resume_mode_drift")
+    if info.st_uid != os.geteuid():
+        raise ThroughputResumeError("resume_owner_drift")
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _require_count(value: Any, *, minimum: int = 0) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise ThroughputResumeError("count_invalid")
+
+
+def _reject_private_keys_recursive(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if key in PRIVATE_PROGRESS_KEYS:
+                raise ThroughputResumeError("progress_not_text_free")
+            _reject_private_keys_recursive(child)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_private_keys_recursive(child)

--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
@@ -657,6 +657,7 @@ class LocalMcpSourcesClient:
         self._tool_call_count = 0
         self._tool_call_counts: Counter[str] = Counter()
         self._tool_call_commitment = contract.sha256_text("phase3-cycle007-mcp-tool-call-chain-v1")
+        self._tool_call_records: list[dict[str, Any]] = []
         # Fail closed immediately on drift/unavailability rather than at the
         # first evidence call.
         self._transport.preflight()
@@ -689,18 +690,79 @@ class LocalMcpSourcesClient:
 
     def _call_text(self, tool: str, arguments: Mapping[str, Any]) -> str:
         response = self._transport.call_tool(tool, arguments)
+        self._record_tool_call(
+            tool=tool,
+            arguments_sha256=contract.sha256_value(arguments),
+            response_sha256=contract.sha256_text(response),
+        )
+        return response
+
+    def _record_tool_call(
+        self,
+        *,
+        tool: str,
+        arguments_sha256: str,
+        response_sha256: str,
+    ) -> None:
         self._tool_call_count += 1
         self._tool_call_counts[tool] += 1
         call = {
             "ordinal": self._tool_call_count,
             "tool": tool,
-            "arguments_sha256": contract.sha256_value(arguments),
-            "response_sha256": contract.sha256_text(response),
+            "arguments_sha256": arguments_sha256,
+            "response_sha256": response_sha256,
         }
         self._tool_call_commitment = contract.sha256_text(
             self._tool_call_commitment + "\n" + contract.canonical_json(call)
         )
-        return response
+        self._tool_call_records.append(call)
+
+    def transport_call_records(self) -> list[dict[str, Any]]:
+        """Return the private text-free ledger behind the public commitment.
+
+        Records contain only ordinals, fixed tool names, and SHA-256 values;
+        arguments, responses, row text, and locators are never persisted here.
+        """
+        return copy.deepcopy(self._tool_call_records)
+
+    def resume_transport_state(
+        self,
+        prior_attestation: Mapping[str, Any],
+        prior_call_records: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Restore a verified sealed-prefix call chain and append this process's identity call.
+
+        The caller must first validate the durable receipt and recompute the
+        prior commitment from ``prior_call_records``. This method repeats the
+        transport-shape checks and can run only immediately after construction,
+        when the sole current-process call is ``mcp_server_identity``.
+        """
+        from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+
+        if self._tool_call_count != 1 or len(self._tool_call_records) != 1:
+            raise LocalMcpSourcesClientError("resume_transport_state_too_late")
+        current_identity_call = dict(self._tool_call_records[0])
+        if current_identity_call.get("tool") != _SERVER_IDENTITY_TOOL:
+            raise LocalMcpSourcesClientError("resume_transport_identity_missing")
+        current_attestation = self.transport_attestation()
+        throughput.validate_transport_state(
+            prior_attestation,
+            prior_call_records,
+            expected_transport=str(current_attestation["transport"]),
+            expected_endpoint_sha256=str(current_attestation["endpoint_sha256"]),
+            expected_tool_set_sha256=str(current_attestation["required_tool_set_sha256"]),
+        )
+        self._tool_call_count = int(prior_attestation["tool_call_count"])
+        self._tool_call_counts = Counter(
+            {str(name): int(count) for name, count in prior_attestation["counts_by_tool"].items()}
+        )
+        self._tool_call_commitment = str(prior_attestation["ordered_call_commitment_sha256"])
+        self._tool_call_records = [dict(record) for record in prior_call_records]
+        self._record_tool_call(
+            tool=str(current_identity_call["tool"]),
+            arguments_sha256=str(current_identity_call["arguments_sha256"]),
+            response_sha256=str(current_identity_call["response_sha256"]),
+        )
 
     def transport_attestation(self) -> Mapping[str, Any]:
         """Return a text-free commitment to the actual ordered MCP calls."""
@@ -1831,6 +1893,323 @@ def compile_sidecar_bundle(
             shutil.rmtree(staging, ignore_errors=True)
 
 
+def _empty_bundle_aggregate() -> dict[str, Any]:
+    return {
+        "channel_counts": Counter(),
+        "status_counts": Counter(),
+        "supports_counts": Counter(),
+        "sufficient_support_rows": 0,
+        "archaic_only_risk_rows": 0,
+        "russian_shadow_suspected_rows": 0,
+        "row_count": 0,
+        "sidecar_index": [],
+    }
+
+
+def _accumulate_validated_sidecar(
+    aggregate: dict[str, Any],
+    sidecar: Mapping[str, Any],
+    sidecar_sha256: str,
+) -> None:
+    for row_record in sidecar["rows"]:
+        aggregate["row_count"] += 1
+        aggregate["sufficient_support_rows"] += int(row_record["sufficient_support"])
+        aggregate["archaic_only_risk_rows"] += int(row_record["archaic_only_risk"])
+        aggregate["russian_shadow_suspected_rows"] += int(row_record["russian_shadow_suspected"])
+        for evidence_record in row_record["evidence"]:
+            aggregate["channel_counts"][evidence_record["channel"]] += 1
+            aggregate["status_counts"][evidence_record["status"]] += 1
+            aggregate["supports_counts"][evidence_record["supports"]] += 1
+    aggregate["sidecar_index"].append(
+        {
+            "packet_index": sidecar["packet_index"],
+            "row_count": sidecar["row_count"],
+            "sidecar_sha256": sidecar_sha256,
+            "sidecar_id": sidecar["sidecar_id"],
+            "lane": sidecar["lane"],
+            "packet_binding": sidecar["packet_binding"],
+        }
+    )
+
+
+def _build_bundle_manifest(
+    *,
+    aggregate: Mapping[str, Any],
+    packet_count: int,
+    identity: Mapping[str, Any],
+    source_package_binding: Mapping[str, Any] | None,
+    transport_attestation: Mapping[str, Any],
+) -> dict[str, Any]:
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "text_free": True,
+        "evaluation_cycle_id": EVALUATION_CYCLE_ID,
+        "tokenizer_id": TOKENIZER_ID,
+        "tokenizer_version": TOKENIZER_VERSION,
+        "code_hashes": CODE_HASHES,
+        "server_code_sha256": identity["server_code_sha256"],
+        "sources_db_sha256": identity["sources_db_sha256"],
+        "vesum_db_sha256": identity["vesum_db_sha256"],
+        "packet_count": packet_count,
+        "row_count": aggregate["row_count"],
+        "network_lookups_performed": 0,
+        "counts_by_channel": dict(sorted(aggregate["channel_counts"].items())),
+        "counts_by_status": dict(sorted(aggregate["status_counts"].items())),
+        "counts_by_supports": dict(sorted(aggregate["supports_counts"].items())),
+        "sufficient_support_rows": aggregate["sufficient_support_rows"],
+        "archaic_only_risk_rows": aggregate["archaic_only_risk_rows"],
+        "russian_shadow_suspected_rows": aggregate["russian_shadow_suspected_rows"],
+        "sidecars": aggregate["sidecar_index"],
+        "source_package_binding": dict(source_package_binding) if source_package_binding is not None else None,
+        "mcp_transport_attestation": dict(transport_attestation),
+    }
+    manifest["manifest_sha256"] = contract.sha256_value(manifest)
+    return manifest
+
+
+def compile_sidecar_bundle_resumable(
+    packets: Sequence[Sequence[Mapping[str, Any]]],
+    client: LocalMcpSourcesClient,
+    output_dir: Path,
+    *,
+    residual_lane_packets: Sequence[bool],
+    packet_bindings: Sequence[Mapping[str, Any] | None],
+    source_package_binding: Mapping[str, Any] | None,
+    _interrupt_after_packet: int | None = None,
+    _interrupt_after_install: bool = False,
+) -> dict[str, Any]:
+    """Compile serially with a validated, durable sealed-packet prefix.
+
+    Resume changes custody only. Every reused sidecar is re-read, checked
+    against the current frozen identity and packet binding, and passed through
+    the production validator before it contributes to the final manifest.
+    """
+    from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+
+    if not isinstance(client, LocalMcpSourcesClient):
+        raise contract.EvidenceContractError("resumable compile requires LocalMcpSourcesClient")
+    residual_flags = list(residual_lane_packets)
+    bindings = list(packet_bindings)
+    contract.require(len(residual_flags) == len(packets), "residual_lane_packets length must match packets")
+    contract.require(len(bindings) == len(packets), "packet_bindings length must match packets")
+    identity = client.server_identity()
+    expected_identity = {
+        "tokenizer_id": TOKENIZER_ID,
+        "tokenizer_version": TOKENIZER_VERSION,
+        "code_hashes": CODE_HASHES,
+        "server_code_sha256": identity["server_code_sha256"],
+        "sources_db_sha256": identity["sources_db_sha256"],
+        "vesum_db_sha256": identity["vesum_db_sha256"],
+    }
+    target_row_count = sum(len(packet) for packet in packets)
+    resume_identity = throughput.build_resume_identity(
+        expected_identity,
+        source_package_binding=source_package_binding,
+        packet_bindings=bindings,
+        residual_lane_packets=residual_flags,
+        target_packet_count=len(packets),
+        target_row_count=target_row_count,
+    )
+    root = throughput.resume_root_for(output_dir)
+
+    # A crash after the single atomic install but before metadata cleanup is
+    # repaired by validating the installed bundle and removing only metadata.
+    if os.path.lexists(output_dir):
+        if os.path.lexists(root) and (not root.is_dir() or root.is_symlink()):
+            raise contract.EvidenceContractError("invalid resume metadata root")
+        root_is_live = root.is_dir()
+        lock_context = throughput.exclusive_resume_lock(root) if root_is_live else contextlib.nullcontext()
+        with lock_context:
+            if root_is_live:
+                throughput.inspect_resume_root(root)
+            throughput.assert_private_tree(output_dir)
+            actual_names = {path.name for path in output_dir.iterdir()}
+            expected_names = {"manifest.json"} | {
+                throughput.sidecar_filename(index) for index in range(1, len(packets) + 1)
+            }
+            contract.require(actual_names == expected_names, "installed bundle shape drift")
+            manifest_path = output_dir / "manifest.json"
+            manifest = throughput.load_sidecar(manifest_path)
+            validator.validate_manifest(manifest, expected_identity=expected_identity)
+            contract.require(manifest["packet_count"] == len(packets), "installed packet count drift")
+            contract.require(manifest["row_count"] == target_row_count, "installed row count drift")
+            contract.require(
+                manifest["source_package_binding"] == source_package_binding,
+                "installed source package binding drift",
+            )
+            progress: Mapping[str, Any] | None = None
+            if root_is_live and os.path.lexists(root / throughput.PROGRESS_NAME):
+                current_attestation = client.transport_attestation()
+                progress = throughput.read_progress(root / throughput.PROGRESS_NAME)
+                throughput.validate_progress_receipt(
+                    progress,
+                    resume_identity,
+                    expected_transport=str(current_attestation["transport"]),
+                    expected_endpoint_sha256=str(current_attestation["endpoint_sha256"]),
+                    expected_tool_set_sha256=str(current_attestation["required_tool_set_sha256"]),
+                    sealed_packet_count=len(packets),
+                )
+            aggregate = _empty_bundle_aggregate()
+            last_sha256: str | None = None
+            for packet_index, expected_binding in enumerate(bindings, start=1):
+                sidecar_path = output_dir / throughput.sidecar_filename(packet_index)
+                sidecar = throughput.load_sidecar(sidecar_path)
+                validator.validate_sidecar(sidecar, expected_identity=expected_identity)
+                contract.require(sidecar["packet_binding"] == expected_binding, "installed packet binding drift")
+                expected_lane = "residual_label" if residual_flags[packet_index - 1] else "clean_label"
+                contract.require(sidecar["lane"] == expected_lane, "installed lane drift")
+                contract.require(sidecar["row_count"] == len(packets[packet_index - 1]), "installed row count drift")
+                last_sha256 = contract.sha256_file(sidecar_path)
+                _accumulate_validated_sidecar(aggregate, sidecar, last_sha256)
+            if progress is not None:
+                contract.require(
+                    progress["last_sealed_sidecar_sha256"] == last_sha256,
+                    "installed last sidecar drift",
+                )
+            rebuilt = _build_bundle_manifest(
+                aggregate=aggregate,
+                packet_count=len(packets),
+                identity=identity,
+                source_package_binding=source_package_binding,
+                transport_attestation=manifest["mcp_transport_attestation"],
+            )
+            contract.require(rebuilt == manifest, "installed manifest/file drift")
+            if root_is_live:
+                throughput.cleanup_resume_metadata(root)
+            else:
+                throughput.reap_cleanup_tombstone(root)
+        return manifest
+
+    root, bundle = throughput.prepare_resume_root(output_dir)
+    with throughput.exclusive_resume_lock(root):
+        throughput.inspect_resume_root(root)
+        indexes, sealed = throughput.inspect_sealed_prefix(bundle)
+        progress_path = root / throughput.PROGRESS_NAME
+        progress: Mapping[str, Any] | None = None
+        if os.path.lexists(progress_path):
+            progress = throughput.read_progress(progress_path)
+            progress_sealed = progress.get("sealed_packet_count")
+            contract.require(
+                isinstance(progress_sealed, int) and not isinstance(progress_sealed, bool),
+                "resume progress count invalid",
+            )
+            if sealed == progress_sealed + 1:
+                trailing = bundle / throughput.sidecar_filename(sealed)
+                trailing.unlink()
+                _fsync_directory(bundle)
+                indexes.pop()
+                sealed -= 1
+            contract.require(sealed == progress_sealed, "resume prefix/progress mismatch")
+        elif sealed:
+            raise contract.EvidenceContractError("resume progress missing")
+
+        aggregate = _empty_bundle_aggregate()
+        last_sha256: str | None = None
+        last_sidecar_id: str | None = None
+        for packet_index in indexes:
+            sidecar_path = bundle / throughput.sidecar_filename(packet_index)
+            sidecar = throughput.load_sidecar(sidecar_path)
+            validator.validate_sidecar(sidecar, expected_identity=expected_identity)
+            contract.require(sidecar["packet_index"] == packet_index, "resume packet index drift")
+            contract.require(sidecar["packet_binding"] == bindings[packet_index - 1], "resume packet binding drift")
+            expected_lane = "residual_label" if residual_flags[packet_index - 1] else "clean_label"
+            contract.require(sidecar["lane"] == expected_lane, "resume lane drift")
+            contract.require(sidecar["row_count"] == len(packets[packet_index - 1]), "resume row count drift")
+            last_sha256 = contract.sha256_file(sidecar_path)
+            last_sidecar_id = str(sidecar["sidecar_id"])
+            _accumulate_validated_sidecar(aggregate, sidecar, last_sha256)
+
+        current_attestation = client.transport_attestation()
+        if progress is not None:
+            throughput.validate_progress_receipt(
+                progress,
+                resume_identity,
+                expected_transport=str(current_attestation["transport"]),
+                expected_endpoint_sha256=str(current_attestation["endpoint_sha256"]),
+                expected_tool_set_sha256=str(current_attestation["required_tool_set_sha256"]),
+                sealed_packet_count=sealed,
+                last_sealed_sidecar_sha256=last_sha256,
+            )
+            contract.require(progress["target_packet_count"] == len(packets), "resume packet target drift")
+            contract.require(progress["target_row_count"] == target_row_count, "resume row target drift")
+            if sealed:
+                contract.require(progress["last_sealed_sidecar_id"] == last_sidecar_id, "resume sidecar id drift")
+            client.resume_transport_state(
+                progress["mcp_transport_attestation"],
+                progress["mcp_call_records"],
+            )
+        else:
+            throughput.write_progress(
+                root,
+                throughput.build_progress_receipt(
+                    sealed_packet_count=0,
+                    target_packet_count=len(packets),
+                    target_row_count=target_row_count,
+                    last_sealed_sidecar_sha256=None,
+                    last_sealed_sidecar_id=None,
+                    resume_identity=resume_identity,
+                    mcp_transport_attestation=client.transport_attestation(),
+                    mcp_call_records=client.transport_call_records(),
+                ),
+            )
+
+        manifest_path = bundle / "manifest.json"
+        if os.path.lexists(manifest_path):
+            manifest_path.unlink()
+            _fsync_directory(bundle)
+        for packet_index in range(sealed + 1, len(packets) + 1):
+            sidecar = compile_packet_sidecar(
+                packet_index,
+                packets[packet_index - 1],
+                client,
+                residual_lane=residual_flags[packet_index - 1],
+                packet_binding=bindings[packet_index - 1],
+            )
+            validator.validate_sidecar(sidecar, expected_identity=expected_identity)
+            payload = (contract.canonical_json(sidecar) + "\n").encode("utf-8")
+            sidecar_path = bundle / throughput.sidecar_filename(packet_index)
+            last_sha256 = _atomic_write_private(sidecar_path, payload)
+            _fsync_directory(bundle)
+            last_sidecar_id = str(sidecar["sidecar_id"])
+            _accumulate_validated_sidecar(aggregate, sidecar, last_sha256)
+            throughput.write_progress(
+                root,
+                throughput.build_progress_receipt(
+                    sealed_packet_count=packet_index,
+                    target_packet_count=len(packets),
+                    target_row_count=target_row_count,
+                    last_sealed_sidecar_sha256=last_sha256,
+                    last_sealed_sidecar_id=last_sidecar_id,
+                    resume_identity=resume_identity,
+                    mcp_transport_attestation=client.transport_attestation(),
+                    mcp_call_records=client.transport_call_records(),
+                ),
+            )
+            if _interrupt_after_packet == packet_index:
+                raise RuntimeError("synthetic_interrupt_after_seal")
+
+        manifest = _build_bundle_manifest(
+            aggregate=aggregate,
+            packet_count=len(packets),
+            identity=identity,
+            source_package_binding=source_package_binding,
+            transport_attestation=client.transport_attestation(),
+        )
+        validator.validate_manifest(manifest, expected_identity=expected_identity)
+        _atomic_write_private(
+            manifest_path,
+            (contract.canonical_json(manifest) + "\n").encode("utf-8"),
+        )
+        _fsync_directory(bundle)
+        throughput.assert_private_tree(root)
+        throughput.atomic_install_bundle(bundle, output_dir)
+        if _interrupt_after_install:
+            raise RuntimeError("synthetic_interrupt_after_install")
+        throughput.cleanup_resume_metadata(root)
+    throughput.assert_private_tree(output_dir)
+    return manifest
+
+
 def _install_staged_bundle(staging: Path, output_dir: Path) -> None:
     """Atomically claim ``output_dir`` and move the staged bundle into it.
 
@@ -2346,7 +2725,16 @@ def compile_cycle007_package(
         fixture=fixture,
     )
 
-    return compile_sidecar_bundle(
+    if fixture:
+        return compile_sidecar_bundle(
+            packets,
+            client,
+            output_dir,
+            residual_lane_packets=residual_flags,
+            packet_bindings=packet_bindings,
+            source_package_binding=source_package_binding,
+        )
+    return compile_sidecar_bundle_resumable(
         packets,
         client,
         output_dir,

--- a/tests/test_phase3_cycle007_evidence_compile_throughput.py
+++ b/tests/test_phase3_cycle007_evidence_compile_throughput.py
@@ -1,0 +1,334 @@
+"""Synthetic proof for Cycle 007 durable sealed-packet resume custody."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+from scripts.projects.open_model_data import phase3_cycle007_evidence_compiler as compiler
+from scripts.projects.open_model_data import phase3_cycle007_evidence_contract as contract
+
+_COMPILER_TEST_PATH = Path(__file__).with_name("test_phase3_cycle007_evidence_compiler.py")
+_SPEC = importlib.util.spec_from_file_location("cycle007_compiler_test_helpers", _COMPILER_TEST_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_HELPERS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_HELPERS)
+
+_RUNNER_PATH = Path(__file__).parents[1] / "batch_state" / "phase3-compile-cycle007-evidence-v1.py"
+_RUNNER_SPEC = importlib.util.spec_from_file_location("cycle007_compile_runner", _RUNNER_PATH)
+assert _RUNNER_SPEC is not None and _RUNNER_SPEC.loader is not None
+_RUNNER = importlib.util.module_from_spec(_RUNNER_SPEC)
+_RUNNER_SPEC.loader.exec_module(_RUNNER)
+
+
+def _client(tmp_path: Path) -> compiler.LocalMcpSourcesClient:
+    tmp_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    files = _HELPERS._stub_client_files(tmp_path)
+    transport = _HELPERS._passing_transport(identity_files=files)
+    return compiler.LocalMcpSourcesClient(transport=transport, **files)
+
+
+def _row(unit_id: str) -> dict[str, object]:
+    return _HELPERS._row(unit_id, "слово")
+
+
+def _inputs() -> tuple[list[list[dict[str, object]]], list[bool], list[dict[str, object]]]:
+    packets = [[_row("unit-1")], [_row("unit-2")]]
+    flags = [False, False]
+    bindings = [compiler._default_packet_binding(index, rows) for index, rows in enumerate(packets, start=1)]
+    return packets, flags, bindings
+
+
+def _run(
+    tmp_path: Path,
+    output: Path,
+    *,
+    interrupt_after_packet: int | None = None,
+    interrupt_after_install: bool = False,
+) -> dict[str, object]:
+    packets, flags, bindings = _inputs()
+    client = _client(tmp_path)
+    try:
+        return compiler.compile_sidecar_bundle_resumable(
+            packets,
+            client,
+            output,
+            residual_lane_packets=flags,
+            packet_bindings=bindings,
+            source_package_binding=None,
+            _interrupt_after_packet=interrupt_after_packet,
+            _interrupt_after_install=interrupt_after_install,
+        )
+    finally:
+        client.close()
+
+
+def _private_parent(tmp_path: Path, name: str) -> Path:
+    parent = tmp_path / name
+    parent.mkdir(mode=0o700)
+    return parent
+
+
+def test_resume_is_serial_only() -> None:
+    assert throughput.packet_loop_is_serial() is True
+    assert throughput.bound_packet_workers(1) == 1
+    with pytest.raises(throughput.ThroughputResumeError, match="packet_workers_not_authorized"):
+        throughput.bound_packet_workers(2, authorized=True)
+
+
+def test_progress_recomputes_hash_only_call_ledger_and_rejects_tamper(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    attestation = client.transport_attestation()
+    records = client.transport_call_records()
+    identity = throughput.build_resume_identity(
+        {
+            "tokenizer_id": compiler.TOKENIZER_ID,
+            "tokenizer_version": compiler.TOKENIZER_VERSION,
+            "code_hashes": compiler.CODE_HASHES,
+            **{key: client.server_identity()[key] for key in ("server_code_sha256", "sources_db_sha256", "vesum_db_sha256")},
+        },
+        source_package_binding=None,
+        packet_bindings=[],
+        residual_lane_packets=[],
+        target_packet_count=2,
+        target_row_count=2,
+    )
+    receipt = throughput.build_progress_receipt(
+        sealed_packet_count=0,
+        target_packet_count=2,
+        target_row_count=2,
+        last_sealed_sidecar_sha256=None,
+        last_sealed_sidecar_id=None,
+        resume_identity=identity,
+        mcp_transport_attestation=attestation,
+        mcp_call_records=records,
+    )
+    dumped = contract.canonical_json(receipt)
+    assert "слово" not in dumped
+    assert "http://" not in dumped
+    assert receipt["activation_state"] == throughput.ACTIVATION_STATE
+
+    tampered = json.loads(json.dumps(receipt))
+    tampered["mcp_call_records"][0]["response_sha256"] = "f" * 64
+    unsigned = {key: value for key, value in tampered.items() if key != "progress_sha256"}
+    tampered["progress_sha256"] = contract.sha256_value(unsigned)
+    with pytest.raises(throughput.ThroughputResumeError, match="transport_commitment_drift"):
+        throughput.validate_progress_receipt(
+            tampered,
+            identity,
+            expected_transport=str(attestation["transport"]),
+            expected_endpoint_sha256=str(attestation["endpoint_sha256"]),
+            expected_tool_set_sha256=str(attestation["required_tool_set_sha256"]),
+        )
+    drifted_identity = {**identity, "target_row_count": 3}
+    with pytest.raises(throughput.ThroughputResumeError, match="identity_drift"):
+        throughput.validate_progress_receipt(
+            receipt,
+            drifted_identity,
+            expected_transport=str(attestation["transport"]),
+            expected_endpoint_sha256=str(attestation["endpoint_sha256"]),
+            expected_tool_set_sha256=str(attestation["required_tool_set_sha256"]),
+        )
+    client.close()
+
+
+def test_recursive_private_key_rejection(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    attestation = dict(client.transport_attestation())
+    records = client.transport_call_records()
+    records[0]["nested"] = {"prompt": "forbidden"}
+    with pytest.raises(throughput.ThroughputResumeError, match="call_record_invalid"):
+        throughput.build_progress_receipt(
+            sealed_packet_count=0,
+            target_packet_count=2,
+            target_row_count=2,
+            last_sealed_sidecar_sha256=None,
+            last_sealed_sidecar_id=None,
+            resume_identity={"x": 1},
+            mcp_transport_attestation=attestation,
+            mcp_call_records=records,
+        )
+    client.close()
+
+
+def test_preplaced_symlink_and_mode_drift_fail_closed(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    output = parent / "evidence"
+    root = throughput.resume_root_for(output)
+    target = _private_parent(tmp_path, "target")
+    root.symlink_to(target, target_is_directory=True)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_symlink"):
+        throughput.prepare_resume_root(output)
+    root.unlink()
+    root.mkdir(mode=0o755)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_mode_drift"):
+        throughput.prepare_resume_root(output)
+
+
+def test_owner_drift_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    parent = _private_parent(tmp_path, "private")
+    current_uid = os.geteuid()
+    monkeypatch.setattr(throughput.os, "geteuid", lambda: current_uid + 1)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_owner_drift"):
+        throughput.prepare_resume_root(parent / "evidence")
+
+
+def test_compiler_level_lock_rejects_concurrent_owner(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    root, _ = throughput.prepare_resume_root(parent / "evidence")
+    with throughput.exclusive_resume_lock(root):
+        with pytest.raises(throughput.ThroughputResumeError, match="compiler_lock_held"):
+            with throughput.exclusive_resume_lock(root):
+                pass
+
+
+def test_foreign_resume_root_entry_fails_closed(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    root, _ = throughput.prepare_resume_root(parent / "evidence")
+    foreign = root / "foreign"
+    foreign.write_text("x", encoding="utf-8")
+    foreign.chmod(0o600)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_foreign_entry"):
+        throughput.inspect_resume_root(root)
+
+
+def test_one_interrupted_progress_temp_is_discarded(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    root, _ = throughput.prepare_resume_root(parent / "evidence")
+    interrupted = root / ".progress.json.interrupted"
+    interrupted.write_text("{", encoding="utf-8")
+    interrupted.chmod(0o600)
+    throughput.inspect_resume_root(root)
+    assert not interrupted.exists()
+
+
+def test_multiple_interrupted_progress_temps_fail_closed(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    root, _ = throughput.prepare_resume_root(parent / "evidence")
+    for suffix in ("one", "two"):
+        interrupted = root / f".progress.json.{suffix}"
+        interrupted.write_text("{", encoding="utf-8")
+        interrupted.chmod(0o600)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_temp_invalid"):
+        throughput.inspect_resume_root(root)
+
+
+def test_crash_after_seal_resumes_without_recompiling_prefix(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "resume")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError, match="synthetic_interrupt_after_seal"):
+        _run(tmp_path / "client-a", output, interrupt_after_packet=1)
+    root = throughput.resume_root_for(output)
+    assert (root / "bundle" / "sidecar-0001.json").is_file()
+    first_bytes = (root / "bundle" / "sidecar-0001.json").read_bytes()
+
+    manifest = _run(tmp_path / "client-b", output)
+    assert manifest["packet_count"] == 2
+    assert manifest["row_count"] == 2
+    assert (output / "sidecar-0001.json").read_bytes() == first_bytes
+    assert not root.exists()
+
+
+def test_one_trailing_uncommitted_sidecar_is_discarded(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "resume")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError):
+        _run(tmp_path / "client-a", output, interrupt_after_packet=1)
+    bundle = throughput.bundle_dir_for(output)
+    trailing = bundle / "sidecar-0002.json"
+    trailing.write_bytes((bundle / "sidecar-0001.json").read_bytes())
+    trailing.chmod(0o600)
+    manifest = _run(tmp_path / "client-b", output)
+    assert manifest["packet_count"] == 2
+    assert json.loads((output / "sidecar-0002.json").read_text())["packet_index"] == 2
+
+
+def test_gap_and_multiple_atomic_temps_fail_closed(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "resume")
+    output = parent / "evidence"
+    _, bundle = throughput.prepare_resume_root(output)
+    for name in ("sidecar-0001.json", "sidecar-0003.json"):
+        path = bundle / name
+        path.write_text("{}", encoding="utf-8")
+        path.chmod(0o600)
+    with pytest.raises(throughput.ThroughputResumeError, match="sealed_prefix_gap"):
+        throughput.inspect_sealed_prefix(bundle)
+
+    for path in list(bundle.iterdir()):
+        path.unlink()
+    for suffix in ("one", "two"):
+        temporary = bundle / f".sidecar-0001.json.{suffix}"
+        temporary.write_text("{", encoding="utf-8")
+        temporary.chmod(0o600)
+    with pytest.raises(throughput.ThroughputResumeError, match="resume_temp_invalid"):
+        throughput.inspect_sealed_prefix(bundle)
+
+
+def test_crash_after_atomic_install_is_repaired(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "repair")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError, match="synthetic_interrupt_after_install"):
+        _run(tmp_path / "client-a", output, interrupt_after_install=True)
+    root = throughput.resume_root_for(output)
+    assert output.is_dir()
+    assert root.is_dir()
+    manifest = _run(tmp_path / "client-b", output)
+    assert manifest["packet_count"] == 2
+    assert not root.exists()
+
+
+def test_crash_during_cleanup_cannot_strand_installed_output(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "repair")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError, match="synthetic_interrupt_after_install"):
+        _run(tmp_path / "client-a", output, interrupt_after_install=True)
+    root = throughput.resume_root_for(output)
+    tombstone = root.with_name(f"{root.name}.cleanup")
+    os.rename(root, tombstone)
+    (tombstone / throughput.PROGRESS_NAME).unlink()
+
+    manifest = _run(tmp_path / "client-b", output)
+    assert manifest["packet_count"] == 2
+    assert output.is_dir()
+    assert not root.exists()
+    assert not tombstone.exists()
+
+
+def test_runner_allows_private_installed_output_for_idempotent_validation(tmp_path: Path) -> None:
+    package = _private_parent(tmp_path, "package")
+    source_manifest = package / "label-manifest.json"
+    source_manifest.write_text("{}", encoding="utf-8")
+    source_manifest.chmod(0o600)
+    output = package / "evidence"
+    output.mkdir(mode=0o700)
+    assert _RUNNER._validate_paths(package, source_manifest, output) == (package, source_manifest, output)
+
+
+def test_straight_and_resumed_sidecars_are_byte_identical(tmp_path: Path) -> None:
+    straight_parent = _private_parent(tmp_path, "straight")
+    resumed_parent = _private_parent(tmp_path, "resumed")
+    straight = straight_parent / "evidence"
+    resumed = resumed_parent / "evidence"
+    _run(tmp_path / "client-straight", straight)
+    with pytest.raises(RuntimeError):
+        _run(tmp_path / "client-first", resumed, interrupt_after_packet=1)
+    _run(tmp_path / "client-second", resumed)
+    for packet_index in (1, 2):
+        name = throughput.sidecar_filename(packet_index)
+        assert (straight / name).read_bytes() == (resumed / name).read_bytes()
+    straight_manifest = json.loads((straight / "manifest.json").read_text())
+    resumed_manifest = json.loads((resumed / "manifest.json").read_text())
+    assert straight_manifest["mcp_transport_attestation"] != resumed_manifest["mcp_transport_attestation"]
+
+
+def test_invalid_existing_output_without_resume_metadata_is_refused(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "private")
+    output = parent / "evidence"
+    output.mkdir(mode=0o700)
+    with pytest.raises(contract.EvidenceContractError, match="bundle shape drift"):
+        _run(tmp_path / "client", output)


### PR DESCRIPTION
Closes the restart-cost gap in #6375 by adding serial, durable sealed-packet resume custody for Cycle007.

- preserves the frozen query plan, validator, endpoint, packet/row denominator, and labeling controls
- revalidates every reused sidecar and exact source/compiler identity
- persists a recomputable hash-only MCP call ledger
- uses a compiler-level nonblocking lock and exact UID/mode checks
- installs the complete bundle with one atomic no-replace directory rename
- repairs terminal crashes and self-heals interrupted cleanup tombstones
- keeps packet parallelism disabled

Verification:
- 132 focused tests passed
- Ruff passed
- py_compile passed
- independent Claude Sonnet 5 exact-head review: APPROVE at 6df75c6bb3cec64e62ca9c838383819fc397f60f

No runtime compiler launch, labeling, merge, or volume teardown is included.

X-Agent: codex/6375-cycle007-resume