### PR TITLE
fix(ci): run repo-wide invariant tests on the PR-tier fastlane (#7171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,9 +240,14 @@ jobs:
             base_ref="origin/main"
           fi
           mkdir -p ci-artifacts
-          python scripts/ci/changed_tests.py \
-            --base "$base_ref" \
+          selector_args=(
+            --base "$base_ref"
             --output ci-artifacts/fastlane-test-files.txt
+          )
+          if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            selector_args+=(--include-repo-invariants)
+          fi
+          python scripts/ci/changed_tests.py "${selector_args[@]}"
           if [[ -s ci-artifacts/fastlane-test-files.txt ]]; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
             echo "Selected test modules:"
@@ -738,31 +743,14 @@ jobs:
       - name: Check internal IDs are not published
         run: .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
-      - name: Resolve secret scan commit scope (#7141)
-        id: secret-scan-scope
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || '' }}
-          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
-          PUSH_AFTER_SHA: ${{ github.event.after || '' }}
-        run: |
-          set -euo pipefail
-          .venv/bin/python scripts/ci/secret_scan_scope.py
-
       - name: Gate scrubbed public identifiers and teacher-cloze answers
         env:
-          EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          OPSEC_RANGE: ${{ steps.secret-scan-scope.outputs.opsec_range }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             .venv/bin/python scripts/audit/lint_opsec_leaks.py \
               "${PR_BASE_SHA}...${PR_HEAD_SHA}" --public-identifiers
-          elif [ -n "$OPSEC_RANGE" ]; then
-            .venv/bin/python scripts/audit/lint_opsec_leaks.py \
-              --commit-range "$OPSEC_RANGE" --public-identifiers
           else
             .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
           fi
@@ -994,8 +982,6 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
-          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 1
@@ -1008,8 +994,6 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
-          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 2
@@ -1022,8 +1006,6 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
-          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Fail if TruffleHog exhausted retries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,14 +743,31 @@ jobs:
       - name: Check internal IDs are not published
         run: .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
+      - name: Resolve secret scan commit scope (#7141)
+        id: secret-scan-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || '' }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          PUSH_AFTER_SHA: ${{ github.event.after || '' }}
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/ci/secret_scan_scope.py
+
       - name: Gate scrubbed public identifiers and teacher-cloze answers
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          OPSEC_RANGE: ${{ steps.secret-scan-scope.outputs.opsec_range }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             .venv/bin/python scripts/audit/lint_opsec_leaks.py \
               "${PR_BASE_SHA}...${PR_HEAD_SHA}" --public-identifiers
+          elif [ -n "$OPSEC_RANGE" ]; then
+            .venv/bin/python scripts/audit/lint_opsec_leaks.py \
+              --commit-range "$OPSEC_RANGE" --public-identifiers
           else
             .venv/bin/python scripts/audit/lint_opsec_leaks.py --public-identifiers
           fi
@@ -982,6 +999,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 1
@@ -994,6 +1013,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Sleep before TruffleHog retry 2
@@ -1006,6 +1027,8 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
+          base: ${{ steps.secret-scan-scope.outputs.trufflehog_base }}
+          head: ${{ steps.secret-scan-scope.outputs.trufflehog_head }}
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob
 
       - name: Fail if TruffleHog exhausted retries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ filterwarnings = [
 markers = [
     "website: Docusaurus website integrity tests (links, frontmatter, sidebar)",
     "slow: tests that load ML models or require long execution time",
+    "repo_invariant: repo-wide invariant checks that run in the PR-tier fastlane",
     "atlas_release: real-DB Atlas runtime-shard release gate (requires data/atlas.db; fails closed)",
     "live_network: opt-out of socket-guard for integration tests requiring outbound network",
 ]

--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -11,7 +11,10 @@ import argparse
 import subprocess
 import sys
 from collections.abc import Iterable, Sequence
-from pathlib import PurePosixPath
+from fnmatch import fnmatchcase
+from pathlib import Path, PurePosixPath
+
+REPO_INVARIANTS_MANIFEST = Path(__file__).with_name("fastlane_always_tests.txt")
 
 
 def comparison_range(base: str, head: str) -> str:
@@ -50,9 +53,38 @@ def is_test_module(path: str) -> bool:
     )
 
 
-def select_test_modules(paths: Iterable[str]) -> list[str]:
-    """Return a sorted, duplicate-free direct-test plan from changed paths."""
-    return sorted({path for path in paths if is_test_module(path)})
+def is_repo_invariant_trigger(path: str) -> bool:
+    """Whether a PR-tier change can affect a repo-wide invariant."""
+    candidate = PurePosixPath(path)
+    return (
+        candidate.suffix == ".py"
+        or path == "pyproject.toml"
+        or fnmatchcase(candidate.name, "requirements*.txt")
+        or path == ".github/workflows/ci.yml"
+        or path.startswith("tests/fixtures/")
+    )
+
+
+def load_repo_invariant_tests() -> list[str]:
+    """Read the explicit fastlane manifest in its declared order."""
+    return [
+        line.strip()
+        for line in REPO_INVARIANTS_MANIFEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def select_test_modules(
+    paths: Iterable[str], *, include_repo_invariants: bool = False
+) -> list[str]:
+    """Return direct tests, optionally unioned with triggered repo invariants."""
+    changed_paths = list(paths)
+    selected = sorted({path for path in changed_paths if is_test_module(path)})
+
+    if include_repo_invariants and any(is_repo_invariant_trigger(path) for path in changed_paths):
+        selected = sorted(set(selected).union(load_repo_invariant_tests()))
+
+    return selected
 
 
 def write_plan(path: str, selected: Sequence[str]) -> None:
@@ -71,10 +103,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--head", default="HEAD", help="head SHA/ref when --base is a ref (default: HEAD)")
     parser.add_argument("--output", help="write the newline-delimited selected test-file plan here")
+    parser.add_argument(
+        "--include-repo-invariants",
+        action="store_true",
+        help="append the invariant manifest when repository-wide trigger paths changed",
+    )
     args = parser.parse_args(argv)
 
     try:
-        selected = select_test_modules(changed_files(comparison_range(args.base, args.head)))
+        selected = select_test_modules(
+            changed_files(comparison_range(args.base, args.head)),
+            include_repo_invariants=args.include_repo_invariants,
+        )
     except subprocess.CalledProcessError as exc:
         print(f"changed-test selection failed: git exited {exc.returncode}", file=sys.stderr)
         return exc.returncode or 1

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -1,0 +1,5 @@
+tests/test_cyrillic_roundtrip_invariant.py
+tests/test_fleet_routing_open_model_data_import_guard.py
+tests/test_lint_test_assertions.py
+tests/test_subprocess_timeout_guard.py
+tests/test_threshold_source_of_truth.py

--- a/scripts/ci/fastlane_requirements.py
+++ b/scripts/ci/fastlane_requirements.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Build a slim dependency file, constrained by the repository lock, for changed pytest modules.
 
-Use this helper only for CI's advisory changed-test fastlane. It maps direct
-third-party imports in selected tests through an explicit, reviewed mapping;
-unknown imports fail closed instead of guessing a distribution name. The
-required full pytest tier remains responsible for the complete dependency set.
+Use this helper only for CI's advisory changed-test fastlane. It maps
+third-party imports reachable from selected tests through an explicit,
+reviewed mapping; unknown imports fail closed instead of guessing a
+distribution name. The required full pytest tier remains responsible for the
+complete dependency set.
 """
 
 from __future__ import annotations
@@ -79,6 +80,96 @@ def import_roots(path: Path) -> set[str]:
     return roots
 
 
+def _imported_modules(path: Path, project_root: Path, *, module_level_only: bool = False) -> set[str]:
+    """Return absolute module names imported by ``path`` for graph traversal."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    rel_path = path.resolve().relative_to(project_root.resolve())
+    module_parts = rel_path.with_suffix("").parts
+    package_parts = module_parts[:-1]
+
+    nodes = ast.walk(tree)
+    if module_level_only:
+        class ModuleImports(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.nodes: list[ast.AST] = []
+
+            def visit(self, node: ast.AST) -> None:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                    return
+                self.nodes.append(node)
+                for child in ast.iter_child_nodes(node):
+                    self.visit(child)
+
+        visitor = ModuleImports()
+        visitor.visit(tree)
+        nodes = visitor.nodes
+
+    for node in nodes:
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        if node.level == 0:
+            base_parts = tuple(node.module.split(".")) if node.module else ()
+        else:
+            trim = max(0, node.level - 1)
+            base_parts = package_parts[: max(0, len(package_parts) - trim)]
+            if node.module:
+                base_parts += tuple(node.module.split("."))
+
+        if base_parts:
+            modules.add(".".join(base_parts))
+        for alias in node.names:
+            if alias.name != "*" and base_parts:
+                modules.add(".".join((*base_parts, alias.name)))
+
+    return modules
+
+
+def _resolve_project_module(module: str, project_root: Path) -> Path | None:
+    """Resolve a module name to a project Python file, if it is project-local."""
+    parts = tuple(part for part in module.split(".") if part)
+    if not parts:
+        return None
+
+    relative = Path(*parts)
+    candidates = (
+        project_root / relative.with_suffix(".py"),
+        project_root / relative / "__init__.py",
+        project_root / "scripts" / relative.with_suffix(".py"),
+        project_root / "scripts" / relative / "__init__.py",
+    )
+    return next((candidate for candidate in candidates if candidate.is_file()), None)
+
+
+def _reachable_import_roots(test_paths: Iterable[Path], project_root: Path) -> set[str]:
+    """Collect third-party roots from selected tests and reachable project modules."""
+    initial_paths = {path.resolve() for path in test_paths}
+    pending = [(path, True) for path in initial_paths]
+    visited: set[Path] = set()
+    roots: set[str] = set()
+
+    while pending:
+        path, is_initial_test = pending.pop()
+        if path in visited:
+            continue
+        visited.add(path)
+        for module in _imported_modules(path, project_root, module_level_only=not is_initial_test):
+            root = module.split(".", 1)[0]
+            if root in LIVE_MODEL_IMPORTS or root == "__future__":
+                continue
+            resolved = _resolve_project_module(module, project_root)
+            if resolved is not None:
+                pending.append((resolved, False))
+            elif not is_project_import(root, project_root):
+                roots.add(root)
+
+    return roots
+
+
 def read_lock(path: Path) -> dict[str, str]:
     """Read exact version pins from the lock file, keyed canonically."""
     requirements: dict[str, str] = {}
@@ -116,8 +207,8 @@ def select_requirements(
     lock_requirements: dict[str, str],
     project_root: Path,
 ) -> list[str]:
-    """Return the base profile plus pins for reviewed direct test imports."""
-    roots = set().union(*(import_roots(path) for path in test_paths))
+    """Return the base profile plus pins for reviewed reachable test imports."""
+    roots = _reachable_import_roots(test_paths, project_root)
     unknown: set[str] = set()
     additions: set[str] = set()
 

--- a/scripts/ci/test_source_cache.py
+++ b/scripts/ci/test_source_cache.py
@@ -1,0 +1,19 @@
+"""Process-local source/AST cache for repo-wide static test guards."""
+
+from __future__ import annotations
+
+import ast
+from functools import cache
+from pathlib import Path
+
+
+@cache
+def read_test_source(path: Path) -> str:
+    """Read one static-scan source file once per pytest process."""
+    return path.read_text(encoding="utf-8")
+
+
+@cache
+def parse_test_source(path: Path) -> ast.Module:
+    """Parse one static-scan source file once per pytest process."""
+    return ast.parse(read_test_source(path), filename=str(path))

--- a/scripts/lint/lint_test_assertions.py
+++ b/scripts/lint/lint_test_assertions.py
@@ -30,6 +30,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from scripts.ci.test_source_cache import parse_test_source, read_test_source
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Regex matching epic ID stream literals
@@ -177,6 +179,79 @@ def _extract_epic_ids(val: object) -> set[str]:
             results.update(_extract_epic_ids(k))
             results.update(_extract_epic_ids(v))
     return results
+
+
+def _may_evaluate_epic_literal(tree: ast.AST) -> bool:
+    """Keep scanning when an assertion can statically evaluate an epic ID."""
+
+    def expression_has_epic(node: ast.AST, env: _Environment) -> bool:
+        return any(
+            _extract_epic_ids(_eval_expr(sub, env))
+            for sub in ast.walk(node)
+        )
+
+    def block_has_epic(stmts: Sequence[ast.stmt], env: _Environment) -> bool:
+        for stmt in stmts:
+            if isinstance(stmt, ast.Assign):
+                _bind_targets(stmt.targets, _eval_expr(stmt.value, env), env)
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                _bind_targets([stmt.target], _eval_expr(stmt.value, env), env)
+            elif isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name):
+                old_val = env.get(stmt.target.id)
+                inc_val = _eval_expr(stmt.value, env)
+                if isinstance(stmt.op, ast.Add) and isinstance(old_val, str) and isinstance(inc_val, str):
+                    env.set(stmt.target.id, old_val + inc_val)
+            elif isinstance(stmt, ast.Assert):
+                if expression_has_epic(stmt.test, env):
+                    return True
+            elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if block_has_epic(stmt.body, _Environment(parent=env)):
+                    return True
+            elif isinstance(stmt, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith)):
+                if block_has_epic(stmt.body, env):
+                    return True
+                if getattr(stmt, "orelse", None) and block_has_epic(stmt.orelse, env):
+                    return True
+            elif isinstance(stmt, ast.Try):
+                if block_has_epic(stmt.body, env):
+                    return True
+                if any(block_has_epic(handler.body, env) for handler in stmt.handlers):
+                    return True
+                if stmt.orelse and block_has_epic(stmt.orelse, env):
+                    return True
+                if stmt.finalbody and block_has_epic(stmt.finalbody, env):
+                    return True
+        return False
+
+    return block_has_epic(tree.body, _Environment()) if isinstance(tree, ast.Module) else False
+
+
+def _source_may_contain_split_epic_literal(source_code: str) -> bool:
+    """Recognize split/escaped literal pieces before paying for an AST scan."""
+    values: list[str] = []
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source_code).readline)
+        for token in tokens:
+            if token.type == tokenize.STRING:
+                try:
+                    value = ast.literal_eval(token.string)
+                except (SyntaxError, ValueError):
+                    value = token.string
+                if isinstance(value, str):
+                    values.append(value)
+            elif token.type == tokenize.NUMBER:
+                values.append(token.string)
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return True
+
+    literal_text = "".join(values).lower()
+    return bool(
+        _EPIC_ID_RE.search(literal_text)
+        or (
+            all(fragment in literal_text for fragment in ("e", "p", "i", "c", ":"))
+            and any(char.isdigit() for char in literal_text)
+        )
+    )
 
 
 def _find_positive_epic_violations(test_node: ast.AST, env: _Environment, polarity: bool = True) -> set[str]:
