### PR TITLE
ci: run repo-invariant guards + xdist parity in the PR tier (#7250)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,17 +953,7 @@ jobs:
         run: .venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main
 
       - name: Check DB-free Atlas manifest freshness
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            .venv/bin/python scripts/lexicon/check_manifest_freshness.py \
-              --pr-scoped --base-ref "$BASE_SHA" --head-ref "$HEAD_SHA"
-          else
-            .venv/bin/python scripts/lexicon/check_manifest_freshness.py
-          fi
+        run: .venv/bin/python scripts/lexicon/check_manifest_freshness.py
 
       # Root-cause guard for the #3631 empty-atlas regression: a manifest
       # committed without enrichment renders an empty Atlas while the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,7 @@ jobs:
           run_tests() {
             local label="$1"
             .venv/bin/python -m pytest \
+              -n auto --dist=loadfile \
               --strict-markers --timeout=120 --timeout-method=thread --durations=10 \
               -m 'not atlas_release and not slow' \
               "${test_files[@]}" 2>&1 | tee "ci-artifacts/fastlane-pytest-${label}.log"

--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -64,6 +64,8 @@ def is_repo_invariant_trigger(path: str) -> bool:
         or fnmatchcase(candidate.name, "requirements*.txt")
         or path == ".github/workflows/ci.yml"
         or path == "scripts/ci/fastlane_always_tests.txt"
+        or candidate.suffix == ".sh"
+        or path == "services.sh"
         or path.startswith("tests/fixtures/")
         or path in {
             "site/src/data/lexicon-manifest.fingerprint.json",

--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -65,6 +65,10 @@ def is_repo_invariant_trigger(path: str) -> bool:
         or path == ".github/workflows/ci.yml"
         or path == "scripts/ci/fastlane_always_tests.txt"
         or path.startswith("tests/fixtures/")
+        or path in {
+            "site/src/data/lexicon-manifest.fingerprint.json",
+            "site/src/data/lexicon-manifest.pointer.json",
+        }
     )
 
 

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -8,6 +8,7 @@ tests/test_fleet_routing_open_model_data_import_guard.py
 tests/test_frontend_change_scope.py
 tests/test_lexicon_manifest_fingerprint.py
 tests/test_lint_test_assertions.py
+tests/test_path_safety.py
 tests/test_repo_invariant_fastlane.py
 tests/test_subprocess_timeout_guard.py
 tests/test_threshold_source_of_truth.py

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -1,7 +1,13 @@
+tests/ai_agent_bridge/test_module_identity.py
+tests/api/test_import_pinning.py
+tests/test_ask_opencode.py
+tests/test_bio_preparation_ci_routing.py
 tests/test_ci_changed_tests.py
 tests/test_cyrillic_roundtrip_invariant.py
 tests/test_fleet_routing_open_model_data_import_guard.py
 tests/test_frontend_change_scope.py
+tests/test_lexicon_manifest_fingerprint.py
 tests/test_lint_test_assertions.py
+tests/test_repo_invariant_fastlane.py
 tests/test_subprocess_timeout_guard.py
 tests/test_threshold_source_of_truth.py

--- a/scripts/lexicon/check_manifest_freshness.py
+++ b/scripts/lexicon/check_manifest_freshness.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -16,10 +14,7 @@ if str(ROOT) not in sys.path:
 
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, build_fingerprint, sidecar_payload
 
-LEXICON_PATH_PREFIX = "scripts/lexicon/"
-DEFAULT_GIT_TIMEOUT_SECONDS: float = 30.0
-FINGERPRINT_SIDECAR_PATH = "site/src/data/lexicon-manifest.fingerprint.json"
-GIT_SCOPE_ENV_VARS = ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_WORK_TREE")
+FINGERPRINT_REFRESH_COMMAND = "python -m scripts.lexicon.manifest_fingerprint --write"
 
 
 def _no_duplicate_keys(pairs: list[tuple[str, object]]) -> dict:
@@ -86,44 +81,18 @@ def _normalized_sidecar(payload: object) -> dict | None:
     }
 
 
-def _git_env() -> dict[str, str]:
-    """Return an environment that lets Git resolve the requested repository."""
-    env = os.environ.copy()
-    for name in GIT_SCOPE_ENV_VARS:
-        env.pop(name, None)
-    return env
-
-
-def pr_touches_manifest_scope(*, root: Path, base_ref: str, head_ref: str = "HEAD") -> bool:
-    """Return whether a PR changes lexicon code or the fingerprint sidecar."""
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "--no-renames", base_ref, head_ref, "--"],
-        cwd=root,
-        check=True,
-        capture_output=True,
-        text=True,
-        env=_git_env(),
-        timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
-    )
-    return any(
-        path.startswith(LEXICON_PATH_PREFIX) or path == FINGERPRINT_SIDECAR_PATH
-        for path in result.stdout.splitlines()
-    )
-
-
 def check_freshness(
     *,
     root: Path = ROOT,
     fingerprint_path: Path = DEFAULT_FINGERPRINT,
-    pr_scoped: bool = False,
-    base_ref: str = "origin/main",
-    head_ref: str = "HEAD",
 ) -> int:
     current = build_fingerprint(root)
     if not fingerprint_path.exists():
         print(
             "::error::Atlas manifest freshness sidecar is missing; "
-            "run `make atlas` locally and commit site/src/data/lexicon-manifest.fingerprint.json."
+            f"run `{FINGERPRINT_REFRESH_COMMAND}` locally and commit "
+            "site/src/data/lexicon-manifest.fingerprint.json. "
+            "Use `make atlas` when the Atlas manifest content itself changed."
         )
         print("# TODO(#3150): dictionary DB/cache version drift is out of scope until CI can access #2928 data.")
         return 2
