### PR TITLE
feat(epics): registry-driven launcher selector + SessionStart remote handoff + docs (M2 #7185 #7183)

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -570,6 +570,90 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ]; then
   esac
 fi
 
+# Additive remote epic hydration for a bound driver.  The API is already a
+# sanitized projection, so render only the typed holder/lease fields and the
+# latest state/next_action bodies.  A missing Monitor, non-200 response, bad
+# JSON, or an exhausted startup budget is fail-open and leaves the existing
+# local thread-rollover flow untouched.
+REMOTE_EPIC_CONTEXT=""
+build_remote_epic_context() {
+  local stream_id="$1"
+  local monitor_base="${LU_MONITOR_LOOPBACK:-http://127.0.0.1:8765}"
+  local authority=""
+  local port=""
+  local response=""
+  local http_status=""
+  local payload=""
+  local field=""
+  local -a fields=()
+
+  [ -n "$monitor_base" ] || return 0
+  case "$monitor_base" in
+    http://*) ;;
+    *) return 0 ;;
+  esac
+  authority="${monitor_base#http://}"
+  case "$authority" in
+    */) authority="${authority%/}" ;;
+  esac
+  case "$authority" in
+    localhost|127.0.0.1) ;;
+    localhost:*|127.0.0.1:*)
+      port="${authority#*:}"
+      case "$port" in
+        ''|*[!0-9]*) return 0 ;;
+      esac
+      ;;
+    *) return 0 ;;
+  esac
+  command -v curl >/dev/null 2>&1 || return 0
+  response="$(_hook_deadline 3 curl -sS --max-time 2 -w '\n%{http_code}' \
+    "${monitor_base%/}/api/epics/v1/${stream_id}" 2>/dev/null)" || return 0
+  http_status="${response##*$'\n'}"
+  [ "$http_status" = "200" ] || return 0
+  payload="${response%$'\n'*}"
+  [ -n "$payload" ] || return 0
+
+  while IFS= read -r -d '' field; do
+    fields+=("$field")
+  done < <(printf '%s' "$payload" | _hook_deadline 2 jq -j --arg stream_id "$stream_id" '
+    def latest_body($kind):
+      ([((.digest.pinned // []) + (.digest.recent // []))[]
+        | select(.type == $kind)]
+       | sort_by(.entry_id // 0)
+       | last
+       | (.body // "none"));
+    select(
+      .schema == "remote-epic-lifecycle.v1"
+      and .stream_id == $stream_id
+      and (.digest | type == "object")
+      and (.digest.pinned | type == "array")
+      and (.digest.recent | type == "array")
+      and ((.lease == null)
+        or ((.lease | type == "object")
+          and (.lease.state | type == "string")
+          and (.lease.holder | type == "object")))
+    ) |
+    [
+      (.stream_id // $stream_id),
+      (.lease.holder.agent // "none"),
+      (.lease.holder.harness // "none"),
+      (.lease.holder.host_id // "none"),
+      (.lease.state // "unclaimed"),
+      latest_body("state"),
+      latest_body("next_action")
+    ] | .[] | tostring, ([0] | implode)
+  ' 2>/dev/null)
+  [ "${#fields[@]}" -eq 7 ] || return 0
+
+  REMOTE_EPIC_CONTEXT="REMOTE EPIC STATE (Monitor API)
+Stream: ${fields[0]}
+Holder: ${fields[1]} · ${fields[2]} · ${fields[3]}
+Lease: ${fields[4]}
+Latest state: ${fields[5]}
+Latest next action: ${fields[6]}"
+}
+
 # --- GATE INVOCATION: one python process for record/venv/primary/lease/detect.
 # Crash honesty (issue #6411): a crashed helper maps to "could not determine",
 # never to a business verdict such as a lease conflict.
@@ -739,6 +823,25 @@ $HANDOFF_CONTEXT"
   fi
 fi
 
+# Hydrate the remote lease after the existing gate and local rollover read have
+# had their chance to run.  This keeps the additive GET from starving the
+# established thread-handoff path under the aggregate startup budget.
+if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ] \
+  && declare -f launcher_selector_stream >/dev/null 2>&1; then
+  REMOTE_EPIC_STREAM="$(launcher_selector_stream "$SESSION_EPIC" 2>/dev/null || true)"
+  case "$REMOTE_EPIC_STREAM" in
+    epic:*)
+      REMOTE_EPIC_NUMBER="${REMOTE_EPIC_STREAM#epic:}"
+      case "$REMOTE_EPIC_NUMBER" in
+        ''|0*|*[!0-9]*) ;;
+        *) build_remote_epic_context "$REMOTE_EPIC_STREAM" ;;
+      esac
+      unset REMOTE_EPIC_NUMBER
+      ;;
+  esac
+  unset REMOTE_EPIC_STREAM
+fi
+
 # Epic assignment banner
 EPIC_BANNER=""
 if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ]; then
@@ -837,6 +940,11 @@ if [ -n "$EPIC_BANNER" ]; then
   CONTEXT="$CONTEXT
 
 $EPIC_BANNER"
+fi
+if [ -n "$REMOTE_EPIC_CONTEXT" ]; then
+  CONTEXT="$CONTEXT
+
+$REMOTE_EPIC_CONTEXT"
 fi
 if [ -n "$HANDOFF_CONTEXT" ]; then
   CONTEXT="$CONTEXT

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -236,22 +236,33 @@ loopback tunnel is therefore the client boundary for another machine.
 | POST | `/api/epics/v1/epic:<N>/handoff` | Appends one existing entry type with an idempotency key |
 | POST | `/api/epics/v1/epic:<N>/release` | Exact release is idempotent; `force` requires actor host and reason |
 
+Driver leases are claimed on the API host through this surface. Remote mode is
+the default; `--local` is an offline-only fallback that prints a warning and
+does not create a fleet-visible lease. A driver on any machine resumes by
+claiming the same stream, and a typed handoff is appended with
+`POST /api/epics/v1/epic:<N>/handoff`.
+
+Every host must export `LU_MONITOR_HOST_ID=<opaque id>` before claiming. The
+value comes from the canonical `MONITOR_OCCUPANCY_HOST_IDS` mapping and is an
+opaque ID such as `host-teacher`, `host-job`, or `mac-operator`; this keeps
+holders from being reported as `local`. Do not use a hostname, alias, or IP
+address as the host ID.
+
 The client is `scripts.session_supervisor` and uses stdlib `urllib` with a
-10-second request timeout. Its default is remote Monitor mode. The explicit
-`--local` mode prints `LOCAL-ONLY LEASE — not visible to the fleet`; launchers
-do not select that mode; launcher normal exit and signal teardown use the
-remote `release` path. Claim preflight requires a healthy (`ok: true`) Monitor
-response before it sends a mutation. API responses contain opaque validated holder IDs but
-no paths, hostnames, IP addresses, SSH aliases, or home paths. Handoff bodies
+10-second request timeout. Launchers use its default remote Monitor mode; the
+explicit `--local` mode prints `LOCAL-ONLY LEASE — not visible to the fleet`.
+Claim preflight requires a healthy (`ok: true`) Monitor response before it
+sends a mutation. API responses contain opaque validated holder IDs but no
+paths, hostnames, IP addresses, SSH aliases, or home paths. Handoff bodies
 containing those tokens are rejected.
 
 Example remote lifecycle probe (the client emits one JSON document per call):
 
 ```bash
-LU_MONITOR_LOOPBACK=http://127.0.0.1:8765 \
-  /path/to/project/.venv/bin/python -m scripts.session_supervisor claim \
-  --role driver --stream epic:7178 --agent codex --harness codex-cli \
-  --instance-id example-driver --process-id 1234 --host-id example-host \
+LU_MONITOR_HOST_ID="<opaque id>" \
+  .venv/bin/python -m scripts.session_supervisor claim \
+  --role driver --stream epic:7177 --agent codex --harness codex-cli \
+  --instance-id example-driver --process-id 1234 \
   --lineage-id example-lineage
 ```
 

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -41,6 +41,25 @@ process starts. Codex additionally performs its transport-health probe during
 adapter preflight, before it claims the lease; a degraded probe refuses the
 launch without acquiring a lane.
 
+### Remote lease and handoff authority
+
+Driver leases are claimed on the API host through `/api/epics/v1`; remote mode is
+the default. The explicit `--local` mode is offline-only and prints a warning;
+it is not a fleet-visible lease. A handoff is an API mutation at
+`POST /api/epics/v1/epic:<N>/handoff`, not a second local ownership record.
+
+A driver on any machine resumes a lane by launching with `--epic <epic>` and
+claiming the corresponding remote stream. Before driving, it reads the remote
+lease and digest surfaced at SessionStart; at the end of a batch it appends the
+typed handoff through the API. The successor claims the same stream and folds
+that digest into its own handoff.
+
+Every host must export `LU_MONITOR_HOST_ID=<opaque id>` before a driver claims a
+lease. Use the opaque IDs from the canonical `MONITOR_OCCUPANCY_HOST_IDS`
+mapping (for example, `host-teacher`, `host-job`, or `mac-operator`), so the
+holder is not reported as `local`. Do not substitute a hostname, alias, or IP
+address for the opaque ID.
+
 **Cursor concurrency (documented serialization, #6956):** A Cursor driver session
 **is** the Cursor lane (`fleet_communications.yaml` `concurrency_limit: 1`). Do not
 also `delegate.py dispatch --agent cursor` from that session. What the runtime
@@ -133,7 +152,7 @@ language + review lanes free and puts the loop on the most replaceable capacity:
   Anthropic capacity that does **not** consume the Opus review-of-record seat.
 - **HydrationCapsuleV1** gives Codex (272K) a measured, low-overhead score-and-hydrate path, so it
   can serve as the harness / infra / devops alternate without co-owning Gemini's stream lease.
-  Infra (`epic:4707`) and DevOps (`epic:5703`) are independent streams: one live driver does
+  Infra (`epic:6943`) and DevOps (`epic:5703`) are independent streams: one live driver does
   not block the other, while a second driver on either same stream still fails closed.
 
 ---
@@ -143,7 +162,7 @@ language + review lanes free and puts the loop on the most replaceable capacity:
 1. Launcher pins `SESSION_EPIC`, claims the stream lease, and — for grok/gemini/kimi —
    mints the session canary; Claude/Sonnet use the SessionStart hook chain (no canary lane).
    The Codex DevOps alternate preflights its dedicated `codex-devops` rollover namespace
-   before acquiring `epic:5703`, independently of Infra's `codex-infra` / `epic:4707`
+   before acquiring `epic:5703`, independently of Infra's `codex-infra` / `epic:6943`
    ownership. It then selects at most one applicable rollover: zero packets starts fresh,
    one fresh unbound CLI packet exports exact IDs, and
    ambiguity, an already-resumed packet, or a native-app packet fails closed. After the

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -29,11 +29,30 @@ driver (e.g. Codex on hramatka) leaves, content dual-write alone is not enough:
 6. **Launcher:** `--epic <name>` must set stream id + handoff slot. Note the
    slot trap: a packet under `claude/` may not appear under `claude-hramatka`.
 
+## Remote lease and handoff authority
+
+Driver leases are claimed on the API host through `/api/epics/v1`; remote mode
+is the default. `--local` is offline-only, prints a warning, and does not make
+the lease visible to other machines. Handoffs are appended with
+`POST /api/epics/v1/epic:<N>/handoff`.
+
+A driver on any machine resumes by launching with `--epic <name>` and claiming
+the same remote stream. It then reads the current holder, lease state, and
+latest digest at SessionStart, and writes the next typed handoff through the
+API. The remote API host is the lease authority; local files remain the
+thread-rollover and lane handoff context, not a competing lease store.
+
+Every host must export `LU_MONITOR_HOST_ID=<opaque id>` before claiming. The
+value must be one of the opaque IDs in the canonical `MONITOR_OCCUPANCY_HOST_IDS`
+mapping (for example, `host-teacher`, `host-job`, or `mac-operator`) so the
+holder is not reported as `local`. Do not use a hostname, alias, or IP address
+as the host ID.
+
 ### Codex DevOps zero-touch boundary
 
 `./start-codex-driver.sh --epic devops` scans only its assigned `codex-devops` rollover
 namespace before acquiring `epic:5703`. Infra keeps the separate `codex-infra`
-namespace and `epic:4707` lease, so a live Infra driver does not block DevOps.
+namespace and `epic:6943` lease, so a live Infra driver does not block DevOps.
 The launcher starts a fresh task when no packet
 exists, or exports one exact fresh unbound `codex-cli` packet for SessionStart
 to bind to the newly created task ID. Multiple packets, an already-resumed
@@ -44,31 +63,29 @@ or selects a packet by title, age, or filesystem order.
 ## CLI
 
 ```bash
-# Read-only diagnosis
-.venv/bin/python -m agents_extensions.shared.session_streams handoff-status \
-  --stream epic:4542
+# Remote claim (the API host owns the lease; set the opaque host identity first)
+LU_MONITOR_HOST_ID="<opaque id>" \
+  .venv/bin/python -m scripts.session_supervisor claim \
+  --role driver --stream epic:4542 \
+  --agent claude --harness claude-code \
+  --instance-id example-driver --process-id 1234 \
+  --lineage-id example-lineage
 
-# Claim as Claude (force-closes expired dead holder if needed, opens session, pins)
-.venv/bin/python -m agents_extensions.shared.session_streams handoff-claim \
-  --stream epic:4542 \
-  --agent claude \
-  --harness claude-code \
-  --instance-id "claude-hramatka-$(uuidgen | tr '[:upper:]' '[:lower:]')" \
-  --lineage-id "lineage-epic-4542-claude-$(date -u +%Y%m%d)"
+# Typed handoff: POST /api/epics/v1/epic:4542/handoff
 ```
 
-Exit codes: `0` ok · `2` usage · `3` stream missing · `4` refuse (live holder,
-PID still up, etc.) · `5` unexpected.
+The driver launcher normally performs the claim. `--local` is the explicit
+offline fallback and prints its warning; it is not a remote handoff path.
 
 ## Manual checklist (until CLI is habitual)
 
-1. `handoff-status --stream epic:N`
-2. If dead PID (`alive=False`) → `handoff-claim` / relaunch (or force-close then open);
-   no need to wait for `expires_at`
-3. If live foreign holder (`alive=True`) → **stop** — ask that harness to close
-4. Tail stream + dual-write board; fold into your handoff file
-5. Launch with `--epic <name>` and bind exact rollover if any
-6. Drive; dual-write after each batch; clean close on end
+1. Read `GET /api/epics/v1/epic:<N>` or the equivalent SessionStart remote state.
+2. If the remote holder is expired/released, relaunch with `--epic <name>` and
+   claim the stream; no local store promotion is needed.
+3. If a live foreign holder remains, **stop** — ask that driver to close.
+4. Read the remote digest surfaced at SessionStart and fold it into your handoff file.
+5. Bind exact rollover IDs if any, then drive.
+6. Append a typed `POST …/handoff` after each batch and cleanly release on end.
 
 ## Related
 

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -12,9 +12,10 @@
 # selected --agent, so each lane reads/writes its OWN slot and we don't maintain
 # a per-lane wrapper script.
 #
-# Launcher lane selectors are intentionally allowlisted below.  Do not derive a
-# slot or stream id from arbitrary user input: that creates phantom handoff
-# files and can silently attach a session to the wrong stream.
+# Launcher selectors resolve against the issue-stream registry, with the
+# compatibility aliases below layered over it.  Do not derive a slot or stream
+# id from arbitrary user input: that creates phantom handoff files and can
+# silently attach a session to the wrong stream.
 #
 # The infra stream id is the issue-stream registry anchor (infra-harness), not
 # a literal epic number. The next succession must not require a launcher edit.
@@ -30,27 +31,79 @@ _launcher_stream_anchor_epic() {
   local key="${1:-}"
   local registry="${HANDOFF_ISSUE_STREAMS_YAML:-$_HANDOFF_IDENTITY_DIR/../config/issue_streams.yaml}"
   local epic=""
-  [ -n "$key" ] && [ -f "$registry" ] || return 1
+  case "$key" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ -f "$registry" ] || return 1
   epic="$(
     awk -v key="$key" '
-      $0 ~ "^  " key ":" { found = 1; next }
-      found && $0 ~ /^  [^[:space:]]/ { exit }
-      found && $0 ~ /^[[:space:]]+epics:/ {
-        if (match($0, /[0-9]+/)) {
-          print substr($0, RSTART, RLENGTH)
-          exit
+      $0 ~ /^streams:[[:space:]]*(#.*)?$/ {
+        in_streams = 1
+        next
+      }
+      !in_streams { next }
+      {
+        candidate = $1
+        if ($0 !~ /^  [^[:space:]]/ || candidate !~ /^[A-Za-z0-9][A-Za-z0-9._-]*:$/) {
+          candidate = ""
+        } else {
+          sub(/:$/, "", candidate)
         }
+        if (candidate != "") {
+          if (candidate in seen) invalid = 1
+          seen[candidate] = 1
+          if (found && !finished) finished = 1
+          if (!finished && candidate == key) found = 1
+          next
+        }
+      }
+      found && !finished && $0 ~ /^[[:space:]]+epics:[[:space:]]*\[[[:space:]]*[1-9][0-9]*([[:space:]]*,[[:space:]]*[1-9][0-9]*)*[[:space:]]*\][[:space:]]*(#.*)?$/ {
+        match($0, /[1-9][0-9]*/)
+        epic = substr($0, RSTART, RLENGTH)
+        finished = 1
+        next
+      }
+      found && !finished && $0 ~ /^[[:space:]]+epics:[[:space:]]*$/ {
         list = 1
         next
       }
-      found && list && match($0, /[0-9]+/) {
-        print substr($0, RSTART, RLENGTH)
-        exit
+      found && !finished && list {
+        if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) next
+        if ($0 ~ /^[[:space:]]*-[[:space:]]*[1-9][0-9]*[[:space:]]*(#.*)?$/) {
+          match($0, /[1-9][0-9]*/)
+          epic = substr($0, RSTART, RLENGTH)
+        }
+        finished = 1
+        next
+      }
+      END {
+        if (!in_streams || invalid || epic == "") exit 1
+        print epic
       }
     ' "$registry"
   )"
   [ -n "$epic" ] || return 1
   printf '%s' "$epic"
+}
+
+# _launcher_registry_stream_keys
+# Print the top-level stream keys in the configured registry.  Keep this parser
+# deliberately narrower than a general YAML parser: launchers only need the
+# registry's two-space stream keys and their first numeric epic.
+_launcher_registry_stream_keys() {
+  local registry="${HANDOFF_ISSUE_STREAMS_YAML:-$_HANDOFF_IDENTITY_DIR/../config/issue_streams.yaml}"
+  [ -f "$registry" ] || return 1
+  awk '
+    $0 ~ /^streams:[[:space:]]*(#.*)?$/ { in_streams = 1; next }
+    in_streams && $0 ~ /^  [^[:space:]]/ && $1 ~ /^[A-Za-z0-9][A-Za-z0-9._-]*:$/ {
+      key = $1
+      sub(/:$/, "", key)
+      print key
+    }
+    END {
+      if (!in_streams) exit 1
+    }
+  ' "$registry"
 }
 
 # _launcher_infra_stream_id
@@ -66,39 +119,64 @@ _launcher_infra_stream_id() {
 # single selector table shared by handoff identities and session supervision.
 # Unknown selectors return 1 and print nothing, so callers can fail closed.
 launcher_selector_resolve() {
-  local stream=""
-  case "${1:-}" in
+  local selector="${1:-}"
+  local key=""
+  local lane=""
+  local epic=""
+
+  # Compatibility aliases preserve the pre-registry lane identity while their
+  # stream anchor still comes from the registry.  Generic selectors below are
+  # intentionally not added here: a new registry row must work without a
+  # launcher edit.
+  case "$selector" in
     infra|harness|infra.fleet-comms)
-      stream="$(_launcher_infra_stream_id)" || return 1
-      case "$stream" in
-        epic:[1-9]*) ;;
-        *) return 1 ;;
-      esac
-      printf 'infra\t%s\n' "$stream"
+      key="infra-harness"
+      lane="infra"
       ;;
     devops|infra.devops)
-      printf 'devops\tepic:5703\n'
+      key="devops"
+      lane="devops"
       ;;
     monitor|infra.monitor)
-      printf 'monitor\tepic:7177\n'
+      key="monitor"
+      lane="monitor"
       ;;
     atlas|practice|practice-hub|atlas.practice)
-      printf 'atlas\tepic:4387\n'
+      key="atlas-practice"
+      lane="atlas"
       ;;
     hramatka|hramatka.lessons)
-      printf 'hramatka\tepic:4542\n'
+      key="hramatka"
+      lane="hramatka"
       ;;
     folk|seminars-folk)
-      printf 'folk\tepic:2836\n'
+      key="seminars-folk"
+      lane="folk"
       ;;
     bio|seminars-bio)
-      printf 'bio\tepic:4431\n'
+      key="seminars-bio"
+      lane="bio"
       ;;
     corpus|corpus-channels)
