### PR TITLE
chore(streams): register monitor epic stream #7177 and launcher selector

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -64,6 +64,7 @@ is the single source of truth for membership (auditor:
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
 | infra-harness | #6943 (successor to closed #4707) | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
+| monitor | #7177 | Monitor API + UI — fleet & host observability |
 | eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
 | open-model-data | #6321 (successor to closed #6164 and #6056) | Build evidence-bearing prepared Ukrainian data products on the completed Foundry engine. Community usefulness is primary; adoption is secondary evidence, not a gate. Every shipped artifact names a concrete consumer decision/use case. Current truth: #6375 is the active Phase 3 v2.1 functional-role and runtime rebinding task; #6333 is historical `ENGINE_READY` evidence only and establishes no linguistic, source, consumer, or completion status; Phase 4 remains blocked. |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -21,6 +21,8 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 | **harness / infra** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-driver.sh --epic infra` |
 | **devops** | Gemini (AGY) | `./start-gemini-driver.sh --epic devops` |
 | **devops** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-driver.sh --epic devops` |
+| **monitor** | Gemini (AGY) | `./start-gemini-driver.sh --epic monitor` |
+| **monitor** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-driver.sh --epic monitor` |
 | **corpus** (acquisition & ingestion) | Gemini (AGY) | `./start-gemini-driver.sh --epic corpus` |
 | **atlas** (Word Atlas + Practice Hub product) | Grok 4.6 | `./start-grok-driver.sh --epic atlas` |
 | **hramatka** (teacher lesson service) | Grok 4.6 · Fable if judgment-heavy | `./start-grok-driver.sh --epic hramatka` |

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -56,6 +56,8 @@ eq "$(handoff_epic_from_argv)" "" "empty argv (epic)"
 eq "$(launcher_selector_lane infra.fleet-comms)" "infra" "fleet-comms resolves to infra"
 eq "$(launcher_selector_lane devops)" "devops" "devops resolves to dedicated lane"
 eq "$(launcher_selector_stream infra.devops)" "epic:5703" "devops resolves to dedicated stream"
+eq "$(launcher_selector_lane monitor)" "monitor" "monitor resolves to dedicated lane"
+eq "$(launcher_selector_stream infra.monitor)" "epic:7177" "monitor resolves to dedicated stream"
 eq "$(launcher_selector_lane atlas.practice)" "atlas" "atlas practice resolves to atlas"
 eq "$(launcher_selector_stream hramatka.lessons)" "epic:4542" "hramatka lessons resolves"
 # corpus is a documented, currently-recommended driver epic
@@ -71,6 +73,8 @@ eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → 
 eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
 eq "$(handoff_identity_for_epic infra.devops)" "claude-devops" "dot devops → claude-devops"
+eq "$(handoff_identity_for_epic monitor)" "claude-monitor" "epic monitor → claude-monitor"
+eq "$(handoff_identity_for_epic infra.monitor)" "claude-monitor" "dot monitor → claude-monitor"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
 # Codex uses provider-specific per-epic slots; DevOps is independent from Infra.
@@ -79,6 +83,8 @@ eq "$(handoff_identity_for_codex_epic hramatka)" "codex-hramatka" "Codex hramatk
 eq "$(handoff_identity_for_codex_epic harness)" "codex-infra" "Codex harness → codex-infra"
 eq "$(handoff_identity_for_codex_epic infra)" "codex-infra" "Codex infra → codex-infra alias"
 eq "$(handoff_identity_for_codex_epic infra.devops)" "codex-devops" "Codex dot devops → codex-devops"
+eq "$(handoff_identity_for_codex_epic monitor)" "codex-monitor" "Codex epic monitor → codex-monitor"
+eq "$(handoff_identity_for_codex_epic infra.monitor)" "codex-monitor" "Codex dot monitor → codex-monitor"
 eq "$(handoff_identity_for_codex_epic)" "" "Codex no epic → empty slot"
 
 # Gemini uses provider-specific per-epic slots; DevOps is independent from Infra.
@@ -87,6 +93,8 @@ eq "$(handoff_identity_for_gemini_epic hramatka)" "gemini-hramatka" "Gemini hram
 eq "$(handoff_identity_for_gemini_epic harness)" "gemini-infra" "Gemini harness → gemini-infra"
 eq "$(handoff_identity_for_gemini_epic infra)" "gemini-infra" "Gemini infra → gemini-infra alias"
 eq "$(handoff_identity_for_gemini_epic infra.devops)" "gemini-devops" "Gemini dot devops → gemini-devops"
+eq "$(handoff_identity_for_gemini_epic monitor)" "gemini-monitor" "Gemini epic monitor → gemini-monitor"
+eq "$(handoff_identity_for_gemini_epic infra.monitor)" "gemini-monitor" "Gemini dot monitor → gemini-monitor"
 eq "$(handoff_identity_for_gemini_epic)" "" "Gemini no epic → empty slot"
 
 

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -25,6 +25,9 @@ streams:
   devops:
     title: "DevOps automation, CI, release & launcher reliability"
     epics: [5703]
+  monitor:
+    title: "Monitor API + UI — fleet & host observability"
+    epics: [7177]
   eval-harness:
     title: "Internal UA quality machinery — QG gates, validators, product adapters"
     epics: [4913]

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -79,6 +79,9 @@ launcher_selector_resolve() {
     devops|infra.devops)
       printf 'devops\tepic:5703\n'
       ;;
+    monitor|infra.monitor)
+      printf 'monitor\tepic:7177\n'
+      ;;
     atlas|practice|practice-hub|atlas.practice)
       printf 'atlas\tepic:4387\n'
       ;;