@@ -133,31 +102,10 @@ def check_freshness(
     except (json.JSONDecodeError, ValueError):
         committed = None
     if committed != sidecar_payload(current):
-        if pr_scoped:
-            try:
-                touches_manifest_scope = pr_touches_manifest_scope(
-                    root=root,
-                    base_ref=base_ref,
-                    head_ref=head_ref,
-                )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
-                detail = error.stderr.strip() if isinstance(error, subprocess.CalledProcessError) else str(error)
-                print(
-                    "::error::Atlas manifest freshness could not determine PR-scoped "
-                    f"changes against {base_ref!r}: {detail}"
-                )
-                return 2
-            if not touches_manifest_scope:
-                print(
-                    "::notice::Atlas manifest freshness sidecar differs, but this PR "
-                    "does not modify lexicon code or the fingerprint sidecar "
-                    f"relative to {base_ref}; "
-                    "allowing unrelated drift."
-                )
-                return 0
         print(
-            "::error::Atlas manifest stale vs lexicon code; "
-            "run `make atlas` locally and commit the updated manifest + fingerprint."
+            "::error::Atlas manifest stale vs lexicon code (fingerprint sidecar); "
+            f"run `{FINGERPRINT_REFRESH_COMMAND}` locally and commit the updated sidecar. "
+            "Use `make atlas` when the Atlas manifest content itself changed."
         )
         print("committed: <invalid or stale sidecar>")
         print(f"current:   {current['fingerprint']}")
@@ -182,21 +130,6 @@ def main() -> int:
         default=DEFAULT_FINGERPRINT,
         help="Committed fingerprint sidecar.",
     )
-    parser.add_argument(
-        "--pr-scoped",
-        action="store_true",
-        help="Allow stale sidecars only when this PR did not change scripts/lexicon/.",
-    )
-    parser.add_argument(
-        "--base-ref",
-        default="origin/main",
-        help="Git base ref used by --pr-scoped (default: origin/main).",
-    )
-    parser.add_argument(
-        "--head-ref",
-        default="HEAD",
-        help="Git head ref used by --pr-scoped (default: HEAD).",
-    )
     args = parser.parse_args()
     root = args.root.resolve()
     fingerprint = args.fingerprint
@@ -205,9 +138,6 @@ def main() -> int:
     return check_freshness(
         root=root,
         fingerprint_path=fingerprint,
-        pr_scoped=args.pr_scoped,
-        base_ref=args.base_ref,
-        head_ref=args.head_ref,
     )
 
 

--- a/scripts/lexicon/manifest_fingerprint.py
+++ b/scripts/lexicon/manifest_fingerprint.py
@@ -6,8 +6,10 @@ not have. This module fingerprints the lexicon source files CI can see.
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -96,3 +98,28 @@ def write_fingerprint(path: Path = DEFAULT_FINGERPRINT, *, root: Path = ROOT) ->
         encoding="utf-8",
     )
     return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Refresh only the DB-free lexicon-code fingerprint sidecar."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the current lexicon-code fingerprint sidecar",
+    )
+    args = parser.parse_args(argv)
+    if not args.write:
+        parser.error("--write is required to refresh the fingerprint sidecar")
+
+    payload = write_fingerprint()
+    print(
+        "Atlas lexicon fingerprint written: "
+        f"{payload['fingerprint']} "
+        f"({payload['stats']['lexicon_code_files']} lexicon code files)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -55,7 +55,7 @@
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
-        "sha256": "002fd1fa8d0d5647de50c49358409d91ee98b66456e3a8fa83013f77c7f0fb33"
+        "sha256": "6737fc9befb4e349e81011713ee8f7fc5c466aadbd34fdd318851391250dd08a"
       },
       {
         "path": "scripts/lexicon/check_manifest_vocabulary_coverage.py",
@@ -159,7 +159,7 @@
       },
       {
         "path": "scripts/lexicon/manifest_fingerprint.py",
-        "sha256": "ec8b76e8979fbbb533f31e8fddc2933fb354ae943203f17d8d7b4648e4bde796"
+        "sha256": "35d3564cc7e75c26d20ecfcd18699410183292ca58ff61d9cdd8663311fa82cb"
       },
       {
         "path": "scripts/lexicon/measure_manifest_coverage.py",

--- a/tests/ai_agent_bridge/test_module_identity.py
+++ b/tests/ai_agent_bridge/test_module_identity.py
@@ -20,6 +20,10 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.repo_invariant
+
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
 _REPO_ROOT = _TESTS_ROOT.parent
 _SELF = Path(__file__).resolve()

--- a/tests/api/test_import_pinning.py
+++ b/tests/api/test_import_pinning.py
@@ -8,10 +8,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from scripts.api.main import app
 from scripts.api.preload import DYNAMIC_LOADERS, OPTIONAL_MODULES, PRELOAD_MODULES
+
+pytestmark = pytest.mark.repo_invariant
 
 
 def resolve_import_names(node: ast.Import | ast.ImportFrom, file_path: Path) -> list[str]:

--- a/tests/test_ask_opencode.py
+++ b/tests/test_ask_opencode.py
@@ -6,6 +6,8 @@ import pytest
 
 from scripts.ai_agent_bridge._opencode import OPENCODE_DEFAULT_MODEL, _invoke_opencode
 
+pytestmark = pytest.mark.repo_invariant
+
 
 def test_opencode_default_model_is_cheap_and_guard_allowed():
     from scripts.ai_agent_bridge.routing_guard import assert_model_routing_allowed

--- a/tests/test_bio_preparation_ci_routing.py
+++ b/tests/test_bio_preparation_ci_routing.py
@@ -34,6 +34,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 
+pytestmark = pytest.mark.repo_invariant
+
 VALIDATOR_STEP_NAME = "Validate BIO preparation capsules and active holds"
 CONTRACTS_TIER_IF = "github.event_name != 'pull_request'"
 LANDING_EVENTS = ("merge_group", "push")

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -74,6 +74,8 @@ def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
         "requirements-dev.txt",
         ".github/workflows/ci.yml",
         "scripts/ci/fastlane_always_tests.txt",
+        "site/src/data/lexicon-manifest.fingerprint.json",
+        "site/src/data/lexicon-manifest.pointer.json",
         "tests/fixtures/example.json",
     ):
         assert changed_tests.select_test_modules([path], include_repo_invariants=True) == sorted(_manifest())

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -68,6 +68,13 @@ def test_docs_only_change_stays_empty_with_repo_invariant_opt_in() -> None:
     assert changed_tests.select_test_modules(["docs/foo.md"], include_repo_invariants=True) == []
 
 
