### PR TITLE
fix(runtime): resolve agent binaries under the login PATH for spawns (#7161)

### DIFF
--- a/scripts/agent_runtime/adapters/acpx.py
+++ b/scripts/agent_runtime/adapters/acpx.py
@@ -87,6 +87,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from ..binary_resolve import resolve_agent_binary
 from ..result import ParseResult
 from ..routes import deepseek_first_party_error, is_deepseek_first_party_forbidden_in_ci
 from .base import InvocationPlan
@@ -1493,7 +1494,7 @@ def _resolve_grok_binary() -> str:
     Uses PATH lookup then ``Path.resolve()`` so the shell-safe ``--agent``
     command embeds an absolute binary. Does not fall back to inventing paths.
     """
-    found = shutil.which("grok")
+    found = resolve_agent_binary("grok")
     if not found:
         raise AcpxShadowRefusalError(
             "AcpxGrokShadowAdapter: grok binary not found on PATH; install the "
@@ -1684,7 +1685,7 @@ def probe_participant_reachability(participant: str) -> str | None:
     failure earlier with the remediation and documented fallback attached.
     """
     executable = _PARTICIPANT_PROVIDER_BINARIES.get(participant)
-    if executable is None or shutil.which(executable):
+    if executable is None or resolve_agent_binary(executable):
         return None
     return _missing_binary_message(executable, adapter_label=f"ACP participant {participant!r}")
 
@@ -1696,7 +1697,7 @@ def _resolve_participant_binary(
 ) -> tuple[str, str]:
     """Resolve and capability-check one provider CLI before constructing argv."""
     contract = _PARTICIPANT_COMPATIBILITY_CONTRACTS[executable]
-    found = shutil.which(executable)
+    found = resolve_agent_binary(executable)
     if not found:
         raise AcpxShadowRefusalError(_missing_binary_message(executable, adapter_label=adapter_label))
     resolved = Path(found).resolve()

--- a/scripts/agent_runtime/binary_resolve.py
+++ b/scripts/agent_runtime/binary_resolve.py
@@ -1,0 +1,59 @@
+"""Resolve agent CLI binaries under login-shell PATH directories.
+
+Dispatch and runtime spawns inherit a minimal PATH (systemd, cron, SSH
+non-interactive shells) that omits ``~/.local/bin`` and ``~/.opencode/bin``
+where seat CLIs are installed on job hosts. Augment lookup with those dirs
+and return absolute paths for ``Popen`` argv[0].
+
+Issue: #7161
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+_LOGIN_BIN_SUFFIXES: tuple[str, ...] = (
+    ".local/bin",
+    ".opencode/bin",
+)
+
+
+def _login_bin_dirs() -> tuple[str, ...]:
+    home = Path.home()
+    return tuple(str(home / suffix) for suffix in _LOGIN_BIN_SUFFIXES)
+
+
+def augment_path_for_login_bins(path: str | None) -> str:
+    """Append login install dirs to *path* when they are not already present."""
+    entries = [entry for entry in (path or "").split(os.pathsep) if entry]
+    present = {os.path.normcase(entry) for entry in entries}
+    for directory in _login_bin_dirs():
+        normalized = os.path.normcase(directory)
+        if normalized not in present:
+            entries.append(directory)
+            present.add(normalized)
+    return os.pathsep.join(entries)
+
+
+def resolve_agent_binary(binary: str, *, path: str | None = None) -> str | None:
+    """Return an absolute executable path for *binary*, or ``None`` if absent.
+
+  When *binary* is a bare name, lookup uses *path* augmented with the login
+  install directories. Existing absolute or relative paths are accepted when
+  they already point at an executable file.
+    """
+    if not binary:
+        return None
+
+    if os.sep in binary or (os.altsep and os.altsep in binary):
+        candidate = Path(binary)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+
+    search_path = augment_path_for_login_bins(path)
+    found = shutil.which(binary, path=search_path)
+    if found:
+        return str(Path(found).resolve())
+    return None

--- a/scripts/agent_runtime/binary_resolve.py
+++ b/scripts/agent_runtime/binary_resolve.py
@@ -14,6 +14,10 @@ import os
 import shutil
 from pathlib import Path
 
+# Patchable lookup seam for tests — ``resolve_agent_binary`` routes here instead
+# of calling ``shutil.which`` directly so fakes can target one module attribute.
+_which = shutil.which
+
 _LOGIN_BIN_SUFFIXES: tuple[str, ...] = (
     ".local/bin",
     ".opencode/bin",
@@ -53,7 +57,7 @@ def resolve_agent_binary(binary: str, *, path: str | None = None) -> str | None:
             return str(candidate.resolve())
 
     search_path = augment_path_for_login_bins(path)
-    found = shutil.which(binary, path=search_path)
+    found = _which(binary, path=search_path)
     if found:
         return str(Path(found).resolve())
     return None

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -72,6 +72,7 @@ from scripts.entire.fleet_capture import FleetCapture, resolved_route
 
 from .adapters.base import AgentAdapter
 from .attribution import InvocationAttribution, resolve_invocation_attribution
+from .binary_resolve import augment_path_for_login_bins, resolve_agent_binary
 from .env_sanitize import build_agent_env
 from .errors import (
     AgentRuntimeError,
@@ -566,6 +567,27 @@ def _spawn_subprocess(
             stacklevel=2,
         )
         return _spawn_pipe_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
+
+
+def _prepare_spawn_command(
+    cmd: Sequence[str],
+    env: Mapping[str, str],
+) -> tuple[list[str], dict[str, str]]:
+    """Resolve argv[0] under login PATH dirs and augment child PATH when needed."""
+    prepared_cmd = list(cmd)
+    prepared_env = dict(env)
+    if not prepared_cmd:
+        return prepared_cmd, prepared_env
+
+    original_path = prepared_env.get("PATH", "")
+    augmented_path = augment_path_for_login_bins(original_path)
+    if augmented_path != original_path:
+        prepared_env["PATH"] = augmented_path
+
+    resolved = resolve_agent_binary(prepared_cmd[0], path=augmented_path)
+    if resolved is not None:
+        prepared_cmd[0] = resolved
+    return prepared_cmd, prepared_env
 
 
 def _normalize_mcp_url(url: str | None) -> str:
@@ -1381,6 +1403,7 @@ def _execute_invocation_plan(
                     )
                 else:
                     stdin_handle, stdin_temp_path = _prepare_stdin_handle(plan.stdin_payload)
+            review_cmd, env = _prepare_spawn_command(review_cmd, env)
             proc, stdout_master_fd, stderr_master_fd = _spawn_subprocess(
                 review_cmd,
                 cwd=review_cwd,

--- a/tests/agent_runtime/test_acpx_adapter.py
+++ b/tests/agent_runtime/test_acpx_adapter.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.agent_runtime import binary_resolve as binary_resolve_module
 from scripts.agent_runtime.adapters import acpx as acpx_module
 from scripts.agent_runtime.adapters.acpx import (
     ACPX_EXIT_PERMISSION_DENIED,
@@ -235,6 +236,17 @@ def _stub_binary(
         },
     )
     return binary
+
+
+def _patch_provider_binary_lookup(monkeypatch, lookup) -> None:
+    """Patch the resolver seam used by acpx provider binary lookups (#7161)."""
+    monkeypatch.setattr(binary_resolve_module, "_which", lookup)
+
+
+def _patch_path_binary_lookup(monkeypatch, lookup) -> None:
+    """Patch node PATH lookup and the provider resolver seam (#7161)."""
+    monkeypatch.setattr(acpx_module.shutil, "which", lookup)
+    monkeypatch.setattr(binary_resolve_module, "_which", lookup)
 
 
 def _assert_acpx_env_overrides(env: dict, *, expected: dict[str, str]) -> None:
@@ -2384,7 +2396,9 @@ def test_new_fleet_discussion_seats_use_fixed_confined_commands(
             path.write_text("#!/bin/sh\n", encoding="utf-8")
             path.chmod(0o755)
         binaries[name] = str(path)
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda name: binaries.get(name))
+    _patch_path_binary_lookup(
+        monkeypatch, lambda name, *_a, **_k: binaries.get(name)
+    )
     _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(
         acpx_module,
@@ -2463,8 +2477,9 @@ def test_gemma_shadow_seat_uses_a_confined_opencode_command(tmp_path, monkeypatc
     opencode = tmp_path / "opencode"
     opencode.write_text("#!/bin/sh\n", encoding="utf-8")
     opencode.chmod(0o755)
-    monkeypatch.setattr(
-        acpx_module.shutil, "which", lambda name: {"opencode": str(opencode)}.get(name)
+    _patch_provider_binary_lookup(
+        monkeypatch,
+        lambda name, *_a, **_k: {"opencode": str(opencode)}.get(name),
     )
     monkeypatch.setattr(
         acpx_module,
@@ -2592,7 +2607,7 @@ def test_missing_hermes_binary_error_carries_remediation_and_fallback(monkeypatc
     never a bare not-found. Hermes is permanently removed (operator order
     2026-08-16), so the message points at the opencode standing path, never
     at a reinstall."""
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    _patch_provider_binary_lookup(monkeypatch, lambda _name, *_a, **_k: None)
 
     with pytest.raises(AcpxShadowRefusalError) as exc_info:
         acpx_module._resolve_participant_binary(
@@ -2612,10 +2627,9 @@ def test_missing_hermes_binary_error_carries_remediation_and_fallback(monkeypatc
 
 
 def test_probe_participant_reachability_reports_only_missing_provider_binaries(monkeypatch):
-    monkeypatch.setattr(
-        acpx_module.shutil,
-        "which",
-        lambda name: {"opencode": "/usr/local/bin/opencode"}.get(name),
+    _patch_provider_binary_lookup(
+        monkeypatch,
+        lambda name, *_a, **_k: {"opencode": "/usr/local/bin/opencode"}.get(name),
     )
 
     assert acpx_module.probe_participant_reachability("gemma") is None
@@ -2630,7 +2644,7 @@ def test_probe_participant_reachability_reports_only_missing_provider_binaries(m
 def test_probe_participant_reachability_flags_deepseek_when_opencode_is_missing(monkeypatch):
     """#6805: the DeepSeek seat now degrades on the opencode binary, with the
     opencode remediation — never on the permanently removed hermes binary."""
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    _patch_provider_binary_lookup(monkeypatch, lambda _name, *_a, **_k: None)
 
     error = acpx_module.probe_participant_reachability("deepseek")
 
@@ -2647,10 +2661,9 @@ def test_new_fleet_discussion_seat_accepts_provider_cli_version_drift(tmp_path, 
     agy.write_text("#!/bin/sh\n", encoding="utf-8")
     agy.chmod(0o755)
     node = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
-    monkeypatch.setattr(
-        acpx_module.shutil,
-        "which",
-        lambda name: str({"agy": agy, "node": node}[name]),
+    _patch_path_binary_lookup(
+        monkeypatch,
+        lambda name, *_a, **_k: str({"agy": agy, "node": node}[name]),
     )
     _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(
@@ -2686,10 +2699,9 @@ def test_new_fleet_discussion_seat_rejects_missing_provider_capability(tmp_path,
     agy.write_text("#!/bin/sh\n", encoding="utf-8")
     agy.chmod(0o755)
     node = _fake_node_binary(tmp_path, version=f"v{required}.14.0")
-    monkeypatch.setattr(
-        acpx_module.shutil,
-        "which",
-        lambda name: str({"agy": agy, "node": node}[name]),
+    _patch_path_binary_lookup(
+        monkeypatch,
+        lambda name, *_a, **_k: str({"agy": agy, "node": node}[name]),
     )
     _isolate_node_fallbacks(monkeypatch)
     monkeypatch.setattr(

--- a/tests/agent_runtime/test_binary_resolve.py
+++ b/tests/agent_runtime/test_binary_resolve.py
@@ -1,0 +1,83 @@
+"""Tests for login-PATH agent binary resolution (#7161)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+
+from scripts.agent_runtime.binary_resolve import augment_path_for_login_bins, resolve_agent_binary
+
+
+def _write_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_resolve_finds_binary_only_under_login_local_bin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolver must find seat CLIs installed under ~/.local/bin when spawn PATH omits it."""
+    fake_home = tmp_path / "home"
+    local_bin = fake_home / ".local" / "bin"
+    binary = local_bin / "cursor-agent"
+    _write_executable(binary)
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    minimal_path = "/usr/bin:/bin"
+
+    resolved = resolve_agent_binary("cursor-agent", path=minimal_path)
+    assert resolved == str(binary.resolve())
+
+    # Mutation check: bare shutil.which on the unaugmented PATH must miss.
+    assert shutil.which("cursor-agent", path=minimal_path) is None
+
+
+def test_resolve_finds_binary_only_under_login_opencode_bin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_home = tmp_path / "home"
+    opencode_bin = fake_home / ".opencode" / "bin"
+    binary = opencode_bin / "opencode"
+    _write_executable(binary)
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    minimal_path = "/usr/bin:/bin"
+
+    resolved = resolve_agent_binary("opencode", path=minimal_path)
+    assert resolved == str(binary.resolve())
+
+
+def test_augment_path_appends_login_dirs_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_home = tmp_path / "home"
+    local_bin = str(fake_home / ".local" / "bin")
+    opencode_bin = str(fake_home / ".opencode" / "bin")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    augmented = augment_path_for_login_bins("/usr/bin:/bin")
+    parts = augmented.split(os.pathsep)
+    assert parts[:2] == ["/usr/bin", "/bin"]
+    assert local_bin in parts
+    assert opencode_bin in parts
+    assert parts.count(local_bin) == 1
+    assert parts.count(opencode_bin) == 1
+
+
+def test_resolve_returns_none_when_binary_genuinely_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    assert resolve_agent_binary("cursor-agent", path="/usr/bin:/bin") is None
+
+
+def test_prepare_spawn_command_resolves_argv0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.agent_runtime.runner import _prepare_spawn_command
+
+    fake_home = tmp_path / "home"
+    local_bin = fake_home / ".local" / "bin"
+    binary = local_bin / "cursor-agent"
+    _write_executable(binary)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    cmd, env = _prepare_spawn_command(["cursor-agent", "--help"], {"PATH": "/usr/bin:/bin"})
+    assert cmd[0] == str(binary.resolve())
+    assert cmd[1:] == ["--help"]
+    assert str(local_bin) in env["PATH"].split(os.pathsep)

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -568,10 +568,10 @@ def test_compat_ask_fails_before_provider_invocation_when_provider_binary_is_mis
     actionable remediation and documented route — not mid-review at spawn.
     The authority job is enqueued and claimed first: terminal-replay paths
     must stay reachable even when the provider CLI is absent."""
-    from scripts.agent_runtime.adapters import acpx as acpx_module
+    from scripts.agent_runtime import binary_resolve as binary_resolve_module
 
     invoke = Mock(side_effect=AssertionError("dead seat invoked the provider"))
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(binary_resolve_module, "_which", lambda _name, *_a, **_k: None)
     monkeypatch.setattr(
         "scripts.fleet_comms.authority.AuthorityService", _RecordingAuthority
     )
@@ -594,9 +594,9 @@ def test_ask_hermes_cli_surfaces_remediation_when_binary_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """#6805: the CLI exits nonzero with the remediation the caller reroutes on."""
-    from scripts.agent_runtime.adapters import acpx as acpx_module
+    from scripts.agent_runtime import binary_resolve as binary_resolve_module
 
-    monkeypatch.setattr(acpx_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(binary_resolve_module, "_which", lambda _name, *_a, **_k: None)
     monkeypatch.setattr(
         "scripts.fleet_comms.authority.AuthorityService", _RecordingAuthority
     )


### PR DESCRIPTION
## Summary
- Add `binary_resolve` module that augments spawn PATH with `~/.local/bin` and `~/.opencode/bin`, resolving seat CLIs to absolute paths before `Popen`.
- Wire resolver into the runner spawn path (`_prepare_spawn_command`) so all adapter invocations benefit.
- Apply the same resolver to ACP participant preflight and binary resolution in `acpx.py`.

Fixes the `AgentUnavailableError ... FileNotFoundError: 'cursor-agent'` class on job hosts where every seat binary exists under `/home/ops/.local/bin` (opencode under `/home/ops/.opencode/bin`) but the dispatch runtime spawns without the login PATH — evidence on #7161. This was the root cause of reviewer-seat spawn failures leaving PRs unreviewed.

## Test plan
- [x] `pytest -q tests/agent_runtime/test_binary_resolve.py` — 5 new tests incl. mutation check (resolver reverted → binary not found; quoted in task log)
- [x] `pytest -q tests/test_agent_runtime.py` + subprocess timeout guard — 214 passed on driver re-probe (worker: 332/333, 1 pre-existing git-shim worktree flake, unrelated)
- [x] `ruff check` clean on changed files
- [ ] Live: `delegate.py dispatch --agent cursor --mode read-only` on hramatka after merge (main-only fetch refspec there makes pre-merge branch proof impractical; issue stays open until this proof)

Refs #7161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
