### PR TITLE
fix(orchestration): resolve Claudex relaunch interpreter in venv-less worktrees (#7210)

### DIFF
--- a/scripts/orchestration/claudex_supervisor.py
+++ b/scripts/orchestration/claudex_supervisor.py
@@ -47,11 +47,14 @@ def resolve_relaunch_python(project_root: Path = PROJECT_ROOT) -> Path:
         canonical = canonical_root / ".venv" / "bin" / "python"
         if canonical.is_file() and os.access(canonical, os.X_OK):
             return canonical
-    except Exception:
-        pass
+    except Exception as exc:
+        print(
+            f"[supervisor] warning: failed to resolve canonical state root ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
 
     if sys.executable:
-        current = Path(sys.executable).resolve()
+        current = Path(sys.executable)
         if current.is_file() and os.access(current, os.X_OK):
             return current
 

--- a/scripts/orchestration/claudex_supervisor.py
+++ b/scripts/orchestration/claudex_supervisor.py
@@ -687,6 +687,14 @@ class ClaudexSupervisor:
         with contextlib.suppress(OSError):
             ready_file.unlink()
         launch_env = self.base_env.copy()
+        venv_bin = os.fspath(REPO_PYTHON.parent)
+        current_path = launch_env.get("PATH", "")
+        if current_path:
+            launch_env["PATH"] = f"{venv_bin}{os.pathsep}{current_path}"
+        else:
+            launch_env["PATH"] = venv_bin
+        if (REPO_PYTHON.parent.parent / "pyvenv.cfg").is_file():
+            launch_env["VIRTUAL_ENV"] = os.fspath(REPO_PYTHON.parent.parent)
         launch_env.update(
             {
                 "LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH": "1",

--- a/scripts/orchestration/claudex_supervisor.py
+++ b/scripts/orchestration/claudex_supervisor.py
@@ -19,8 +19,6 @@ from pathlib import Path
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-# Pin child launches to this checkout; an inherited interpreter may belong to another worktree.
-REPO_PYTHON = PROJECT_ROOT / ".venv/bin/python"
 if __package__:
     from scripts.lib.session_record import canonical_state_root, validate_session_id
     from scripts.orchestration import thread_handoff
@@ -28,6 +26,40 @@ else:
     sys.path.insert(0, os.fspath(PROJECT_ROOT))
     from scripts.lib.session_record import canonical_state_root, validate_session_id
     from scripts.orchestration import thread_handoff
+
+
+def resolve_relaunch_python(project_root: Path = PROJECT_ROOT) -> Path:
+    """Resolve the Python interpreter for launching supervisor child gates.
+
+    Preserves the launcher contract:
+    1. Local checkout virtualenv (project_root / ".venv/bin/python") if present.
+    2. Canonical repository virtualenv (canonical_state_root(project_root) / ".venv/bin/python")
+       for venv-less linked worktrees or detached checkouts.
+    3. The active interpreter (sys.executable), e.g. for CI or environments without .venv.
+    4. Fallback to project_root / ".venv/bin/python" if no valid executable is found.
+    """
+    local = project_root / ".venv" / "bin" / "python"
+    if local.is_file() and os.access(local, os.X_OK):
+        return local
+
+    try:
+        canonical_root = canonical_state_root(project_root)
+        canonical = canonical_root / ".venv" / "bin" / "python"
+        if canonical.is_file() and os.access(canonical, os.X_OK):
+            return canonical
+    except Exception:
+        pass
+
+    if sys.executable:
+        current = Path(sys.executable).resolve()
+        if current.is_file() and os.access(current, os.X_OK):
+            return current
+
+    return local
+
+
+# Pin child launches to this checkout or its canonical virtualenv in worktrees
+REPO_PYTHON = resolve_relaunch_python(PROJECT_ROOT)
 
 SCHEMA_VERSION = 1
 REQUEST_TTL_SECONDS = 300

--- a/tests/orchestration/test_claudex_supervisor.py
+++ b/tests/orchestration/test_claudex_supervisor.py
@@ -28,8 +28,13 @@ from scripts.orchestration.claudex_supervisor import (
 from tests.project_python import project_python
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL_REPO_ROOT = th.canonical_state_root(_REPO_ROOT)
+
+
 def _repo_python() -> Path:
     return project_python()
+
+
 _SUPERVISOR = _REPO_ROOT / "scripts/orchestration/claudex_supervisor.py"
 _SESSION_ID = "official-session-5265"
 _HANDOFF_AGENT = "claude-infra"
@@ -155,11 +160,7 @@ def _wait_for_runtime(
 
 def _write_child(path: Path, *, wait_on_first_launch: bool) -> None:
     wait_source = (
-        "\nif generation == 0:\n"
-        "    while True:\n"
-        "        time.sleep(1)\n"
-        if wait_on_first_launch
-        else "\nsys.exit(7)\n"
+        "\nif generation == 0:\n    while True:\n        time.sleep(1)\n" if wait_on_first_launch else "\nsys.exit(7)\n"
     )
     path.write_text(
         "#!/usr/bin/env python\n"
@@ -181,8 +182,7 @@ def _write_child(path: Path, *, wait_on_first_launch: bool) -> None:
         "}\n"
         "log = Path(os.environ['SUPERVISOR_CHILD_LOG'])\n"
         "with log.open('a', encoding='utf-8') as handle:\n"
-        "    handle.write(json.dumps(record, sort_keys=True) + '\\n')\n"
-        + wait_source,
+        "    handle.write(json.dumps(record, sort_keys=True) + '\\n')\n" + wait_source,
         encoding="utf-8",
     )
     path.chmod(0o755)
@@ -336,9 +336,7 @@ def test_malformed_request_is_quarantined_once_without_persisting_payload(
     supervisor = _seed_running_supervisor(tmp_path)
     _bind(supervisor)
     request_path = _request_path(tmp_path, supervisor.run_id)
-    request_path.write_text(
-        json.dumps({"authorization": "private-rejected-value"}), encoding="utf-8"
-    )
+    request_path.write_text(json.dumps({"authorization": "private-rejected-value"}), encoding="utf-8")
     request_path.chmod(0o600)
 
     assert supervisor._check_request() is None
@@ -444,7 +442,7 @@ def test_valid_rollover_relaunches_exact_route_once(
         monkeypatch.setenv("LEARN_UKRAINIAN_CLAUDEX_LAUNCH_GENERATION", "0")
         monkeypatch.setenv("LEARN_UKRAINIAN_SESSION_ID", _SESSION_ID)
         request = th.request_claudex_rollover(
-            repo_root=_repo_python().parent.parent,
+            repo_root=_CANONICAL_REPO_ROOT,
             state_root=tmp_path,
             lineage_id=state["lineage_id"],
             replacement=replacement,
@@ -533,9 +531,7 @@ def test_relaunch_failure_leaves_handoff_lease_for_manual_recovery(tmp_path: Pat
     assert preserved["replacement"]["status"] == "pending_start"
 
 
-def test_resolve_relaunch_python_priorities(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_relaunch_python_priorities(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     sentinel_python = tmp_path / "sentinel_python"
     sentinel_python.touch(mode=0o755)
     monkeypatch.setattr(sys, "executable", os.fspath(sentinel_python))
@@ -554,6 +550,7 @@ def test_resolve_relaunch_python_priorities(
         cwd=_REPO_ROOT,
         check=True,
         capture_output=True,
+        timeout=30,
     )
     try:
         assert resolve_relaunch_python(worktree) == _repo_python()
@@ -563,6 +560,7 @@ def test_resolve_relaunch_python_priorities(
             cwd=_REPO_ROOT,
             check=False,
             capture_output=True,
+            timeout=30,
         )
 
     # 3. Non-git directory falls back to sys.executable
@@ -579,6 +577,7 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
         cwd=_REPO_ROOT,
         check=True,
         capture_output=True,
+        timeout=30,
     )
     try:
         assert not (worktree / ".venv").exists()
@@ -603,7 +602,7 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
             env=env,
             capture_output=True,
             text=True,
-            timeout=20,
+            timeout=60,
         )
         assert completed.returncode == 7, completed.stderr
         rows = _wait_for_log(child_log, 1)
@@ -618,5 +617,5 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
             cwd=_REPO_ROOT,
             check=False,
             capture_output=True,
+            timeout=30,
         )
-

--- a/tests/orchestration/test_claudex_supervisor.py
+++ b/tests/orchestration/test_claudex_supervisor.py
@@ -162,7 +162,7 @@ def _write_child(path: Path, *, wait_on_first_launch: bool) -> None:
         else "\nsys.exit(7)\n"
     )
     path.write_text(
-        "#!/usr/bin/env python3\n"
+        "#!/usr/bin/env python\n"
         "import json\n"
         "import os\n"
         "import sys\n"
@@ -171,6 +171,7 @@ def _write_child(path: Path, *, wait_on_first_launch: bool) -> None:
         "generation = int(os.environ['LEARN_UKRAINIAN_CLAUDEX_LAUNCH_GENERATION'])\n"
         "record = {\n"
         "    'argv': sys.argv[1:],\n"
+        "    'executable': sys.executable,\n"
         "    'generation': generation,\n"
         "    'profile': os.environ['LEARN_UKRAINIAN_PROFILE_ID'],\n"
         "    'lead': os.environ['LEARN_UKRAINIAN_MAIN_MODEL_ID'],\n"
@@ -532,7 +533,13 @@ def test_relaunch_failure_leaves_handoff_lease_for_manual_recovery(tmp_path: Pat
     assert preserved["replacement"]["status"] == "pending_start"
 
 
-def test_resolve_relaunch_python_priorities(tmp_path: Path) -> None:
+def test_resolve_relaunch_python_priorities(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sentinel_python = tmp_path / "sentinel_python"
+    sentinel_python.touch(mode=0o755)
+    monkeypatch.setattr(sys, "executable", os.fspath(sentinel_python))
+
     # 1. Local checkout with .venv/bin/python
     mock_local = tmp_path / "local"
     local_python = mock_local / ".venv/bin/python"
@@ -541,12 +548,27 @@ def test_resolve_relaunch_python_priorities(tmp_path: Path) -> None:
     assert resolve_relaunch_python(mock_local) == local_python
 
     # 2. Venv-less checkout in git repository finds canonical venv
-    assert resolve_relaunch_python(_REPO_ROOT) == _repo_python()
+    worktree = tmp_path / "venv_less_wt"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", os.fspath(worktree), "HEAD"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    try:
+        assert resolve_relaunch_python(worktree) == _repo_python()
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", os.fspath(worktree)],
+            cwd=_REPO_ROOT,
+            check=False,
+            capture_output=True,
+        )
 
     # 3. Non-git directory falls back to sys.executable
     non_git = tmp_path / "non_git"
     non_git.mkdir()
-    assert resolve_relaunch_python(non_git) == Path(sys.executable).resolve()
+    assert resolve_relaunch_python(non_git) == sentinel_python
 
 
 def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
@@ -580,6 +602,7 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
         assert completed.returncode == 7, completed.stderr
         rows = _wait_for_log(child_log, 1)
         assert len(rows) == 1
+        assert Path(rows[0]["executable"]) == _repo_python()
     finally:
         subprocess.run(
             ["git", "worktree", "remove", "--force", os.fspath(worktree)],

--- a/tests/orchestration/test_claudex_supervisor.py
+++ b/tests/orchestration/test_claudex_supervisor.py
@@ -4,6 +4,7 @@ import json
 import os
 import stat
 import subprocess
+import sys
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -22,6 +23,7 @@ from scripts.orchestration.claudex_supervisor import (
     compute_command_hash,
     create_rollover_request,
     load_runtime,
+    resolve_relaunch_python,
 )
 from tests.project_python import project_python
 
@@ -441,7 +443,7 @@ def test_valid_rollover_relaunches_exact_route_once(
         monkeypatch.setenv("LEARN_UKRAINIAN_CLAUDEX_LAUNCH_GENERATION", "0")
         monkeypatch.setenv("LEARN_UKRAINIAN_SESSION_ID", _SESSION_ID)
         request = th.request_claudex_rollover(
-            repo_root=_REPO_ROOT,
+            repo_root=_repo_python().parent.parent,
             state_root=tmp_path,
             lineage_id=state["lineage_id"],
             replacement=replacement,
@@ -528,3 +530,61 @@ def test_relaunch_failure_leaves_handoff_lease_for_manual_recovery(tmp_path: Pat
     assert lease_path.exists()
     preserved = json.loads(lease_path.read_text(encoding="utf-8"))
     assert preserved["replacement"]["status"] == "pending_start"
+
+
+def test_resolve_relaunch_python_priorities(tmp_path: Path) -> None:
+    # 1. Local checkout with .venv/bin/python
+    mock_local = tmp_path / "local"
+    local_python = mock_local / ".venv/bin/python"
+    local_python.parent.mkdir(parents=True)
+    local_python.touch(mode=0o755)
+    assert resolve_relaunch_python(mock_local) == local_python
+
+    # 2. Venv-less checkout in git repository finds canonical venv
+    assert resolve_relaunch_python(_REPO_ROOT) == _repo_python()
+
+    # 3. Non-git directory falls back to sys.executable
+    non_git = tmp_path / "non_git"
+    non_git.mkdir()
+    assert resolve_relaunch_python(non_git) == Path(sys.executable).resolve()
+
+
+def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
+    """Issue #7210: supervisor child relaunch must work from venv-less linked worktrees."""
+    worktree = tmp_path / "venv_less_wt"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", os.fspath(worktree), "HEAD"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    try:
+        assert not (worktree / ".venv").exists()
+        child = tmp_path / "child.py"
+        child_log = tmp_path / "child.jsonl"
+        _write_child(child, wait_on_first_launch=False)
+        env = _route_env(
+            CLAUDEX_SUPERVISOR_TEST_STATE_ROOT=os.fspath(tmp_path),
+            SUPERVISOR_CHILD_LOG=os.fspath(child_log),
+        )
+        supervisor_script = worktree / "scripts/orchestration/claudex_supervisor.py"
+        supervisor_script.write_text(_SUPERVISOR.read_text(encoding="utf-8"), encoding="utf-8")
+        completed = subprocess.run(
+            [os.fspath(_repo_python()), os.fspath(supervisor_script), os.fspath(child), *_argv()],
+            cwd=worktree,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert completed.returncode == 7, completed.stderr
+        rows = _wait_for_log(child_log, 1)
+        assert len(rows) == 1
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", os.fspath(worktree)],
+            cwd=_REPO_ROOT,
+            check=False,
+            capture_output=True,
+        )
+

--- a/tests/orchestration/test_claudex_supervisor.py
+++ b/tests/orchestration/test_claudex_supervisor.py
@@ -585,7 +585,13 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
         child = tmp_path / "child.py"
         child_log = tmp_path / "child.jsonl"
         _write_child(child, wait_on_first_launch=False)
+        raw_path = os.environ.get("PATH", "")
+        repo_venv_bin = _repo_python().parent.resolve()
+        cleaned_path = os.pathsep.join(
+            p for p in raw_path.split(os.pathsep) if p and Path(p).resolve() != repo_venv_bin
+        )
         env = _route_env(
+            PATH=cleaned_path,
             CLAUDEX_SUPERVISOR_TEST_STATE_ROOT=os.fspath(tmp_path),
             SUPERVISOR_CHILD_LOG=os.fspath(child_log),
         )
@@ -601,8 +607,11 @@ def test_supervisor_launches_in_venv_less_worktree(tmp_path: Path) -> None:
         )
         assert completed.returncode == 7, completed.stderr
         rows = _wait_for_log(child_log, 1)
-        assert len(rows) == 1
-        assert Path(rows[0]["executable"]) == _repo_python()
+        assert len(rows) == 1, f"expected 1 log row, got {len(rows)}\nstderr:\n{completed.stderr}"
+        assert Path(rows[0]["executable"]) == _repo_python(), (
+            f"expected child interpreter {_repo_python()} but got {rows[0]['executable']}\n"
+            f"supervisor stderr:\n{completed.stderr}"
+        )
     finally:
         subprocess.run(
             ["git", "worktree", "remove", "--force", os.fspath(worktree)],

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -83,7 +83,7 @@ def seed_supervised_claudex(
     *,
     session_id: str = "official-session-5265",
 ) -> cs.ClaudexSupervisor:
-    (tmp_path / ".venv").symlink_to(_REPO_ROOT / ".venv", target_is_directory=True)
+    (tmp_path / ".venv").symlink_to(project_python().parent.parent, target_is_directory=True)
     supervisor_env = os.environ.copy()
     supervisor_env.update(
         {


### PR DESCRIPTION
Fixes #7210. Addresses the fixture half of #7234.

`ClaudexSupervisor` resolved its relaunch interpreter as a hardcoded `PROJECT_ROOT / ".venv/bin/python"`, so the relaunch gate died with `FileNotFoundError` in any venv-less linked worktree (every sparse/full dispatch worktree, any detached verify checkout).

## Changes (three commits)
1. **f10dbebd35** — `resolve_relaunch_python(project_root)` priority contract: local checkout venv → canonical repo venv (Git common directory) → `sys.executable` → old fallback; `REPO_PYTHON` assigned from it. Venv-less-worktree E2E test added.
2. **c5329c9a05** (CF findings delta) — tier 3 returns `sys.executable` UNRESOLVED (`.resolve()` followed the venv symlink to the base interpreter, silently dropping `pyvenv.cfg` discovery); tier-2 fallback is loud (stderr warning, never silent); priorities test discriminates tiers regardless of symlink-ness; E2E asserts the CHILD's actual interpreter.
3. **4e29649a21** (root cause the strengthened E2E exposed) — child scripts launched via `#!/usr/bin/env python` resolved the shebang through the inherited `PATH`, so children landed on the base pyenv interpreter whenever `.venv/bin` wasn't on the caller's `PATH` (masked in one worker env, reproduced by the driver). `_launch()` now prepends `REPO_PYTHON.parent` to `launch_env["PATH"]` and sets `VIRTUAL_ENV`; the E2E strips the venv from `PATH` before spawning so it passes only when the supervisor injects it; supervisor stderr is attached to assertion failures. **Deliberate scope expansion accepted by the driver:** 1-line `seed_supervised_claudex` fixture fix in `tests/orchestration/test_thread_handoff.py` (links the canonical venv via `project_python()`) — the exact subject of #7234, which the monitor-epic lane declined by adjacency; with it the whole `tests/orchestration/` pair runs from venv-less worktrees.

## Verification
- Driver independent re-probe at 4e29649a21, primary interpreter, from the venv-less dispatch worktree: `test_claudex_supervisor.py` + `test_thread_handoff.py` → **165 passed** (previously the thread_handoff suite could not run there at all).
- Driver mutation-check (executed): reverting the tier resolution → venv-less E2E fails; wrong child executable → E2E fails.
- CF review of record: kimi PASS-with-nits at f10dbebd35 (on the PR); exact-head re-stamp of the delta range f10dbebd35..4e29649a21 in flight — merge gates on it.

Refs #7192 (where the unreviewed candidate was deliberately dropped and handed to this lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKAACyNj7cxjPsdsFw5Lho