### PR TITLE
fix(bridge): apply codex connector lockdown to UI resume spawn (#7202)

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -324,6 +324,13 @@ class CodexAdapter:
             cmd.extend(["-c", 'sandbox_mode="read-only"'])
         else:
             cmd.extend(self._mode_flags(mode))
+        # Dispatched workers must have NO write-capable GitHub connector tools
+        # (#7181). Disabling the `apps` feature suppresses `codex_apps` MCP
+        # connectors (including `github.create_commit`, `github.update_ref`,
+        # `github.create_pr`) across all runtime invocations (fresh & resume).
+        # ORDER MATTERS: must come after `_mode_flags` in case any mode
+        # enables toggles.
+        cmd.extend(["--disable", "apps"])
         cmd.extend(self._tool_config_flags(tool_config))
         if has_session_to_resume:
             cmd.append(session_id)
@@ -401,7 +408,7 @@ class CodexAdapter:
         disable_features = tool_config.get("disable_features")
         if isinstance(disable_features, (list, tuple)):
             for feature in disable_features:
-                if isinstance(feature, str) and feature:
+                if isinstance(feature, str) and feature and feature != "apps":
                     flags.extend(["--disable", feature])
 
         output_schema_path = tool_config.get("output_schema_path")

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -371,10 +371,12 @@ class CodexAdapter:
           Used by ``linear_pipeline._runtime_tool_config`` to enforce
           writer tool-isolation: V7 writers may only call ``mcp__sources__*``
           tools, so feature flags such as ``shell_tool``, ``goals``,
-          ``apps``, ``plugins``, ``browser_use``, ``in_app_browser``,
+          ``plugins``, ``browser_use``, ``in_app_browser``,
           ``image_generation``, and ``multi_agent`` must be disabled
           before invocation so the model can't reach for them and trip
-          the ``writer_trace_isolation`` gate with ``wrong_tool_family``.
+          the ``writer_trace_isolation`` gate with ``wrong_tool_family``
+          (``apps`` is filtered here because it is emitted unconditionally
+          in ``build_invocation``).
           See ``codex_home_override`` for the companion MCP-scoping fix.
         - ``codex_home_override``: NOT translated to flags here — it's a
           companion ``env_overrides`` key handled in

--- a/scripts/ai_agent_bridge/_ui_codex.py
+++ b/scripts/ai_agent_bridge/_ui_codex.py
@@ -137,7 +137,7 @@ def send(
     start = datetime.now(UTC)
     try:
         proc = subprocess.run(
-            ["codex", "exec", "resume", "--json", thread_id, "-"],
+            ["codex", "exec", "resume", "--json", "--disable", "apps", thread_id, "-"],
             input=framed_message,
             cwd=str(cwd) if cwd else None,
             capture_output=True,

--- a/tests/ai_agent_bridge/test_ui_codex.py
+++ b/tests/ai_agent_bridge/test_ui_codex.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts.ai_agent_bridge import _ui_codex as ui_codex
+
+THREAD_ID = "019e6063-c3da-78d1-acaa-4cd684a08786"
+
+
+def _patch_codex_sessions_root(monkeypatch, tmp_path: Path) -> Path:
+    sessions_root = tmp_path / ".codex" / "sessions"
+    monkeypatch.setattr(ui_codex, "CODEX_SESSIONS_ROOT", sessions_root)
+    return sessions_root
+
+
+def test_find_session_file_happy_path_and_missing(tmp_path: Path, monkeypatch) -> None:
+    sessions_root = _patch_codex_sessions_root(monkeypatch, tmp_path)
+    day_dir = sessions_root / "2026" / "05" / "26"
+    day_dir.mkdir(parents=True)
+    older_session = day_dir / f"rollout-2026-05-26T10-00-00-{THREAD_ID}.jsonl"
+    older_session.write_text("older\n", encoding="utf-8")
+    newer_session = day_dir / f"rollout-2026-05-26T12-00-00-{THREAD_ID}.jsonl"
+    newer_session.write_text("newer\n", encoding="utf-8")
+
+    assert ui_codex.find_session_file(THREAD_ID) == newer_session
+    assert ui_codex.find_session_file("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_extract_final_message_from_synthetic_codex_event_stream() -> None:
+    events = [
+        {
+            "type": "item.completed",
+            "item": {"type": "command_execution", "aggregated_output": "echo intermediate"},
+        },
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "final answer text"},
+        },
+    ]
+    assert ui_codex._extract_final_message(events) == "final answer text"
+
+
+def test_extract_final_message_fallback_to_command_output() -> None:
+    events = [
+        {
+            "type": "item.completed",
+            "item": {"type": "command_execution", "aggregated_output": "PONG 123"},
+        },
+    ]
+    assert ui_codex._extract_final_message(events) == "PONG 123"
+
+
+def test_send_disables_apps_connector_in_final_argv(tmp_path: Path, monkeypatch) -> None:
+    """Dispatched UI resume spawn must unconditionally include --disable apps (#7202, #7181)."""
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(ui_codex.subprocess, "run", fake_run)
+
+    result = ui_codex.send(
+        thread_id=THREAD_ID,
+        message="ping",
+        bridge_id="bridge-test-7202",
+        cwd=tmp_path,
+        timeout_s=30,
+    )
+
+    assert result["exit_code"] == 0
+    assert len(captured_cmds) == 1
+    final_argv = captured_cmds[0]
+    assert final_argv == ["codex", "exec", "resume", "--json", "--disable", "apps", THREAD_ID, "-"]
+    disable_indices = [i for i, token in enumerate(final_argv[:-1]) if token == "--disable"]
+    assert len(disable_indices) == 1
+    assert final_argv[disable_indices[0] + 1] == "apps"
+
+
+def test_send_with_mocked_subprocess_parses_stdout_event_stream(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    sessions_root = _patch_codex_sessions_root(monkeypatch, tmp_path)
+    day_dir = sessions_root / "2026" / "05" / "26"
+    day_dir.mkdir(parents=True)
+    session = day_dir / f"rollout-2026-05-26T12-00-00-{THREAD_ID}.jsonl"
+    session.write_text("session data\n", encoding="utf-8")
+
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "turn.started"}),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "Known reply"},
+                }
+            ),
+        ]
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["codex", "exec", "resume", "--json", "--disable", "apps", THREAD_ID, "-"]
+        assert kwargs["input"].startswith("Bridge-ID: bridge-parse-test\n\nhello from bridge")
+        assert kwargs["cwd"] == str(tmp_path)
+        assert kwargs["timeout"] == 60
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(ui_codex.subprocess, "run", fake_run)
+
+    result = ui_codex.send(
+        thread_id=THREAD_ID,
+        message="hello from bridge",
+        bridge_id="bridge-parse-test",
+        cwd=tmp_path,
+        timeout_s=60,
+    )
+
+    assert result["bridge_id"] == "bridge-parse-test"
+    assert result["thread_id"] == THREAD_ID
+    assert result["exit_code"] == 0
+    assert result["final_message"] == "Known reply"
+    assert len(result["events"]) == 2
+    assert result["session_file"] == str(session)
+
+
+def test_send_handles_timeout_expired(tmp_path: Path, monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=5, output=b"", stderr=b"hung")
+
+    monkeypatch.setattr(ui_codex.subprocess, "run", fake_run)
+
+    result = ui_codex.send(
+        thread_id=THREAD_ID,
+        message="timed out task",
+        timeout_s=5,
+    )
+
+    assert result["exit_code"] == -1
+    assert "[timeout after 5s]" in result["stderr"]
+    assert "hung" in result["stderr"]

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -785,9 +785,9 @@ def test_codex_adapter_disable_features_emits_flags(tmp_path):
             "disable_features": ["shell_tool"],
         },
     )
