### PR TITLE
feat(ci): push-to-main dedup — skip re-validating trees the merge queue already proved (#7173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ name: CI
 #
 # Two-tier merge-queue cutover (#6943 stage 2): one workflow, two events.
 # pull_request tier (light): ruff + fastlane + contracts + frontend.
-# merge_group / push / workflow_dispatch tier (full): light PLUS planner
-# contract, four shards, and coverage floor. CI Gate remains the sole required context,
-# reports on both events, and fail-closes on missing/skipped required deps.
+# merge_group / push / schedule / workflow_dispatch tier (full): light PLUS
+# planner contract, four shards, and coverage floor. CI Gate remains the sole
+# required context, reports on all full-tier events, and fail-closes on
+# missing/skipped required deps.
 #
 # Third class (#7018): docs_skills — decided by scripts/ci/landing_class.py on
 # merge_group / push / workflow_dispatch (NOT GitHub paths:/paths-ignore).
@@ -18,6 +19,22 @@ name: CI
 # verify-artifacts so CI Gate still sees success, never skipped (#5762).
 # Any off-allowlist path or classifier error → full suite (fail closed).
 # The full tier still never path-filters pytest collection for product code.
+#
+# Push-to-main dedup (#7173) ships OFF: only vars.CI_PUSH_DEDUP == 'on' may
+# classify a plain push as mq_validated. That class is a run-level proof of one
+# ci.yml merge_group run for the pushed SHA with successful CI Gate, all four
+# Python jobs, and pytest-shard-1..4 artifacts; unknown or ambiguous proof is
+# full. The push parent must equal that run's queue base, an independent
+# before..sha re-derivation must be non-docs_skills, and the push must be plain
+# with no self-reference in its diff. It skips only the pytest
+# spine/planner/coverage combine/Gate artifact verify on the push run; frontend
+# and E2E stay out of this patch.
+#
+# Residual: main-scoped pip-wheels-*, lexicon-manifest-*, and npm caches can
+# stay cold after a lockfile/manifest rotation because queue-branch caches are
+# not readable from main. They refresh on the daily backstop only until Wave B
+# patch 4 adds cache warming. Measure every push run, with >=10 pushes after
+# enablement, using scripts/ci/ci_timings.py.
 #
 # Invariant (encodes #3873 #4888 #4936 #5351 #5354): on the full tier, pytest
 # must NEVER be selected or skipped by changed files. pytest-fastlane uses
@@ -42,6 +59,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * *'
 
 jobs:
   # ---------------------------------------------------------------------
@@ -84,11 +103,10 @@ jobs:
           python -m ruff check scripts/
 
   # ---------------------------------------------------------------------
-  # 0b. landing-class — classify merge_group/push/dispatch diffs (#7018).
+  # 0b. landing-class — classify merge_group/push/dispatch diffs (#7018/#7173).
   #     Always runs on the full tier; always succeeds; outputs class=
-  #     docs_skills|full (fail closed → full). Downstream pytest-plan /
-  #     python / coverage-floor take no-op success when docs_skills so CI
-  #     Gate can require them unconditionally (never skipped).
+  #     docs_skills|full|mq_validated (fail closed → full). mq_validated is
+  #     push-only; merge_group never takes a class-keyed mq skip path.
   # ---------------------------------------------------------------------
   landing-class:
     name: Landing class
@@ -97,9 +115,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      actions: read
     outputs:
       # Belt-and-suspenders: empty/missing step output → full (fail closed).
       class: ${{ steps.classify.outputs.class || 'full' }}
+      validating_run_id: ${{ steps.classify.outputs.validating_run_id || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -109,7 +129,12 @@ jobs:
         id: classify
         env:
           BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_FORCED: ${{ github.event.forced || 'false' }}
+          CI_PUSH_DEDUP: ${{ vars.CI_PUSH_DEDUP || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # Stdlib-only classifier; system python3 matches frontend_change_scope.
@@ -117,6 +142,9 @@ jobs:
           python3 scripts/ci/landing_class.py \
             --base "${BASE_SHA:-}" \
             --head "${HEAD_SHA:-HEAD}" \
+            --before "${BEFORE_SHA:-}" \
+            --event "${EVENT_NAME:-}" \
+            --repository "${GITHUB_REPOSITORY:-}" \
             --github-output
           if ! grep -q '^class=' "${GITHUB_OUTPUT}"; then
             echo "class=full" >> "${GITHUB_OUTPUT}"
@@ -180,28 +208,38 @@ jobs:
       contents: read
     steps:
       - name: Docs/skills-only — planner no-op success
-        if: needs.landing-class.outputs.class == 'docs_skills'
-        run: echo "landing-class=docs_skills; pytest-plan no-op success (#7018)"
+        if: >-
+          needs.landing-class.outputs.class == 'docs_skills'
+          || (github.event_name == 'push' && needs.landing-class.outputs.class == 'mq_validated')
+        run: echo "landing-class=${{ needs.landing-class.outputs.class }}; pytest-plan no-op success"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           python-version-file: '.python-version'
 
       - name: Download immutable pytest duration snapshot
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-duration-snapshot
           path: ci-artifacts
 
       - name: Validate planner contract without collection
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         run: |
           python scripts/ci/pytest_shards.py validate-snapshot \
             --snapshot ci-artifacts/pytest-duration-snapshot.json \
@@ -387,7 +425,8 @@ jobs:
   # exactly once. Each shard makes the same deterministic plan from one frozen
   # duration snapshot; four parallel jobs are the topology that completed under
   # the #5776 hang investigation; one xdist session did not.
-  # docs_skills (#7018): no-op success (job still runs; never skipped).
+  # docs_skills (#7018) and mq_validated (#7173): no-op success (job still
+  # runs; never skipped). mq_validated is explicitly push-only.
   python:
     name: Python (pytest) [${{ matrix.shard }}/4]
     if: github.event_name != 'pull_request'
@@ -398,42 +437,59 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     needs: [landing-class]
+    outputs:
+      no_op: ${{ steps.noop.outputs.no_op || 'false' }}
     permissions:
       contents: read
     steps:
       - name: Docs/skills-only — shard no-op success
-        if: needs.landing-class.outputs.class == 'docs_skills'
-        run: echo "landing-class=docs_skills; python shard ${{ matrix.shard }} no-op success (#7018)"
+        id: noop
+        if: >-
+          needs.landing-class.outputs.class == 'docs_skills'
+          || (github.event_name == 'push' && needs.landing-class.outputs.class == 'mq_validated')
+        run: |
+          echo "no_op=true" >> "$GITHUB_OUTPUT"
+          echo "landing-class=${{ needs.landing-class.outputs.class }}; python shard ${{ matrix.shard }} no-op success"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           python-version-file: '.python-version'
 
       # Keep the ACP protocol test's Node runtime deterministic regardless of
       # which round-robin shard owns its test file.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Download immutable pytest duration snapshot
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-duration-snapshot
           path: ci-artifacts
 
       - name: Restore Atlas lexicon manifest cache
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         id: atlas-manifest-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -441,12 +497,17 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         run: |
           python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
-        if: needs.landing-class.outputs.class != 'docs_skills' && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
+          && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: site/src/data/lexicon-manifest.json
@@ -456,7 +517,9 @@ jobs:
       # Cache-service errors are recoverable: continue to a cold pip install.
       # A restore miss or outage must not kill the shard (#7002).
       - name: Restore pip wheel cache
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         id: pip-wheel-cache
         continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -469,7 +532,9 @@ jobs:
       # but exclude Stanza and torch: every live Stressifier test is slow and
       # belongs to the dedicated scheduled model-provisioning lane.
       - name: Install dependencies
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         run: |
           set -euo pipefail
           python -m venv .venv
@@ -493,14 +558,19 @@ jobs:
           exit 1
 
       - name: Save pip wheel cache
-        if: needs.landing-class.outputs.class != 'docs_skills' && steps.pip-wheel-cache.outputs.cache-hit != 'true'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
+          && steps.pip-wheel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-no-live-ml
 
       - name: Collect and plan this pytest shard locally
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         env:
           SHARD: ${{ matrix.shard }}
         run: |
@@ -516,14 +586,16 @@ jobs:
       # exception, never a changed-file filter; all other collected tests run
       # through the file-grouped LPT plan exactly once.
       - name: Run planned pytest shard
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         id: pytest
         continue-on-error: true
         timeout-minutes: 25
         env:
-          # Coverage collection on the trees that land: merge_group (queued
-          # merge commit) and push to main. PR heads stay coverage-free.
-          COLLECT_COVERAGE: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+          # Coverage collection on landing trees and the daily backstop:
+          # merge_group, push to main, and schedule. PR heads stay coverage-free.
+          COLLECT_COVERAGE: ${{ github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' }}
           # LINE coverage only (no branch=true). sys.monitoring is near-free
           # on coverage 7.14.1 / Python 3.12 vs the C-tracer's ~35% tax.
           # Unused when COLLECT_COVERAGE is false (--cov is not passed).
@@ -566,7 +638,10 @@ jobs:
 
       - name: Playground perf probe (serial, shard 1 only)
         id: playground
-        if: needs.landing-class.outputs.class != 'docs_skills' && matrix.shard == 1
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
+          && matrix.shard == 1
         continue-on-error: true
         run: |
           for attempt in 1 2 3; do
@@ -581,20 +656,29 @@ jobs:
           exit 1
 
       - name: Upload pytest shard plan and results
-        if: always() && needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          always()
+          && needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-shard-${{ matrix.shard }}
           path: ci-artifacts/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 3
 
       - name: Fail after preserving pytest evidence
-        if: needs.landing-class.outputs.class != 'docs_skills' && (steps.pytest.outcome != 'success' || (matrix.shard == 1 && steps.playground.outcome != 'success'))
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
+          && (steps.pytest.outcome != 'success' || (matrix.shard == 1 && steps.playground.outcome != 'success'))
         run: exit 1
 
       - name: Upload test breadcrumbs
-        if: always() && needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          always()
+          && needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-breadcrumbs-shard-${{ matrix.shard }}
@@ -614,8 +698,10 @@ jobs:
       - name: Upload shard coverage data
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
           && (github.event_name == 'merge_group'
-           || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+           || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+           || github.event_name == 'schedule')
           && steps.pytest.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1319,16 +1405,24 @@ jobs:
   #    failure as `failure`/`cancelled`.
 
   # Duration data is intentionally published only after every matrix member of
-  # a push to main succeeds. PRs and failed main runs can consume a prior main
-  # dataset but can never overwrite it.
+  # a push to main succeeds. For mq_validated it republishes the proof run's
+  # shard artifacts; the job is in the push Gate required set, so missing
+  # artifacts fail visibly instead of silently starving the main cache. PRs
+  # and failed main runs can consume a prior main dataset but can never
+  # overwrite it.
   pytest-duration-publish:
     name: Publish pytest durations
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.python.result == 'success'
-    needs: [python]
+    if: >-
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.python.result == 'success'
+      && needs.landing-class.outputs.class != 'docs_skills'
+    needs: [python, landing-class]
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1348,6 +1442,18 @@ jobs:
         with:
           pattern: pytest-shard-*
           path: ci-artifacts
+          run-id: ${{ needs.landing-class.outputs.validating_run_id || github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Require four shard logs for duration publication
+        run: |
+          set -euo pipefail
+          for shard in 1 2 3 4; do
+            log="ci-artifacts/pytest-shard-${shard}/main.log"
+            if [[ ! -s "$log" ]]; then
+              echo "::error::pytest shard artifact/log missing for duration publication: $log" >&2
+              exit 1
+            fi
+          done
       - name: Publish successful-main durations and p95 summary
         run: |
           python scripts/ci/pytest_shards.py publish-durations \
@@ -1367,7 +1473,8 @@ jobs:
   # ---------------------------------------------------------------------
   # Enforces the 35% floor ONCE, over the combined four-shard data. Restores the
   # guarantee cross-family review flagged as a P1 when the reboot dropped it.
-  # docs_skills (#7018): no-op success (do not download missing coverage).
+  # docs_skills (#7018) and mq_validated (#7173): no-op success (do not
+  # download missing coverage). mq_validated is push-only.
   # Gate path ends at `coverage report --fail-under=35`. XML/HTML rendering is
   # off-path because nothing in-repo consumes those artifacts; combined
   # `.coverage` + text report remain downloadable for offline
@@ -1382,22 +1489,30 @@ jobs:
       contents: read
     steps:
       - name: Docs/skills-only — coverage floor no-op success
-        if: needs.landing-class.outputs.class == 'docs_skills'
-        run: echo "landing-class=docs_skills; coverage-floor no-op success (#7018)"
+        if: >-
+          needs.landing-class.outputs.class == 'docs_skills'
+          || (github.event_name == 'push' && needs.landing-class.outputs.class == 'mq_validated')
+        run: echo "landing-class=${{ needs.landing-class.outputs.class }}; coverage-floor no-op success"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        if: needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         with:
           python-version: '3.12'
       - name: Download shard coverage data
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
           && (github.event_name == 'merge_group'
-              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+              || github.event_name == 'schedule')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-shard-*
@@ -1405,8 +1520,10 @@ jobs:
       - name: Combine and enforce
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
           && (github.event_name == 'merge_group'
-              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+              || github.event_name == 'schedule')
         run: |
           set -euo pipefail
           # Bounded retry absorbs transient PyPI blips (#7002; Stanza idiom).
@@ -1437,8 +1554,10 @@ jobs:
       - name: Upload coverage report and combined data
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
           && (github.event_name == 'merge_group'
-              || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+              || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+              || github.event_name == 'schedule')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
@@ -1449,12 +1568,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Not a landing event — coverage floor is merge_group/main-push only
+      - name: Not a landing event — coverage floor is merge_group/main-push/schedule only
         if: >-
           needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
           && github.event_name != 'merge_group'
+          && github.event_name != 'schedule'
           && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: echo "coverage floor applies to merge_group and pushes to main; job succeeds so CI Gate can require it unconditionally"
+        run: echo "coverage floor applies to merge_group, pushes to main, and schedule; job succeeds so CI Gate can require it unconditionally"
 
   ci-gate:
     name: CI Gate
@@ -1474,6 +1595,7 @@ jobs:
       - contracts
       - frontend
       - coverage-floor
+      - pytest-duration-publish
     permissions:
       contents: read
       pull-requests: write
@@ -1485,16 +1607,25 @@ jobs:
         with:
           python-version-file: '.python-version'
       - name: Docs/skills-only — skip shard artifact verify (no-op success)
-        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class == 'docs_skills'
-        run: echo "landing-class=docs_skills; CI Gate verify-artifacts no-op success (#7018)"
+        if: >-
+          github.event_name != 'pull_request'
+          && (needs.landing-class.outputs.class == 'docs_skills'
+              || (github.event_name == 'push' && needs.landing-class.outputs.class == 'mq_validated'))
+        run: echo "landing-class=${{ needs.landing-class.outputs.class }}; CI Gate verify-artifacts no-op success"
       - name: Download pytest shard plans and JUnit results
-        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          github.event_name != 'pull_request'
+          && needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pytest-shard-*
           path: ci-artifacts
       - name: Verify pytest shard completeness
-        if: github.event_name != 'pull_request' && needs.landing-class.outputs.class != 'docs_skills'
+        if: >-
+          github.event_name != 'pull_request'
+          && needs.landing-class.outputs.class != 'docs_skills'
+          && (github.event_name != 'push' || needs.landing-class.outputs.class != 'mq_validated')
         run: |
           python scripts/ci/pytest_shards.py verify-artifacts \
             --artifact-dir ci-artifacts \
@@ -1504,13 +1635,19 @@ jobs:
       - name: Fail unless every event-required job succeeded
         env:
           EVENT_NAME: ${{ github.event_name }}
+          LANDING_CLASS: ${{ needs.landing-class.outputs.class || 'full' }}
+          PYTHON_NOOP: ${{ needs.python.outputs.no_op || 'false' }}
+          VALIDATING_RUN_ID: ${{ needs.landing-class.outputs.validating_run_id || '' }}
           # Explicit pairs — join(needs.*.result) loses job ids and cannot
           # distinguish expected PR-tier skips from unexpected ones.
           RESULTS: >-
-            ruff=${{ needs.ruff.result }},pytest-plan=${{ needs.pytest-plan.result }},pytest-fastlane=${{ needs.pytest-fastlane.result }},python=${{ needs.python.result }},contracts=${{ needs.contracts.result }},frontend=${{ needs.frontend.result }},coverage-floor=${{ needs.coverage-floor.result }}
+            ruff=${{ needs.ruff.result }},pytest-plan=${{ needs.pytest-plan.result }},pytest-fastlane=${{ needs.pytest-fastlane.result }},python=${{ needs.python.result }},contracts=${{ needs.contracts.result }},frontend=${{ needs.frontend.result }},coverage-floor=${{ needs.coverage-floor.result }},pytest-duration-publish=${{ needs.pytest-duration-publish.result }}
         run: |
           python scripts/ci/gate_required_results.py \
             --event "$EVENT_NAME" \
+            --class "$LANDING_CLASS" \
+            --python-noop "$PYTHON_NOOP" \
+            --validating-run-id "$VALIDATING_RUN_ID" \
             --results "$RESULTS"
 
       # Kicked PRs must not look CLEAN and sit (#7042): a merge_group failure

--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -61,6 +61,7 @@ def is_repo_invariant_trigger(path: str) -> bool:
         or path == "pyproject.toml"
         or fnmatchcase(candidate.name, "requirements*.txt")
         or path == ".github/workflows/ci.yml"
+        or path == "scripts/ci/fastlane_always_tests.txt"
         or path.startswith("tests/fixtures/")
     )
 

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -1,5 +1,6 @@
 tests/test_cyrillic_roundtrip_invariant.py
 tests/test_fleet_routing_open_model_data_import_guard.py
+tests/test_frontend_change_scope.py
 tests/test_lint_test_assertions.py
 tests/test_subprocess_timeout_guard.py
 tests/test_threshold_source_of_truth.py

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -1,3 +1,4 @@
+tests/test_ci_changed_tests.py
 tests/test_cyrillic_roundtrip_invariant.py
 tests/test_fleet_routing_open_model_data_import_guard.py
 tests/test_frontend_change_scope.py

--- a/scripts/ci/gate_required_results.py
+++ b/scripts/ci/gate_required_results.py
@@ -32,17 +32,27 @@ FULL_REQUIRED: tuple[str, ...] = (
     "coverage-floor",
 )
 
+# A push to main also owns the duration publish. Keeping it in the push gate
+# set makes a missing validating-run artifact fail on the visible push check.
+PUSH_REQUIRED: tuple[str, ...] = (*FULL_REQUIRED, "pytest-duration-publish")
+
 FULL_TIER_EVENTS: frozenset[str] = frozenset(
-    {"merge_group", "push", "workflow_dispatch"}
+    {"merge_group", "push", "schedule", "workflow_dispatch"}
 )
 
 SUCCESS = "success"
+CLASS_DOCS_SKILLS = "docs_skills"
+CLASS_FULL = "full"
+CLASS_MQ_VALIDATED = "mq_validated"
+KNOWN_CLASSES = frozenset({CLASS_DOCS_SKILLS, CLASS_FULL, CLASS_MQ_VALIDATED})
 
 
-def required_jobs(event_name: str) -> tuple[str, ...]:
+def required_jobs(event_name: str, landing_class: str = CLASS_FULL) -> tuple[str, ...]:
     """Return the job ids CI Gate must see as success for this event."""
     if event_name == "pull_request":
         return LIGHT_REQUIRED
+    if event_name == "push" and landing_class != CLASS_DOCS_SKILLS:
+        return PUSH_REQUIRED
     if event_name in FULL_TIER_EVENTS:
         return FULL_REQUIRED
     # Unknown events fail closed as full tier — never treat as light.
@@ -52,6 +62,10 @@ def required_jobs(event_name: str) -> tuple[str, ...]:
 def evaluate_gate(
     event_name: str,
     results: Mapping[str, str],
+    *,
+    landing_class: str = CLASS_FULL,
+    python_noop: bool = False,
+    validating_run_id: str = "",
 ) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ gate green).
 
@@ -59,7 +73,17 @@ def evaluate_gate(
     Missing keys for required jobs are failures (not silent success).
     """
     failures: list[str] = []
-    required = required_jobs(event_name)
+    if landing_class not in KNOWN_CLASSES:
+        failures.append(f"class: {landing_class} (unknown landing class)")
+    if landing_class == CLASS_FULL and python_noop:
+        failures.append("class=full: python no-op is not allowed")
+    if landing_class == CLASS_MQ_VALIDATED:
+        if not validating_run_id.strip():
+            failures.append("class=mq_validated: validating run proof is missing")
+        if not python_noop:
+            failures.append("class=mq_validated: python jobs did not take the no-op path")
+
+    required = required_jobs(event_name, landing_class)
     for job in required:
         if job not in results:
             failures.append(f"{job}: missing (required for {event_name})")
@@ -92,12 +116,30 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--event",
         required=True,
-        help="github.event_name (pull_request|merge_group|push|workflow_dispatch)",
+        help="github.event_name (pull_request|merge_group|push|schedule|workflow_dispatch)",
     )
     parser.add_argument(
         "--results",
         required=True,
         help="Comma-separated job=result pairs from needs.*.result",
+    )
+    parser.add_argument(
+        "--class",
+        dest="landing_class",
+        default=CLASS_FULL,
+        choices=sorted(KNOWN_CLASSES),
+        help="landing-class output",
+    )
+    parser.add_argument(
+        "--python-noop",
+        default="false",
+        choices=("true", "false"),
+        help="whether the Python matrix used its intentional no-op success path",
+    )
+    parser.add_argument(
+        "--validating-run-id",
+        default="",
+        help="run id proving mq_validated (required for that class)",
     )
     args = parser.parse_args(argv)
 
@@ -107,9 +149,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 2
 
-    failures = evaluate_gate(args.event, results)
+    failures = evaluate_gate(
+        args.event,
+        results,
+        landing_class=args.landing_class,
+        python_noop=args.python_noop == "true",
+        validating_run_id=args.validating_run_id,
+    )
     print(f"event={args.event}")
-    print(f"required={','.join(required_jobs(args.event))}")
+    print(f"class={args.landing_class}")
+    print(f"required={','.join(required_jobs(args.event, args.landing_class))}")
     print(f"results={args.results}")
     if failures:
         for reason in failures:

--- a/scripts/ci/landing_class.py
+++ b/scripts/ci/landing_class.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classify merge-queue diffs as docs/skills-only vs full CI (#7018).
+"""Classify landing events for the two-tier CI workflow.
 
 Fail-closed: empty path lists, unreadable git, unexpected errors, and any
 path outside the allowlist yield ``full``. Only an exhaustive allowlist match
@@ -10,8 +10,14 @@ Allowlist (deny by omission):
   - ``docs/**/*.md``
   - repo-root ``*.md``
 
+On a plain push to ``main``, ``mq_validated`` is emitted only when the exact
+push SHA has one ``ci.yml`` merge-group run whose Gate, four Python jobs, and
+four shard artifacts prove the pytest spine, and the run's queue base matches
+the push parent. Any uncertainty returns ``full``. The proof is the run, not a
+cache (#7173).
+
 Stdlib only so GitHub runners can invoke it with system ``python3`` before
-``actions/setup-python``. The CLI always exits 0 and always emits a class
+``actions/setup-python``. The CLI always exits 0 and always emits ``class=``
 (``full`` on any failure) so CI Gate can require downstream jobs as success
 via no-op paths, never via ``skipped`` (#5762).
 """
@@ -21,15 +27,33 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
 
 CLASS_DOCS_SKILLS = "docs_skills"
 CLASS_FULL = "full"
+CLASS_MQ_VALIDATED = "mq_validated"
 
 SKILLS_PREFIX = "agents_extensions/shared/skills"
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+SELF_REFERENCE_PATHS = frozenset(
+    {
+        CI_WORKFLOW_PATH,
+        "scripts/ci/landing_class.py",
+        "scripts/ci/gate_required_results.py",
+    }
+)
+PYTHON_JOB_RE = re.compile(r"^Python \(pytest\)\s*\[?([1-4])\s*/\s*4\]?$")
+GIT_DIFF_TIMEOUT_SECONDS = 30
+GITHUB_API_TIMEOUT_SECONDS = 10
+
+ApiGet = Callable[[str], Any]
 
 
 def path_allowed(path: str) -> bool:
@@ -73,6 +97,7 @@ def changed_files(git_range: str, *, cwd: Path | None = None) -> list[str]:
         check=True,
         capture_output=True,
         cwd=cwd or Path.cwd(),
+        timeout=GIT_DIFF_TIMEOUT_SECONDS,
     )
     return _parse_nul_delimited_paths(result.stdout)
 
@@ -87,7 +112,12 @@ def read_paths_from_stdin(stream: Iterable[str] | None = None) -> list[str]:
     return [line.strip() for line in source if line.strip()]
 
 
-def write_github_output(landing_class: str, path: Path | None = None) -> None:
+def write_github_output(
+    landing_class: str,
+    path: Path | None = None,
+    *,
+    validating_run_id: str | None = None,
+) -> None:
     output = path
     if output is None:
         raw = os.environ.get("GITHUB_OUTPUT")
@@ -96,9 +126,17 @@ def write_github_output(landing_class: str, path: Path | None = None) -> None:
         output = Path(raw)
     with output.open("a", encoding="utf-8") as handle:
         handle.write(f"class={landing_class}\n")
+        if landing_class == CLASS_MQ_VALIDATED and validating_run_id:
+            handle.write(f"validating_run_id={validating_run_id}\n")
 
 
-def write_step_summary(landing_class: str, *, path_count: int, path: Path | None = None) -> None:
+def write_step_summary(
+    landing_class: str,
+    *,
+    path_count: int,
+    path: Path | None = None,
+    validating_run_id: str | None = None,
+) -> None:
     summary = path
     if summary is None:
         raw = os.environ.get("GITHUB_STEP_SUMMARY")
@@ -108,16 +146,227 @@ def write_step_summary(landing_class: str, *, path_count: int, path: Path | None
     with summary.open("a", encoding="utf-8") as handle:
         handle.write("## Landing class (#7018)\n\n")
         handle.write(f"`class={landing_class}` changed_files={path_count}\n")
+        if landing_class == CLASS_MQ_VALIDATED and validating_run_id:
+            handle.write(f"`validating_run_id={validating_run_id}`\n")
 
 
-def emit(landing_class: str, *, path_count: int, as_json: bool, github_output: bool) -> None:
+def emit(
+    landing_class: str,
+    *,
+    path_count: int,
+    as_json: bool,
+    github_output: bool,
+    validating_run_id: str | None = None,
+) -> None:
+    payload: dict[str, Any] = {"class": landing_class, "changed_files": path_count}
+    if landing_class == CLASS_MQ_VALIDATED and validating_run_id:
+        payload["validating_run_id"] = validating_run_id
     if as_json:
-        print(json.dumps({"class": landing_class, "changed_files": path_count}, sort_keys=True))
+        print(json.dumps(payload, sort_keys=True))
     else:
         print(landing_class)
-    write_step_summary(landing_class, path_count=path_count)
+    write_step_summary(landing_class, path_count=path_count, validating_run_id=validating_run_id)
     if github_output:
-        write_github_output(landing_class)
+        write_github_output(landing_class, validating_run_id=validating_run_id)
+
+
+def _api_items(payload: Any, key: str) -> list[Mapping[str, Any]]:
+    """Return object entries from a GitHub collection response."""
+    if isinstance(payload, Mapping):
+        raw = payload.get(key, [])
+    elif key in {"jobs", "artifacts"} and isinstance(payload, list):
+        raw = payload
+    else:
+        raw = []
+    return [item for item in raw if isinstance(item, Mapping)] if isinstance(raw, list) else []
+
+
+def github_api_get(
+    path: str,
+    *,
+    token: str | None = None,
+    api_url: str | None = None,
+    timeout: int = GITHUB_API_TIMEOUT_SECONDS,
+) -> Any:
+    """Read one GitHub REST resource with a bounded request."""
+    base_url = (api_url or os.environ.get("GITHUB_API_URL") or "https://api.github.com").rstrip("/")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(f"{base_url}/{path.lstrip('/')}", headers=headers)
+    with urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+
+def _repository(repository: str) -> str:
+    value = repository.strip()
+    if not value or "/" not in value:
+        raise ValueError("GITHUB_REPOSITORY must be OWNER/REPOSITORY")
+    return value
+
+
+def _matching_merge_group_run(
+    *,
+    repository: str,
+    head_sha: str,
+    api_get: ApiGet,
+) -> Mapping[str, Any]:
+    query = urlencode({"event": "merge_group", "head_sha": head_sha, "per_page": 100})
+    payload = api_get(f"repos/{repository}/actions/workflows/ci.yml/runs?{query}")
+    candidates: list[Mapping[str, Any]] = []
+    for run in _api_items(payload, "workflow_runs"):
+        run_path = run.get("path")
+        if run.get("event") != "merge_group" or run.get("head_sha") != head_sha:
+            continue
+        if run_path is not None and str(run_path).strip() not in {CI_WORKFLOW_PATH, "ci.yml"}:
+            continue
+        candidates.append(run)
+    if len(candidates) != 1:
+        raise ValueError(f"expected exactly one ci.yml merge_group run, found {len(candidates)}")
+    return candidates[0]
+
+
+def _merge_group_base_sha(
+    run: Mapping[str, Any],
+    *,
+    repository: str,
+    head_sha: str,
+    api_get: ApiGet,
+) -> str:
+    """Resolve the queue base; REST run objects do not expose event payload fields.
+
+    GitHub's merge-group synthetic commit has the event's ``base_sha`` as its
+    first parent. Fixtures may provide the event field directly; production
+    falls back to the commit endpoint rather than guessing from branch names.
+    """
+    direct = run.get("base_sha")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    merge_group = run.get("merge_group")
+    if isinstance(merge_group, Mapping):
+        nested = merge_group.get("base_sha")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    head_commit = run.get("head_commit")
+    parents = head_commit.get("parents") if isinstance(head_commit, Mapping) else None
+    if not isinstance(parents, list) or not parents:
+        commit = api_get(f"repos/{repository}/commits/{quote(head_sha, safe='')}")
+        parents = commit.get("parents") if isinstance(commit, Mapping) else None
+    if not isinstance(parents, list) or not parents:
+        raise ValueError("merge_group head commit has no parent to bind base_sha")
+    parent = parents[0]
+    base_sha = parent.get("sha") if isinstance(parent, Mapping) else None
+    if not isinstance(base_sha, str) or not base_sha.strip():
+        raise ValueError("merge_group head commit has an invalid first parent")
+    return base_sha.strip()
+
+
+def _verify_merge_group_run(
+    run: Mapping[str, Any],
+    *,
+    repository: str,
+    head_sha: str,
+    api_get: ApiGet,
+) -> str:
+    run_id = run.get("id")
+    if run_id is None or not str(run_id).strip():
+        raise ValueError("validating merge_group run has no id")
+    run_id_text = str(run_id)
+    jobs_payload = api_get(f"repos/{repository}/actions/runs/{quote(run_id_text, safe='')}/jobs?per_page=100")
+    jobs = _api_items(jobs_payload, "jobs")
+    gate_jobs = [
+        job
+        for job in jobs
+        if job.get("name") == "CI Gate" or job.get("id") == "ci-gate"
+    ]
+    if len(gate_jobs) != 1 or gate_jobs[0].get("conclusion") != "success":
+        raise ValueError("validating merge_group run has no successful CI Gate job")
+
+    python_jobs: dict[int, list[Mapping[str, Any]]] = {}
+    for job in jobs:
+        name = job.get("name")
+        if not isinstance(name, str):
+            continue
+        match = PYTHON_JOB_RE.fullmatch(name.strip())
+        if match:
+            python_jobs.setdefault(int(match.group(1)), []).append(job)
+    for shard in range(1, 5):
+        shard_jobs = python_jobs.get(shard, [])
+        if len(shard_jobs) != 1 or shard_jobs[0].get("conclusion") != "success":
+            raise ValueError(f"validating merge_group run is missing successful Python shard {shard}")
+
+    artifacts_payload = api_get(
+        f"repos/{repository}/actions/runs/{quote(run_id_text, safe='')}/artifacts?per_page=100"
+    )
+    artifact_names = {
+        str(artifact.get("name"))
+        for artifact in _api_items(artifacts_payload, "artifacts")
+        if artifact.get("expired") is not True
+    }
+    required_artifacts = {f"pytest-shard-{shard}" for shard in range(1, 5)}
+    if not required_artifacts <= artifact_names:
+        missing = sorted(required_artifacts - artifact_names)
+        raise ValueError(f"validating merge_group run is missing shard artifacts: {', '.join(missing)}")
+
+    return _merge_group_base_sha(
+        run,
+        repository=repository,
+        head_sha=head_sha,
+        api_get=api_get,
+    )
+
+
+def _has_self_reference(paths: Iterable[str]) -> bool:
+    return any(PurePosixPath(path.strip()).as_posix() in SELF_REFERENCE_PATHS for path in paths)
+
+
+def classify_push_to_main(
+    paths: Sequence[str],
+    *,
+    before_sha: str,
+    head_sha: str,
+    event_name: str,
+    ref: str,
+    forced: str,
+    kill_switch: str,
+    repository: str,
+    api_get: ApiGet | None = None,
+    cwd: Path | None = None,
+) -> tuple[str, str | None]:
+    """Classify a landing and return ``(class, validating_run_id)``."""
+    landing = classify(paths)
+    if landing == CLASS_DOCS_SKILLS:
+        return landing, None
+    if event_name != "push" or ref != "refs/heads/main" or forced != "false" or kill_switch != "on":
+        return CLASS_FULL, None
+    if not before_sha or set(before_sha) == {"0"} or not head_sha or _has_self_reference(paths):
+        return CLASS_FULL, None
+    try:
+        repository = _repository(repository)
+    except ValueError:
+        return CLASS_FULL, None
+
+    get = api_get or (lambda path: github_api_get(path, token=os.environ.get("GITHUB_TOKEN")))
+    try:
+        # Re-derive from the exact push range; do not trust an earlier class
+        # or any cached artifact as evidence of the merge-group result.
+        rederived_paths = changed_files(f"{before_sha}..{head_sha}", cwd=cwd)
+        if classify(rederived_paths) == CLASS_DOCS_SKILLS or _has_self_reference(rederived_paths):
+            return CLASS_FULL, None
+        run = _matching_merge_group_run(repository=repository, head_sha=head_sha, api_get=get)
+        base_sha = _verify_merge_group_run(
+            run,
+            repository=repository,
+            head_sha=head_sha,
+            api_get=get,
+        )
+        if before_sha != base_sha:
+            return CLASS_FULL, None
+        return CLASS_MQ_VALIDATED, str(run["id"])
+    except Exception:
+        # API errors, timeouts, malformed responses, and unexpected git state
+        # are all unknown proof and therefore full CI.
+        return CLASS_FULL, None
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -132,6 +381,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--head",
         default="HEAD",
         help="head SHA/ref (merge_group.head_sha / github.sha); default HEAD",
+    )
+    parser.add_argument(
+        "--before",
+        default=os.environ.get("GITHUB_EVENT_BEFORE", ""),
+        help="push before SHA (github.event.before), used for the MQ proof",
+    )
+    parser.add_argument(
+        "--event",
+        default=os.environ.get("GITHUB_EVENT_NAME", ""),
+        help="GitHub event name",
+    )
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="OWNER/REPOSITORY for the Actions API",
     )
     parser.add_argument(
         "--json",
@@ -151,11 +415,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         github_output = bool(args.github_output)
         base = (args.base or "").strip()
         head = (args.head or "HEAD").strip() or "HEAD"
+        event_name = (args.event or "").strip()
         if base:
             if set(base) == {"0"}:
                 emit(CLASS_FULL, path_count=-1, as_json=as_json, github_output=github_output)
                 return 0
-            paths = changed_files(comparison_range(base, head))
+            if event_name == "push":
+                paths = changed_files(f"{base}..{head}")
+            else:
+                paths = changed_files(comparison_range(base, head))
         elif github_output:
             # CI without a usable base SHA — fail closed (do not read stdin).
             emit(CLASS_FULL, path_count=-1, as_json=as_json, github_output=github_output)
@@ -166,8 +434,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         else:
             paths = read_paths_from_stdin()
-        landing = classify(paths)
-        emit(landing, path_count=len(paths), as_json=as_json, github_output=github_output)
+        before = (args.before or "").strip() or (base if event_name == "push" else "")
+        landing, validating_run_id = classify_push_to_main(
+            paths,
+            before_sha=before,
+            head_sha=head,
+            event_name=event_name,
+            ref=os.environ.get("GITHUB_REF", ""),
+            forced=os.environ.get("GITHUB_EVENT_FORCED", "false").strip().lower(),
+            kill_switch=os.environ.get("CI_PUSH_DEDUP", ""),
+            repository=args.repository or "",
+        )
+        emit(
+            landing,
+            path_count=len(paths),
+            as_json=as_json,
+            github_output=github_output,
+            validating_run_id=validating_run_id,
+        )
         return 0
     except Exception as exc:
         # Fail closed to full; never crash the landing-class job.

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.ci import changed_tests
 
+pytestmark = pytest.mark.repo_invariant
+
 REPO_INVARIANT_TESTS = [
+    "tests/test_ci_changed_tests.py",
     "tests/test_cyrillic_roundtrip_invariant.py",
     "tests/test_fleet_routing_open_model_data_import_guard.py",
+    "tests/test_frontend_change_scope.py",
     "tests/test_lint_test_assertions.py",
     "tests/test_subprocess_timeout_guard.py",
     "tests/test_threshold_source_of_truth.py",
@@ -64,6 +70,7 @@ def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
         "pyproject.toml",
         "requirements-dev.txt",
         ".github/workflows/ci.yml",
+        "scripts/ci/fastlane_always_tests.txt",
         "tests/fixtures/example.json",
     ):
         assert changed_tests.select_test_modules([path], include_repo_invariants=True) == REPO_INVARIANT_TESTS
@@ -76,8 +83,10 @@ def test_repo_invariant_manifest_entries_are_not_duplicated() -> None:
     )
 
     assert selected == [
+        "tests/test_ci_changed_tests.py",
         "tests/test_cyrillic_roundtrip_invariant.py",
         "tests/test_fleet_routing_open_model_data_import_guard.py",
+        "tests/test_frontend_change_scope.py",
         "tests/test_lint_test_assertions.py",
         "tests/test_subprocess_timeout_guard.py",
         "tests/test_threshold_source_of_truth.py",

--- a/tests/test_ci_gate_required_results.py
+++ b/tests/test_ci_gate_required_results.py
@@ -7,6 +7,7 @@ import pytest
 from scripts.ci.gate_required_results import (
     FULL_REQUIRED,
     LIGHT_REQUIRED,
+    PUSH_REQUIRED,
     evaluate_gate,
     main,
     parse_results,
@@ -31,12 +32,14 @@ def test_required_jobs_merge_group_is_full_superset() -> None:
 
 
 def test_required_jobs_push_and_dispatch_are_full() -> None:
-    assert required_jobs("push") == FULL_REQUIRED
+    assert required_jobs("push") == PUSH_REQUIRED
+    assert set(FULL_REQUIRED) < set(PUSH_REQUIRED)
     assert required_jobs("workflow_dispatch") == FULL_REQUIRED
+    assert required_jobs("schedule") == FULL_REQUIRED
 
 
 def test_unknown_event_fails_closed_as_full_tier() -> None:
-    assert required_jobs("schedule") == FULL_REQUIRED
+    assert required_jobs("unknown-event") == FULL_REQUIRED
 
 
 def test_merge_group_green_when_all_full_deps_succeed() -> None:

--- a/tests/test_ci_push_dedup.py
+++ b/tests/test_ci_push_dedup.py
@@ -1,0 +1,408 @@
+"""Acceptance tests for push-to-main merge-queue deduplication (#7173)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.ci import landing_class
+from scripts.ci.gate_required_results import (
+    FULL_REQUIRED,
+    FULL_TIER_EVENTS,
+    PUSH_REQUIRED,
+    evaluate_gate,
+    required_jobs,
+)
+
+REPOSITORY = "learn-ukrainian/learn-ukrainian.github.io"
+BEFORE_SHA = "before-sha"
+HEAD_SHA = "head-sha"
+PRODUCT_PATHS = ["scripts/app.py"]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _valid_run(*, run_id: int = 7173, base_sha: str = BEFORE_SHA) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "event": "merge_group",
+        "head_sha": HEAD_SHA,
+        "path": ".github/workflows/ci.yml",
+        "base_sha": base_sha,
+        "status": "in_progress",
+    }
+
+
+def _valid_jobs() -> list[dict[str, Any]]:
+    return [
+        {"id": "ci-gate", "name": "CI Gate", "conclusion": "success"},
+        *[
+            {"id": f"python-{shard}", "name": f"Python (pytest) [{shard}/4]", "conclusion": "success"}
+            for shard in range(1, 5)
+        ],
+    ]
+
+
+def _valid_artifacts() -> list[dict[str, Any]]:
+    return [{"name": f"pytest-shard-{shard}", "expired": False} for shard in range(1, 5)]
+
+
+def _api(
+    *,
+    runs: list[dict[str, Any]] | None = None,
+    jobs: list[dict[str, Any]] | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
+    error: BaseException | None = None,
+) -> tuple[Any, list[str]]:
+    calls: list[str] = []
+
+    def get(path: str) -> Any:
+        calls.append(path)
+        if error is not None:
+            raise error
+        if "/actions/workflows/ci.yml/runs?" in path:
+            return {"workflow_runs": [_valid_run()] if runs is None else runs}
+        if path.endswith("/jobs?per_page=100"):
+            return {"jobs": _valid_jobs() if jobs is None else jobs}
+        if path.endswith("/artifacts?per_page=100"):
+            return {"artifacts": _valid_artifacts() if artifacts is None else artifacts}
+        if "/commits/" in path:
+            return {"parents": [{"sha": BEFORE_SHA}]}
+        raise AssertionError(f"unexpected injected API path: {path}")
+
+    return get, calls
+
+
+def _classify(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    paths: list[str] | None = None,
+    rederived_paths: list[str] | None = None,
+    api: Any | None = None,
+    event_name: str = "push",
+    ref: str = "refs/heads/main",
+    forced: str = "false",
+    kill_switch: str = "on",
+    before_sha: str = BEFORE_SHA,
+) -> tuple[str, str | None]:
+    monkeypatch.setattr(
+        landing_class,
+        "changed_files",
+        lambda _git_range, *, cwd=None: list(PRODUCT_PATHS if rederived_paths is None else rederived_paths),
+    )
+    if api is None:
+        api, _calls = _api()
+    return landing_class.classify_push_to_main(
+        PRODUCT_PATHS if paths is None else paths,
+        before_sha=before_sha,
+        head_sha=HEAD_SHA,
+        event_name=event_name,
+        ref=ref,
+        forced=forced,
+        kill_switch=kill_switch,
+        repository=REPOSITORY,
+        api_get=api,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "no run",
+        "two ci.yml runs",
+        "only a hygiene.yml run",
+        "Gate failed",
+        "one Python job failed",
+        "shard artifacts missing",
+        "docs_skills re-derivation",
+        "API error",
+        "API timeout",
+        "forced push",
+        "workflow_dispatch",
+        "schedule",
+        "self-reference file in diff",
+        "kill switch unset",
+        "kill switch off",
+        "kill switch garbage",
+        "before differs from base_sha",
+    ],
+    ids=lambda case: case.replace(" ", "-").replace("/", "-") if isinstance(case, str) else case,
+)
+def test_each_unproven_condition_fails_closed_to_full(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    """Each locked proof bullet is independently mutation-sensitive."""
+    run = _valid_run()
+    jobs = _valid_jobs()
+    artifacts = _valid_artifacts()
+    rederived_paths = PRODUCT_PATHS
+    event_name = "push"
+    forced = "false"
+    kill_switch = "on"
+    before_sha = BEFORE_SHA
+
+    if case == "no run":
+        runs: list[dict[str, Any]] = []
+    elif case == "two ci.yml runs":
+        runs = [_valid_run(run_id=1), _valid_run(run_id=2)]
+    elif case == "only a hygiene.yml run":
+        hygiene_run = _valid_run()
+        hygiene_run["path"] = ".github/workflows/hygiene.yml"
+        runs = [hygiene_run]
+    else:
+        runs = [run]
+    if case == "Gate failed":
+        jobs[0]["conclusion"] = "failure"
+    if case == "one Python job failed":
+        jobs[2]["conclusion"] = "failure"
+    if case == "shard artifacts missing":
+        artifacts.pop()
+    if case == "docs_skills re-derivation":
+        rederived_paths = ["docs/only.md"]
+    if case in {"API error", "API timeout"}:
+        error: BaseException = RuntimeError("API error") if case == "API error" else TimeoutError("API timeout")
+        api, _calls = _api(error=error)
+    else:
+        api, _calls = _api(runs=runs, jobs=jobs, artifacts=artifacts)
+    if case == "forced push":
+        forced = "true"
+    if case == "workflow_dispatch":
+        event_name = "workflow_dispatch"
+    if case == "schedule":
+        event_name = "schedule"
+    paths = ["scripts/ci/landing_class.py"] if case == "self-reference file in diff" else None
+    if case == "kill switch unset":
+        kill_switch = ""
+    if case == "kill switch off":
+        kill_switch = "off"
+    if case == "kill switch garbage":
+        kill_switch = "garbage"
+    if case == "before differs from base_sha":
+        before_sha = "different-before"
+
+    result, run_id = _classify(
+        monkeypatch,
+        paths=paths,
+        rederived_paths=rederived_paths,
+        api=api,
+        event_name=event_name,
+        forced=forced,
+        kill_switch=kill_switch,
+        before_sha=before_sha,
+    )
+    assert result == landing_class.CLASS_FULL, case
+    assert run_id is None, case
+
+
+def test_all_locked_proof_bullets_emit_mq_validated_and_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    api, calls = _api()
+    result, run_id = _classify(monkeypatch, api=api)
+
+    assert result == landing_class.CLASS_MQ_VALIDATED
+    assert run_id == "7173"
+    assert any("event=merge_group" in path and "head_sha=head-sha" in path for path in calls)
+    assert any(path.endswith("/jobs?per_page=100") for path in calls)
+    assert any(path.endswith("/artifacts?per_page=100") for path in calls)
+
+
+def test_merge_group_base_falls_back_to_first_commit_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    run = _valid_run()
+    del run["base_sha"]
+    api, calls = _api(runs=[run])
+    result, run_id = _classify(monkeypatch, api=api)
+
+    assert (result, run_id) == (landing_class.CLASS_MQ_VALIDATED, "7173")
+    assert any("/commits/head-sha" in path for path in calls)
+
+
+def test_rederived_range_is_exact_push_before_to_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    api, _calls = _api()
+
+    monkeypatch.setattr(
+        landing_class,
+        "changed_files",
+        lambda git_range, *, cwd=None: seen.append(git_range) or list(PRODUCT_PATHS),
+    )
+    result, _run_id = landing_class.classify_push_to_main(
+        PRODUCT_PATHS,
+        before_sha=BEFORE_SHA,
+        head_sha=HEAD_SHA,
+        event_name="push",
+        ref="refs/heads/main",
+        forced="false",
+        kill_switch="on",
+        repository=REPOSITORY,
+        api_get=api,
+    )
+
+    assert result == landing_class.CLASS_MQ_VALIDATED
+    assert seen == [f"{BEFORE_SHA}..{HEAD_SHA}"]
+
+
+def test_main_always_exits_zero_and_writes_full_on_api_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(landing_class, "changed_files", lambda _git_range, *, cwd=None: list(PRODUCT_PATHS))
+    monkeypatch.setattr(landing_class, "github_api_get", lambda _path, **_kwargs: (_ for _ in ()).throw(TimeoutError()))
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    monkeypatch.setenv("GITHUB_EVENT_FORCED", "false")
+    monkeypatch.setenv("CI_PUSH_DEDUP", "on")
+    monkeypatch.setenv("GITHUB_REPOSITORY", REPOSITORY)
+    output = tmp_path / "github-output"
+    summary = tmp_path / "summary"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    exit_code = landing_class.main(
+        [
+            "--base",
+            BEFORE_SHA,
+            "--before",
+            BEFORE_SHA,
+            "--head",
+            HEAD_SHA,
+            "--event",
+            "push",
+            "--repository",
+            REPOSITORY,
+            "--json",
+            "--github-output",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["class"] == landing_class.CLASS_FULL
+    assert output.read_text(encoding="utf-8") == "class=full\n"
+
+
+def test_mq_output_contains_validating_run_id(tmp_path: Path) -> None:
+    output = tmp_path / "github-output"
+    landing_class.write_github_output(
+        landing_class.CLASS_MQ_VALIDATED,
+        output,
+        validating_run_id="7173",
+    )
+
+    assert output.read_text(encoding="utf-8") == "class=mq_validated\nvalidating_run_id=7173\n"
+
+
+def _success_results(required: tuple[str, ...] = PUSH_REQUIRED) -> dict[str, str]:
+    return {job: "success" for job in required}
+
+
+def test_gate_rejects_full_class_python_noop() -> None:
+    failures = evaluate_gate(
+        "push",
+        _success_results(),
+        landing_class="full",
+        python_noop=True,
+    )
+
+    assert failures == ["class=full: python no-op is not allowed"]
+
+
+def test_gate_rejects_mq_class_without_validating_run_proof() -> None:
+    failures = evaluate_gate(
+        "push",
+        _success_results(),
+        landing_class="mq_validated",
+        python_noop=True,
+        validating_run_id="",
+    )
+
+    assert failures == ["class=mq_validated: validating run proof is missing"]
+
+
+def test_gate_accepts_mq_class_with_noop_and_validating_run() -> None:
+    assert (
+        evaluate_gate(
+            "push",
+            _success_results(),
+            landing_class="mq_validated",
+            python_noop=True,
+            validating_run_id="7173",
+        )
+        == []
+    )
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for step in job.get("steps", []) if isinstance(step, dict)]
+
+
+def _step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    return next(step for step in _steps(job) if step.get("name") == name)
+
+
+def test_ci_workflow_wires_push_dedup_and_scheduled_coverage() -> None:
+    workflow_text = _WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    jobs = workflow["jobs"]
+    triggers = workflow.get("on", workflow.get(True))
+
+    assert "schedule" in triggers
+    assert "github.event_name == 'schedule'" in workflow_text
+    assert "github.event_name == 'schedule' }}" in workflow_text
+    assert jobs["landing-class"]["permissions"]["actions"] == "read"
+    assert "validating_run_id" in jobs["landing-class"]["outputs"]
+    for job_name in ("pytest-plan", "python", "coverage-floor", "ci-gate"):
+        job_text = str(jobs[job_name])
+        assert "mq_validated" in job_text
+        assert "github.event_name == 'push'" in job_text
+    for step_name in ("Download shard coverage data", "Combine and enforce", "Upload coverage report and combined data"):
+        assert "github.event_name == 'schedule'" in _step(jobs["coverage-floor"], step_name)["if"]
+
+    python_env = _step(jobs["python"], "Run planned pytest shard")["env"]
+    assert "github.event_name == 'schedule'" in python_env["COLLECT_COVERAGE"]
+
+    for job_name in ("pytest-plan", "python", "coverage-floor", "ci-gate"):
+        for step in _steps(jobs[job_name]):
+            condition = str(step.get("if", ""))
+            if "mq_validated" in condition:
+                assert (
+                    "github.event_name == 'push'" in condition
+                    or "github.event_name != 'push'" in condition
+                )
+
+    publish = jobs["pytest-duration-publish"]
+    assert set(publish["needs"]) == {"python", "landing-class"}
+    assert publish["permissions"]["actions"] == "read"
+    download = _step(publish, "Download pytest shard results")
+    assert download["with"]["run-id"] == "${{ needs.landing-class.outputs.validating_run_id || github.run_id }}"
+    assert download["with"]["github-token"] == "${{ github.token }}"
+    assert "for shard in 1 2 3 4" in _step(publish, "Require four shard logs for duration publication")["run"]
+    assert "pytest-duration-publish" in jobs["ci-gate"]["needs"]
+    gate_run = _step(jobs["ci-gate"], "Fail unless every event-required job succeeded")["run"]
+    assert "--class" in gate_run
+    assert "--python-noop" in gate_run
+    assert "--validating-run-id" in gate_run
+    assert "pytest-duration-publish" in str(_step(jobs["ci-gate"], "Fail unless every event-required job succeeded"))
+
+    shard_upload = _step(jobs["python"], "Upload pytest shard plan and results")
+    assert shard_upload["with"]["retention-days"] == 3
+    assert "mq_validated" not in str(jobs["frontend"])
+    assert "mq_validated" not in str(jobs["frontend-e2e"])
+
+
+def test_publish_missing_artifacts_fails_visibly_on_push_gate() -> None:
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+    guard = _step(jobs["pytest-duration-publish"], "Require four shard logs for duration publication")["run"]
+
+    assert "::error::pytest shard artifact/log missing" in guard
+    assert "exit 1" in guard
+    assert "pytest-duration-publish" in jobs["ci-gate"]["needs"]
+
+
+def test_full_tier_events_include_daily_schedule() -> None:
+    assert "schedule" in FULL_TIER_EVENTS
+    assert required_jobs("schedule") == FULL_REQUIRED

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -55,6 +55,7 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
         "contracts",
         "frontend",
         "coverage-floor",
+        "pytest-duration-publish",
     }
     assert jobs["pytest-plan"].get("if") == "github.event_name != 'pull_request'"
     assert jobs["python"].get("if") == "github.event_name != 'pull_request'"

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -13,6 +13,8 @@ import yaml
 
 from scripts.ci import frontend_change_scope as scope
 
+pytestmark = pytest.mark.repo_invariant
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CI = _REPO_ROOT / ".github/workflows/ci.yml"
 _DENOMINATOR = _REPO_ROOT / scope.DENOMINATOR_REL
@@ -380,6 +382,7 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
     assert "if" not in jobs["frontend"]
     # Two-tier cutover (#6943 stage 2): CI Gate also needs `ruff` so the
     # pull_request light tier can require lint without the four-shard suite.
+    # #7173: push Gate requires duration publication so publish failures are visible.
     assert set(jobs["ci-gate"]["needs"]) == {
         "ruff",
         "landing-class",
@@ -389,6 +392,7 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
         "contracts",
         "frontend",
         "coverage-floor",
+        "pytest-duration-publish",
     }
 
     for job_name in ("frontend", "frontend-e2e"):


### PR DESCRIPTION
## Summary

- Add fail-closed `mq_validated` proof for plain pushes to `main`.
- Skip only the merge-queue-proven pytest spine, planner, coverage combine, and Gate artifact verification with no-op success.
- Re-publish pytest durations from the validating merge-group run and make missing artifacts fail visibly through CI Gate.
- Add the daily scheduled coverage backstop, kill-switch documentation, cold-cache residual, and measurement plan.

## Acceptance evidence

- 152 affected CI, landing-class, and subprocess-timeout tests passed.
- Classifier proof/negative matrix: 28 passed.
- Gate class-aware tests: 42 passed.
- Ruff: `All checks passed!`
- Actionlint: all workflow files valid.
- Feature ships disabled until `vars.CI_PUSH_DEDUP == 'on'`.

*(Full quoted evidence in the dispatch task result `ci-push-dedup-7173` on the job host; design of record: #7173 body + the two critique comments + the reconciled final design comment. Authored on the job host, relayed by the driver per #7181's no-connector rule — commit `d7726c789b` is the worker's own.)*

Refs #7141
Closes #7173