@@ -122,6 +125,7 @@ launcher_selector_help() {
 Valid lane selectors:
   infra | harness | infra.fleet-comms
   devops | infra.devops
+  monitor | infra.monitor
   atlas | practice | atlas.practice
   hramatka | hramatka.lessons
   folk | seminars-folk

--- a/tests/test_fleet_taxonomy_aliases.py
+++ b/tests/test_fleet_taxonomy_aliases.py
@@ -169,6 +169,8 @@ def test_inventory_session_streams_wiring() -> None:
         ("infra.fleet-comms", "infra", INFRA_STREAM_ID),
         ("devops", "devops", "epic:5703"),
         ("infra.devops", "devops", "epic:5703"),
+        ("monitor", "monitor", "epic:7177"),
+        ("infra.monitor", "monitor", "epic:7177"),
         ("atlas", "atlas", "epic:4387"),
         ("practice", "atlas", "epic:4387"),
         ("practice-hub", "atlas", "epic:4387"),

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -83,11 +83,35 @@ def test_devops_resolves_to_dedicated_provider_slot(resolver: str, expected: str
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
 @pytest.mark.parametrize(
+    ("resolver", "expected"),
+    [
+        ("handoff_identity_for_epic", "claude-monitor"),
+        ("handoff_identity_for_gemini_epic", "gemini-monitor"),
+        ("handoff_identity_for_codex_epic", "codex-monitor"),
+        ("handoff_identity_for_cursor_epic", "cursor-monitor"),
+    ],
+)
+def test_monitor_resolves_to_dedicated_provider_slot(resolver: str, expected: str) -> None:
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; "$2" monitor', "bash", str(_HANDOFF_IDENTITY), resolver],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
     ("selector", "lane", "stream", "claude_slot", "gemini_slot", "grok_slot"),
     [
         ("infra.fleet-comms", "infra", INFRA_STREAM_ID, "claude-infra", "gemini-infra", "grok-infra"),
         ("infra.devops", "devops", "epic:5703", "claude-devops", "gemini-devops", "grok-devops"),
         ("devops", "devops", "epic:5703", "claude-devops", "gemini-devops", "grok-devops"),
+        ("infra.monitor", "monitor", "epic:7177", "claude-monitor", "gemini-monitor", "grok-monitor"),
+        ("monitor", "monitor", "epic:7177", "claude-monitor", "gemini-monitor", "grok-monitor"),
         ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),
@@ -162,6 +186,15 @@ def test_devops_epic_is_registered_separately_from_infra() -> None:
     assert registry["devops"]["epics"] == [5703]
     assert registry["infra-harness"]["epics"] != registry["devops"]["epics"]
     assert f"epic:{int(registry['infra-harness']['epics'][0])}" == INFRA_STREAM_ID
+
+
+def test_monitor_epic_is_registered_separately_from_infra() -> None:
+    registry = yaml.safe_load(_ISSUE_STREAMS.read_text(encoding="utf-8"))["streams"]
+
+    assert registry["infra-harness"]["epics"]
+    assert registry["monitor"]["epics"] == [7177]
+    assert registry["infra-harness"]["epics"] != registry["monitor"]["epics"]
+    assert registry["devops"]["epics"] != registry["monitor"]["epics"]
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")


### PR DESCRIPTION
Parent: #7177 (stream `monitor`). Authored by the AGY lane (delegate task `monitor-epic-register-7177`); PR opened by main because the worker lost `gh` auth after pushing (#7166 class, reproduced on the notebook).

## What changed
- `scripts/config/issue_streams.yaml`: new stream `monitor` → epics `[7177]` (SSOT for membership audit).
- `scripts/lib/handoff_identity.sh`: selector `monitor | infra.monitor` → lane `monitor`, stream `epic:7177`; help text updated; existing selectors unchanged.
- `docs/WORKSTREAMS.md` § Streams mirror row; `docs/runbooks/epic-orchestrator-roster.md` driver rows (AGY default, Codex alternate).
- Tests: `scripts/audit/test_handoff_identity.sh` (+8), `tests/test_handoff_identity.py` (+33: lane, stream, per-provider handoff slots, dot-notation), `tests/test_fleet_taxonomy_aliases.py` (+2).

## Evidence (main re-ran in the dispatch worktree at 882956d)
- `bash scripts/audit/test_handoff_identity.sh` → exit 0 (`ok - handoff identity fixtures passed`)
- `pytest -q tests/test_handoff_identity.py tests/test_fleet_taxonomy_aliases.py` → 88 passed
- `issue_stream_audit.py --json` → stream `monitor` registered; `--check` exit 1 only for 7 pre-existing orphans (#7161, #7172, …) unrelated to this branch.
- Mutation check (worker): reverting the selector case → shell test `FAIL: monitor resolves to dedicated lane` and 7 pytest failures; restored → green.

Not in scope: registry-driven selector refactor (M2 child of #7177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkDWzR5qEqEd3WpMux4XzP