### PR TITLE
test(delegate): document the repo-root sidecar guard case; runbook rule for stale launchers (#7208)

### DIFF
--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -93,6 +93,20 @@ represent ordinary merged-PR dispatch cleanup:
   its executor repeats frozen-plan, merged-PR, bundle, and candidate checks
   immediately before deletion. Do not replace or remove that path here.
 
+## Before re-firing a task id
+
+A detached `delegate.py dispatch` launcher that is still grinding from a prior
+attempt can finish after you re-fire the same task id, leaving two workers on
+one worktree (the task record points at the newer pid; the older process is an
+orphan). Before re-using a task id, kill any stale detached launcher for it:
+
+```bash
+/bin/ps -axo pid,etime,command | grep 'delegate.py dispatch .*--task-id <id>'
+```
+
+Confirm the match is the stale launcher, then terminate that pid before the
+new dispatch.
+
 ## Immediate cleanup after merge
 
 The merge owner removes the exact worktree as soon as GitHub reports the PR

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2767,15 +2767,26 @@ def _is_read_only_runtime_telemetry_path(path: str) -> bool:
     )
 
 
+def _is_read_only_delegate_snapshot_sidecar_path(path: str) -> bool:
+    """Return whether *path* is a delegate-owned read-only snapshot sidecar."""
+    normalized = _normalize_read_only_relpath(path)
+    if not normalized.endswith(".json"):
+        return False
+    parts = normalized.split("/")
+    if len(parts) < 2:
+        return False
+    return parts[-2].endswith(f"{_READ_ONLY_CHECKOUT_SNAPSHOT_SUFFIX}") and parts[-1].startswith("read_only_checkout_")
+
+
 def _is_read_only_runtime_state_path(path: str) -> bool:
     """Return whether a path is harness/tooling runtime state, not repo content.
 
     Covers Entire telemetry (#6803) plus the gitignored runtime dirs and sqlite
     sidecars that false-failed successful read-only tasks (#6860). Task-authored
     ignored leaks such as ``.cache/`` stay visible to the guard (#4840).
-    Delegate read-only snapshot sidecars live under ``batch_state/tasks/``
-    (#7203), so the ``batch_state`` dir-name check already exempts them (#7208).
     """
+    if _is_read_only_delegate_snapshot_sidecar_path(path):
+        return True
     if _is_read_only_runtime_telemetry_path(path):
         return True
     normalized = _normalize_read_only_relpath(path)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2767,26 +2767,15 @@ def _is_read_only_runtime_telemetry_path(path: str) -> bool:
     )
 
 
-def _is_read_only_delegate_snapshot_sidecar_path(path: str) -> bool:
-    """Return whether *path* is a delegate-owned read-only snapshot sidecar."""
-    normalized = _normalize_read_only_relpath(path)
-    if not normalized.endswith(".json"):
-        return False
-    parts = normalized.split("/")
-    if len(parts) < 2:
-        return False
-    return parts[-2].endswith(f"{_READ_ONLY_CHECKOUT_SNAPSHOT_SUFFIX}") and parts[-1].startswith("read_only_checkout_")
-
-
 def _is_read_only_runtime_state_path(path: str) -> bool:
     """Return whether a path is harness/tooling runtime state, not repo content.
 
     Covers Entire telemetry (#6803) plus the gitignored runtime dirs and sqlite
     sidecars that false-failed successful read-only tasks (#6860). Task-authored
     ignored leaks such as ``.cache/`` stay visible to the guard (#4840).
+    Delegate read-only snapshot sidecars live under ``batch_state/tasks/``
+    (#7203), so the ``batch_state`` dir-name check already exempts them (#7208).
     """
-    if _is_read_only_delegate_snapshot_sidecar_path(path):
-        return True
     if _is_read_only_runtime_telemetry_path(path):
         return True
     normalized = _normalize_read_only_relpath(path)

--- a/tests/test_delegate_readonly_guard.py
+++ b/tests/test_delegate_readonly_guard.py
@@ -124,10 +124,18 @@ def test_read_only_snapshot_excluded_path_classification():
     assert not delegate._is_read_only_snapshot_excluded_path(".worktreesish/file")
 
 
