### PR TITLE
fix(phase3): finalize resumed evidence ledger

### DIFF
--- a/batch_state/phase3-compile-cycle007-evidence-v1.py
+++ b/batch_state/phase3-compile-cycle007-evidence-v1.py
@@ -18,7 +18,8 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Sequence
+from collections import Counter
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -26,6 +27,7 @@ from urllib.parse import urlparse
 ROOT = Path(__file__).resolve().parents[1]
 SERVER_PATH = ROOT / ".mcp" / "servers" / "sources" / "server.py"
 MCP_START_TIMEOUT_SECONDS = 15.0
+_SERVER_IDENTITY_TOOL = "mcp_server_identity"
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -266,6 +268,119 @@ def _admit_reviewed_resume_root(package: Path, output: Path):
         materializer.OUTPUT_TOP_LEVEL = original_top_level
 
 
+def _normalize_resume_identity_ledger(
+    output: Path,
+    client: compiler.LocalMcpSourcesClient,
+) -> None:
+    """Normalize a live receipt while holding the compiler's exclusive lock."""
+    root = throughput.resume_root_for(output)
+    if not os.path.lexists(root):
+        return
+    with throughput.exclusive_resume_lock(root):
+        _normalize_resume_identity_ledger_locked(output, client)
+
+
+def _normalize_resume_identity_ledger_locked(
+    output: Path,
+    client: compiler.LocalMcpSourcesClient,
+) -> None:
+    """Remove validation-only identity calls before the frozen compiler resumes.
+
+    The compiler attests the endpoint once when each process starts and appends
+    that call while restoring the prior ledger. Earlier resumptions therefore
+    accumulated identical identity calls even though the final evidence
+    contract requires exactly one. The outer runner owns this checkpoint-safe
+    normalization because changing either hashed resume module would invalidate
+    the existing durable prefix.
+    """
+    root = throughput.resume_root_for(output)
+    progress_path = root / throughput.PROGRESS_NAME
+    if not os.path.lexists(progress_path):
+        return
+    receipt = throughput.read_progress(progress_path)
+    if set(receipt) != throughput.PROGRESS_REQUIRED_KEYS:
+        raise RunnerError("resume_progress_invalid")
+    unsigned_receipt = {key: value for key, value in receipt.items() if key != "progress_sha256"}
+    if receipt.get("progress_sha256") != evidence_contract.sha256_value(unsigned_receipt):
+        raise RunnerError("resume_progress_invalid")
+
+    prior_attestation = receipt.get("mcp_transport_attestation")
+    prior_records = receipt.get("mcp_call_records")
+    current_attestation = client.transport_attestation()
+    current_records = client.transport_call_records()
+    if not isinstance(prior_attestation, Mapping) or not isinstance(prior_records, list):
+        raise RunnerError("resume_transport_invalid")
+    if len(current_records) != 1 or current_records[0].get("tool") != _SERVER_IDENTITY_TOOL:
+        raise RunnerError("resume_identity_invalid")
+    throughput.validate_transport_state(
+        prior_attestation,
+        prior_records,
+        expected_transport=str(current_attestation["transport"]),
+        expected_endpoint_sha256=str(current_attestation["endpoint_sha256"]),
+        expected_tool_set_sha256=str(current_attestation["required_tool_set_sha256"]),
+    )
+
+    current_identity = current_records[0]
+    current_fingerprint = (
+        current_identity["tool"],
+        current_identity["arguments_sha256"],
+        current_identity["response_sha256"],
+    )
+    for record in prior_records:
+        if record.get("tool") != _SERVER_IDENTITY_TOOL:
+            continue
+        if (
+            record["tool"],
+            record["arguments_sha256"],
+            record["response_sha256"],
+        ) != current_fingerprint:
+            raise RunnerError("resume_identity_drift")
+
+    normalized_records = [
+        {
+            "ordinal": ordinal,
+            "tool": record["tool"],
+            "arguments_sha256": record["arguments_sha256"],
+            "response_sha256": record["response_sha256"],
+        }
+        for ordinal, record in enumerate(
+            (record for record in prior_records if record.get("tool") != _SERVER_IDENTITY_TOOL),
+            start=1,
+        )
+    ]
+    commitment, next_ordinal = throughput.extend_serial_call_commitment(
+        throughput.initial_call_commitment(),
+        normalized_records,
+        starting_ordinal=1,
+    )
+    if next_ordinal != len(normalized_records) + 1:
+        raise RunnerError("resume_transport_invalid")
+    counts_by_tool = Counter(str(record["tool"]) for record in normalized_records)
+    normalized_attestation = dict(prior_attestation)
+    normalized_attestation.update(
+        {
+            "tool_call_count": len(normalized_records),
+            "counts_by_tool": dict(sorted(counts_by_tool.items())),
+            "server_identity_call_count": 0,
+            "ordered_call_commitment_sha256": commitment,
+        }
+    )
+    throughput.validate_transport_state(
+        normalized_attestation,
+        normalized_records,
+        expected_transport=str(current_attestation["transport"]),
+        expected_endpoint_sha256=str(current_attestation["endpoint_sha256"]),
+        expected_tool_set_sha256=str(current_attestation["required_tool_set_sha256"]),
+    )
+    normalized_receipt = dict(receipt)
+    normalized_receipt["mcp_transport_attestation"] = normalized_attestation
+    normalized_receipt["mcp_call_records"] = normalized_records
+    normalized_receipt["progress_sha256"] = evidence_contract.sha256_value(
+        {key: value for key, value in normalized_receipt.items() if key != "progress_sha256"}
+    )
+    throughput.write_progress(root, normalized_receipt)
+
+
 def _compile(package: Path, source_manifest: Path, output: Path, endpoint: str) -> dict[str, Any]:
     process: subprocess.Popen[bytes] | None = None
     try:
