### PR TITLE
test(ci): derive guard pins from source of truth (#7194)

### DIFF
--- a/scripts/ci/gate_required_results.py
+++ b/scripts/ci/gate_required_results.py
@@ -36,6 +36,13 @@ FULL_REQUIRED: tuple[str, ...] = (
 # set makes a missing validating-run artifact fail on the visible push check.
 PUSH_REQUIRED: tuple[str, ...] = (*FULL_REQUIRED, "pytest-duration-publish")
 
+# The one canonical inventory of the workflow's ``ci-gate.needs``: every job
+# whose result the gate evaluates across all events (the push tier is the
+# superset) plus ``landing-class``, whose outputs the gate step consumes.
+# Tests compare ci.yml against this set instead of restating it, so a
+# legitimate needs change is a one-file edit here, not a test-pin cascade.
+GATE_NEEDS_JOBS: frozenset[str] = frozenset({"landing-class", *PUSH_REQUIRED})
+
 FULL_TIER_EVENTS: frozenset[str] = frozenset(
     {"merge_group", "push", "schedule", "workflow_dispatch"}
 )

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -1,4 +1,12 @@
-"""Unit tests for the advisory changed-test fastlane selector."""
+"""Unit tests for the advisory changed-test fastlane selector.
+
+Rule of thumb for every guard in this file: assert an invariant, not a
+snapshot; if changing X legitimately requires editing >1 test, the test is a
+snapshot. The fastlane manifest content is owned by
+``scripts/ci/fastlane_always_tests.txt`` and its property guards (sorted, no
+dupes, marker parity, slim-deps satisfiable, work-privacy excluded) live in
+``tests/test_subprocess_timeout_guard.py`` — nothing here restates the list.
+"""
 
 from __future__ import annotations
 
@@ -10,15 +18,10 @@ from scripts.ci import changed_tests
 
 pytestmark = pytest.mark.repo_invariant
 
-REPO_INVARIANT_TESTS = [
-    "tests/test_ci_changed_tests.py",
-    "tests/test_cyrillic_roundtrip_invariant.py",
-    "tests/test_fleet_routing_open_model_data_import_guard.py",
-    "tests/test_frontend_change_scope.py",
-    "tests/test_lint_test_assertions.py",
-    "tests/test_subprocess_timeout_guard.py",
-    "tests/test_threshold_source_of_truth.py",
-]
+
+def _manifest() -> list[str]:
+    """Read the fastlane repo-invariant manifest from its source of truth."""
+    return changed_tests.load_repo_invariant_tests()
 
 
 def test_comparison_range_accepts_base_ref_or_explicit_range() -> None:
@@ -58,7 +61,7 @@ def test_code_only_change_can_opt_into_repo_invariant_manifest() -> None:
         ["scripts/ci/changed_tests.py"], include_repo_invariants=True
     )
 
-    assert selected == REPO_INVARIANT_TESTS
+    assert selected == sorted(_manifest())
 
 
 def test_docs_only_change_stays_empty_with_repo_invariant_opt_in() -> None:
@@ -73,22 +76,16 @@ def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
         "scripts/ci/fastlane_always_tests.txt",
         "tests/fixtures/example.json",
     ):
-        assert changed_tests.select_test_modules([path], include_repo_invariants=True) == REPO_INVARIANT_TESTS
+        assert changed_tests.select_test_modules([path], include_repo_invariants=True) == sorted(_manifest())
 
 
 def test_repo_invariant_manifest_entries_are_not_duplicated() -> None:
+    manifest = _manifest()
+    assert manifest, "the repo-invariant manifest must not be empty"
     selected = changed_tests.select_test_modules(
-        ["tests/test_threshold_source_of_truth.py", "pyproject.toml"],
+        [manifest[0], "pyproject.toml"],
         include_repo_invariants=True,
     )
 
-    assert selected == [
-        "tests/test_ci_changed_tests.py",
-        "tests/test_cyrillic_roundtrip_invariant.py",
-        "tests/test_fleet_routing_open_model_data_import_guard.py",
-        "tests/test_frontend_change_scope.py",
-        "tests/test_lint_test_assertions.py",
-        "tests/test_subprocess_timeout_guard.py",
-        "tests/test_threshold_source_of_truth.py",
-    ]
+    assert selected == sorted(manifest)
     assert len(selected) == len(set(selected))

--- a/tests/test_ci_gate_merge_kick_comment.py
+++ b/tests/test_ci_gate_merge_kick_comment.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import yaml
 
