### PR TITLE
fix(lexicon): cached-slovnyk-only must not live-fetch; add --no-pointer (#6371)

### DIFF
--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -429,7 +429,11 @@ def _translation_for_entry(
     lemma = str(entry.get("lemma") or "")
     entry_pos = entry.get("pos")
     gloss_hints = enrich_manifest._surface_gloss_hints(entry)
-    slovnyk_cache = enrich_manifest._slovnyk_cache(lemma)
+    slovnyk_cache = (
+        enrich_manifest._load_current_slovnyk_cache_file(enrich_manifest._slovnyk_cache_path(lemma))
+        if cached_slovnyk_only
+        else enrich_manifest._slovnyk_cache(lemma)
+    )
     if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
         slovnyk_cache,
         enrich_manifest._SLOVNYK_UKRENG_SLUG,
@@ -447,7 +451,11 @@ def _translation_for_entry(
         return translation
     fallback_base = enrich_manifest._base_lookup_for_entry(lemma, entry_pos)
     if fallback_base:
-        fallback_cache = enrich_manifest._slovnyk_cache(fallback_base)
+        fallback_cache = (
+            enrich_manifest._load_current_slovnyk_cache_file(enrich_manifest._slovnyk_cache_path(fallback_base))
+            if cached_slovnyk_only
+            else enrich_manifest._slovnyk_cache(fallback_base)
+        )
         if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
             fallback_cache,
             enrich_manifest._SLOVNYK_UKRENG_SLUG,
@@ -751,6 +759,11 @@ def main() -> int:
         action="store_true",
         help="Write only an initial pointer when no canonical release asset exists; records bootstrap=true.",
     )
+    parser.add_argument(
+        "--no-pointer",
+        action="store_true",
+        help="Do not update the release pointer when writing the manifest.",
+    )
     args = parser.parse_args()
 
     manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
@@ -821,13 +834,14 @@ def main() -> int:
     if args.write:
         _refresh_manifest_fingerprint(manifest)
         _write_manifest(manifest_path, manifest)
-        pointer = _write_default_release_pointer(
-            manifest_path,
-            bootstrap_no_baseline=args.bootstrap_no_baseline,
-            allow_richness_regression_reason=args.allow_richness_regression,
-        )
-        if pointer:
-            print(f"Updated local atlas-manifest pointer {pointer['manifest_fingerprint']} {pointer['json_sha256']}")
+        if not args.no_pointer:
+            pointer = _write_default_release_pointer(
+                manifest_path,
+                bootstrap_no_baseline=args.bootstrap_no_baseline,
+                allow_richness_regression_reason=args.allow_richness_regression,
+            )
+            if pointer:
+                print(f"Updated local atlas-manifest pointer {pointer['manifest_fingerprint']} {pointer['json_sha256']}")
     else:
         print("Dry run only; pass --write to update the manifest.")
     return 0

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -227,7 +227,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "c0ebd40f96d0271eb9f2394bf955ac83bb5ac5c7aded0e73b559ec524a5e968c"
+        "sha256": "d3254c40b672d083e05b8cb5563f2b2d12986fa7b8871b1f442190d32c56a27f"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -191,16 +191,20 @@ def test_load_slug_filter_rejects_unknown_shape(tmp_path) -> None:
         _load_slug_filter(path)
 
 
-def test_cached_slovnyk_only_skips_uncached_slovnyk_lookup(monkeypatch) -> None:
+def test_cached_slovnyk_only_skips_uncached_slovnyk_lookup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     entry = {"lemma": "невідоме", "enrichment": {}}
 
     def fake_translation(conn, lemma, kaikki_lookup, *, entry_pos=None, gloss_hints=None, slovnyk_cache=None):
         assert slovnyk_cache is None
         return None
 
+    def fail_live_slovnyk(*args, **kwargs):
+        raise AssertionError("_slovnyk_cache must not be called when cached_slovnyk_only=True")
+
+    monkeypatch.setattr(enrich_manifest, "SLOVNYK_CACHE", tmp_path)
     monkeypatch.setattr(enrich_manifest, "_translation", fake_translation)
     monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
-    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", fail_live_slovnyk)
 
     with sqlite3.connect(":memory:") as conn:
         _reenrich_translation_only(conn, entry, {}, cached_slovnyk_only=True)
@@ -208,18 +212,36 @@ def test_cached_slovnyk_only_skips_uncached_slovnyk_lookup(monkeypatch) -> None:
     assert "translation" not in entry["enrichment"]
 
 
-def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> None:
+def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     entry = {"lemma": "бризки", "gloss": "splashes", "enrichment": {}}
 
     def fail_fetch(*args, **kwargs):
         raise AssertionError("cached-only mode must not live-fetch Slovnyk")
 
+    def fail_live_slovnyk(*args, **kwargs):
+        raise AssertionError("_slovnyk_cache must not be called when cached_slovnyk_only=True")
+
+    monkeypatch.setattr(enrich_manifest, "SLOVNYK_CACHE", tmp_path)
     monkeypatch.setattr(enrich_manifest, "_DMKLINGER_INDEX", None)
     monkeypatch.setattr(enrich_manifest, "_BALLA_REVERSE_INDEX", {})
     monkeypatch.setattr(enrich_manifest, "query_goroh_translate", lambda lemma: [])
-    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {"lookups": {}})
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", fail_live_slovnyk)
     monkeypatch.setattr(enrich_manifest, "_fetch_slovnyk_entry", fail_fetch)
     monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+
+    cache_path = tmp_path / "бризки.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schema_version": enrich_manifest._SLOVNYK_CACHE_SCHEMA_VERSION,
+                "lemma": "бризки",
+                "lookup_word": "бризки",
+                "lookups": {},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
 
     with sqlite3.connect(":memory:") as conn:
         conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -284,6 +285,40 @@ def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(tmp_path,
         reenrich._write_default_release_pointer(manifest_path)
 
     assert gzip_calls == []
+
+
+def test_reenrich_no_pointer_skips_pointer_write(tmp_path, monkeypatch) -> None:
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    manifest_path.write_text('{"entries": [{"lemma": "тест", "url_slug": "тест"}]}\n', encoding="utf-8")
+    pointer_called = []
+
+    monkeypatch.setattr(
+        reenrich,
+        "_write_default_release_pointer",
+        lambda *args, **kwargs: pointer_called.append(True),
+    )
+    monkeypatch.setattr(
+        reenrich,
+        "reenrich_thin_entries",
+        lambda *args, **kwargs: {"target": "missing-translation", "targets": 1},
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reenrich_thin_manifest_entries.py",
+            "--manifest",
+            str(manifest_path),
+            "--local",
+            "--write",
+            "--no-pointer",
+        ],
+    )
+    res = reenrich.main()
+    assert res == 0
+    assert pointer_called == []
+
 
 
 def test_canary_check_passes_when_all_layers_filled(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

While measuring #6371 fillability, `--cached-slovnyk-only` still called `_slovnyk_cache()` (live HTTP). That blocked a local estimate (~4s/word). This PR:

- Loads the on-disk schema-v4 cache file directly when `cached_slovnyk_only` is set (headword and fallback base).
- Adds `--no-pointer` so `--write` can update a worktree manifest without touching the release pointer.
- Tests for `--no-pointer`.

Does **not** undraft #6809, does not flip the pointer, does not promote the 7750.

Fillability result (local sources): 4022 EN fills, **0** richness-ok, union `poc_thin` 8804→12826 (would fail the publish gate). Tracked on #6371.

## Test

`.venv/bin/python -m pytest tests/test_reenrich_thin_manifest_entries.py -q`

X-Agent: grok-atlas (PR opened from agy/atlas-6371-fillability)

Refs #6371