### PR TITLE
fix(dispatch): harden branch-holder release — unparseable-state refusal + refusal-record clobber guard (#7242)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -586,6 +586,20 @@ def _read_state(path: Path) -> dict[str, Any] | None:
     return _hydrate_read_only_checkout_snapshots(state)
 
 
+def _state_file_unparseable(path: Path) -> bool:
+    """True when a state file exists on disk but cannot be parsed to a dict."""
+    return path.is_file() and _read_state_json(path) is None
+
+
+def _bound_task_state_unparseable_reason(path: Path) -> str | None:
+    """Return a refusal reason when a layout-bound state file is corrupt."""
+    for task_id in _task_status_candidates_for_worktree(path):
+        state_path = _state_path(task_id)
+        if _state_file_unparseable(state_path):
+            return f"unparseable task state for task-id={task_id}"
+    return None
+
+
 def _pid_alive(pid: int) -> bool:
     """Check if a PID is currently alive via signal-0 probe.
 
@@ -2320,6 +2334,10 @@ def _branch_holder_activity_reason(
     if not candidate_task_ids:
         return "holder is outside the dispatch layout"
 
+    unparseable = _bound_task_state_unparseable_reason(path)
+    if unparseable is not None:
+        return unparseable
+
     try:
         from scripts.orchestration import reap_worktrees
 
@@ -2373,6 +2391,9 @@ def _stale_branch_holder_releasable(path: Path, branch: str) -> tuple[bool, str]
         return False, "dirty"
     if not _worktree_matches_origin_branch(path, branch):
         return False, "HEAD != origin/<branch>"
+    unparseable = _bound_task_state_unparseable_reason(path)
+    if unparseable is not None:
+        return False, unparseable
     task_id, task_state = _task_state_for_worktree(path)
     activity = _branch_holder_activity_reason(
         path,
@@ -2417,7 +2438,9 @@ def _release_stale_branch_holders(
             released.append(path)
             continue
         # No --force: if the tree went dirty after the cleanliness check
-        # (TOCTOU), git refuses removal and we leave the holder mounted (#5708 CF).
+        # (dirty-TOCTOU), or a process adopted the holder as cwd after the
+        # live-CWD probe (live-cwd TOCTOU — accepted residual), git refuses
+        # removal and we leave the holder mounted (#5708 CF, #7242).
         try:
             proc = subprocess.run(
                 ["git", "worktree", "remove", str(path)],
@@ -5063,8 +5086,12 @@ def _record_worktree_prep_failure(
     silence_timeout: float | None = None,
     initial_response_timeout: float | None = None,
     max_budget_usd: float | None = None,
-) -> None:
-    """Persist a terminal failed task record when worktree provisioning is refused."""
+) -> bool:
+    """Persist a terminal failed task record when worktree provisioning is refused.
+
+    Returns True when a record was written. Refuses to overwrite an existing
+    running/spawning record (pre-write re-check closes the guard→write race).
+    """
     if str(_REPO_ROOT / "scripts") not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
@@ -5132,7 +5159,12 @@ def _record_worktree_prep_failure(
         failed_state["harness"] = requested_harness
     if lifecycle_carrier is not None:
         failed_state["task_lifecycle"] = lifecycle_carrier
-    _write_state_atomic(_state_path(task_id), failed_state)
+    state_path = _state_path(task_id)
+    existing = _read_state(state_path)
+    if existing is not None and existing.get("status") in ("running", "spawning"):
+        return False
+    _write_state_atomic(state_path, failed_state)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -9381,3 +9381,98 @@ def test_cmd_dispatch_refusal_on_base_resolution_writes_terminal_task_record(
     assert state["returncode_reason"] == "worktree preparation failed"
     assert "could not fetch origin/non-existent-base-branch" in (state["last_error"] or "")
     assert state["finished_at"] is not None
+
+
+# --- Issue #7242: Branch-holder release hardening ---
+
+
+def test_branch_holder_refuses_unparseable_bound_task_state(tmp_path, monkeypatch, tmp_tasks_dir):
+    """#7242: exists-but-unparseable bound state must refuse release (P0-reaper posture)."""
+    from scripts.orchestration import reap_worktrees
+
+    occupied = Path(delegate._REPO_ROOT) / ".worktrees" / "dispatch" / "codex" / "corrupt-7242"
+    branch = "codex/corrupt-7242"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    monkeypatch.setattr(delegate.subprocess, "run", base_stub)
+    monkeypatch.setattr(reap_worktrees, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(reap_worktrees, "_live_cwd_paths", lambda _repo: set())
+
+    corrupt_path = delegate._state_path("codex-corrupt-7242")
+    corrupt_path.parent.mkdir(parents=True, exist_ok=True)
+    corrupt_path.write_text("{not valid json", encoding="utf-8")
+
+    releasable, reason = delegate._stale_branch_holder_releasable(occupied, branch)
+
+    assert releasable is False
+    assert reason == "unparseable task state for task-id=codex-corrupt-7242"
+
+    # Mutation check: bypassing the guard must falsely treat corrupt state as absent.
+    original_unparseable_check = delegate._bound_task_state_unparseable_reason
+    monkeypatch.setattr(delegate, "_bound_task_state_unparseable_reason", lambda _path: None)
+    releasable_broken, reason_broken = delegate._stale_branch_holder_releasable(occupied, branch)
+    assert releasable_broken is True, (
+        "mutation check failed: without unparseable guard corrupt state must not read as releasable"
+    )
+    assert "task record absent" in reason_broken
+
+    # Restore and confirm refusal again.
+    monkeypatch.setattr(delegate, "_bound_task_state_unparseable_reason", original_unparseable_check)
+    releasable_restored, reason_restored = delegate._stale_branch_holder_releasable(occupied, branch)
+    assert releasable_restored is False
+    assert reason_restored == "unparseable task state for task-id=codex-corrupt-7242"
+
+
+def test_record_worktree_prep_failure_refuses_clobber_running_record(tmp_tasks_dir, monkeypatch):
+    """#7242: prep-failure record must not overwrite a concurrent running task."""
+    path = delegate._state_path("prep-clobber-7242")
+    original = {
+        "task_id": "prep-clobber-7242",
+        "status": "running",
+        "pid": os.getpid(),
+        "receipt": "do-not-clobber-prep-failure",
+    }
+    delegate._write_state_atomic(path, original)
+
+    wrote = delegate._record_worktree_prep_failure(
+        task_id="prep-clobber-7242",
+        run_nonce="nonce-7242",
+        attribution=type("Attr", (), {"initiator": "test", "source": "test"})(),
+        agent="cursor",
+        mode="workspace-write",
+        prompt="prep failure probe",
+        error=RuntimeError("simulated worktree prep failure"),
+    )
+
+    assert wrote is False
+    assert delegate._read_state(path) == original
+
+    # Mutation check: bypassing the live-record guard must clobber running state.
+    original_read_state = delegate._read_state
+    monkeypatch.setattr(delegate, "_read_state", lambda _path: None)
+    wrote_broken = delegate._record_worktree_prep_failure(
+        task_id="prep-clobber-7242",
+        run_nonce="nonce-7242-broken",
+        attribution=type("Attr", (), {"initiator": "test", "source": "test"})(),
+        agent="cursor",
+        mode="workspace-write",
+        prompt="prep failure probe",
+        error=RuntimeError("simulated worktree prep failure"),
+    )
+    assert wrote_broken is True
+    clobbered = json.loads(path.read_text(encoding="utf-8"))
+    assert clobbered["status"] == "failed", "mutation check failed: guard must block clobber of running record"
+
+    # Restore and confirm the live record is preserved again.
+    monkeypatch.setattr(delegate, "_read_state", original_read_state)
+    delegate._write_state_atomic(path, original)
+    wrote_restored = delegate._record_worktree_prep_failure(
+        task_id="prep-clobber-7242",
+        run_nonce="nonce-7242-restored",
+        attribution=type("Attr", (), {"initiator": "test", "source": "test"})(),
+        agent="cursor",
+        mode="workspace-write",
+        prompt="prep failure probe",
+        error=RuntimeError("simulated worktree prep failure"),
+    )
+    assert wrote_restored is False
+    assert delegate._read_state(path) == original


### PR DESCRIPTION
Closes #7242 (the three CF findings from PR #7241's review of record, hardening #7236).

- **Unparseable-state refusal:** a layout-bound task state file that exists but fails to parse now REFUSES release ("uncertainty never reads as releasable" — P0-reaper posture). Previously it read as absent and could degrade toward releasable.
- **Refusal-record clobber guard:** `_record_worktree_prep_failure` re-checks before writing and refuses to overwrite a concurrent `running`/`spawning` record (closes the guard→write race from finding 2).
- **cwd TOCTOU documented** beside the existing dirty-TOCTOU comment (accepted residual, finding 3 — no code).

## Verification
- Worker (cursor, attested Composer 2.5, task `release-hardening-7242`): both new tests mutation-checked (guard bypassed → test fails; restored → passes); full delegate probe 414 passed; ruff clean.
- Driver independent re-probe: same 8-suite probe → **414 passed, 0 failed**; commit scope 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKAACyNj7cxjPsdsFw5Lho