+def test_shell_changes_trigger_repo_invariant_manifest_but_docs_do_not() -> None:
+    for path in ("scripts/cleanup.sh", "services.sh"):
+        assert changed_tests.select_test_modules([path], include_repo_invariants=True) == sorted(_manifest())
+
+    assert changed_tests.select_test_modules(["docs/cleanup.md"], include_repo_invariants=True) == []
+
+
 def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
     for path in (
         "pyproject.toml",

--- a/tests/test_ci_shard_partition.py
+++ b/tests/test_ci_shard_partition.py
@@ -408,6 +408,7 @@ def test_required_lanes_exclude_live_model_setup_and_fastlane_matches_shard_inst
     assert all("-no-live-ml" in str(step) for step in fastlane_cache_steps)
     assert "No module named" in fastlane_run["run"]
     assert "CPU torch" in fastlane_run["run"]
+    assert "-n auto --dist=loadfile" in fastlane_run["run"]
     names = [step.get("name", "") for step in fastlane_steps]
     assert names.index("Select directly changed test modules") < names.index(
         "Install fastlane test dependencies (lock minus live ML)"

--- a/tests/test_lexicon_manifest_fingerprint.py
+++ b/tests/test_lexicon_manifest_fingerprint.py
@@ -3,13 +3,16 @@ import os
 import subprocess
 from pathlib import Path
 
-from scripts.lexicon.check_manifest_freshness import (
-    GIT_SCOPE_ENV_VARS,
-    check_freshness,
-    pr_touches_manifest_scope,
-)
+import pytest
+
+from scripts.lexicon.check_manifest_freshness import check_freshness
 from scripts.lexicon.check_manifest_vocabulary_coverage import check_vocabulary_coverage
 from scripts.lexicon.manifest_fingerprint import build_fingerprint, sidecar_payload, write_fingerprint
+
+pytestmark = pytest.mark.repo_invariant
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_GIT_SCOPE_ENV_VARS = ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_WORK_TREE")
 
 
 def _fixture_repo(tmp_path: Path) -> Path:
@@ -31,7 +34,7 @@ def _fixture_repo(tmp_path: Path) -> Path:
 
 def _git(root: Path, *args: str) -> None:
     env = os.environ.copy()
-    for name in GIT_SCOPE_ENV_VARS:
+    for name in _GIT_SCOPE_ENV_VARS:
         env.pop(name, None)
     subprocess.run(
         ["git", "-c", "core.hooksPath=/dev/null", *args],
@@ -114,9 +117,9 @@ def test_manifest_fingerprint_ignores_vocab_lemma_churn(tmp_path: Path) -> None:
 
 
 def test_write_fingerprint_is_idempotent(tmp_path: Path) -> None:
-    # The pre-commit hook regenerates the sidecar then `git diff --exit-code`s it.
-    # If write_fingerprint were non-deterministic, that gate would block every
-    # commit. Guarantee re-running on unchanged code yields byte-identical output.
+    # The PR-tier repo-invariant guard compares the committed sidecar with the
+    # real lexicon tree. If write_fingerprint were non-deterministic, that guard
+    # would report drift on every run. Guarantee byte-identical output.
     root = _fixture_repo(tmp_path)
     sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
 
@@ -141,7 +144,7 @@ def test_sidecar_omits_aggregate_fields_that_cause_concurrent_conflicts(tmp_path
 
 def test_write_fingerprint_changes_after_lexicon_edit(tmp_path: Path) -> None:
     # Conversely, editing lexicon code MUST change the regenerated sidecar — that
-    # is the drift the pre-commit `git diff --exit-code` is meant to catch.
+    # is the drift the PR-tier repo-invariant guard is meant to catch.
     root = _fixture_repo(tmp_path)
     sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
 
@@ -165,6 +168,12 @@ def test_manifest_freshness_check_passes_on_matching_sidecar(tmp_path: Path, cap
     assert "Atlas manifest freshness OK" in output
 
 
+def test_committed_manifest_fingerprint_matches_real_lexicon_tree(capsys) -> None:
+    """The PR tier must catch drift in the committed sidecar itself."""
+    assert check_freshness(root=REPO_ROOT) == 0
+    assert "Atlas manifest freshness OK" in capsys.readouterr().out
+
+
 def test_manifest_freshness_check_fails_on_mismatched_sidecar(tmp_path: Path, capsys) -> None:
     root = _fixture_repo(tmp_path)
     sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
@@ -174,6 +183,8 @@ def test_manifest_freshness_check_fails_on_mismatched_sidecar(tmp_path: Path, ca
     assert check_freshness(root=root, fingerprint_path=sidecar) == 2
     output = capsys.readouterr().out
     assert "Atlas manifest stale vs lexicon code" in output
+    assert "python -m scripts.lexicon.manifest_fingerprint --write" in output
+    assert "make atlas" in output
     assert "dictionary DB/cache version drift is out of scope" in output
 
 
@@ -206,64 +217,6 @@ def test_manifest_freshness_rejects_conflicting_union_duplicate_record(tmp_path:
     sidecar.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
     assert check_freshness(root=root, fingerprint_path=sidecar) == 2
-
-
-def test_pr_scoped_freshness_allows_unrelated_drift(tmp_path: Path, capsys) -> None:
-    root = _fixture_repo(tmp_path)
-    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
-    write_fingerprint(sidecar, root=root)
-    _commit_fixture_repo(root)
-    (root / "README.md").write_text("unrelated PR change\n", encoding="utf-8")
-    _git(root, "add", "README.md")
-    _git(root, "commit", "--quiet", "-m", "docs change")
-    (root / "scripts" / "lexicon" / "beta.py").write_text("VALUE = 200\n", encoding="utf-8")
-
-    assert pr_touches_manifest_scope(root=root, base_ref="base") is False
-    assert check_freshness(
-        root=root,
-        fingerprint_path=sidecar,
-        pr_scoped=True,
-        base_ref="base",
-    ) == 0
-    assert "allowing unrelated drift" in capsys.readouterr().out
-
-
-def test_pr_scoped_freshness_fails_when_pr_changes_lexicon(tmp_path: Path, capsys) -> None:
-    root = _fixture_repo(tmp_path)
-    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
-    write_fingerprint(sidecar, root=root)
-    _commit_fixture_repo(root)
-    (root / "scripts" / "lexicon" / "beta.py").write_text("VALUE = 200\n", encoding="utf-8")
-    _git(root, "add", "scripts/lexicon/beta.py")
-    _git(root, "commit", "--quiet", "-m", "lexicon change")
-
-    assert pr_touches_manifest_scope(root=root, base_ref="base") is True
-    assert check_freshness(
-        root=root,
-        fingerprint_path=sidecar,
-        pr_scoped=True,
-        base_ref="base",
-    ) == 2
-    assert "Atlas manifest stale vs lexicon code" in capsys.readouterr().out
-
-
-def test_pr_scoped_freshness_fails_when_pr_changes_sidecar(tmp_path: Path, capsys) -> None:
-    root = _fixture_repo(tmp_path)
-    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
-    write_fingerprint(sidecar, root=root)
-    _commit_fixture_repo(root)
-    sidecar.write_text('{"fingerprint": "stale"}\n', encoding="utf-8")
-    _git(root, "add", sidecar.relative_to(root).as_posix())
-    _git(root, "commit", "--quiet", "-m", "sidecar change")
-
-    assert pr_touches_manifest_scope(root=root, base_ref="base") is True
-    assert check_freshness(
-        root=root,
-        fingerprint_path=sidecar,
-        pr_scoped=True,
-        base_ref="base",
-    ) == 2
-    assert "Atlas manifest stale vs lexicon code" in capsys.readouterr().out
 
 
 def test_union_merge_keeps_independent_fingerprint_updates_fresh(tmp_path: Path) -> None:

--- a/tests/test_lexicon_timeouts.py
+++ b/tests/test_lexicon_timeouts.py
@@ -47,29 +47,6 @@ def test_anchor_curation_evidence_audit_entries_timeout() -> None:
             ace.audit_entries()
 
 
-def test_check_manifest_freshness_pr_touches_manifest_scope_timeout(tmp_path: Path) -> None:
-    from scripts.lexicon import check_manifest_freshness as cmf
-
-    calls: list[dict] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append({"cmd": cmd, **kwargs})
-        return _completed(cmd, returncode=0, stdout="scripts/lexicon/foo.py\n")
-
-    with patch("subprocess.run", side_effect=fake_run):
-        assert cmf.pr_touches_manifest_scope(root=tmp_path, base_ref="origin/main") is True
-
-    assert len(calls) == 1
-    assert calls[0]["timeout"] == cmf.DEFAULT_GIT_TIMEOUT_SECONDS
-
-    with patch(
-        "subprocess.run",
-        side_effect=subprocess.TimeoutExpired(["git", "diff"], cmf.DEFAULT_GIT_TIMEOUT_SECONDS),
-    ):
-        with pytest.raises(subprocess.TimeoutExpired):
-            cmf.pr_touches_manifest_scope(root=tmp_path, base_ref="origin/main")
-
-
 def test_check_manifest_vocabulary_coverage_changed_vocab_modules_timeout(tmp_path: Path) -> None:
     from scripts.lexicon import check_manifest_vocabulary_coverage as cmvc
 

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -9,6 +9,8 @@ import pytest
 from scripts.hygiene import lint_raw_rm_rf
 from scripts.path_safety import assert_delete_target
 
+pytestmark = pytest.mark.repo_invariant
+
 
 def test_delete_guard_allows_descendants_of_standard_and_approved_roots(
     tmp_path: Path,

--- a/tests/test_repo_invariant_fastlane.py
+++ b/tests/test_repo_invariant_fastlane.py
@@ -1,0 +1,390 @@
+"""Keep repo-wide invariant tests reachable from the PR-tier fastlane.
+
+The detector is deliberately coarse: a test that resolves the real checkout
+and walks a ``scripts/`` or ``tests/`` tree, or parses files discovered there,
+must be listed in the fastlane manifest or carry an explicit exemption. The
+adjudication table is intentionally local and reasoned so a new exception is
+visible in the same review as the scope change.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_invariant
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = REPO_ROOT / "tests"
+FASTLANE_MANIFEST = REPO_ROOT / "scripts" / "ci" / "fastlane_always_tests.txt"
+
+_ROOT_IDENTIFIERS = frozenset(
+    {
+        "REPO_ROOT",
+        "_REPO_ROOT",
+        "PROJECT_ROOT",
+        "_PROJECT_ROOT",
+        "TESTS_ROOT",
+        "_TESTS_ROOT",
+        "SCRIPTS_ROOT",
+        "_SCRIPTS_ROOT",
+        "CI_WORKFLOW",
+    }
+)
+_ROOTISH_PARAMETERS = frozenset({"root", "repo_root", "project_root", "tests_root", "scripts_root"})
+_TREE_SEGMENTS = frozenset({"scripts", "tests", ".github"})
+_DISCOVERY_METHODS = frozenset({"glob", "rglob", "walk"})
+
+# Every named adjudication from the #7250 critique is recorded here, including
+# positive decisions, so adding a candidate cannot silently become an omission.
+# The reason is one line by policy; it is also rendered in a failure below.
+ADJUDICATIONS: dict[str, tuple[str, str]] = {
+    "tests/orchestration/test_reap_worktrees.py": (
+        "exempt",
+        "marked slow and performs a broad production deletion-call-site scan",
+    ),
+    "tests/test_ask_opencode.py": (
+        "listed",
+        "cheap deterministic scan of the script-path bridge package",
+    ),
+    "tests/test_work_privacy.py": (
+        "exempt",
+        "private-boundary canary sweep stays out of the public PR fastlane",
+    ),
+    "tests/test_research_registry.py": (
+        "exempt",
+        "committed-registry checks use fixed inputs plus synthetic temporary projects",
+    ),
+    "tests/test_research_registry_api.py": (
+        "exempt",
+        "static dependency check parses two fixed modules, not a discovered tree",
+    ),
+    "tests/test_python_qg_correction_loop.py": (
+        "exempt",
+        "parses inspect.getsource and synthetic QG output rather than repository files",
+    ),
+    "tests/test_llm_reviewer_dispatch.py": (
+        "exempt",
+        "large review-bakeoff and fixture scan is outside the PR-tier budget",
+    ),
+    "tests/test_gemini_adapter_auth.py": (
+        "exempt",
+        "large adapter/auth suite parses one imported module and uses live-lane setup",
+    ),
+    "tests/test_atlas_conformance.py": (
+        "exempt",
+        "socket-guard test is intentionally landing-tier-only per #7248",
+    ),
+    "tests/test_agent_fleet_tooling_guardrails.py": (
+        "exempt",
+        "global and private guidance-surface audit belongs to the fleet tooling lane",
+    ),
+    "tests/test_fleet_comms_launcher_awareness.py": (
+        "exempt",
+        "cross-plane launcher audit requires fleet-comms surfaces outside the public PR tier",
+    ),
+    "tests/test_launcher_contract.py": (
+        "exempt",
+        "launcher lifecycle and subprocess contract suite is an integration-heavy fleet lane",
+    ),
+    "tests/test_lint_prompts.py": (
+        "exempt",
+        "prompt-template and retired-template inventory is a documentation policy lane",
+    ),
+    "tests/api/test_release_snapshot.py": (
+        "exempt",
+        "release snapshot service and subprocess integration suite is outside the PR-tier budget",
+    ),
+    "tests/orchestration/test_thread_restart_e2e.py": (
+        "exempt",
+        "subprocess-heavy restart fixture bootstrap is outside the PR-tier budget",
+    ),
+    "tests/test_dashboards.py": (
+        "exempt",
+        "dashboard and API-surface checks cover fixed product assets, not the whole checkout",
+    ),
+    "tests/test_layerb_candidates.py": (
+        "exempt",
+        "candidate replay checks are fixture-bound and belong with the Layer-B evaluation lane",
+    ),
+    "tests/test_paths_filter_fail_open.py": (
+        "exempt",
+        "fixed action/workflow fail-open checks are covered by the workflow policy lane",
+    ),
+    "tests/test_prompt_template_render.py": (
+        "exempt",
+        "single fixed prompt-phase template sweep is not a whole-repository invariant",
+    ),
+    "tests/test_workflow_head_concurrency.py": (
+        "exempt",
+        "fixed workflow concurrency expectations are covered by the workflow policy lane",
+    ),
+}
+
+_EXEMPTIONS = {path for path, (disposition, _reason) in ADJUDICATIONS.items() if disposition == "exempt"}
+
+
+def _manifest() -> list[str]:
+    return [
+        line.strip()
+        for line in FASTLANE_MANIFEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _target_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Set, ast.Tuple)):
+        return {item.id for item in node.elts if isinstance(item, ast.Name)}
+    return set()
+
+
+def _has_tree_segment(node: ast.AST | None) -> bool:
+    if node is None:
+        return False
+    return any(
+        isinstance(descendant, ast.Constant)
+        and isinstance(descendant.value, str)
+        and (
+            descendant.value in _TREE_SEGMENTS
+            or any(descendant.value.startswith(f"{segment}/") for segment in _TREE_SEGMENTS)
+        )
+        for descendant in ast.walk(node)
+    )
+
+
+def _is_root_path(node: ast.AST | None, root_aliases: set[str]) -> bool:
+    if node is None:
+        return False
+    if isinstance(node, ast.Name):
+        return node.id in root_aliases or node.id in _ROOT_IDENTIFIERS
+    if isinstance(node, ast.Call):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "Path"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "__file__"
+        ):
+            return True
+        return isinstance(node.func, ast.Attribute) and node.func.attr in {"absolute", "joinpath", "resolve"} and _is_root_path(
+            node.func.value, root_aliases
+        )
+    if isinstance(node, ast.Attribute):
+        return node.attr in {"parent", "parents"} and _is_root_path(node.value, root_aliases)
+    if isinstance(node, ast.Subscript):
+        return _is_root_path(node.value, root_aliases)
+    return False
+
+
+def _is_tree_path(node: ast.AST | None, root_aliases: set[str], tree_aliases: set[str]) -> bool:
+    if node is None:
+        return False
+    if isinstance(node, ast.Name):
+        return node.id in tree_aliases or node.id in root_aliases
+    if isinstance(node, ast.Call):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "Path"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "__file__"
+        ):
+            return True
+        if isinstance(node.func, ast.Name) and node.func.id == "sorted" and node.args:
+            return _is_tree_path(node.args[0], root_aliases, tree_aliases)
+        if isinstance(node.func, ast.Attribute) and node.func.attr in {"absolute", "joinpath", "resolve"}:
+            return _is_tree_path(node.func.value, root_aliases, tree_aliases)
+        return False
+    if isinstance(node, ast.Attribute):
+        return node.attr in {"parent", "parents"} and _is_tree_path(node.value, root_aliases, tree_aliases)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        left_is_root = (
+            _is_root_path(node.left, root_aliases)
+            or _is_tree_path(node.left, root_aliases, tree_aliases)
+            or (isinstance(node.left, ast.Name) and node.left.id in _ROOTISH_PARAMETERS)
+        )
+        return left_is_root and _has_tree_segment(node)
+    if isinstance(node, ast.Subscript):
+        return _is_tree_path(node.value, root_aliases, tree_aliases)
+    if isinstance(node, (ast.List, ast.Set, ast.Tuple)):
+        return any(_is_tree_path(item, root_aliases, tree_aliases) for item in node.elts)
+    return False
+
+
+def _repo_tree_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
+    root_aliases = set(_ROOT_IDENTIFIERS)
+    tree_aliases: set[str] = set()
+
+    for _ in range(8):
+        changed = False
+        for statement in ast.walk(tree):
+            if isinstance(statement, ast.Assign):
+                value = statement.value
+                targets = statement.targets
+            elif isinstance(statement, ast.AnnAssign):
+                value = statement.value
+                targets = [statement.target]
+            else:
+                continue
+            names = {name for target in targets for name in _target_names(target)}
+            if not names:
+                continue
+            if _is_root_path(value, root_aliases) and not names <= root_aliases:
+                root_aliases.update(names)
+                changed = True
+            if _is_tree_path(value, root_aliases, tree_aliases) and not names <= tree_aliases:
+                tree_aliases.update(names)
+                changed = True
+
+        for statement in ast.walk(tree):
+            if not isinstance(statement, ast.For) or not _is_tree_path(statement.iter, root_aliases, tree_aliases):
+                continue
+            names = _target_names(statement.target)
+            if not names <= tree_aliases:
+                tree_aliases.update(names)
+                changed = True
+        if not changed:
+            break
+
+    return root_aliases, tree_aliases
+
+
+def _contains_tree_path(node: ast.AST | None, root_aliases: set[str], tree_aliases: set[str]) -> bool:
+    if node is None:
+        return False
+    return any(_is_tree_path(descendant, root_aliases, tree_aliases) for descendant in ast.walk(node))
+
+
+def _is_discovered_path(node: ast.AST | None, root_aliases: set[str], tree_aliases: set[str]) -> bool:
+    """Use aliases or literal scripts/tests segments for high-recall discovery."""
+    return _contains_tree_path(node, root_aliases, tree_aliases) or _has_tree_segment(node)
+
+
+def _references_repo_tree(path: Path) -> bool:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return False
+
+    root_aliases, tree_aliases = _repo_tree_aliases(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in _DISCOVERY_METHODS
+            and _is_discovered_path(node.func.value, root_aliases, tree_aliases)
+        ):
+            return True
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "glob"
+            and node.func.attr == "glob"
+            and node.args
+            and _is_discovered_path(node.args[0], root_aliases, tree_aliases)
+        ):
+            return True
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "glob"
+            and node.args
+            and _is_discovered_path(node.args[0], root_aliases, tree_aliases)
+        ):
+            return True
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "os"
+            and node.func.attr == "walk"
+            and node.args
+            and _is_discovered_path(node.args[0], root_aliases, tree_aliases)
+        ):
+            return True
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "ast"
+            and node.func.attr == "parse"
+            and node.args
+            and _is_discovered_path(node.args[0], root_aliases, tree_aliases)
+        ):
+            return True
+
+    # Helpers can read a real tree into a string before passing it to ast.parse.
+    return bool(tree_aliases and "read_text" in path.read_text(encoding="utf-8") and any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "ast"
+        and node.func.attr == "parse"
+        for node in ast.walk(tree)
+    ))
+
+
+def _pytest_marks(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and node.attr in {"repo_invariant", "slow", "atlas_release"}
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "pytest"
+    }
+
+
+def test_repo_tree_invariants_are_listed_or_explicitly_exempted() -> None:
+    manifest = set(_manifest())
+    candidates = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in sorted(TESTS_ROOT.rglob("test_*.py"))
+        if _references_repo_tree(path)
+    }
+    uncovered = sorted(candidates - manifest - _EXEMPTIONS)
+    assert not uncovered, (
+        "repo-tree test modules are absent from fastlane_always_tests.txt and the exemption table: "
+        + ", ".join(uncovered)
+    )
+
+
+def test_fastlane_manifest_entries_are_fast_and_marked() -> None:
+    manifest = _manifest()
+    assert manifest == sorted(set(manifest)), "fastlane manifest must be sorted and duplicate-free"
+    assert manifest, "fastlane manifest must not be empty"
+    for entry in manifest:
+        path = REPO_ROOT / entry
+        assert path.is_file(), f"fastlane manifest entry does not exist: {entry}"
+        marks = _pytest_marks(path)
+        assert "repo_invariant" in marks, f"fastlane entry lacks repo_invariant marker: {entry}"
+        assert "slow" not in marks, f"fastlane entry carries deselected slow mark: {entry}"
+        assert "atlas_release" not in marks, f"fastlane entry carries deselected atlas_release mark: {entry}"
+
+
+def test_named_candidate_adjudications_are_explicit() -> None:
+    manifest = set(_manifest())
+    required = {
+        "tests/orchestration/test_reap_worktrees.py",
+        "tests/test_ask_opencode.py",
+        "tests/test_work_privacy.py",
+        "tests/test_research_registry.py",
+        "tests/test_research_registry_api.py",
+        "tests/test_python_qg_correction_loop.py",
+        "tests/test_llm_reviewer_dispatch.py",
+        "tests/test_gemini_adapter_auth.py",
+        "tests/test_atlas_conformance.py",
+    }
+    assert required <= ADJUDICATIONS.keys()
+    for path, (disposition, reason) in ADJUDICATIONS.items():
+        assert reason.strip(), f"missing adjudication reason: {path}"
+        assert disposition in {"listed", "exempt"}, f"invalid adjudication: {path}"
+        if disposition == "listed":
+            assert path in manifest, f"adjudicated listed module is absent from fastlane: {path}"
+        else:
+            assert path not in manifest, f"adjudicated exemption is listed in fastlane: {path}"

--- a/tests/test_repo_invariant_fastlane.py
+++ b/tests/test_repo_invariant_fastlane.py
@@ -36,6 +36,10 @@ _ROOT_IDENTIFIERS = frozenset(
 _ROOTISH_PARAMETERS = frozenset({"root", "repo_root", "project_root", "tests_root", "scripts_root"})
 _TREE_SEGMENTS = frozenset({"scripts", "tests", ".github"})
 _DISCOVERY_METHODS = frozenset({"glob", "rglob", "walk"})
+_SCANNER_PACKAGES = ("scripts.hygiene", "scripts.lint", "scripts.ci", "scripts.audit")
+_SCANNER_NAME_PREFIXES = ("find_", "lint_")
+_SCANNER_ROOT_PARAMETERS = _ROOTISH_PARAMETERS | {"primary_root", "repo"}
+_SCANNER_DISCOVERY_METHODS = _DISCOVERY_METHODS | {"iterdir"}
 
 # Every named adjudication from the #7250 critique is recorded here, including
 # positive decisions, so adding a candidate cannot silently become an omission.
@@ -264,11 +268,144 @@ def _is_discovered_path(node: ast.AST | None, root_aliases: set[str], tree_alias
     return _contains_tree_path(node, root_aliases, tree_aliases) or _has_tree_segment(node)
 
 
+def _dotted_name(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else None
+    return None
+
+
+def _is_scanner_package(module: str) -> bool:
+    return any(module == package or module.startswith(f"{package}.") for package in _SCANNER_PACKAGES)
+
+
+def _module_source_path(module: str) -> Path | None:
+    candidate = REPO_ROOT / f"{module.replace('.', '/')}.py"
+    return candidate if candidate.is_file() else None
+
+
+def _function_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    arguments = node.args
+    return {
+        argument.arg
+        for argument in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs)
+    }
+
+
+def _function_calls(node: ast.AST) -> set[str]:
+    called: set[str] = set()
+    for descendant in ast.walk(node):
+        if not isinstance(descendant, ast.Call):
+            continue
+        if isinstance(descendant.func, ast.Name):
+            called.add(descendant.func.id)
+    return called
+
+
+def _function_reaches_directory_discovery(
+    function_name: str,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+    visiting: set[str] | None = None,
+) -> bool:
+    """Follow local helper calls to recognize imported directory scanners."""
+    function = functions.get(function_name)
+    if function is None:
+        return False
+    active = set() if visiting is None else set(visiting)
+    if function_name in active:
+        return False
+    active.add(function_name)
+
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr in _SCANNER_DISCOVERY_METHODS:
+            return True
+        if isinstance(node.func, ast.Name) and node.func.id == "glob":
+            return True
+
+    return any(
+        _function_reaches_directory_discovery(callee, functions, active)
+        for callee in _function_calls(function)
+        if callee in functions
+    )
+
+
+def _module_exposes_repo_scanner(module: str, helper_name: str) -> bool:
+    if not helper_name.startswith(_SCANNER_NAME_PREFIXES):
+        return False
+    source_path = _module_source_path(module)
+    if source_path is None:
+        return False
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    except SyntaxError:
+        return False
+    if not _has_tree_segment(tree):
+        return False
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    function = functions.get(helper_name)
+    return bool(
+        function
+        and _function_parameters(function) & _SCANNER_ROOT_PARAMETERS
+        and _function_reaches_directory_discovery(helper_name, functions)
+    )
+
+
+def _imported_scanner_bindings(tree: ast.AST) -> dict[str, tuple[str, str | None]]:
+    bindings: dict[str, tuple[str, str | None]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and _is_scanner_package(node.module):
+            for alias in node.names:
+                if alias.name != "*":
+                    bindings[alias.asname or alias.name] = (node.module, alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_scanner_package(alias.name) and alias.asname:
+                    bindings[alias.asname] = (alias.name, None)
+    return bindings
+
+
+def _references_imported_repo_scanner(tree: ast.AST) -> bool:
+    bindings = _imported_scanner_bindings(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            binding = bindings.get(node.func.id)
+            if binding:
+                module, imported_name = binding
+                if imported_name and _module_exposes_repo_scanner(module, imported_name):
+                    return True
+            continue
+
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        receiver = _dotted_name(node.func.value)
+        binding = bindings.get(receiver or "")
+        if not binding:
+            continue
+        module, imported_name = binding
+        imported_module = module if imported_name is None else f"{module}.{imported_name}"
+        if _module_exposes_repo_scanner(imported_module, node.func.attr):
+            return True
+    return False
+
+
 def _references_repo_tree(path: Path) -> bool:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     except SyntaxError:
         return False
+
+    if _references_imported_repo_scanner(tree):
+        return True
 
     root_aliases, tree_aliases = _repo_tree_aliases(tree)
     for node in ast.walk(tree):
@@ -352,6 +489,10 @@ def test_repo_tree_invariants_are_listed_or_explicitly_exempted() -> None:
         "repo-tree test modules are absent from fastlane_always_tests.txt and the exemption table: "
         + ", ".join(uncovered)
     )
+
+
+def test_imported_repo_scanner_is_a_repo_tree_candidate() -> None:
+    assert _references_repo_tree(REPO_ROOT / "tests" / "test_path_safety.py")
 
 
 def test_fastlane_manifest_entries_are_fast_and_marked() -> None:


### PR DESCRIPTION
## Summary

Implements the amended #7250 PR-tier protections:

- A: Added coarse repo-tree invariant detection, explicit adjudications, required fastlane entries, marker parity, and slow/atlas_release exclusions.
- B: Fastlane now runs with `-n auto --dist=loadfile`, matching merge-queue shard execution.
- C: Added a real normalized sidecar freshness guard, fingerprint-only refresh CLI, trigger coverage, and refreshed the committed sidecar.
- D: Removed the dead `--pr-scoped` checker path, arguments, and tests. The merge-group contracts job remains untouched.

## Acceptance evidence

Focused guards:

```text
29 passed in 5.64s
```

Manifest mutation:

```text
AssertionError: ... tests/api/test_import_pinning.py
1 failed, 2 passed in 5.34s
```

Fingerprint mutation by appending exactly one byte:

```text
1 scripts/lexicon/__init__.py
AssertionError: assert 2 == 0
1 failed in 0.48s
```

After restoration:

```text
0 scripts/lexicon/__init__.py
1 passed in 0.39s
```

Final fastlane parity, exact xdist invocation, run twice:

```text
232 passed in 21.58s
real 21.76

232 passed in 24.32s
real 24.51
```

Current #7249 nodes:

```text
2 passed in 2.26s
real 2.47
```

Pre-#7249 forms:

```text
2 failed in 2.66s
real 2.93
```

Other checks:

```text
ruff check scripts/ci: All checks passed!
tests/test_subprocess_timeout_guard.py: 8 passed in 3.99s
yaml ok
```

The requested broad `ruff check scripts/ci tests` remains blocked by 23 pre-existing diagnostics in untouched test files under local Ruff 0.16.3. The lock specifies Ruff 0.15.21; CI's Ruff job checks `scripts/` only.

PR-run wall-clock timing is pending because this environment could not push the branch.

## CLOBBER SELF-AUDIT

Every deleted line is intentional:

- `scripts/lexicon/check_manifest_freshness.py`: removed dead PR-scope Git helpers, scope constants, `pr_touches_manifest_scope`, PR-scoped function parameters, conditional bypass branch, and CLI arguments.
- `tests/test_lexicon_manifest_fingerprint.py`: removed the obsolete PR-scoped helper import and three PR-scoped tests; replaced stale pre-commit-hook documentation.
- `tests/test_lexicon_timeouts.py`: removed the timeout test for the deleted PR-scoped helper.
- No other deletions are accidental; the sidecar hash replacements are the regenerated source-of-truth values.

## Driver notes
- Design + kimi critique + binding amendments: #7250 comments (2026-08-24). Author lane: codex; CF: kimi at exact head.
- Driver re-ran acceptance in the primary env at 390cce1923: targeted guards 63 passed (-n 2); full always-list under the new fastlane invocation 232 passed / 22.8 s; `check_manifest_freshness.py` full mode OK; ruff (lock 0.15.x) clean on touched files; ci.yml yaml ok.
- Second commit `81ec32720d` (fourth kick class, #7112): `*.sh` / `services.sh` changes now trigger the invariant list (contract test added); `tests/test_path_safety.py` is on the always-list and marked `repo_invariant`; the meta-test also treats modules that import a tree-walking scanner helper (`find_*`/`lint_*` from `scripts.hygiene|lint|ci|audit`) as repo-tree candidates, so helper-hidden walks can no longer slip off the list. Driver re-ran acceptance in the primary env: 28 targeted passed (-n 2); always-list 248 passed / 43.5 s under the fastlane xdist invocation; ruff clean.

Closes #7250. Refs #7042 #7213 #7247 #7246 #7249 #7112.

