### PR TITLE
feat(atlas): add e2u.org.ua UK-headword translation fallback

### DIFF
--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -115,7 +115,7 @@ Wikipedia is NEVER cited as the primary source for historical dates, names, or e
 - **ukrainianlessons.com** (Ukrainian Lessons Podcast, Anna Ohoiko) — **commercial, all rights reserved.** We may reference their free blog articles as external resources (link out only) but NEVER copy content from the paid ULP membership. The relationship is understood by the ULP author; see `docs/resources/external_resources.yaml` for the referenced URL set.
 - **Реальна Історія (Akím Galímov), imtgsh, Istoria-Movy, Speak Ukrainian, Red Purple Ukrainian** — YouTube channels with free-to-view content. Subtitle transcripts are used internally for wiki compilation as context, not republished. Links to the original videos appear in module Ресурси tabs for learners.
 - **Dobra Forma (opentext.ku.edu)** — Creative Commons licensed by the University of Kansas. We reference the URLs; derivative teaching material is separately attributed.
-- **Горох (goroh.pp.ua), VESUM** — linguistic dictionaries, freely available for educational use. Never redistributed in bulk; used only as query services.
+- **Горох (goroh.pp.ua), e2u (e2u.org.ua), VESUM** — linguistic dictionaries, freely available for educational use. Never redistributed in bulk; used only as query services.
 
 ### Dictionaries
 