@@ -274,6 +389,7 @@ def _compile(package: Path, source_manifest: Path, output: Path, endpoint: str) 
             compiler.LocalMcpSourcesClient(endpoint_url=endpoint) as client,
             _admit_reviewed_resume_root(package, output),
         ):
+            _normalize_resume_identity_ledger(output, client)
             manifest = compiler.compile_cycle007_package(
                 package,
                 source_manifest,

--- a/tests/test_phase3_cycle007_evidence_compile_throughput.py
+++ b/tests/test_phase3_cycle007_evidence_compile_throughput.py
@@ -74,6 +74,46 @@ def _private_parent(tmp_path: Path, name: str) -> Path:
     return parent
 
 
+def _append_legacy_identity_calls(
+    output: Path,
+    *,
+    count: int,
+    response_sha256: str | None = None,
+) -> None:
+    root = throughput.resume_root_for(output)
+    receipt = throughput.read_progress(root / throughput.PROGRESS_NAME)
+    records = list(receipt["mcp_call_records"])
+    identity = next(record for record in records if record["tool"] == "mcp_server_identity")
+    for _ in range(count):
+        records.append(
+            {
+                "ordinal": len(records) + 1,
+                "tool": identity["tool"],
+                "arguments_sha256": identity["arguments_sha256"],
+                "response_sha256": response_sha256 or identity["response_sha256"],
+            }
+        )
+    commitment, next_ordinal = throughput.extend_serial_call_commitment(
+        throughput.initial_call_commitment(),
+        records,
+        starting_ordinal=1,
+    )
+    assert next_ordinal == len(records) + 1
+    attestation = dict(receipt["mcp_transport_attestation"])
+    attestation["tool_call_count"] = len(records)
+    counts_by_tool = dict(attestation["counts_by_tool"])
+    counts_by_tool["mcp_server_identity"] += count
+    attestation["counts_by_tool"] = dict(sorted(counts_by_tool.items()))
+    attestation["server_identity_call_count"] += count
+    attestation["ordered_call_commitment_sha256"] = commitment
+    receipt["mcp_call_records"] = records
+    receipt["mcp_transport_attestation"] = attestation
+    receipt["progress_sha256"] = contract.sha256_value(
+        {key: value for key, value in receipt.items() if key != "progress_sha256"}
+    )
+    throughput.write_progress(root, receipt)
+
+
 def test_runner_temporarily_admits_only_reviewed_resume_root(tmp_path: Path) -> None:
     package = _private_parent(tmp_path, "package")
     output = package / "evidence"
@@ -111,6 +151,106 @@ def test_runner_admission_preserves_strict_compiler_and_allows_actual_compile(tm
         )
     assert manifest["packet_count"] == 2
     assert manifest["row_count"] == 4
+
+
+def test_runner_normalizes_legacy_identity_calls_without_changing_frozen_modules(tmp_path: Path) -> None:
+    straight_parent = _private_parent(tmp_path, "straight-normalized")
+    resumed_parent = _private_parent(tmp_path, "resumed-normalized")
+    straight = straight_parent / "evidence"
+    resumed = resumed_parent / "evidence"
+    _run(tmp_path / "client-straight-normalized", straight)
+    with pytest.raises(RuntimeError):
+        _run(tmp_path / "client-first-normalized", resumed, interrupt_after_packet=1)
+    _append_legacy_identity_calls(resumed, count=2)
+
+    client = _client(tmp_path / "client-second-normalized")
+    try:
+        _RUNNER._normalize_resume_identity_ledger(resumed, client)
+        progress = throughput.read_progress(
+            throughput.resume_root_for(resumed) / throughput.PROGRESS_NAME
+        )
+        assert progress["mcp_transport_attestation"]["server_identity_call_count"] == 0
+        assert all(record["tool"] != "mcp_server_identity" for record in progress["mcp_call_records"])
+        packets, flags, bindings = _inputs()
+        compiler.compile_sidecar_bundle_resumable(
+            packets,
+            client,
+            resumed,
+            residual_lane_packets=flags,
+            packet_bindings=bindings,
+            source_package_binding=None,
+        )
+    finally:
+        client.close()
+
+    for packet_index in (1, 2):
+        name = throughput.sidecar_filename(packet_index)
+        assert (straight / name).read_bytes() == (resumed / name).read_bytes()
+    resumed_manifest = json.loads((resumed / "manifest.json").read_text())
+    assert resumed_manifest["packet_count"] == 2
+    assert resumed_manifest["row_count"] == 2
+    assert resumed_manifest["mcp_transport_attestation"]["server_identity_call_count"] == 1
+
+
+def test_runner_leaves_missing_progress_window_for_frozen_compiler_to_self_heal(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "missing-progress")
+    output = parent / "evidence"
+    throughput.resume_root_for(output).mkdir(mode=0o700)
+    client = _client(tmp_path / "client-missing-progress")
+    try:
+        _RUNNER._normalize_resume_identity_ledger(output, client)
+        packets, flags, bindings = _inputs()
+        manifest = compiler.compile_sidecar_bundle_resumable(
+            packets,
+            client,
+            output,
+            residual_lane_packets=flags,
+            packet_bindings=bindings,
+            source_package_binding=None,
+        )
+    finally:
+        client.close()
+
+    assert manifest["packet_count"] == 2
+    assert manifest["row_count"] == 2
+    assert output.is_dir()
+    assert not throughput.resume_root_for(output).exists()
+
+
+def test_runner_normalization_rejects_concurrent_owner_before_rewriting_progress(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "normalizer-lock")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError):
+        _run(tmp_path / "client-first-lock", output, interrupt_after_packet=1)
+    progress_path = throughput.resume_root_for(output) / throughput.PROGRESS_NAME
+    before = progress_path.read_bytes()
+
+    client = _client(tmp_path / "client-second-lock")
+    try:
+        with throughput.exclusive_resume_lock(throughput.resume_root_for(output)):
+            with pytest.raises(throughput.ThroughputResumeError, match="compiler_lock_held"):
+                _RUNNER._normalize_resume_identity_ledger(output, client)
+    finally:
+        client.close()
+    assert progress_path.read_bytes() == before
+
+
+def test_runner_rejects_legacy_identity_drift_before_rewriting_progress(tmp_path: Path) -> None:
+    parent = _private_parent(tmp_path, "identity-drift")
+    output = parent / "evidence"
+    with pytest.raises(RuntimeError):
+        _run(tmp_path / "client-first-drift", output, interrupt_after_packet=1)
+    _append_legacy_identity_calls(output, count=1, response_sha256="d" * 64)
+    progress_path = throughput.resume_root_for(output) / throughput.PROGRESS_NAME
+    before = progress_path.read_bytes()
+
+    client = _client(tmp_path / "client-second-drift")
+    try:
+        with pytest.raises(_RUNNER.RunnerError, match="resume_identity_drift"):
+            _RUNNER._normalize_resume_identity_ledger(output, client)
+    finally:
+        client.close()
+    assert progress_path.read_bytes() == before
 
 
 @pytest.mark.parametrize("entry_type", ("file", "symlink"))


### PR DESCRIPTION
Refs #6375.\n\nNormalizes identical validation-only Sources identity records in the checkpoint-safe outer runner before the unchanged frozen compiler resumes. The normalization holds the existing exclusive resume lock, preserves the missing-progress self-heal window, verifies receipt integrity and current identity, fails closed on drift, and atomically re-signs only the text-free progress receipt. It does not change sidecars, compiler/resume modules, validator, protocol, denominator, endpoint, disk floors, or labeling.\n\nVerification:\n- 116 focused tests passed\n- Ruff passed\n- git diff --check passed\n- Independent cross-family Claude Sonnet review: no material findings after two findings were fixed and re-reviewed