### PR TITLE
fix(ci): resolve sibling fallback imports as first-party in fastlane scanner (#7141)

### DIFF
--- a/scripts/ci/fastlane_requirements.py
+++ b/scripts/ci/fastlane_requirements.py
@@ -129,18 +129,39 @@ def _imported_modules(path: Path, project_root: Path, *, module_level_only: bool
     return modules
 
 
-def _resolve_project_module(module: str, project_root: Path) -> Path | None:
-    """Resolve a module name to a project Python file, if it is project-local."""
+def _resolve_project_module(
+    module: str,
+    project_root: Path,
+    *,
+    importing_file: Path | None = None,
+) -> Path | None:
+    """Resolve a module name to a project Python file, if it is project-local.
+
+    Script entry points can put their own directory on ``sys.path`` and use a
+    flat import as the fallback for a package import. Include that directory
+    when resolving a module reached from such a file so the fallback remains
+    first-party instead of being treated as an unmapped dependency.
+    """
     parts = tuple(part for part in module.split(".") if part)
     if not parts:
         return None
 
     relative = Path(*parts)
-    candidates = (
-        project_root / relative.with_suffix(".py"),
-        project_root / relative / "__init__.py",
-        project_root / "scripts" / relative.with_suffix(".py"),
-        project_root / "scripts" / relative / "__init__.py",
+    candidates: list[Path] = []
+    if importing_file is not None:
+        candidates.extend(
+            (
+                importing_file.parent / relative.with_suffix(".py"),
+                importing_file.parent / relative / "__init__.py",
+            )
+        )
+    candidates.extend(
+        (
+            project_root / relative.with_suffix(".py"),
+            project_root / relative / "__init__.py",
+            project_root / "scripts" / relative.with_suffix(".py"),
+            project_root / "scripts" / relative / "__init__.py",
+        )
     )
     return next((candidate for candidate in candidates if candidate.is_file()), None)
 
@@ -161,7 +182,7 @@ def _reachable_import_roots(test_paths: Iterable[Path], project_root: Path) -> s
             root = module.split(".", 1)[0]
             if root in LIVE_MODEL_IMPORTS or root == "__future__":
                 continue
-            resolved = _resolve_project_module(module, project_root)
+            resolved = _resolve_project_module(module, project_root, importing_file=path)
             if resolved is not None:
                 pending.append((resolved, False))
             elif not is_project_import(root, project_root):

--- a/tests/test_ci_fastlane_requirements.py
+++ b/tests/test_ci_fastlane_requirements.py
@@ -165,6 +165,38 @@ def test_project_import_graph_adds_transitive_third_party_pin(tmp_path: Path) ->
     assert selected == ["requests==2.34.2"]
 
 
+def test_script_context_fallback_import_resolves_relative_to_importer(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    orchestration = project_root / "scripts" / "orchestration"
+    _write(orchestration / "__init__.py", "")
+    _write(orchestration / "task_identity.py", "import requests\n")
+    _write(orchestration / "thread_handoff_canary.py", "")
+    _write(
+        orchestration / "thread_handoff.py",
+        """\
+try:
+    from scripts.orchestration import task_identity, thread_handoff_canary
+except ImportError:
+    import task_identity
+    import thread_handoff_canary
+""",
+    )
+    test_path = _write(
+        project_root / "tests" / "test_example.py",
+        "from scripts.orchestration import thread_handoff\n",
+    )
+
+    assert fastlane_requirements._reachable_import_roots([test_path], project_root) == {"requests"}
+    selected = fastlane_requirements.select_requirements(
+        [test_path],
+        base_requirements=[],
+        lock_requirements=_lock(tmp_path),
+        project_root=project_root,
+    )
+
+    assert selected == ["requests==2.34.2"]
+
+
 def test_unknown_transitive_project_import_fails_closed(tmp_path: Path) -> None:
     project_root = tmp_path / "project"
     _write(project_root / "scripts" / "__init__.py", "")


### PR DESCRIPTION
## Summary
- The fastlane slim-deps scanner (`scripts/ci/fastlane_requirements.py`) walked the whole AST and took the flat script-context fallback of the try/except dual-import idiom (`import task_identity` in the `except ImportError` branch of `scripts/orchestration/thread_handoff.py:55`) at face value, then failed to resolve it as project-local → hard-failed the fastlane install step as an "unmapped third-party module".
- Fix at the resolver layer: `_resolve_project_module` now also tries the importing file's own directory, so a fallback that resolves as a sibling module is first-party. Genuinely unknown third-party names still fail closed exactly as before (`is_project_import` path unchanged).
- Unblocks #7197, whose new review-isolation test made `thread_handoff.py` reachable for the first time. Refs #7141.

## Validation
- 24 relevant tests pass (`tests/test_ci_fastlane_requirements.py` incl. new dual-import sibling fixture + fail-closed coverage, `tests/test_ci_changed_tests.py`, `tests/test_subprocess_timeout_guard.py`); worker run and independent driver re-probe.
- Mutation check with the resolver reverted: the sibling fixture test fails with `task_identity`/`thread_handoff_canary` leaking into third-party roots (quoted in the task log).
- Driver repro against the #7197 import graph: neither name in roots; `jsonschema`/`psutil`/`pytest`/`yaml` still classified third-party.
- `ruff check` clean on changed files. `except ImportError` scan: one site repo-wide (`thread_handoff.py`), covered by the class fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