@@ -137,6 +137,7 @@ The following dictionaries are ingested as SQLite FTS5 indices for internal ling
 | **Правопис 2019** | Public (Академія наук України) | Orthography rules |
 | **Ukrajinet WordNet** | 122K synsets; auto-translated from Open English WordNet per upstream README. ⚠️ Quality concern documented (#1657 Tier 3 audit). | Synonym lookup (with caveats) |
 | **English Wiktionary via Kaikki.org / wiktextract** | English Wiktionary extract, **CC BY-SA 3.0**. Preprocessed from the local Kaikki Ukrainian JSONL extract into a compact per-lemma lookup; Atlas pages that use it render the attribution line "Pronunciation / etymology from English Wiktionary, CC BY-SA 3.0." | IPA pronunciation and final-fallback etymology |
+| **e2u.org.ua** | Aggregator © r2u.org.ua (compilers Rysin, Starko et al.; constituent works: Гороть 2011/2016, Андрусишин–Крет 1955, scientific UK↔EN, …). Non-commercial educational use. | Per-query UK→EN lookup + short learner gloss + attribution. No bulk dump, no GitHub ingest. |
 
 ---
 
@@ -164,4 +165,4 @@ For modified derivative works:
 
 Licensing questions go to issues on GitHub or the maintainer directly. The above is a best-effort plain-language summary of the legal position — it is not legal advice. If you need formal permissions or have commercial redistribution questions beyond the standard CC BY-SA 4.0 terms, open an issue and we'll figure it out.
 
-Last updated: 2026-06-12 — added English Wiktionary via Kaikki.org / wiktextract (CC BY-SA 3.0) for Word Atlas IPA pronunciation and final-fallback etymology. Predecessor: 2026-05-05 — added good-faith / non-profit-posture section (user-requested defensive documentation), expanded dictionary inventory (ЕСУМ vol 1, slovnyk.me as СУМ-20 supersession, Гринчишин/Сербенська paronyms, Karavansky r2u, Holovashchuk pending, Ukrajinet caveat), noted СУМ-11 sovietization risk + Грінченко rename. Predecessor: 2026-04-11 (#1092).
+Last updated: 2026-08-24 — added e2u.org.ua (Rysin, Starko et al.) for Word Atlas English translation lookup fallback (#4387). Predecessor: 2026-06-12 — added English Wiktionary via Kaikki.org / wiktextract (CC BY-SA 3.0) for Word Atlas IPA pronunciation and final-fallback etymology. Predecessor: 2026-05-05 — added good-faith / non-profit-posture section (user-requested defensive documentation), expanded dictionary inventory (ЕСУМ vol 1, slovnyk.me as СУМ-20 supersession, Гринчишин/Сербенська paronyms, Karavansky r2u, Holovashchuk pending, Ukrajinet caveat), noted СУМ-11 sovietization risk + Грінченко rename. Predecessor: 2026-04-11 (#1092).

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -6344,6 +6344,7 @@ _E2U_REVERSE_POS_MAP: dict[str, str] = {
     "n": "noun",
     "noun": "noun",
     "імен": "noun",
+    "іменник": "noun",
     "ім": "noun",
     "ч": "noun",
     "ж": "noun",
@@ -6418,17 +6419,26 @@ def _extract_e2u_uk_glosses(raw_translation: str, *, limit: int = 6) -> list[str
     return out
 
 
+_E2U_POS_TAG_RE = re.compile(
+    r"(?:"
+    r"\b(n|v|vb|a|ч|ж|с|ім|імен|дієсл|прикм|присл|чол|жін|сер|adj|adv)\."
+    r"|"
+    r"\b(noun|verb|adjective|adverb|infinitive|дієслово|прикметник|прислівник|іменник)\b"
+    r"|"
+    r"\b(adj|adv|дієсл|прикм|присл|імен|чол|жін|сер)\b"
+    r")",
+    flags=re.IGNORECASE,
+)
+
+
 def _e2u_extract_row_pos(text: str) -> str | None:
     """Extract and normalize POS tag from an e2u translation string or None if unmapped."""
     cleaned = clean_html_entities(text)
-    match = re.search(
-        r"\b(n|noun|імен|ім|ч|ж|с|чол|жін|сер|v|vb|verb|дієсл|дієслово|adj|a|adjective|прикм|прикметник|adv|adverb|присл|прислівник)\b\.?",
-        cleaned,
-        flags=re.IGNORECASE,
-    )
+    match = _E2U_POS_TAG_RE.search(cleaned)
     if match:
-        tag = match.group(1).lower()
-        return _E2U_REVERSE_POS_MAP.get(tag)
+        tag = next((g.lower() for g in match.groups() if g is not None), None)
+        if tag:
+            return _E2U_REVERSE_POS_MAP.get(tag)
     return None
 
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -87,6 +87,7 @@ from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
     CORRECTION_DICTIONARIES_LABEL,
     DAVYDOV_LABEL,
+    E2U_LABEL,
     ESUM_LABEL,
     GOROH_LABEL,
     GRINCHENKO_LABEL,
@@ -237,6 +238,9 @@ _SLOVNYK_UKRENG_SLUG = "ukreng"
 _SLOVNYK_UKRENG_LABEL = BALLA_LABEL
 _SLOVNYK_UKRENG_SOURCE = BALLA_LABEL
 _GOROH_TRANSLATION_SOURCE = GOROH_LABEL
+_E2U_TRANSLATION_SOURCE = E2U_LABEL
+_E2U_DELAY_SECONDS = float(os.environ.get("LEXICON_E2U_DELAY", "0.34"))
+_E2U_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational per-lemma lookup)"
 _SLOVNYK_BASE = "https://slovnyk.me"
 # v3 (#6524 P1): bumped because every schema_version==2 cache file on disk was
 # written by the pre-fix `" ".join(...)` article-text join (#6465's root-cause
@@ -328,6 +332,7 @@ _SYNONYM_LABEL_RE = re.compile(
 )
 
 _last_slovnyk_fetch = 0.0
+_last_e2u_fetch = 0.0
 _stressifier: Any | None = None
 
 # Same-sense A1 allowlist. A synonym is emitted only when it is both present in
@@ -1516,6 +1521,15 @@ def _polite_slovnyk_delay() -> None:
         if elapsed < _SLOVNYK_DELAY_SECONDS:
             time.sleep(_SLOVNYK_DELAY_SECONDS - elapsed)
     _last_slovnyk_fetch = time.monotonic()
+
+
+def _polite_e2u_delay() -> None:
+    global _last_e2u_fetch
+    if _last_e2u_fetch:
+        elapsed = time.monotonic() - _last_e2u_fetch
+        if elapsed < _E2U_DELAY_SECONDS:
+            time.sleep(_E2U_DELAY_SECONDS - elapsed)
+    _last_e2u_fetch = time.monotonic()
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -6069,8 +6083,9 @@ def _clean_ukreng_gloss(candidate: str) -> str | None:
     cleaned = clean_html_entities(candidate)
     cleaned = re.sub(r"\b(?:also|fig|figurative|literally|lit)\.?\b", " ", cleaned, flags=re.IGNORECASE)
     cleaned = re.sub(r"\(\s*(?:pl|sg|plural|singular)\.?\s*\)", " ", cleaned, flags=re.IGNORECASE)
-    cleaned = re.sub(r"\s+", " ", cleaned).strip(" \t\r\n.,;:!?()[]{}«»\"“”")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(" \t\r\n.,;:!?()[]{}«»\"“”▪•–—·*~")
     cleaned = re.sub(r"^(?:to|a|an|the)\s+", "", cleaned, flags=re.IGNORECASE)
+    cleaned = cleaned.strip(" \t\r\n.,;:!?()[]{}«»\"“”▪•–—·*~")
     # A sense boundary the chunker cannot split on (no preceding ")" before the
     # next "2)") leaves the next sense's number glued to the gloss tail
     # («амброзія міф. ambrosia 2) бот. ragweed» -> "ambrosia 2"). Strip a
@@ -6325,6 +6340,192 @@ def _goroh_translation(lemma: str) -> dict[str, object] | None:
     return None
 
 
+_E2U_REVERSE_POS_MAP: dict[str, str] = {
+    "n": "noun",
+    "noun": "noun",
+    "імен": "noun",
+    "ім": "noun",
+    "ч": "noun",
+    "ж": "noun",
+    "с": "noun",
+    "чол": "noun",
+    "жін": "noun",
+    "сер": "noun",
+    "v": "verb",
+    "vb": "verb",
+    "verb": "verb",
+    "дієсл": "verb",
+    "дієслово": "verb",
+    "infinitive": "verb",
+    "adj": "adj",
+    "a": "adj",
+    "adjective": "adj",
+    "прикм": "adj",
+    "прикметник": "adj",
+    "adv": "adv",
+    "adverb": "adv",
+    "присл": "adv",
+    "прислівник": "adv",
+}
+
+
+def _normalize_e2u_uk_headword(hw: str) -> str:
+    """Normalize a Ukrainian headword from e2u (strip stress, parenthetical morphology, expand ||, casefold)."""
+    cleaned = _strip_stress(hw)
+    cleaned = re.sub(r"\([^)]*\)", " ", cleaned)
+    cleaned = cleaned.replace("||", "")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.casefold()
+
+
+def _extract_e2u_uk_glosses(raw_translation: str, *, limit: int = 6) -> list[str]:
+    """Extract English glosses from a UK-headword translation text."""
+    text = clean_html_entities(str(raw_translation or "")).strip()
+    text = re.sub(r"<[^>]+>", " ", text)
+    if not text:
+        return []
+    first_latin = _LATIN_RE.search(text)
+    if not first_latin:
+        return []
+    english_part = text[first_latin.start() :]
+    first_cyrillic = _CYRILLIC_RE.search(english_part)
+    if first_cyrillic:
+        english_part = english_part[: first_cyrillic.start()]
+    english_part = re.sub(r"\([^)]*\)", " ", english_part)
+    english_part = re.split(r"\s+[—–-]\s+", english_part, maxsplit=1)[0]
+    out: list[str] = []
+    seen: set[str] = set()
+    for chunk in re.split(r";|\n", english_part):
+        chunk = re.sub(r"^\s*\d+[\).]\s*", "", chunk.strip())
+        for candidate in re.split(r",|/|\bor\b", chunk, flags=re.IGNORECASE):
+            candidate = re.sub(r"^(?:[a-zA-Z]{1,6}\.\s*)+", "", candidate.strip())
+            candidate = re.sub(
+                r"^(?:[mfnvd]|adj|adv|prep|conj|interj|phr)\b[\s:.-]*",
+                "",
+                candidate.strip(),
+                flags=re.IGNORECASE,
+            )
+            gloss = _clean_ukreng_gloss(candidate)
+            if not gloss or not _is_learner_english_text(gloss):
+                continue
+            key = gloss.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(gloss)
+            if len(out) >= limit:
+                return out
+    return out
+
+
+def _e2u_extract_row_pos(text: str) -> str | None:
+    """Extract and normalize POS tag from an e2u translation string or None if unmapped."""
+    cleaned = clean_html_entities(text)
+    match = re.search(
+        r"\b(n|noun|імен|ім|ч|ж|с|чол|жін|сер|v|vb|verb|дієсл|дієслово|adj|a|adjective|прикм|прикметник|adv|adverb|присл|прислівник)\b\.?",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        tag = match.group(1).lower()
+        return _E2U_REVERSE_POS_MAP.get(tag)
+    return None
+
+
+@functools.cache
+def query_e2u_uk_en(lemma: str) -> list[dict[str, str]]:
+    """Wrapper around rag.source_query.e2u_translate to support caching and unit test mocking."""
+    if _phase1_offline_mode():
+        return []
+
+    try:
+        _polite_e2u_delay()
+        from scripts.rag.source_query import e2u_translate
+
+        headers = {"User-Agent": _E2U_USER_AGENT}
+        return e2u_translate(lemma, exact=False, headers=headers) or []
+    except Exception:
+        return []
+
+
+def _e2u_translation(lemma: str, *, entry_pos: object = None) -> dict[str, object] | None:
+    """English translations for a Ukrainian lemma via e2u.org.ua (#4387)."""
+    # Step 1 & 2: Preferred UK-headword exact match across all variants
+    for variant in _split_lemma_variants(lemma):
+        rows = query_e2u_uk_en(variant)
+        if not rows:
+            continue
+        variant_key = _strip_stress(variant).strip().casefold()
+        uk_glosses: list[str] = []
+        seen: set[str] = set()
+        for row in rows:
+            hw = str(row.get("headword") or "")
+            if not _CYRILLIC_RE.search(hw):
+                continue
+            if _normalize_e2u_uk_headword(hw) != variant_key:
+                continue
+            for gloss in _extract_e2u_uk_glosses(str(row.get("translation") or "")):
+                key = gloss.casefold()
+                if key not in seen:
+                    seen.add(key)
+                    uk_glosses.append(gloss)
+                    if len(uk_glosses) >= 6:
+                        break
+            if len(uk_glosses) >= 6:
+                break
+        if uk_glosses:
+            block: dict[str, object] = {
+                "en": uk_glosses[:6],
+                "source": _E2U_TRANSLATION_SOURCE,
+            }
+            e2u_url = f"https://e2u.org.ua/s?w={quote(variant, safe='')}&dicts=all"
+            attach_official_url(block, mirror_url=e2u_url, word=variant)
+            return block
+
+    # Step 4: EN reverse match only if UK-headword exact produced nothing
+    target_pos = (
+        _E2U_REVERSE_POS_MAP.get(_lookup_key(str(entry_pos or "")))
+        or _MANIFEST_POS_TO_VESUM_POS.get(_lookup_key(str(entry_pos or "")))
+    )
+    for variant in _split_lemma_variants(lemma):
+        rows = query_e2u_uk_en(variant)
+        if not rows:
+            continue
+        distinct_en_headwords: dict[str, str] = {}
+        for row in rows:
+            hw = str(row.get("headword") or "").strip()
+            # Must be EN headword: no Cyrillic, has Latin
+            if not hw or _CYRILLIC_RE.search(hw) or not _LATIN_RE.search(hw):
+                continue
+            translation_text = clean_html_entities(str(row.get("translation") or ""))
+            # Must contain Ukrainian token as a whole word
+            if not _contains_whole_token(translation_text, variant):
+                continue
+            # POS filter: if target_pos is present and row has POS, check if they agree
+            if target_pos:
+                row_pos = _e2u_extract_row_pos(translation_text)
+                if row_pos and row_pos != target_pos:
+                    continue
+            clean_hw = _clean_ukreng_gloss(hw) or hw
+            if not clean_hw or not _is_learner_english_text(clean_hw):
+                continue
+            key = clean_hw.casefold()
+            if key not in distinct_en_headwords:
+                distinct_en_headwords[key] = clean_hw
+
+        if len(distinct_en_headwords) == 1:
+            unique_headword = next(iter(distinct_en_headwords.values()))
+            block = {
+                "en": [unique_headword],
+                "source": _E2U_TRANSLATION_SOURCE,
+            }
+            e2u_url = f"https://e2u.org.ua/s?w={quote(variant, safe='')}&dicts=all"
+            attach_official_url(block, mirror_url=e2u_url, word=variant)
+            return block
+
+    return None
+
+
 def _translation(
     conn: sqlite3.Connection,
     lemma: str,
@@ -6343,7 +6544,8 @@ def _translation(
     exact Ukrainian token resolves to one unique English headword that matches an
     existing learner-gloss hint from the source entry. When slovnyk.me has a cached or
     fetched ukreng entry, that is used next. When all previous sources miss, fall back
-    to goroh.pp.ua translation (#6876). Returns up to six glosses.
+    to goroh.pp.ua translation (#6876). When goroh misses, fall back to e2u.org.ua
+    translation (#4387). Returns up to six glosses.
     """
     for variant in _split_lemma_variants(lemma):
         rows = _dmklinger_lookup(conn, _dmklinger_key(variant))
@@ -6382,6 +6584,9 @@ def _translation(
     goroh_translation = _goroh_translation(lemma)
     if goroh_translation:
         return goroh_translation
+    e2u_translation = _e2u_translation(lemma, entry_pos=entry_pos)
+    if e2u_translation:
+        return e2u_translation
 
     for variant in _split_lemma_variants(lemma):
         curated = _CURATED_LEARNER_TRANSLATIONS.get(_lookup_key(variant).casefold())

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -59,6 +59,7 @@ ORTHOGRAPHY_LABEL = "Орфографічний словник українсь�
 HOLOSKEVYCH_LABEL = "Правописний словник Голоскевича (1929)"
 ORTHOEPY_LABEL = "Орфоепічний словник української мови"
 GOROH_LABEL = "Горох (переклад)"
+E2U_LABEL = "e2u.org.ua (Rysin, Starko et al.)"
 
 
 RELATION_PAIRS_PREFIX = "relation_pairs/"
@@ -97,6 +98,12 @@ LEGACY_LABEL_ALIASES: dict[str, str] = {
     "goroh.pp.ua": GOROH_LABEL,
     "Горох (переклад)": GOROH_LABEL,
     "Горох: Переклад": GOROH_LABEL,
+    "e2u": E2U_LABEL,
+    "e2u.org.ua": E2U_LABEL,
+    "e2u (переклад)": E2U_LABEL,
+    "e2u: Переклад": E2U_LABEL,
+    "E2U": E2U_LABEL,
+    E2U_LABEL: E2U_LABEL,
 }
 
 KNOWN_ACADEMIC_LABELS = frozenset(
@@ -125,6 +132,8 @@ KNOWN_ACADEMIC_LABELS = frozenset(
         ORTHOGRAPHY_LABEL,
         HOLOSKEVYCH_LABEL,
         ORTHOEPY_LABEL,
+        GOROH_LABEL,
+        E2U_LABEL,
     }
 )
 
@@ -244,6 +253,8 @@ def normalize_academic_label(label: str) -> str:
         return CORRECTION_DICTIONARIES_LABEL
     if cleaned.casefold().startswith("goroh.pp.ua"):
         return GOROH_LABEL
+    if cleaned.casefold().startswith("e2u.org.ua") or cleaned.casefold() == "e2u":
+        return E2U_LABEL
     if cleaned.casefold().startswith(RELATION_PAIRS_PREFIX):
         return _remap_relation_pairs_label(cleaned)
     if cleaned in LEGACY_LABEL_ALIASES:

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -919,7 +919,11 @@ def r2u_translate(russian_word: str) -> list[dict[str, str]]:
 E2U_BASE = "https://e2u.org.ua"
 
 
-def e2u_translate(english_word: str, exact: bool = True) -> list[dict[str, str]]:
+def e2u_translate(
+    english_word: str,
+    exact: bool = True,
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, str]]:
     """Look up English→Ukrainian translation on e2u.org.ua.
 
     Uses the /s endpoint (?w=word). 331,723 entries across general, IT,
@@ -929,9 +933,13 @@ def e2u_translate(english_word: str, exact: bool = True) -> list[dict[str, str]]
         english_word: English word or phrase to look up.
         exact: If True, only return entries whose headword starts with the
                search word (filters out compound-word noise).
+        headers: Optional HTTP headers for the request.
     """
     try:
-        r = _get(f"{E2U_BASE}/s", params={"w": english_word, "dicts": "all"}, timeout=20)
+        kwargs: dict[str, Any] = {}
+        if headers:
+            kwargs["headers"] = headers
+        r = _get(f"{E2U_BASE}/s", params={"w": english_word, "dicts": "all"}, timeout=20, **kwargs)
         if r.status_code == 404:
             return []
         r.raise_for_status()

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "01aada2efd85d9768050a6a56120df49c747cb0cae42560b22c594fc7cfcd3af"
+        "sha256": "452c1b6cfa734f4cca9493ace9f6918f53d83694474c88f64fd759a24fdc6cb5"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -247,7 +247,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "4252dbeec41754d296fc848196b1621453946b1326a227e7a5a87286e3bc469e"
+        "sha256": "cd3b50ea237554ffe1d3df1d2ab34a93abfa257fd4f4ca50005ac5a15e9e9bba"
       },
       {
         "path": "scripts/lexicon/sync_teacher_table_deck.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3320,6 +3320,24 @@ def test_e2u_translation_pos_filtering(monkeypatch) -> None:
     assert res_untagged["en"] == ["untaggedword"]
 
 
+def test_e2u_translation_article_a_in_translation_not_treated_as_adjective(monkeypatch) -> None:
+    # Unique EN reverse whose translation contains ordinary article "a " (e.g. "a piece of furniture")
+    # with entry_pos="noun" still returns that unique headword, never treated as adj.
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "furniturepiece", "translation": "a piece of furniture: перевіркамеблі"},
+        ]
+        if lemma == "перевіркамеблі"
+        else [],
+    )
+    res = enrich_manifest_module._e2u_translation("перевіркамеблі", entry_pos="noun")
+    assert res is not None
+    assert res["en"] == ["furniturepiece"]
+    assert res["source"] == E2U_LABEL
+
+
 def test_e2u_translation_decode_html_entities(monkeypatch) -> None:
     monkeypatch.setattr(
         enrich_manifest_module,

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -84,6 +84,7 @@ from scripts.lexicon.enrich_manifest import (
 )
 from scripts.lexicon.source_attribution import (
     DAVYDOV_LABEL,
+    E2U_LABEL,
     GOROH_LABEL,
     HOLOSKEVYCH_LABEL,
     MIYKLAS_LABEL,
@@ -3029,7 +3030,7 @@ def test_translation_uses_goroh_after_source_misses(monkeypatch) -> None:
     assert translation["source"] == "Горох (переклад)"
 
 
-def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monkeypatch) -> None:
+def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(monkeypatch) -> None:
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
@@ -3041,12 +3042,18 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monke
     monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
 
     goroh_calls: list[str] = []
+    e2u_calls: list[str] = []
 
     def mock_goroh(lemma: str) -> list[str]:
         goroh_calls.append(lemma)
         return ["basilica", "basilicas"]
 
+    def mock_e2u(lemma: str) -> list[dict[str, str]]:
+        e2u_calls.append(lemma)
+        return [{"headword": "базиліка", "translation": "arch. basilica"}]
+
     monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", mock_goroh)
+    monkeypatch.setattr(enrich_manifest_module, "query_e2u_uk_en", mock_e2u)
 
     # 1. dmklinger wins over everything
     conn.execute(
@@ -3058,6 +3065,7 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monke
     assert res_dmklinger is not None
     assert res_dmklinger["source"] == enrich_manifest_module._TRANSLATION_SOURCE
     assert not goroh_calls
+    assert not e2u_calls
 
     # 2. Kaikki wins when dmklinger misses
     conn.execute("DELETE FROM dmklinger_uk_en")
@@ -3066,12 +3074,14 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monke
     assert res_kaikki is not None
     assert res_kaikki["source"] == KAIKKI_SOURCE
     assert not goroh_calls
+    assert not e2u_calls
 
     # 3. Balla reverse wins when dmklinger and Kaikki miss
     res_balla = _translation(conn, "базиліка", {}, entry_pos="noun", gloss_hints={"basilica"})
     assert res_balla is not None
     assert res_balla["source"] == _BALLA_REVERSE_SOURCE
     assert not goroh_calls
+    assert not e2u_calls
 
     # 4. Slovnyk ukreng wins when Balla reverse misses
     slovnyk_cache = {
@@ -3087,14 +3097,26 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh(monke
     assert res_slovnyk is not None
     assert res_slovnyk["source"] == _SLOVNYK_UKRENG_SOURCE
     assert not goroh_calls
+    assert not e2u_calls
 
-    # 5. Goroh wins when all previous miss
+    # 5. Goroh wins when all previous miss (e2u is not called)
     empty_cache = {"lookups": {"ukreng": None}}
     res_goroh = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
     assert res_goroh is not None
     assert res_goroh["source"] == GOROH_LABEL
     assert res_goroh["en"] == ["basilica", "basilicas"]
     assert goroh_calls == ["базиліка"]
+    assert not e2u_calls
+
+    # 6. e2u wins when Goroh misses
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    res_e2u = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
+    assert res_e2u is not None
+    assert res_e2u["source"] == E2U_LABEL
+    assert res_e2u["en"] == ["basilica"]
+    assert "source_url" in res_e2u
+    assert "e2u.org.ua" in res_e2u["source_url"]
+    assert e2u_calls == ["базиліка"]
 
 
 def test_goroh_translation_filters_non_english_and_caps_at_6(monkeypatch) -> None:
@@ -3120,6 +3142,211 @@ def test_goroh_translation_filters_non_english_and_caps_at_6(monkeypatch) -> Non
     assert translation is not None
     assert translation["en"] == ["one", "two", "three", "four", "five", "six"]
     assert translation["source"] == GOROH_LABEL
+
+
+def test_e2u_translation_ampir_uk_headword_exact(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "стил||ь", "translation": "style"},
+            {"headword": "ампір", "translation": "мист. ( стиль ) Empire style."},
+        ]
+        if lemma == "ампір"
+        else [],
+    )
+
+    translation = _translation(conn, "ампір", {})
+    assert translation is not None
+    assert translation["en"] == ["Empire style"]
+    assert translation["source"] == E2U_LABEL
+    assert translation["source_url"] == "https://e2u.org.ua/s?w=%D0%B0%D0%BC%D0%BF%D1%96%D1%80&dicts=all"
+
+
+def test_e2u_translation_shkola_expands_stem_ending_never_council(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "council", "translation": "рада (при міській школі)"},
+            {"headword": "школ||а", "translation": "ж. school, schoolhouse."},
+        ]
+        if lemma == "школа"
+        else [],
+    )
+
+    translation = _translation(conn, "школа", {})
+    assert translation is not None
+    assert "school" in translation["en"]
+    assert "council" not in translation["en"]
+    assert translation["source"] == E2U_LABEL
+
+
+def test_e2u_translation_stil_uk_headword_never_bench(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "bench", "translation": "лавка, лава, стіл суддів"},
+            {"headword": "стіл", "translation": "ч. table, desk."},
+        ]
+        if lemma == "стіл"
+        else [],
+    )
+
+    translation = _translation(conn, "стіл", {})
+    assert translation is not None
+    assert "table" in translation["en"]
+    assert "bench" not in translation["en"]
+    assert translation["source"] == E2U_LABEL
+
+
+def test_e2u_translation_vikno_expands_stem_ending_never_grille(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "grille", "translation": "грати, вікно каси"},
+            {"headword": "вікн||о", "translation": "с. window, casement."},
+        ]
+        if lemma == "вікно"
+        else [],
+    )
+
+    translation = _translation(conn, "вікно", {})
+    assert translation is not None
+    assert "window" in translation["en"]
+    assert "grille" not in translation["en"]
+    assert translation["source"] == E2U_LABEL
+
+
+def test_e2u_translation_knyha_multiple_en_reverse_returns_none(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "bankbook", "translation": "банківська книга"},
+            {"headword": "codebook", "translation": "шифрувальна книга"},
+        ]
+        if lemma == "книга"
+        else [],
+    )
+
+    translation = _translation(conn, "книга", {})
+    # Should fall back to None or curated if not present in curated
+    # 'книга' might be in curated translations or None
+    # Let's test _e2u_translation directly as well
+    e2u_res = enrich_manifest_module._e2u_translation("книга")
+    assert e2u_res is None
+
+
+def test_e2u_translation_ambiguous_reverse_returns_none(monkeypatch) -> None:
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "headword1", "translation": "приклад термін"},
+            {"headword": "headword2", "translation": "інший термін"},
+        ],
+    )
+    assert enrich_manifest_module._e2u_translation("термін") is None
+
+
+def test_e2u_translation_unique_reverse_returns_single_headword(monkeypatch) -> None:
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "uniqueheadword", "translation": "опис рідкіснийтермін у словнику"},
+        ],
+    )
+    res = enrich_manifest_module._e2u_translation("рідкіснийтермін")
+    assert res is not None
+    assert res["en"] == ["uniqueheadword"]
+    assert res["source"] == E2U_LABEL
+    assert res["source_url"] == "https://e2u.org.ua/s?w=%D1%80%D1%96%D0%B4%D0%BA%D1%96%D1%81%D0%BD%D0%B8%D0%B9%D1%82%D0%B5%D1%80%D0%BC%D1%96%D0%BD&dicts=all"
+
+
+def test_e2u_translation_pos_filtering(monkeypatch) -> None:
+    # Test POS filter on reverse: drops noun when looking for verb, keeps verb
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "nounword", "translation": "n. перевіркадія"},
+            {"headword": "verbword", "translation": "v. перевіркадія"},
+        ],
+    )
+    # With entry_pos="verb", nounword is filtered out, verbword remains as unique match
+    res = enrich_manifest_module._e2u_translation("перевіркадія", entry_pos="verb")
+    assert res is not None
+    assert res["en"] == ["verbword"]
+
+    # Fails open when row has no POS tag
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "untaggedword", "translation": "перевіркадія без мітки"},
+        ],
+    )
+    res_untagged = enrich_manifest_module._e2u_translation("перевіркадія", entry_pos="verb")
+    assert res_untagged is not None
+    assert res_untagged["en"] == ["untaggedword"]
+
+
+def test_e2u_translation_decode_html_entities(monkeypatch) -> None:
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_e2u_uk_en",
+        lambda lemma: [
+            {"headword": "тест", "translation": "<i>n.</i>&nbsp;first&amp;second,&nbsp;third"},
+        ],
+    )
+    res = enrich_manifest_module._e2u_translation("тест")
+    assert res is not None
+    assert res["en"] == ["first&second", "third"]
+
+
+def test_e2u_translation_offline_mode(monkeypatch) -> None:
+    called = False
+
+    def fake_e2u(lemma: str, **kwargs) -> list[dict[str, str]]:
+        nonlocal called
+        called = True
+        return [{"headword": "тест", "translation": "test"}]
+
+    monkeypatch.setattr("scripts.rag.source_query.e2u_translate", fake_e2u)
+    monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: True)
+    enrich_manifest_module.query_e2u_uk_en.cache_clear()
+    res = enrich_manifest_module.query_e2u_uk_en("тест_offline_unique")
+    assert res == []
+    assert not called
 
 
 def test_goroh_translate_mock_html_parsing(monkeypatch) -> None:

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from scripts.lexicon.enrich_manifest import _merge_homonym_relations, _relation_source_label
 from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
+    E2U_LABEL,
     GOROH_LABEL,
     GRAC_LABEL,
     GRINCHENKO_LABEL,
@@ -222,3 +223,34 @@ def test_normalize_academic_label_maps_goroh() -> None:
     assert normalize_academic_label("goroh.pp.ua: Переклад") == GOROH_LABEL
     assert normalize_academic_label("Горох") == GOROH_LABEL
     assert normalize_academic_label("Горох (переклад)") == GOROH_LABEL
+
+
+def test_apply_entry_attribution_handles_e2u_translation() -> None:
+    entry = {
+        "lemma": "ампір",
+        "enrichment": {
+            "translation": {
+                "en": ["Empire style"],
+                "source": "e2u.org.ua",
+                "source_url": "https://e2u.org.ua/s?w=%D0%B0%D0%BC%D0%BF%D1%96%D1%80&dicts=all",
+            },
+            "sources": ["e2u.org.ua"],
+        },
+    }
+    assert apply_entry_attribution(entry) is True
+    assert entry["enrichment"]["translation"]["source"] == E2U_LABEL
+    assert (
+        entry["enrichment"]["translation"]["source_url"]
+        == "https://e2u.org.ua/s?w=%D0%B0%D0%BC%D0%BF%D1%96%D1%80&dicts=all"
+    )
+    assert entry["enrichment"]["sources"] == [E2U_LABEL]
+    assert learner_facing_mirror_violations(entry) == []
+    assert learner_facing_unmapped_source_violations(entry) == []
+
+
+def test_normalize_academic_label_maps_e2u() -> None:
+    assert normalize_academic_label("e2u") == E2U_LABEL
+    assert normalize_academic_label("e2u.org.ua") == E2U_LABEL
+    assert normalize_academic_label("e2u: Переклад") == E2U_LABEL
+    assert normalize_academic_label("e2u (переклад)") == E2U_LABEL
+    assert normalize_academic_label(E2U_LABEL) == E2U_LABEL


### PR DESCRIPTION
# Dispatch: atlas-e2u-translation

Wire live `e2u.org.ua` into Atlas UK→EN translation chain after Goroh (§11 fallback chain).
Part of the Word Atlas epic (#4387). Closes nothing.

X-Agent: agy/atlas-e2u-translation-agy

## Summary

- Implemented `query_e2u_uk_en` and `_e2u_translation` in `scripts/lexicon/enrich_manifest.py` placed after Goroh in the `_translation()` chain.
- Added UK-headword exact match (normalizing combining stress, parenthetical morphology `(...)`, expanding stem||ending, casefolded) with gloss extraction.
- Added strict English reverse lookup fallback only when UK-headword produces nothing: requires whole-word match, POS agreement (fail open if untagged), and exactly 1 distinct English headword (never first-hit reverse).
- Added `E2U_LABEL = "e2u.org.ua (Rysin, Starko et al.)"` and label normalization/aliases in `scripts/lexicon/source_attribution.py`. Learner-facing `source_url` is preserved directly (`e2u.org.ua` is not in `MIRROR_HOSTS`).
- Added documentation for `e2u.org.ua` per-query non-commercial lookup under `LICENSE-CONTENT.md`.
- Added unit and regression tests in `tests/test_lexicon_enrich_manifest.py` and `tests/test_source_attribution.py` covering all precedence rules, held-out evaluation lemmas (`ампір`, `школа`, `стіл`, `вікно`, `книга`), stem/ending expansion, POS filters, entity decoding, and offline mode.

## Acceptance Tests

```bash
.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py tests/test_source_attribution.py -q
```
Result: `221 passed in 9.29s`

## Measurement Report

Measurement pass over the 1,828 thin old-gate entries lacking English anchors in the hydrated manifest:

```json
{
  "before": 1828,
  "uk_headword_hits": 1092,
  "unique_reverse_hits": 105,
  "ambiguous_skips": 106,
  "errors": 0,
  "after": 631
}
```

- Residual reduced by 1,197 (65.5% reduction) without publishing pointer or mutating catalog HTML.
- `site/src/data/lexicon-manifest.pointer.json` unchanged.