### PR TITLE
feat(epics): launcher auto-resolves its own opaque host_id (#7229)

### DIFF
--- a/scripts/api/occupancy_local.py
+++ b/scripts/api/occupancy_local.py
@@ -399,9 +399,31 @@ def foundry_marker_host_id(mapping: dict[str, str]) -> str | None:
     return None
 
 
+def resolve_launcher_host_id() -> str:
+    """Resolve the launcher host id from the canonical occupancy configuration."""
+    explicit = os.environ.get("LU_MONITOR_HOST_ID")
+    if explicit is not None:
+        return explicit or "local"
+
+    driver_host_id = os.environ.get(ENV_DRIVER_HOST_ID, "").strip().lower()
+    if driver_host_id and _opaque_host_id(driver_host_id):
+        return driver_host_id
+
+    try:
+        from scripts.api.occupancy import parse_host_id_map  # noqa: PLC0415 — breaks the occupancy import cycle
+
+        claimed = self_host_opaque_ids(parse_host_id_map())
+    except Exception:
+        return "local"
+    if len(claimed) == 1:
+        return next(iter(claimed))
+    return "local"
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Publish or clear a sanitized occupancy marker (opaque host_id only).")
     sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("resolve-host-id", help="resolve the current process's opaque occupancy host id")
     heartbeat = sub.add_parser("heartbeat", help="write one marker")
     heartbeat.add_argument("--kind", required=True)
     heartbeat.add_argument("--task-id", required=True)
@@ -417,6 +439,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
+    if args.command == "resolve-host-id":
+        print(resolve_launcher_host_id())
+        return 0
     if args.command == "heartbeat":
         written = write_marker(
             kind=args.kind,

--- a/scripts/api/occupancy_local.py
+++ b/scripts/api/occupancy_local.py
@@ -410,7 +410,7 @@ def resolve_launcher_host_id() -> str:
         return driver_host_id
 
     try:
-        from scripts.api.occupancy import parse_host_id_map  # noqa: PLC0415 — breaks the occupancy import cycle
+        from scripts.api.occupancy import parse_host_id_map  # noqa: PLC0415 — # lazy-ok: occupancy cycle breaker
 
         claimed = self_host_opaque_ids(parse_host_id_map())
     except Exception:

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -126,7 +126,15 @@ claim_session_supervisor_env() {
   # Remote v1 uses the design-note TTL; liveness is carried by the independent
   # launcher renew loop, never by a server-side PID probe.
   local ttl_seconds=900
-  local host_id="${LU_MONITOR_HOST_ID:-local}"
+  local host_id
+  if [ "${LU_MONITOR_HOST_ID+x}" = x ]; then
+    host_id="${LU_MONITOR_HOST_ID:-local}"
+  else
+    host_id="$("$python_bin" -m scripts.api.occupancy_local resolve-host-id 2>/dev/null)" || host_id="local"
+    if [ -z "$host_id" ]; then
+      host_id="local"
+    fi
+  fi
   export LU_MONITOR_HOST_ID="$host_id"
   local heartbeat_at
   heartbeat_at="$(_iso_timestamp)"

--- a/tests/api/test_occupancy_local.py
+++ b/tests/api/test_occupancy_local.py
@@ -16,6 +16,7 @@ from scripts.api.occupancy_local import (
     occupancy_marker_scope,
     occupants_from_markers,
     occupants_from_session_streams,
+    resolve_launcher_host_id,
     write_marker,
 )
 
@@ -60,6 +61,25 @@ def test_driver_seat_host_id_uses_explicit_opaque_then_self_host(monkeypatch: py
 
     monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "atlas-runner")
     assert driver_seat_host_id(mapping, selected) is None
+
+
+def test_resolve_launcher_host_id_uses_occupancy_mapping_and_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LU_MONITOR_HOST_ID", raising=False)
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", "teach-box=host-teacher,job-box=host-job")
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "job-box")
+    assert resolve_launcher_host_id() == "host-job"
+
+    monkeypatch.setenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", "host-driver")
+    assert resolve_launcher_host_id() == "host-driver"
+    monkeypatch.delenv("MONITOR_OCCUPANCY_DRIVER_HOST_ID", raising=False)
+    monkeypatch.setenv("ATLAS_JOB_SELF_HOST", "unknown-box")
+    assert resolve_launcher_host_id() == "local"
+
+    monkeypatch.setenv("LU_MONITOR_HOST_ID", "host-explicit")
+    assert resolve_launcher_host_id() == "host-explicit"
 
 
 def test_occupants_from_session_streams_reads_active_lease_only(

--- a/tests/test_session_supervisor_shell.py
+++ b/tests/test_session_supervisor_shell.py
@@ -36,6 +36,14 @@ def _write_executable(path: Path, body: str) -> None:
 
 def _supervisor_ok_body(capture: Path) -> str:
     return f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.api.occupancy_local" && "${{3:-}}" == "resolve-host-id" ]]; then
+  if [[ "${{FAKE_RESOLVER_FAILURE:-0}}" == "1" ]]; then
+    echo "resolver unavailable" >&2
+    exit 1
+  fi
+  printf '%s\\n' "${{FAKE_RESOLVED_HOST_ID:-local}}"
+  exit 0
+fi
 if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:-}}" == "open" ]]; then
   {{
     printf '%s\\n' "$@" > "{capture}"
@@ -204,6 +212,57 @@ printf 'INSTANCE=%s\\n' "$SESSION_STREAM_INSTANCE_ID"
 
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     assert supervisor_args[supervisor_args.index("--instance-id") + 1].startswith("test-agent-")
+
+
+def test_claim_resolves_unset_host_id_and_preserves_explicit_override(tmp_path: Path) -> None:
+    project, supervisor_capture = _build_fake_project(tmp_path)
+    env = _clean_environ()
+    env["FAKE_RESOLVED_HOST_ID"] = "host-job"
+
+    script = f"""
+set -euo pipefail
+source "{project}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env "epic:9999" "test-agent" "test-harness" "" "" "{project}" "test-launcher.sh" "hramatka"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    assert supervisor_args[supervisor_args.index("--host-id") + 1] == "host-job"
+
+    env["LU_MONITOR_HOST_ID"] = "host-explicit"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    assert supervisor_args[supervisor_args.index("--host-id") + 1] == "host-explicit"
+
+    env.pop("LU_MONITOR_HOST_ID")
+    env["FAKE_RESOLVER_FAILURE"] = "1"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stderr == ""
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    assert supervisor_args[supervisor_args.index("--host-id") + 1] == "local"
 
 
 def test_claim_fails_closed_on_missing_required_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
Parent: #7177. Closes #7229. Authored by codex lane (task monitor-host-id-autoresolve); PR opened by main (worker gh unauth).

Launcher self-identifies its opaque host_id instead of defaulting driver leases to `local`:
- canonical opaque-host resolver (reuses occupancy self-host mapping: `hramatka=host-teacher, atlas-runner=host-job`, Mac=`mac-operator`)
- explicit `LU_MONITOR_HOST_ID` still wins; unresolvable → `local` (fail-safe)
- tests: resolver + explicit-override + failure-fallback, mutation-sensitive

Worker evidence: 45 tests passed; Ruff + `bash -n` + ShellCheck clean.
**NOT yet independently reviewed by main** — needs cross-family review + own verification before merge (next session). No auto-merge.