@@ -329,9 +404,11 @@ def scan_file(file_path: Path, repo_root: Path | None = None) -> list[AssertionV
     rel_path = file_path.resolve().relative_to(root).as_posix()
 
     try:
-        content = file_path.read_text(encoding="utf-8")
-        tree = ast.parse(content, filename=str(file_path))
+        content = read_test_source(file_path)
+        tree = parse_test_source(file_path)
     except (OSError, UnicodeDecodeError, SyntaxError):
+        return []
+    if not _may_evaluate_epic_literal(tree):
         return []
 
     lines = content.splitlines()
@@ -359,6 +436,14 @@ def find_stale_pinned_assertions(
 
     findings: list[AssertionViolation] = []
     for file_path in target_files:
+        try:
+            source = read_test_source(file_path)
+            if "epic" not in source.lower() and not _source_may_contain_split_epic_literal(source):
+                tree = parse_test_source(file_path)
+                if not _may_evaluate_epic_literal(tree):
+                    continue
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
         findings.extend(scan_file(file_path, repo_root=root))
 
     return findings

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -6,6 +6,14 @@ from pathlib import Path
 
 from scripts.ci import changed_tests
 
+REPO_INVARIANT_TESTS = [
+    "tests/test_cyrillic_roundtrip_invariant.py",
+    "tests/test_fleet_routing_open_model_data_import_guard.py",
+    "tests/test_lint_test_assertions.py",
+    "tests/test_subprocess_timeout_guard.py",
+    "tests/test_threshold_source_of_truth.py",
+]
+
 
 def test_comparison_range_accepts_base_ref_or_explicit_range() -> None:
     assert changed_tests.comparison_range("abc123", "def456") == "abc123...def456"
@@ -37,3 +45,41 @@ def test_write_plan_is_newline_delimited_and_empty_for_docs_only_change(tmp_path
 
     changed_tests.write_plan(str(output), [])
     assert output.read_text(encoding="utf-8") == ""
+
+
+def test_code_only_change_can_opt_into_repo_invariant_manifest() -> None:
+    selected = changed_tests.select_test_modules(
+        ["scripts/ci/changed_tests.py"], include_repo_invariants=True
+    )
+
+    assert selected == REPO_INVARIANT_TESTS
+
+
+def test_docs_only_change_stays_empty_with_repo_invariant_opt_in() -> None:
+    assert changed_tests.select_test_modules(["docs/foo.md"], include_repo_invariants=True) == []
+
+
+def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
+    for path in (
+        "pyproject.toml",
+        "requirements-dev.txt",
+        ".github/workflows/ci.yml",
+        "tests/fixtures/example.json",
+    ):
+        assert changed_tests.select_test_modules([path], include_repo_invariants=True) == REPO_INVARIANT_TESTS
+
+
+def test_repo_invariant_manifest_entries_are_not_duplicated() -> None:
+    selected = changed_tests.select_test_modules(
+        ["tests/test_threshold_source_of_truth.py", "pyproject.toml"],
+        include_repo_invariants=True,
+    )
+
+    assert selected == [
+        "tests/test_cyrillic_roundtrip_invariant.py",
+        "tests/test_fleet_routing_open_model_data_import_guard.py",
+        "tests/test_lint_test_assertions.py",
+        "tests/test_subprocess_timeout_guard.py",
+        "tests/test_threshold_source_of_truth.py",
+    ]
+    assert len(selected) == len(set(selected))

--- a/tests/test_ci_fastlane_requirements.py
+++ b/tests/test_ci_fastlane_requirements.py
@@ -147,3 +147,37 @@ from ukrainian_word_stress import Stressifier
     )
 
     assert selected == ["pytest==9.0.3"]
+
+
+def test_project_import_graph_adds_transitive_third_party_pin(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    _write(project_root / "scripts" / "__init__.py", "")
+    _write(project_root / "scripts" / "helper.py", "import requests\n")
+    test_path = _write(project_root / "tests" / "test_example.py", "from scripts.helper import value\n")
+
+    selected = fastlane_requirements.select_requirements(
+        [test_path],
+        base_requirements=[],
+        lock_requirements=_lock(tmp_path),
+        project_root=project_root,
+    )
+
+    assert selected == ["requests==2.34.2"]
+
+
+def test_unknown_transitive_project_import_fails_closed(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    _write(project_root / "scripts" / "__init__.py", "")
+    _write(project_root / "scripts" / "helper.py", "import unreviewed_transitive_vendor\n")
+    test_path = _write(project_root / "tests" / "test_example.py", "from scripts.helper import value\n")
+
+    with pytest.raises(
+        fastlane_requirements.RequirementSelectionError,
+        match="unreviewed_transitive_vendor",
+    ):
+        fastlane_requirements.select_requirements(
+            [test_path],
+            base_requirements=[],
+            lock_requirements=_lock(tmp_path),
+            project_root=project_root,
+        )

--- a/tests/test_cyrillic_roundtrip_invariant.py
+++ b/tests/test_cyrillic_roundtrip_invariant.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+pytestmark = pytest.mark.repo_invariant
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:

--- a/tests/test_fleet_routing_open_model_data_import_guard.py
+++ b/tests/test_fleet_routing_open_model_data_import_guard.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.repo_invariant
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Fleet routing surfaces only. WHY this list (not broader scripts/): #6870

--- a/tests/test_lint_test_assertions.py
+++ b/tests/test_lint_test_assertions.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.lint import lint_test_assertions
+
+pytestmark = pytest.mark.repo_invariant
 
 
 def test_lint_detects_hardcoded_epic_in_assertion(tmp_path: Path) -> None:
@@ -77,6 +81,21 @@ def test_lint_detects_string_concatenation(tmp_path: Path) -> None:
     epic_ids = {v.epic_id for v in violations}
     assert "epic:4707" in epic_ids  # allow-hardcoded-epic: test linter detection
     assert "epic:5703" in epic_ids  # allow-hardcoded-epic: test linter detection
+
+
+def test_lint_detects_split_epic_fragments(tmp_path: Path) -> None:
+    """The static-scan fast path must retain split literal constructions."""
+    test_file = tmp_path / "tests" / "test_example.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        'def test_split(out):\n    assert ("e" + "pic:" + str(5703)) in out\n',
+        encoding="utf-8",
+    )
+
+    violations = lint_test_assertions.scan_file(test_file, repo_root=tmp_path)
+    assert len(violations) == 1
+    assert violations[0].epic_id == "epic:5703"  # allow-hardcoded-epic: test linter detection
+    assert lint_test_assertions.find_stale_pinned_assertions(repo_root=tmp_path) == violations
 
 
 def test_lint_detects_fstring_assertion(tmp_path: Path) -> None:

--- a/tests/test_subprocess_timeout_guard.py
+++ b/tests/test_subprocess_timeout_guard.py
@@ -17,24 +17,36 @@ from __future__ import annotations
 
 import ast
 import os
+import re
 import subprocess
 import textwrap
 from pathlib import Path
 
+import pytest
+
+from scripts.ci import fastlane_requirements
+from scripts.ci.test_source_cache import parse_test_source, read_test_source
 from tests.project_python import project_python
+
+pytestmark = pytest.mark.repo_invariant
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TESTS_ROOT = _REPO_ROOT / "tests"
 _BOUNDED_FUNCS = frozenset({"run", "check_output", "call", "check_call"})
+_SUBPROCESS_IMPORT_RE = re.compile(r"(?m)^\s*(?:import subprocess|from subprocess import)\b")
 
 # Documented per-test budget (must stay aligned with pyproject + ci.yml).
 _EXPECTED_PYTEST_TIMEOUT_SECONDS = 120
 _EXPECTED_TIMEOUT_METHOD = "thread"
 
 
-def _subprocess_aliases(tree: ast.AST) -> dict[str, str | None]:
-    """Map local names to subprocess attrs (None => the module itself)."""
+def _timeout_less_calls(path: Path) -> list[tuple[int, str]]:
+    src = read_test_source(path)
+    if not _SUBPROCESS_IMPORT_RE.search(src):
+        return []
+    tree = parse_test_source(path)
     aliases: dict[str, str | None] = {}
+    calls: list[ast.Call] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
             for alias in node.names:
@@ -43,33 +55,24 @@ def _subprocess_aliases(tree: ast.AST) -> dict[str, str | None]:
             for alias in node.names:
                 if alias.name == "subprocess":
                     aliases[alias.asname or "subprocess"] = None
-    return aliases
+        elif isinstance(node, ast.Call):
+            calls.append(node)
 
-
-def _timeout_less_calls(path: Path) -> list[tuple[int, str]]:
-    src = path.read_text(encoding="utf-8")
-    tree = ast.parse(src, filename=str(path))
-    aliases = _subprocess_aliases(tree)
     found: list[tuple[int, str]] = []
-
-    class Visitor(ast.NodeVisitor):
-        def visit_Call(self, node: ast.Call) -> None:
-            name: str | None = None
-            if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
-                base = node.func.value.id
-                if base in aliases and aliases[base] is None and node.func.attr in _BOUNDED_FUNCS:
-                    name = f"subprocess.{node.func.attr}"
-            elif isinstance(node.func, ast.Name) and node.func.id in aliases:
-                attr = aliases[node.func.id]
-                if attr in _BOUNDED_FUNCS:
-                    name = f"subprocess.{attr}"
-            if name is not None:
-                kwargs = {kw.arg for kw in node.keywords if kw.arg}
-                if "timeout" not in kwargs:
-                    found.append((node.lineno, name))
-            self.generic_visit(node)
-
-    Visitor().visit(tree)
+    for node in calls:
+        name: str | None = None
+        if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+            base = node.func.value.id
+            if base in aliases and aliases[base] is None and node.func.attr in _BOUNDED_FUNCS:
+                name = f"subprocess.{node.func.attr}"
+        elif isinstance(node.func, ast.Name) and node.func.id in aliases:
+            attr = aliases[node.func.id]
+            if attr in _BOUNDED_FUNCS:
+                name = f"subprocess.{attr}"
+        if name is not None:
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            if "timeout" not in kwargs:
+                found.append((node.lineno, name))
     return found
 
 
@@ -94,10 +97,6 @@ def test_no_timeout_less_subprocess_calls_under_tests() -> None:
     """Fail CI when a new ``subprocess.run``/``check_*``/``call`` lacks ``timeout=``."""
     offenders: list[str] = []
     for path in sorted(_TESTS_ROOT.rglob("*.py")):
-        if path.name == Path(__file__).name:
-            # This file deliberately constructs a hanging child; its own
-            # subprocess.run calls carry timeout=.
-            pass
         try:
             hits = _timeout_less_calls(path)
         except SyntaxError as exc:
@@ -118,7 +117,7 @@ def test_deliberately_hanging_test_is_named_by_pytest_timeout(tmp_path: Path) ->
     """Prove pytest-timeout fails fast and names the hanging nodeid (#5740 AC).
 
     Runs an isolated child pytest so the hang cannot stall this suite. The child
-    uses a 2-second budget; we allow a generous outer bound so flake from
+    uses a 0.25-second budget; we allow a generous outer bound so flake from
     process startup does not become another hang.
     """
     hang_dir = tmp_path / "hang_suite"
@@ -152,7 +151,7 @@ def test_deliberately_hanging_test_is_named_by_pytest_timeout(tmp_path: Path) ->
             "no:xdist",
             "-p",
             "timeout",
-            "--timeout=2",
+            "--timeout=0.25",
             f"--timeout-method={_EXPECTED_TIMEOUT_METHOD}",
             "-o",
             "addopts=",
@@ -172,10 +171,109 @@ def test_deliberately_hanging_test_is_named_by_pytest_timeout(tmp_path: Path) ->
     )
     assert "test_intentional_forever_sleep" in combined, (
         "pytest-timeout must name the hanging test in its output "
-        f"(budget={_EXPECTED_PYTEST_TIMEOUT_SECONDS}s documented; child used 2s):\n"
+        f"(budget={_EXPECTED_PYTEST_TIMEOUT_SECONDS}s documented; child used 0.25s):\n"
         + combined
     )
     # Either Failed: Timeout / +++ Timeout / Failed: Timeout >… depending on version.
     assert "timeout" in combined.lower(), (
         "expected a timeout failure signal in child pytest output:\n" + combined
     )
+
+
+_FASTLANE_MANIFEST = _REPO_ROOT / "scripts" / "ci" / "fastlane_always_tests.txt"
+_FASTLANE_BASE_REQUIREMENTS = _REPO_ROOT / "scripts" / "ci" / "requirements-fastlane.txt"
+_REQUIREMENTS_LOCK = _REPO_ROOT / "requirements-lock.txt"
+
+
+def _fastlane_manifest() -> list[str]:
+    return [
+        line.strip()
+        for line in _FASTLANE_MANIFEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _has_repo_invariant_marker(path: Path) -> bool:
+    source = path.read_text(encoding="utf-8")
+    if "repo_invariant" not in source:
+        return False
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        pytest.fail(f"cannot parse test module {path}: {exc}")
+
+    for statement in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(statement, ast.Assign):
+            targets = [target for target in statement.targets if isinstance(target, ast.expr)]
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = [statement.target]
+            value = statement.value
+        if not value or not any(isinstance(target, ast.Name) and target.id == "pytestmark" for target in targets):
+            continue
+        if any(
+            isinstance(node, ast.Attribute)
+            and node.attr == "repo_invariant"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "mark"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "pytest"
+            for node in ast.walk(value)
+        ):
+            return True
+    return False
+
+
+def _marked_repo_invariant_modules() -> set[str]:
+    return {
+        path.relative_to(_REPO_ROOT).as_posix()
+        for path in sorted(_TESTS_ROOT.rglob("test_*.py"))
+        if _has_repo_invariant_marker(path)
+    }
+
+
+def test_fastlane_manifest_entries_exist_and_excludes_work_privacy() -> None:
+    entries = _fastlane_manifest()
+    assert entries == sorted(set(entries)), "fastlane invariant manifest must be sorted and duplicate-free"
+    assert entries, "fastlane invariant manifest must not be empty"
+    assert "tests/test_work_privacy.py" not in entries
+    for entry in entries:
+        path = _REPO_ROOT / entry
+        assert path.is_file(), f"fastlane invariant manifest entry does not exist: {entry}"
+        assert entry.startswith("tests/") and entry.endswith(".py"), f"invalid manifest entry: {entry}"
+
+
+def test_fastlane_manifest_matches_repo_invariant_markers() -> None:
+    manifest = set(_fastlane_manifest())
+    marked = _marked_repo_invariant_modules()
+    assert manifest - marked == set(), (
+        "manifest entries missing repo_invariant marker: " + ", ".join(sorted(manifest - marked))
+    )
+    assert marked - manifest == set(), (
+        "repo_invariant test modules missing from fastlane manifest: " + ", ".join(sorted(marked - manifest))
+    )
+
+
+def test_fastlane_manifest_requirements_fit_slim_profile() -> None:
+    manifest = [
+        _REPO_ROOT / entry
+        for entry in _fastlane_manifest()
+    ]
+    try:
+        selected = fastlane_requirements.select_requirements(
+            manifest,
+            base_requirements=fastlane_requirements.read_requirements(_FASTLANE_BASE_REQUIREMENTS),
+            lock_requirements=fastlane_requirements.read_lock(_REQUIREMENTS_LOCK),
+            project_root=_REPO_ROOT,
+        )
+    except fastlane_requirements.RequirementSelectionError as exc:
+        pytest.fail(f"fastlane invariant manifest imports are not satisfiable by the slim profile: {exc}")
+
+    lock = fastlane_requirements.read_lock(_REQUIREMENTS_LOCK)
+    exact_pins = set(lock.values()) | set(fastlane_requirements.EXPLICIT_REQUIREMENTS.values())
+    for requirement in selected:
+        assert requirement in exact_pins, (
+            f"fastlane requirement is not an exact lock pin: {requirement}"
+        )

--- a/tests/test_threshold_source_of_truth.py
+++ b/tests/test_threshold_source_of_truth.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import ast
 import re
 import sys
+from functools import cache
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
@@ -28,6 +31,7 @@ from common.thresholds import (
 
 SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
 SOURCE_OF_TRUTH = SCRIPTS_ROOT / "common" / "thresholds.py"
+pytestmark = pytest.mark.repo_invariant
 
 # Canonical names that must never be redeclared outside the source-of-truth.
 # The values are the source-of-truth values — any other file claiming to
@@ -115,14 +119,30 @@ _EXCLUDED_DIRS: tuple[str, ...] = (
 )
 
 
-def _iter_python_files() -> list[Path]:
+@cache
+def _iter_python_files() -> tuple[Path, ...]:
     files: list[Path] = []
     for path in SCRIPTS_ROOT.rglob("*.py"):
         rel = path.relative_to(SCRIPTS_ROOT).as_posix()
         if any(excl in rel for excl in _EXCLUDED_DIRS):
             continue
         files.append(path)
-    return files
+    return tuple(files)
+
+
+@cache
+def _read_script_text(path: Path) -> str:
+    """Read each scanned script once for the module's repeated invariants."""
+    return path.read_text("utf-8")
+
+
+@cache
+def _parse_script(path: Path) -> ast.Module | None:
+    """Parse each scanned script once for the module's AST invariants."""
+    try:
+        return ast.parse(_read_script_text(path), filename=str(path))
+    except SyntaxError:
+        return None
 
 
 def _module_level_name_assignments(tree: ast.Module) -> list[tuple[str, int]]:
@@ -164,9 +184,11 @@ def test_no_canonical_name_redeclared_outside_thresholds() -> None:
     for path in _iter_python_files():
         if path.resolve() == SOURCE_OF_TRUTH.resolve():
             continue
-        try:
-            tree = ast.parse(path.read_text("utf-8"))
-        except SyntaxError:
+        source = _read_script_text(path)
+        if not any(name in source for name in _CANONICAL_NAMES):
+            continue
+        tree = _parse_script(path)
+        if tree is None:
             continue
         for name, lineno in _module_level_name_assignments(tree):
             if name in _CANONICAL_NAMES:
@@ -190,9 +212,11 @@ def test_review_pass_floor_imports_are_legacy_allowlisted() -> None:
         if path.resolve() == SOURCE_OF_TRUTH.resolve():
             continue
         rel = path.relative_to(SCRIPTS_ROOT).as_posix()
-        try:
-            tree = ast.parse(path.read_text("utf-8"))
-        except SyntaxError:
+        source = _read_script_text(path)
+        if "REVIEW_PASS_FLOOR" not in source or "threshold" not in source.lower():
+            continue
+        tree = _parse_script(path)
+        if tree is None:
             continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.ImportFrom):
@@ -225,8 +249,9 @@ def test_no_duplicate_target_words_module_level() -> None:
     for path in _iter_python_files():
         if path.resolve() == SOURCE_OF_TRUTH.resolve():
             continue
-        for match in pattern.finditer(path.read_text("utf-8")):
-            lineno = path.read_text("utf-8")[: match.start()].count("\n") + 1
+        source = _read_script_text(path)
+        for match in pattern.finditer(source):
+            lineno = source[: match.start()].count("\n") + 1
             rel = path.relative_to(SCRIPTS_ROOT).as_posix()
             offenders.append(f"{rel}:{lineno} — {match.group(0).strip()}")
 
@@ -249,7 +274,10 @@ def test_no_threshold_float_literals_in_threshold_context() -> None:
         if path.resolve() == SOURCE_OF_TRUTH.resolve():
             continue
         rel = path.relative_to(SCRIPTS_ROOT).as_posix()
-        lines = path.read_text("utf-8").splitlines()
+        source = _read_script_text(path)
+        if not any(f"{value:.1f}" in source for value in _THRESHOLD_VALUES):
+            continue
+        lines = source.splitlines()
         for idx, line in enumerate(lines, start=1):
             stripped_line = line.strip()
             if _matching_allowlist_patterns(rel, stripped_line):


### PR DESCRIPTION
## Summary

- Enable the explicit repo-invariant fastlane manifest only for the PR-tier workflow path.
- Register and enforce the `repo_invariant` marker/manifest parity, file existence, slim-profile dependency closure, and `tests/test_work_privacy.py` exclusion.
- Resolve reachable project imports transitively and cache static source/AST scans so the invariant lane stays bounded.

## Acceptance evidence

1. Scratch timeout-less subprocess diff and docs-only diff:

```
changed-test fastlane plan: 6 test module(s)
tests/test_cyrillic_roundtrip_invariant.py
tests/test_fleet_routing_open_model_data_import_guard.py
tests/test_lint_test_assertions.py
tests/test_subprocess_timeout_guard.py
tests/test_threshold_source_of_truth.py
tests/test_timeoutless.py
changed-test fastlane plan: 0 test module(s)
```

2. Fresh venv, generated slim profile, lock-constrained install, and CI-equivalent pytest flags:

```
changed-test fastlane plan: 7 test module(s)
fastlane slim requirements: 15 requirement(s)
changed plan: 7 test module(s)
generated requirements: 15 requirement(s)
============================= 169 passed in 10.02s =============================
```

3. Mutation checks failed as intended:

```
AssertionError: repo_invariant test modules missing from fastlane manifest: tests/test_threshold_source_of_truth.py
AssertionError: manifest entries missing repo_invariant marker: tests/test_threshold_source_of_truth.py
AssertionError: repo_invariant test modules missing from fastlane manifest: tests/test_extra_repo_invariant.py
Failed: fastlane invariant manifest imports are not satisfiable by the slim profile: selected tests import unmapped third-party module(s): definitely_unavailable_vendor; add a reviewed mapping instead of installing the full lock
======================= 3 passed, 4 deselected in 0.27s ========================
```

4. Five static guards with `--durations=10`:

```
5.07s call     tests/test_lint_test_assertions.py::test_repo_test_suite_is_clean
0.40s call     tests/test_subprocess_timeout_guard.py::test_deliberately_hanging_test_is_named_by_pytest_timeout
0.37s call     tests/test_subprocess_timeout_guard.py::test_no_timeout_less_subprocess_calls_under_tests
0.32s call     tests/test_threshold_source_of_truth.py::test_no_threshold_float_literals_in_threshold_context
0.27s call     tests/test_fleet_routing_open_model_data_import_guard.py::test_fleet_routing_surfaces_do_not_import_open_model_data
0.21s call     tests/test_threshold_source_of_truth.py::test_no_canonical_name_redeclared_outside_thresholds
0.16s call     tests/test_threshold_source_of_truth.py::test_no_duplicate_target_words_module_level
0.15s call     tests/test_cyrillic_roundtrip_invariant.py::test_new_unicode_handler_names_require_inventory_updates
0.12s call     tests/test_threshold_source_of_truth.py::test_review_pass_floor_imports_are_legacy_allowlisted
0.10s call     tests/test_subprocess_timeout_guard.py::test_fastlane_manifest_requirements_fit_slim_profile
============================= 153 passed in 8.24s =============================
```

5. Work-privacy exclusion:

```
tests/test_work_privacy.py absent from scripts/ci/fastlane_always_tests.txt
```

6. Final changed-file validation:

```
All checks passed!
============================= 169 passed in 8.61s =============================
```

`actionlint .github/workflows/ci.yml` exited 0 with no output.

Refs #7141

Closes #7171