-def test_read_only_delegate_snapshot_sidecar_path_is_runtime_state():
-    """#7203: task snapshot sidecars live under ``tasks/``, not ``batch_state/``."""
-    sidecar = "tasks/read-only-task.snapshots/read_only_checkout_pre.json"
-    assert delegate._is_read_only_delegate_snapshot_sidecar_path(sidecar)
+def test_real_delegate_snapshot_sidecar_is_runtime_state_via_batch_state():
+    """#7208: real sidecars under batch_state/tasks/<task>.snapshots/ are exempt.
+
+    Sidecars are built from ``_TASKS_DIR`` (``batch_state/tasks``), so the
+    existing ``batch_state`` runtime-state dir-name check covers them. A
+    synthetic ``tasks/…`` path without that prefix is not a production shape.
+    """
+    abs_path = delegate._read_only_snapshot_sidecar_path("read-only-task", "pre")
+    sidecar = str(abs_path.relative_to(delegate._REPO_ROOT)).replace("\\", "/")
+    assert sidecar == (
+        "batch_state/tasks/read-only-task.snapshots/read_only_checkout_pre.json"
+    )
     assert delegate._is_read_only_runtime_state_path(sidecar)
     assert not delegate._is_read_only_runtime_telemetry_path(sidecar)
 

--- a/tests/test_delegate_readonly_guard.py
+++ b/tests/test_delegate_readonly_guard.py
@@ -128,14 +128,25 @@ def test_real_delegate_snapshot_sidecar_is_runtime_state_via_batch_state():
     """#7208: real sidecars under batch_state/tasks/<task>.snapshots/ are exempt.
 
     Sidecars are built from ``_TASKS_DIR`` (``batch_state/tasks``), so the
-    existing ``batch_state`` runtime-state dir-name check covers them. A
-    synthetic ``tasks/…`` path without that prefix is not a production shape.
+    existing ``batch_state`` runtime-state dir-name check covers them.
     """
     abs_path = delegate._read_only_snapshot_sidecar_path("read-only-task", "pre")
     sidecar = str(abs_path.relative_to(delegate._REPO_ROOT)).replace("\\", "/")
     assert sidecar == (
         "batch_state/tasks/read-only-task.snapshots/read_only_checkout_pre.json"
     )
+    assert delegate._is_read_only_runtime_state_path(sidecar)
+    assert not delegate._is_read_only_runtime_telemetry_path(sidecar)
+
+
+def test_read_only_delegate_snapshot_sidecar_path_is_runtime_state():
+    """#7203/#7208: repo-root dispatches observe the sidecar as ``tasks/<id>.snapshots/…``.
+
+    The ``batch_state`` dir-name exemption does not apply there — see
+    ``tests/test_delegate.py`` ``[repo-root]`` cases.
+    """
+    sidecar = "tasks/read-only-task.snapshots/read_only_checkout_pre.json"
+    assert delegate._is_read_only_delegate_snapshot_sidecar_path(sidecar)
     assert delegate._is_read_only_runtime_state_path(sidecar)
     assert not delegate._is_read_only_runtime_telemetry_path(sidecar)
 


### PR DESCRIPTION
## Summary
Refs #7208 (re-scoped: the helper is NOT dead — see below).

- `_is_read_only_delegate_snapshot_sidecar_path` stays. Repo-root dispatches observe the read-only snapshot sidecar as `tasks/<id>.snapshots/read_only_checkout_*.json` (no `batch_state/` prefix), so the `batch_state` dir-name exemption does not apply there and the suffix-shape guard is what keeps the sidecar out of the mutation diff — proven by the four `[repo-root]` cases in `tests/test_delegate.py`, which fail when it is removed (merge-queue run 32684231450).
- Tests: the `tasks/…` case now carries a correct docstring citing that scenario; a second test covers the real `batch_state/tasks/<id>.snapshots/…` path via the runtime-state exemption.
- Runbook: `docs/runbooks/worktree-cleanup.md` gains "Before re-firing a task id" — kill any stale detached launcher for that id first (duplicate-worker incident after #7206), with the `ps … grep 'delegate.py dispatch .*--task-id <id>'` one-liner.

Net change to `scripts/delegate.py` vs main: none.

## Verification
- `pytest -q tests/test_delegate_readonly_guard.py tests/test_delegate_runtime_tmp_sweep.py` — 22 passed; `tests/test_delegate.py -k read_only` — 30 passed (incl. the four repo-root cases); both without `LU_ALLOW_NOTEBOOK_DISPATCH`; ruff clean.
- Mutation check: removing the helper fails the four repo-root tests (quoted in the task log).

Refs #7203, #7206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