+from scripts.ci import gate_required_results as gate
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
@@ -80,19 +82,13 @@ def test_comment_step_reads_pr_number_and_results_from_env_not_interpolation() -
 
 def test_no_new_job_was_added_to_ci_workflow() -> None:
     workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    expected_jobs = {
-        "ruff",
-        "landing-class",
-        "pytest-plan",
-        "pytest-fastlane",
-        "python",
-        "contracts",
-        "frontend",
-        "frontend-e2e",
-        "pytest-duration-publish",
-        "coverage-floor",
-        "ci-gate",
-    }
+    # Rule of thumb: assert an invariant, not a snapshot; if changing X
+    # legitimately requires editing >1 test, the test is a snapshot. The job
+    # inventory derives from the one canonical ci-gate.needs set exported by
+    # the gate evaluator, plus the two frozen-by-decision jobs that hang off
+    # the gate rather than feed it (frontend-e2e waits on ci-gate; ci-gate is
+    # the gate itself).
+    expected_jobs = set(gate.GATE_NEEDS_JOBS) | {"frontend-e2e", "ci-gate"}
     assert set(workflow["jobs"]) == expected_jobs, (
         "the merge-group kick comment must be a step on ci-gate, not a new job "
         "(brief: no new workflow, no new required check)"

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from scripts.ci import gate_required_results as gate
 from scripts.ci.queue_starvation_recovery import (
     TAIL_JOB_NAMES,
     decide_queue_starvation_rerun,
@@ -46,17 +47,11 @@ def test_ci_folds_secret_scan_and_pr_body_into_contracts() -> None:
     )
     assert "trufflesecurity/trufflehog@" in contracts_steps
     assert "lint_pr_closing_references.py" in contracts_steps
-    assert set(jobs["ci-gate"]["needs"]) == {
-        "ruff",
-        "landing-class",
-        "pytest-plan",
-        "pytest-fastlane",
-        "python",
-        "contracts",
-        "frontend",
-        "coverage-floor",
-        "pytest-duration-publish",
-    }
+    # Rule of thumb: assert an invariant, not a snapshot; if changing X
+    # legitimately requires editing >1 test, the test is a snapshot.
+    # ci-gate.needs is pinned exactly once — by the canonical set the gate
+    # evaluator itself exports (gate_required_results.GATE_NEEDS_JOBS).
+    assert set(jobs["ci-gate"]["needs"]) == set(gate.GATE_NEEDS_JOBS)
     assert jobs["pytest-plan"].get("if") == "github.event_name != 'pull_request'"
     assert jobs["python"].get("if") == "github.event_name != 'pull_request'"
     assert jobs["python"]["needs"] == ["landing-class"]

--- a/tests/test_frontend_change_scope.py
+++ b/tests/test_frontend_change_scope.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from scripts.ci import frontend_change_scope as scope
+from scripts.ci import gate_required_results as gate
 
 pytestmark = pytest.mark.repo_invariant
 
@@ -380,20 +381,13 @@ def test_ci_yml_uses_shared_scope_helper_without_job_level_frontend_skip() -> No
     jobs = workflow["jobs"]
 
     assert "if" not in jobs["frontend"]
-    # Two-tier cutover (#6943 stage 2): CI Gate also needs `ruff` so the
-    # pull_request light tier can require lint without the four-shard suite.
-    # #7173: push Gate requires duration publication so publish failures are visible.
-    assert set(jobs["ci-gate"]["needs"]) == {
-        "ruff",
-        "landing-class",
-        "pytest-plan",
-        "pytest-fastlane",
-        "python",
-        "contracts",
-        "frontend",
-        "coverage-floor",
-        "pytest-duration-publish",
-    }
+    # Rule of thumb: assert an invariant, not a snapshot; if changing X
+    # legitimately requires editing >1 test, the test is a snapshot.
+    # ci-gate.needs is pinned exactly once — by the canonical set the gate
+    # evaluator itself exports (gate_required_results.GATE_NEEDS_JOBS: the
+    # push tier, which is the superset of the light/full tiers, plus
+    # landing-class whose outputs the gate step consumes).
+    assert set(jobs["ci-gate"]["needs"]) == set(gate.GATE_NEEDS_JOBS)
 
     for job_name in ("frontend", "frontend-e2e"):
         steps = jobs[job_name]["steps"]


### PR DESCRIPTION
Closes #7194

## Problem
Guard tests pinned repo-wide CI state as literal copies: the fastlane manifest
was restated in three tests in `tests/test_ci_changed_tests.py`, the
`ci-gate.needs` set was restated in two files, and the workflow job inventory
in a third. Every legitimate change to the pinned thing cascaded into
merge-queue kicks (three on 2026-08-23 alone).

## Change
- `scripts/ci/gate_required_results.py` exports `GATE_NEEDS_JOBS`, the one
  canonical `ci-gate.needs` inventory, derived from the push tier (the
  superset of all event tiers) plus `landing-class`.
- `tests/test_ci_changed_tests.py` reads `fastlane_always_tests.txt` via
  `changed_tests.load_repo_invariant_tests()` and asserts properties
  (sorted-set equality, dedup, non-empty) — no hardcoded module list.
- `tests/test_frontend_change_scope.py`, `tests/test_ci_queue_starvation.py`
  compare `ci-gate.needs` against `GATE_NEEDS_JOBS`; the job-inventory guard
  in `tests/test_ci_gate_merge_kick_comment.py` derives from it plus the two
  frozen-by-decision gate-adjacent jobs.
- Each guard carries the rule of thumb: "assert an invariant, not a snapshot;
  if changing X legitimately requires editing >1 test, the test is a snapshot."

## Verification
- Growing the manifest by one entry (+marker) in a scratch copy: 10 passed,
  zero test edits; parity guard still fails when the marker is missing.
- Mutation checks: removing a manifest entry fails the marker-parity guard;
  dropping a job from `ci-gate.needs` fails both needs pins.
- Worker sweep: 180 passed; driver re-probe: 95 passed on the 7 guard files +
  `ruff check` clean on changed files.
- Note: 4 `test_moved_base_*` fixture tests require `git checkout -b` in tmp
  repos, which the local agent git shim denies (pre-existing on base; CI
  unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