-    assert "--disable" in plan.cmd
-    disable_idx = plan.cmd.index("--disable")
-    assert plan.cmd[disable_idx + 1] == "shell_tool"
+    disable_pairs = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
+    assert "apps" in disable_pairs
+    assert "shell_tool" in disable_pairs
     # Both flags coexist with MCP override.
     config_values = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "-c"]
     assert 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"' in config_values
@@ -808,7 +808,78 @@ def test_codex_adapter_disable_features_multiple(tmp_path):
         },
     )
     disable_pairs = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
-    assert disable_pairs == ["shell_tool", "browser_use"]
+    assert disable_pairs == ["apps", "shell_tool", "browser_use"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "session_id", "tool_config"),
+    [
+        ("workspace-write", None, None),
+        ("read-only", None, None),
+        ("workspace-write", "prior-session-123", None),
+        ("read-only", "prior-session-123", None),
+        ("workspace-write", None, {"disable_features": ["apps"]}),
+        ("workspace-write", None, {"disable_features": ["shell_tool", "apps"]}),
+    ],
+)
+def test_codex_adapter_disables_apps_connector_across_all_invocations(tmp_path, mode, session_id, tool_config):
+    """Dispatched workers must have NO write-capable GitHub connector tools (#7181).
+
+    --disable apps must be present across fresh, read-only, and resumed
+    invocations, and must not duplicate when disable_features explicitly lists apps.
+    """
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode=mode,
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=session_id,
+        tool_config=tool_config,
+    )
+    disable_flags = [plan.cmd[i + 1] for i, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
+    assert "apps" in disable_flags
+    assert disable_flags.count("apps") == 1
+    if "--enable" in plan.cmd:
+        enable_indices = [i for i, token in enumerate(plan.cmd) if token == "--enable"]
+        apps_indices = [i for i, token in enumerate(plan.cmd[:-1]) if token == "--disable" and plan.cmd[i + 1] == "apps"]
+        assert apps_indices[0] > max(enable_indices)
+
+
+def test_codex_adapter_disables_apps_connector_in_review_isolation(tmp_path):
+    """Dispatched review isolation workers must also disable apps connector (#7181)."""
+    from scripts.review.isolation import review_isolation_tool_config
+    from tests.test_review_isolation import _private_review_roots
+
+    fake = tmp_path / "codex"
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake.chmod(0o755)
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    write_root, exec_root = _private_review_roots(tmp_path, "codex-test-7181")
+
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="review prompt",
+        mode="read-only",
+        cwd=snapshot,
+        model=None,
+        task_id="review-7181-test",
+        session_id=None,
+        tool_config={
+            **review_isolation_tool_config("codex"),
+            "review_engine_binary": str(fake.resolve()),
+            "review_snapshot_root": str(snapshot),
+            "review_reject_root": str(snapshot),
+            "review_reject_roots": [str(snapshot)],
+            "review_write_root": str(write_root),
+            "review_exec_root": str(exec_root),
+        },
+    )
+    disable_flags = [plan.cmd[i + 1] for i, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
+    assert "apps" in disable_flags
+    assert disable_flags.count("apps") == 1
 
 
 def test_codex_adapter_binds_valid_output_schema(tmp_path):
@@ -908,7 +979,7 @@ def test_codex_adapter_disable_features_ignores_non_string_entries(tmp_path):
         },
     )
     disable_pairs = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