-      printf 'corpus\tepic:4706\n'
+      key="corpus-channels"
+      lane="corpus"
       ;;
+    infra.*)
+      key="${selector#infra.}"
+      lane="$key"
+      ;;
+    *)
+      key="$selector"
+      lane="$key"
+      ;;
+  esac
+
+  epic="$(_launcher_stream_anchor_epic "$key")" || return 1
+  case "$epic" in
+    [1-9][0-9]*) ;;
     *) return 1 ;;
   esac
+  printf '%s\tepic:%s\n' "$lane" "$epic"
 }
 
 # launcher_selector_lane "<selector>"
@@ -121,16 +199,25 @@ launcher_selector_stream() {
 # Keep launcher diagnostics in one place so every entry point documents the
 # exact same public selector surface.
 launcher_selector_help() {
+  local key=""
   cat <<'EOF'
 Valid lane selectors:
-  infra | harness | infra.fleet-comms
-  devops | infra.devops
-  monitor | infra.monitor
-  atlas | practice | atlas.practice
-  hramatka | hramatka.lessons
-  folk | seminars-folk
-  bio | seminars-bio
-  corpus | corpus-channels
+  Registry stream keys (and infra.<key>):
+EOF
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    printf '    %s | infra.%s\n' "$key" "$key"
+  done < <(_launcher_registry_stream_keys 2>/dev/null || true)
+  cat <<'EOF'
+  Compatibility aliases:
+    infra | harness | infra.fleet-comms
+    devops | infra.devops
+    monitor | infra.monitor
+    atlas | practice | practice-hub | atlas.practice
+    hramatka | hramatka.lessons
+    folk | seminars-folk
+    bio | seminars-bio
+    corpus | corpus-channels
 EOF
 }
 

--- a/tests/test_fleet_taxonomy_aliases.py
+++ b/tests/test_fleet_taxonomy_aliases.py
@@ -353,6 +353,9 @@ def test_session_setup_hook_epic_validation_contract(
     scripts_lib = project_dir / "scripts" / "lib"
     scripts_lib.mkdir(parents=True)
     shutil.copy2(_HANDOFF_IDENTITY_SH, scripts_lib / "handoff_identity.sh")
+    registry = project_dir / "scripts" / "config" / "issue_streams.yaml"
+    registry.parent.mkdir(parents=True)
+    shutil.copy2(_ISSUE_STREAMS, registry)
 
     env = {
         "CLAUDE_PROJECT_DIR": str(project_dir),

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -352,7 +352,7 @@ def test_infra_stream_follows_registry_mutation(tmp_path: Path) -> None:
 def test_new_registry_stream_resolves_without_shell_edit(tmp_path: Path) -> None:
     """A new stream key and its infra.<key> form need only a registry row."""
     fresh_key = "future-ops"
-    fresh_epic = 888002
+    fresh_epic = 888001
     fixture = tmp_path / "issue_streams.yaml"
     fixture.write_text(
         yaml.safe_dump(

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -105,6 +105,50 @@ def test_monitor_resolves_to_dedicated_provider_slot(resolver: str, expected: st
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
 @pytest.mark.parametrize(
+    ("selector", "expected"),
+    [
+        ("infra", "infra\tepic:6943\n"),
+        ("harness", "infra\tepic:6943\n"),
+        ("infra.fleet-comms", "infra\tepic:6943\n"),
+        ("devops", "devops\tepic:5703\n"),
+        ("infra.devops", "devops\tepic:5703\n"),
+        ("atlas", "atlas\tepic:4387\n"),
+        ("practice", "atlas\tepic:4387\n"),
+        ("practice-hub", "atlas\tepic:4387\n"),
+        ("atlas.practice", "atlas\tepic:4387\n"),
+        ("hramatka", "hramatka\tepic:4542\n"),
+        ("hramatka.lessons", "hramatka\tepic:4542\n"),
+        ("folk", "folk\tepic:2836\n"),
+        ("seminars-folk", "folk\tepic:2836\n"),
+        ("bio", "bio\tepic:4431\n"),
+        ("seminars-bio", "bio\tepic:4431\n"),
+        ("corpus", "corpus\tepic:4706\n"),
+        ("corpus-channels", "corpus\tepic:4706\n"),
+        ("monitor", "monitor\tepic:7177\n"),
+        ("infra.monitor", "monitor\tepic:7177\n"),
+    ],
+)
+def test_legacy_selector_outputs_remain_byte_identical(selector: str, expected: str) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; launcher_selector_resolve "$2"',
+            "bash",
+            str(_HANDOFF_IDENTITY),
+            selector,
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
     ("selector", "lane", "stream", "claude_slot", "gemini_slot", "grok_slot"),
     [
         ("infra.fleet-comms", "infra", INFRA_STREAM_ID, "claude-infra", "gemini-infra", "grok-infra"),
@@ -302,6 +346,66 @@ def test_infra_stream_follows_registry_mutation(tmp_path: Path) -> None:
     expected = f"epic:{fresh_epic}"
     assert result.stdout == f"{expected}|{expected}|{expected}"
     assert expected != INFRA_STREAM_ID
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_new_registry_stream_resolves_without_shell_edit(tmp_path: Path) -> None:
+    """A new stream key and its infra.<key> form need only a registry row."""
+    fresh_key = "future-ops"
+    fresh_epic = 888002
+    fixture = tmp_path / "issue_streams.yaml"
+    fixture.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "streams": {
+                    fresh_key: {
+                        "title": "Future operations fixture",
+                        "epics": [fresh_epic, 888003],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HANDOFF_ISSUE_STREAMS_YAML"] = str(fixture)
+
+    for selector in (fresh_key, f"infra.{fresh_key}"):
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; launcher_selector_resolve "$2"',
+                "bash",
+                str(_HANDOFF_IDENTITY),
+                selector,
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == f"{fresh_key}\tepic:{fresh_epic}\n"
+
+    help_result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; launcher_selector_help',
+            "bash",
+            str(_HANDOFF_IDENTITY),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    assert help_result.returncode == 0, help_result.stderr
+    assert f"{fresh_key} | infra.{fresh_key}" in help_result.stdout
 
 
 def test_launch_path_does_not_literal_mint_infra_epic() -> None:

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -41,7 +41,11 @@ def test_session_start_defers_optional_network_diagnostics() -> None:
     source = SESSION_SETUP.read_text(encoding="utf-8")
 
     assert "gh issue list" not in source
-    assert "curl " not in source
+    # The only optional network read is the bounded, fail-open remote epic
+    # hydration required by #7185.
+    assert "/api/epics/v1/" in source
+    assert source.count("curl -sS") == 1
+    assert 'response="$(_hook_deadline 3 curl -sS --max-time 2' in source
     assert "check_decisions.py" not in source
     assert "check_adrs.py" not in source
     assert "check_postmortems.py" not in source

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -153,6 +153,7 @@ def _core_canary_failure_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
     for relative in (
         "start-claude-driver.sh",
         "scripts/lib/handoff_identity.sh",
+        "scripts/config/issue_streams.yaml",
         "scripts/lib/launcher_core.sh",
         "scripts/lib/session_supervisor.sh",
         # The core's deploy staleness gate sources this; without package.json
@@ -241,6 +242,7 @@ def _core_driver_exit_fixture(
     for relative in (
         "start-claude-driver.sh",
         "scripts/lib/handoff_identity.sh",
+        "scripts/config/issue_streams.yaml",
         "scripts/lib/launcher_core.sh",
         "scripts/lib/session_supervisor.sh",
         "scripts/lib/deploy_extensions.sh",

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -10,10 +10,13 @@ makes the guard load-bearing: it runs in the required ``Test (pytest)`` job.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
+import threading
 import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -59,6 +62,143 @@ def test_legacy_table_parser_avoids_gnu_sed_anchor_escape() -> None:
     )
 
     assert "\\`" not in parser_line
+
+
+def test_session_setup_renders_remote_epic_state_and_fails_open(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    subprocess.run(["git", "init", "-q", str(project_dir)], check=True, timeout=30)
+
+    fake_python = project_dir / ".venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.write_text("#!/bin/sh\nprintf 'Python 3.12.8\\n'\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+    (project_dir / ".python-version").write_text("3.12.8\n", encoding="utf-8")
+
+    remote_payload = {
+        "schema": "remote-epic-lifecycle.v1",
+        "stream_id": "epic:7177",
+        "lease": {
+            "state": "active",
+            "holder": {
+                "agent": "remote-agent",
+                "harness": "remote-harness",
+                "host_id": "host-job",
+            },
+        },
+        "digest": {
+            "pinned": [
+                {
+                    "entry_id": 2,
+                    "type": "state",
+                    "body": "remote state from handoff",
+                }
+            ],
+            "recent": [
+                {
+                    "entry_id": 3,
+                    "type": "next_action",
+                    "body": "claim remote lease",
+                }
+            ],
+        },
+    }
+    requested_paths: list[str] = []
+    return_non_200 = False
+
+    class RemoteEpicHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requested_paths.append(self.path)
+            if return_non_200:
+                self.send_response(503)
+                self.end_headers()
+                return
+            if self.path != "/api/epics/v1/epic:7177":
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps(remote_payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RemoteEpicHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    hook = _REPO_ROOT / "agents_extensions/shared/hooks/session-setup.sh"
+    env = os.environ.copy()
+    env.update(
+        {
+            "CLAUDE_PROJECT_DIR": str(project_dir),
+            "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
+            "HOME": str(tmp_path / "home"),
+            "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
+            "XDG_CACHE_HOME": str(tmp_path / "xdg-cache"),
+            "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+            "XDG_STATE_HOME": str(tmp_path / "xdg-state"),
+            "GH_CONFIG_DIR": str(tmp_path / "gh-config"),
+            "CODEX_THREAD_ID": "remote-epic-session",
+            "CODEX_CANONICAL_REPO_ROOT": str(project_dir),
+            "LEARN_UKRAINIAN_REQUESTED_PROFILE_ID": "native_claude",
+            "CLAUDE_PROFILE_RESOLVER_SH": str(_REPO_ROOT / "scripts/lib/profile_resolver.sh"),
+            "CLAUDE_PROFILE_RESOLVER_PY": str(_REPO_ROOT / "scripts/lib/context_profiles.py"),
+            "CLAUDE_PROFILE_RESOLVER_PYTHON": str(_canonical_python()),
+            "CLAUDE_SESSION_RECORD_PYTHON": str(fake_python),
+            "SESSION_BOUNDED_RUNNER": str(_REPO_ROOT / "scripts/agent_runtime/bounded_command.py"),
+            "CLAUDE_HANDOFF_IDENTITY_SH": str(_REPO_ROOT / "scripts/lib/handoff_identity.sh"),
+            "THREAD_ROLLOVER_PYTHON": str(fake_python),
+            "THREAD_ROLLOVER_SCRIPT": str(_REPO_ROOT / "scripts/orchestration/thread_handoff.py"),
+            "SESSION_HANDOFF_AGENT": "claude",
+            "SESSION_EPIC": "monitor",
+            "LU_MONITOR_LOOPBACK": f"http://127.0.0.1:{server.server_port}",
+        }
+    )
+
+    def run_hook(loopback: str) -> tuple[subprocess.CompletedProcess[str], str]:
+        run_env = {**env, "LU_MONITOR_LOOPBACK": loopback}
+        result = subprocess.run(
+            ["bash", str(hook)],
+            input="",
+            cwd=_REPO_ROOT,
+            env=run_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        output = json.loads(result.stdout)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        return result, context
+
+    try:
+        result, context = run_hook(env["LU_MONITOR_LOOPBACK"])
+        assert result.returncode == 0, result.stderr
+        assert "/api/epics/v1/epic:7177" in requested_paths
+        assert "REMOTE EPIC STATE (Monitor API)" in context
+        assert "Stream: epic:7177" in context
+        assert "Holder: remote-agent · remote-harness · host-job" in context
+        assert "Lease: active" in context
+        assert "Latest state: remote state from handoff" in context
+        assert "Latest next action: claim remote lease" in context
+        assert str(project_dir) not in context
+
+        return_non_200 = True
+        unavailable_result, unavailable_context = run_hook(env["LU_MONITOR_LOOPBACK"])
+        assert unavailable_result.returncode == 0, unavailable_result.stderr
+        assert "REMOTE EPIC STATE (Monitor API)" not in unavailable_context
+
+        dead_result, dead_context = run_hook("http://127.0.0.1:1")
+        assert dead_result.returncode == 0, dead_result.stderr
+        assert "REMOTE EPIC STATE (Monitor API)" not in dead_context
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def test_session_setup_reports_machine_repairs_without_applying_them(

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -20,6 +20,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_session_setup_hook.sh"
@@ -34,6 +35,14 @@ def _canonical_python() -> Path:
         text=True, timeout=30,
     )
     return Path(result.stdout.strip()).parent / ".venv" / "bin" / "python"
+
+
+def _stream_id_from_registry(stream_key: str) -> str:
+    registry = yaml.safe_load(
+        (_REPO_ROOT / "scripts/config/issue_streams.yaml").read_text(encoding="utf-8")
+    )
+    epic = registry["streams"][stream_key]["epics"][0]
+    return f"epic:{epic}"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
@@ -69,6 +78,8 @@ def test_session_setup_renders_remote_epic_state_and_fails_open(tmp_path: Path) 
     project_dir.mkdir()
     subprocess.run(["git", "init", "-q", str(project_dir)], check=True, timeout=30)
 
+    monitor_stream_id = _stream_id_from_registry("monitor")
+
     fake_python = project_dir / ".venv" / "bin" / "python"
     fake_python.parent.mkdir(parents=True)
     fake_python.write_text("#!/bin/sh\nprintf 'Python 3.12.8\\n'\n", encoding="utf-8")
@@ -77,7 +88,7 @@ def test_session_setup_renders_remote_epic_state_and_fails_open(tmp_path: Path) 
 
     remote_payload = {
         "schema": "remote-epic-lifecycle.v1",
-        "stream_id": "epic:7177",
+        "stream_id": monitor_stream_id,
         "lease": {
             "state": "active",
             "holder": {
@@ -113,7 +124,7 @@ def test_session_setup_renders_remote_epic_state_and_fails_open(tmp_path: Path) 
                 self.send_response(503)
                 self.end_headers()
                 return
-            if self.path != "/api/epics/v1/epic:7177":
+            if self.path != f"/api/epics/v1/{monitor_stream_id}":
                 self.send_response(404)
                 self.end_headers()
                 return
@@ -178,9 +189,9 @@ def test_session_setup_renders_remote_epic_state_and_fails_open(tmp_path: Path) 
     try:
         result, context = run_hook(env["LU_MONITOR_LOOPBACK"])
         assert result.returncode == 0, result.stderr
-        assert "/api/epics/v1/epic:7177" in requested_paths
+        assert f"/api/epics/v1/{monitor_stream_id}" in requested_paths
         assert "REMOTE EPIC STATE (Monitor API)" in context
-        assert "Stream: epic:7177" in context
+        assert f"Stream: {monitor_stream_id}" in context
         assert "Holder: remote-agent · remote-harness · host-job" in context
         assert "Lease: active" in context
         assert "Latest state: remote state from handoff" in context

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -15,6 +15,7 @@ _LAUNCHER_FILES = (
     Path("start-codex.sh"),
     Path("start-codex-driver.sh"),
     Path("scripts/config/context_profiles.yaml"),
+    Path("scripts/config/issue_streams.yaml"),
     Path("scripts/lib/context_profiles.py"),
     Path("scripts/lib/deploy_extensions.sh"),
     Path("scripts/lib/fleet_comms_cold_start.sh"),


### PR DESCRIPTION
Parent: #7177. Closes #7183, #7185. Authored by codex lane (task monitor-m2-migrate); PR opened by main (worker gh unauth).

M2 migrate:
- **#7183** `scripts/lib/handoff_identity.sh`: `launcher_selector_resolve` now resolves from `scripts/config/issue_streams.yaml` (key→lane, first epic→stream) with an explicit alias map preserving every existing selector byte-identical; dynamic `launcher_selector_help`; new-epic-without-launcher-edit fixture test.
- **#7185** `agents_extensions/shared/hooks/session-setup.sh`: additive, fail-open section that surfaces the remote epic lease + latest handoff (`GET /api/epics/v1/{stream}`) at cold-start for an epic-bound session; local rollover-packet flow untouched; renders nothing if the API is unreachable.
- Docs: epic-orchestrator-roster.md, epic-stream-handoff.md, MONITOR-API.md — remote claim by default, `--local` offline-only, per-host `LU_MONITOR_HOST_ID`.

Evidence in review comment. No auto-merge.