### PR TITLE
fix(foundry): resume Cycle007 with durable metadata present

### DIFF
--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
@@ -2337,6 +2337,7 @@ def _validate_cycle007_materialization(
     source_manifest_path: Path,
     *,
     fixture: bool,
+    allowed_top_level_entries: Sequence[str] = (),
 ) -> tuple[
     list[list[Mapping[str, Any]]],
     list[bool],
@@ -2357,7 +2358,17 @@ def _validate_cycle007_materialization(
     contract.require(isinstance(manifest, Mapping), "source_binding_drift")
     materializer._verify_source_package_modes(package_dir, manifest, fixture)
     contract.require(
-        {path.name for path in package_dir.iterdir()} == materializer.OUTPUT_TOP_LEVEL,
+        all(
+            isinstance(name, str)
+            and bool(name)
+            and Path(name).name == name
+            for name in allowed_top_level_entries
+        ),
+        "manifest_binding_drift",
+    )
+    contract.require(
+        {path.name for path in package_dir.iterdir()}
+        == materializer.OUTPUT_TOP_LEVEL | set(allowed_top_level_entries),
         "manifest_binding_drift",
     )
     contract.require(set(manifest) == _MATERIALIZATION_MANIFEST_FIELDS, "manifest_binding_drift")
@@ -2719,10 +2730,20 @@ def compile_cycle007_package(
             "real package compile requires the reviewed streamable-HTTP MCP transport"
         )
 
+    allowed_top_level_entries: tuple[str, ...] = ()
+    if not fixture:
+        from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+
+        resume_root = throughput.resume_root_for(output_dir)
+        contract.require(resume_root.parent == package_dir, "manifest_binding_drift")
+        if os.path.lexists(resume_root):
+            allowed_top_level_entries = (resume_root.name,)
+
     packets, residual_flags, packet_bindings, source_package_binding = _validate_cycle007_materialization(
         package_dir,
         source_manifest_path,
         fixture=fixture,
+        allowed_top_level_entries=allowed_top_level_entries,
     )
 
     if fixture:

--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_compiler.py
@@ -2361,6 +2361,8 @@ def _validate_cycle007_materialization(
         all(
             isinstance(name, str)
             and bool(name)
+            and name not in {".", ".."}
+            and not Path(name).is_absolute()
             and Path(name).name == name
             for name in allowed_top_level_entries
         ),
@@ -2703,6 +2705,32 @@ def _validate_cycle007_materialization(
     return packets, residual_flags, packet_bindings, source_package_binding
 
 
+def _allowed_materialization_runtime_entries(
+    package_dir: Path,
+    output_dir: Path,
+    *,
+    fixture: bool,
+) -> tuple[str, ...]:
+    if fixture:
+        return ()
+
+    from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
+
+    resume_root = throughput.resume_root_for(output_dir)
+    contract.require(resume_root.parent == package_dir, "manifest_binding_drift")
+    if not os.path.lexists(resume_root):
+        return ()
+    try:
+        resume_info = resume_root.lstat()
+    except OSError as exc:
+        raise contract.EvidenceContractError("manifest_binding_drift") from exc
+    contract.require(
+        stat.S_ISDIR(resume_info.st_mode) and not stat.S_ISLNK(resume_info.st_mode),
+        "manifest_binding_drift",
+    )
+    return (resume_root.name,)
+
+
 def compile_cycle007_package(
     package_dir: Path,
     source_manifest_path: Path,
@@ -2730,20 +2758,15 @@ def compile_cycle007_package(
             "real package compile requires the reviewed streamable-HTTP MCP transport"
         )
 
-    allowed_top_level_entries: tuple[str, ...] = ()
-    if not fixture:
-        from scripts.projects.open_model_data import phase3_cycle007_evidence_compile_throughput as throughput
-
-        resume_root = throughput.resume_root_for(output_dir)
-        contract.require(resume_root.parent == package_dir, "manifest_binding_drift")
-        if os.path.lexists(resume_root):
-            allowed_top_level_entries = (resume_root.name,)
-
     packets, residual_flags, packet_bindings, source_package_binding = _validate_cycle007_materialization(
         package_dir,
         source_manifest_path,
         fixture=fixture,
-        allowed_top_level_entries=allowed_top_level_entries,
+        allowed_top_level_entries=_allowed_materialization_runtime_entries(
+            package_dir,
+            output_dir,
+            fixture=fixture,
+        ),
     )
 
     if fixture:

--- a/tests/test_phase3_cycle007_evidence_compiler.py
+++ b/tests/test_phase3_cycle007_evidence_compiler.py
@@ -1332,6 +1332,32 @@ def test_compile_cycle007_package_binds_legacy_source_without_text_hash(tmp_path
     assert manifest["row_count"] == 4
 
 
+def test_materialization_validation_allows_only_the_reviewed_resume_root(tmp_path: Path):
+    source = _write_cycle005_fixture(tmp_path)
+    package = tmp_path / "cycle007-package"
+    materializer.materialize(source, package, fixture=True)
+    resume_root_name = ".evidence.resume-v1"
+    (package / resume_root_name).mkdir()
+
+    packets, _, _, binding = compiler._validate_cycle007_materialization(
+        package,
+        source / "label-manifest.json",
+        fixture=True,
+        allowed_top_level_entries=(resume_root_name,),
+    )
+    assert len(packets) == 2
+    assert binding["packet_count"] == 2
+
+    (package / "foreign-entry").mkdir()
+    with pytest.raises(contract.EvidenceContractError, match="manifest_binding_drift"):
+        compiler._validate_cycle007_materialization(
+            package,
+            source / "label-manifest.json",
+            fixture=True,
+            allowed_top_level_entries=(resume_root_name,),
+        )
+
+
 def test_compile_sidecar_bundle_bare_compile_has_a_null_source_package_binding(tmp_path: Path):
     """A bare (package-free) compile still carries the key, but its value is None."""
     client = SyntheticSourcesClient()

--- a/tests/test_phase3_cycle007_evidence_compiler.py
+++ b/tests/test_phase3_cycle007_evidence_compiler.py
@@ -1336,14 +1336,20 @@ def test_materialization_validation_allows_only_the_reviewed_resume_root(tmp_pat
     source = _write_cycle005_fixture(tmp_path)
     package = tmp_path / "cycle007-package"
     materializer.materialize(source, package, fixture=True)
+    output = package / "evidence"
     resume_root_name = ".evidence.resume-v1"
-    (package / resume_root_name).mkdir()
+    resume_root = package / resume_root_name
+    assert compiler._allowed_materialization_runtime_entries(package, output, fixture=False) == ()
+    resume_root.mkdir()
+    allowed_entries = compiler._allowed_materialization_runtime_entries(package, output, fixture=False)
+    assert allowed_entries == (resume_root_name,)
+    assert compiler._allowed_materialization_runtime_entries(package, output, fixture=True) == ()
 
     packets, _, _, binding = compiler._validate_cycle007_materialization(
         package,
         source / "label-manifest.json",
         fixture=True,
-        allowed_top_level_entries=(resume_root_name,),
+        allowed_top_level_entries=allowed_entries,
     )
     assert len(packets) == 2
     assert binding["packet_count"] == 2
@@ -1354,7 +1360,40 @@ def test_materialization_validation_allows_only_the_reviewed_resume_root(tmp_pat
             package,
             source / "label-manifest.json",
             fixture=True,
-            allowed_top_level_entries=(resume_root_name,),
+            allowed_top_level_entries=allowed_entries,
+        )
+
+
+@pytest.mark.parametrize("entry_type", ("file", "symlink"))
+def test_materialization_runtime_entry_rejects_non_directory_resume_root(
+    tmp_path: Path,
+    entry_type: str,
+):
+    package = tmp_path / "cycle007-package"
+    package.mkdir()
+    output = package / "evidence"
+    resume_root = package / ".evidence.resume-v1"
+    if entry_type == "file":
+        resume_root.touch()
+    else:
+        resume_root.symlink_to(tmp_path / "outside")
+
+    with pytest.raises(contract.EvidenceContractError, match="manifest_binding_drift"):
+        compiler._allowed_materialization_runtime_entries(package, output, fixture=False)
+
+
+@pytest.mark.parametrize("name", (".", "..", "/absolute", "nested/entry"))
+def test_materialization_validation_rejects_invalid_runtime_entry_names(tmp_path: Path, name: str):
+    source = _write_cycle005_fixture(tmp_path)
+    package = tmp_path / "cycle007-package"
+    materializer.materialize(source, package, fixture=True)
+
+    with pytest.raises(contract.EvidenceContractError, match="manifest_binding_drift"):
+        compiler._validate_cycle007_materialization(
+            package,
+            source / "label-manifest.json",
+            fixture=True,
+            allowed_top_level_entries=(name,),
         )
 
 


### PR DESCRIPTION
## Summary
- allow only the exact reviewed durable resume directory during package top-level validation
- keep all foreign package entries fail-closed
- add regression coverage for the resume-root allowlist

## Verification
- 107 focused tests passed
- Ruff passed
- py_compile passed

Fixes the Cycle007 `compile_manifest_binding_drift` resume blocker for #6375.

X-Agent: codex/6375-resume-binding-fix