-    assert disable_pairs == ["shell_tool", "browser_use"]
+    assert disable_pairs == ["apps", "shell_tool", "browser_use"]
 
 
 def test_codex_adapter_ignores_unknown_tool_config_keys(tmp_path):

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -859,6 +859,11 @@ def test_codex_adapter_disables_apps_connector_in_review_isolation(tmp_path):
     snapshot.mkdir()
     write_root, exec_root = _private_review_roots(tmp_path, "codex-test-7181")
 
+    base_config = review_isolation_tool_config("codex")
+    # Strip disable_features from tool_config to prove build_invocation emits
+    # --disable apps unconditionally rather than relying on tool_config.
+    config_without_disable_features = {k: v for k, v in base_config.items() if k != "disable_features"}
+
     adapter = CodexAdapter()
     plan = adapter.build_invocation(
         prompt="review prompt",
@@ -868,7 +873,7 @@ def test_codex_adapter_disables_apps_connector_in_review_isolation(tmp_path):
         task_id="review-7181-test",
         session_id=None,
         tool_config={
-            **review_isolation_tool_config("codex"),
+            **config_without_disable_features,
             "review_engine_binary": str(fake.resolve()),
             "review_snapshot_root": str(snapshot),
             "review_reject_root": str(snapshot),
@@ -877,9 +882,10 @@ def test_codex_adapter_disables_apps_connector_in_review_isolation(tmp_path):
             "review_exec_root": str(exec_root),
         },
     )
+    bypass_idx = plan.cmd.index("--dangerously-bypass-approvals-and-sandbox")
+    assert plan.cmd[bypass_idx + 1 : bypass_idx + 3] == ["--disable", "apps"]
     disable_flags = [plan.cmd[i + 1] for i, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
-    assert "apps" in disable_flags
-    assert disable_flags.count("apps") == 1
+    assert disable_flags == ["apps"]
 
 
 def test_codex_adapter_binds_valid_output_schema(tmp_path):


### PR DESCRIPTION
## Summary
Close the UI-bridge connector lockdown gap identified in the cross-family review of #7197 (Closes #7202, Refs #7181).

## Rationale
PR #7197 made `CodexAdapter.build_invocation` emit `--disable apps` unconditionally across all runtime invocation plans. However, `scripts/ai_agent_bridge/_ui_codex.py:139` spawned raw `codex exec resume --json <thread_id> -` subprocesses outside the adapter.

Emitting `--disable apps` directly at the `_ui_codex.py` site was chosen over routing through `CodexAdapter` because `_ui_codex.py` is a lightweight resume-only bridge utility that captures stdout directly in-memory to parse the event stream for the UI caller, avoiding unnecessary adapter sandbox overrides or output redirection files.

## Changes
- `scripts/ai_agent_bridge/_ui_codex.py`: add `--disable apps` unconditionally to the `codex exec resume` argv.
- `scripts/agent_runtime/adapters/codex.py`: clarify in the `_tool_config_flags` docstring that `apps` is filtered because `build_invocation` emits it unconditionally.
- `tests/test_agent_runtime.py`: harden `test_codex_adapter_disables_apps_connector_in_review_isolation` to strip `disable_features` and assert unconditional emission (it previously passed with the lockdown reverted).
- `tests/ai_agent_bridge/test_ui_codex.py`: new tests covering `--disable apps` in the final argv and event-stream parsing.

## Verification
- Mutation check: reverting the flag in `_ui_codex.py` fails `test_send_disables_apps_connector_in_final_argv` (quoted in the task log); reverting the adapter lockdown fails the hardened isolation test.
- Worker: 245 passed; driver re-probe: 222 passed (`test_ui_codex.py` + `test_agent_runtime.py`), ruff clean.
- Inventory of every `"codex"` argv builder under `scripts/`: the adapter and this bridge site are the only two, both carry the flag.

Stacked on #7197 (queued to merge): until it lands this PR's diff also shows #7197's commit; the review target is the top commit `6e5de0b014`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
