### PR TITLE
fix(api): bound subprocess calls in Monitor-API handlers — allowlist burn-down slice 2 (#7213)

### DIFF
--- a/scripts/api/blue_router.py
+++ b/scripts/api/blue_router.py
@@ -35,6 +35,8 @@ from audit.status_cache import get_source_paths, read_status
 from slug_utils import to_bare_slug
 from yaml_activities import ActivityParser
 
+AUDIT_MODULE_TIMEOUT_SECONDS: float = 60.0
+
 router = APIRouter(tags=["blue"])
 
 
@@ -65,9 +67,7 @@ async def live_status(response: Response):
     """
     response.headers["X-Deprecated"] = "true"
     response.headers["X-Deprecated-Use"] = "/api/state/build-status"
-    response.headers["Warning"] = (
-        '299 - "This endpoint is deprecated; migrate to /api/state/build-status (#1309)"'
-    )
+    response.headers["Warning"] = '299 - "This endpoint is deprecated; migrate to /api/state/build-status (#1309)"'
 
     results = {}
     for level_cfg in LEVELS:
@@ -108,8 +108,10 @@ async def live_status(response: Response):
                     "slug": slug,
                     "state": state,
                     "files": {
-                        "meta": has_meta, "lesson": has_lesson,
-                        "activities": has_activities, "vocabulary": has_vocab,
+                        "meta": has_meta,
+                        "lesson": has_lesson,
+                        "activities": has_activities,
+                        "vocabulary": has_vocab,
                     },
                 }
                 if result:
@@ -196,10 +198,19 @@ async def get_audit_status(track_id: str, slug: str, fresh: bool = False):
         if not md_path.exists():
             raise HTTPException(status_code=404, detail=f"Module file not found: {md_path}")
         audit_script = PROJECT_ROOT / "scripts" / "audit_module.sh"
-        subprocess.run(
-            [str(audit_script), str(md_path)],
-            capture_output=True, text=True, cwd=PROJECT_ROOT
-        )
+        try:
+            subprocess.run(
+                [str(audit_script), str(md_path)],
+                capture_output=True,
+                text=True,
+                cwd=PROJECT_ROOT,
+                timeout=AUDIT_MODULE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            raise HTTPException(
+                status_code=504,
+                detail=f"Audit execution timed out after {AUDIT_MODULE_TIMEOUT_SECONDS}s",
+            ) from None
         # Script writes status JSON as a side effect — re-read below
 
     if not status_file.exists():
@@ -386,8 +397,7 @@ async def get_final_review_summary(track_id: str, slug: str):
     review_ok = review_status["exists"] and not review_status["warnings"]
     stale = audit_age_seconds is not None and audit_age_seconds > 3600
 
-    verdict = "READY_TO_APPROVE" if (audit_ok and activities_ok and review_ok and not stale) \
-        else "NEEDS_REVIEW"
+    verdict = "READY_TO_APPROVE" if (audit_ok and activities_ok and review_ok and not stale) else "NEEDS_REVIEW"
 
     return {
         "track": track_id,

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -36,6 +36,8 @@ WRAPPER_NAME = "run_monitor_api_supervisor.sh"
 _LOG_ROTATE_BYTES = 10 * 1024 * 1024
 _STOP_UNLOAD_TIMEOUT_SECONDS = 12.0
 _STOP_UNLOAD_POLL_SECONDS = 0.1
+LAUNCHCTL_TIMEOUT_SECONDS: float = 15.0
+GIT_REV_PARSE_TIMEOUT_SECONDS: float = 15.0
 
 
 class LaunchdError(RuntimeError):
@@ -204,7 +206,10 @@ def _launchctl(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
             check=False,
             capture_output=True,
             text=True,
+            timeout=LAUNCHCTL_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise LaunchdError(f"/bin/launchctl {' '.join(command)} timed out after {exc.timeout}s") from exc
     except FileNotFoundError as exc:
         raise LaunchdError("/bin/launchctl is unavailable; Monitor API supervision requires macOS") from exc
 
@@ -423,19 +428,20 @@ def _prepare_api_command(repo_root: Path, *, live_mode: bool, port: int) -> tupl
         launch_dir = repo_root
         release_line = "WARNING: API live mode enabled; serving mutable checkout code"
     else:
-        head_sha = subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", "--verify", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
+        try:
+            head_sha = subprocess.run(
+                ["git", "-C", str(repo_root), "rev-parse", "--verify", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=GIT_REV_PARSE_TIMEOUT_SECONDS,
+            ).stdout.strip()
+        except subprocess.TimeoutExpired as exc:
+            raise LaunchdError(f"git rev-parse HEAD timed out after {exc.timeout}s in {repo_root}") from exc
         release_dir, reused = build_release(repo_root, head_sha)
         prune_result = prune_releases(repo_root, keep=3)
         launch_dir = release_dir
-        release_line = (
-            f"release: {head_sha} reused: {reused} "
-            f"pruned: {','.join(prune_result.removed) or 'none'}"
-        )
+        release_line = f"release: {head_sha} reused: {reused} pruned: {','.join(prune_result.removed) or 'none'}"
 
     environment = os.environ.copy()
     for key in (
@@ -617,7 +623,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "start":
             print(
                 json.dumps(
-                    start(repo_root=args.repo_root.expanduser().resolve(), home=home, live_mode=args.live, port=args.port),
+                    start(
+                        repo_root=args.repo_root.expanduser().resolve(), home=home, live_mode=args.live, port=args.port
+                    ),
                     sort_keys=True,
                 )
             )

--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -35,9 +35,6 @@ scripts/ai_agent_bridge/_review_worktree.py::_changed_line_numbers_for_snapshot:
 scripts/ai_agent_bridge/_review_worktree.py::_changed_lines_between_bytes::subprocess.run
 scripts/ai_agent_bridge/_review_worktree.py::_run_command::subprocess.run
 scripts/ai_agent_bridge/_worktree_brief.py::_run_git::subprocess.run
-scripts/api/blue_router.py::get_audit_status::subprocess.run
-scripts/api/launchd_supervisor.py::_launchctl::subprocess.run
-scripts/api/launchd_supervisor.py::_prepare_api_command::subprocess.run
 scripts/audit/_judge_eval_lib.py::pull_calibration_cases::subprocess.run
 scripts/audit/atlas_source_census.py::scan_textbook_pdf_root::subprocess.run
 scripts/audit/audit_level.py::run_audit::subprocess.run

--- a/tests/api/test_blue_router.py
+++ b/tests/api/test_blue_router.py
@@ -1,0 +1,54 @@
+"""Tests for Blue API router timeout handling and endpoints."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.api import blue_router
+from scripts.api.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_get_audit_status_passes_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    track_dir = tmp_path / "a1"
+    track_dir.mkdir(parents=True)
+    md_file = track_dir / "01-test.md"
+    md_file.write_text("# Test Module\n", encoding="utf-8")
+    status_dir = track_dir / "status"
+    status_dir.mkdir()
+    status_file = status_dir / "01-test.json"
+    status_file.write_text(json.dumps({"overall": {"status": "pass"}, "gates": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(blue_router, "CURRICULUM_ROOT", tmp_path)
+
+    fake = subprocess.CompletedProcess(["audit_module.sh"], 0, "", "")
+    with patch("subprocess.run", return_value=fake) as run_mock:
+        resp = client.get("/api/blue/audit/a1/01-test?fresh=true")
+
+    assert resp.status_code == 200
+    assert run_mock.call_args.kwargs.get("timeout") == blue_router.AUDIT_MODULE_TIMEOUT_SECONDS
+
+
+def test_get_audit_status_timeout_returns_504(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    track_dir = tmp_path / "a1"
+    track_dir.mkdir(parents=True)
+    md_file = track_dir / "01-test.md"
+    md_file.write_text("# Test Module\n", encoding="utf-8")
+
+    monkeypatch.setattr(blue_router, "CURRICULUM_ROOT", tmp_path)
+
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["audit_module.sh"], blue_router.AUDIT_MODULE_TIMEOUT_SECONDS),
+    ):
+        resp = client.get("/api/blue/audit/a1/01-test?fresh=true")
+
+    assert resp.status_code == 504
+    assert "Audit execution timed out after 60.0s" in resp.json()["detail"]

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -9,6 +9,9 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from scripts.api import launchd_supervisor as supervisor
 
@@ -20,9 +23,7 @@ def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> 
     assert payload["Label"] == supervisor.LABEL
     assert payload["KeepAlive"] == {"SuccessfulExit": False}
     assert payload["ThrottleInterval"] == supervisor.THROTTLE_INTERVAL_SECONDS
-    assert payload["EnvironmentVariables"] == {
-        "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-    }
+    assert payload["EnvironmentVariables"] == {"PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"}
     assert payload["RunAtLoad"] is True
     assert payload["ProgramArguments"][0] == supervisor.STABLE_PROGRAM
     assert payload["ProgramArguments"] == [
@@ -72,7 +73,8 @@ def test_api_child_disables_bytecode_writes(tmp_path: Path, monkeypatch) -> None
         env=environment,
         check=True,
         capture_output=True,
-        text=True, timeout=30,
+        text=True,
+        timeout=30,
     )
     assert json.loads(inherited.stdout) == {"env": "1", "dont_write": True}
 
@@ -315,9 +317,7 @@ def test_wrapper_execs_primary_interpreter(tmp_path: Path) -> None:
     python = primary / ".venv" / "bin" / "python"
     python.parent.mkdir(parents=True)
     python.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' \"$@\"\n"
-        "exit 0\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$@\"\nexit 0\n",
         encoding="utf-8",
     )
     python.chmod(python.stat().st_mode | stat.S_IXUSR)
@@ -342,3 +342,44 @@ def test_wrapper_execs_primary_interpreter(tmp_path: Path) -> None:
     assert "scripts.api.launchd_supervisor" in proc.stdout
     assert "run" in proc.stdout
     assert str(primary) in proc.stdout
+
+
+def test_launchctl_passes_timeout() -> None:
+    fake = subprocess.CompletedProcess(["/bin/launchctl", "print", "gui/501/test"], 0, "", "")
+    with patch("subprocess.run", return_value=fake) as run_mock:
+        res = supervisor._launchctl(["print", "gui/501/test"])
+
+    assert res == fake
+    assert run_mock.call_args.kwargs.get("timeout") == supervisor.LAUNCHCTL_TIMEOUT_SECONDS
+
+
+def test_launchctl_timeout_raises_launchd_error() -> None:
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["/bin/launchctl", "print"], supervisor.LAUNCHCTL_TIMEOUT_SECONDS),
+    ):
+        with pytest.raises(supervisor.LaunchdError, match=r"/bin/launchctl print timed out after 15\.0s"):
+            supervisor._launchctl(["print"])
+
+
+def test_prepare_api_command_passes_timeout(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    fake = subprocess.CompletedProcess(["git", "rev-parse"], 0, "a" * 40 + "\n", "")
+    with (
+        patch("subprocess.run", return_value=fake) as run_mock,
+        patch.object(supervisor, "build_release", return_value=(repo / "releases" / "v1", False)),
+        patch.object(supervisor, "prune_releases", return_value=type("PruneResult", (), {"removed": []})()),
+    ):
+        supervisor._prepare_api_command(repo, live_mode=False, port=8765)
+
+    assert run_mock.call_args.kwargs.get("timeout") == supervisor.GIT_REV_PARSE_TIMEOUT_SECONDS
+
+
+def test_prepare_api_command_timeout_raises_launchd_error(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["git", "rev-parse"], supervisor.GIT_REV_PARSE_TIMEOUT_SECONDS),
+    ):
+        with pytest.raises(supervisor.LaunchdError, match=r"git rev-parse HEAD timed out after 15\.0s in"):
+            supervisor._prepare_api_command(repo, live_mode=False, port=8765)


### PR DESCRIPTION
## Summary
Slice 2 of the #7213 burn-down: every `scripts/api/` entry in `scripts/ci/subprocess_timeout_allowlist.txt` is bounded and removed (268 → 265; `scripts/api/` remaining: 0). Fixed 3, skipped 0. Monitor-API handlers now fail typed instead of hanging a request worker.

## Per-entry table
| `scripts/api/blue_router.py::get_audit_status::subprocess.run` | Fixed | `AUDIT_MODULE_TIMEOUT_SECONDS = 60.0` (audit script takes 10–30s; 60s prevents request worker thread exhaustion; raises HTTP 504 on timeout) |
| `scripts/api/launchd_supervisor.py::_launchctl::subprocess.run` | Fixed | `LAUNCHCTL_TIMEOUT_SECONDS = 15.0` (local macOS launchd IPC; bounds process control commands; raises `LaunchdError` on timeout) |
| `scripts/api/launchd_supervisor.py::_prepare_api_command::subprocess.run` | Fixed | `GIT_REV_PARSE_TIMEOUT_SECONDS = 15.0` (local `git rev-parse HEAD`; bounds startup verification; raises `LaunchdError` on timeout) |

## Verification
- `pytest -q tests/test_subprocess_timeout_guard.py` — green (allowlist shrank, no stale entries).
- Worker: 35 passed across guard + `tests/api/test_blue_router.py` + `tests/api/test_launchd_supervisor.py`; driver re-probe 99 passed + 4 environmental failures in `tests/test_api_endpoints.py` (curriculum tree absent in the sparse worktree; same files 89/89 on the primary). Ruff clean.
- Post-merge: the api service on the job host gets restarted (#M-19) — bounded `launchctl`/`git rev-parse` in the supervisor path.

Refs #7213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPqtNmkEFyfYckxLSVReq
