### PR TITLE
fix(fleet): worker map keeps 'local'-host driver leases in the unattributed bucket (#7265)

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -593,6 +593,9 @@ function renderWorkers(data) {
     if (workersStatus === 'unreported') {
       banners.push(`<div class="context-muted">Workers unknown for ${escapeHtml(hostId)} — reporter has not published a v2 workers block.</div>`);
     }
+    if (hostId === 'unattributed' && host.reason) {
+      banners.push(`<div class="context-muted">${escapeHtml(hostId)} — ${escapeHtml(host.reason)} (launcher <span class="mono">local</span> is not a host).</div>`);
+    }
     const workers = listValue(host.workers);
     if (!workers.length) {
       rows.push(`<tr><td class="mono">${escapeHtml(hostId)}</td><td>${pill(freshness)}</td><td>${pill(workersStatus)}</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td><td class="muted">—</td></tr>`);

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -275,8 +275,10 @@ Joins every live AI worker exactly once per source on each opaque host. Response
 schema: `monitor-fleet-workers.v1` with `hosts[]` entries containing
 `host_id`, `freshness`, `workers_status` (`reported|unreported`), sanitized
 `workers[]` (each with `source`, `related`, and `WorkerRow` fields),
-`unattributed_burn`, and optional `reason`. Hostless driver leases appear under
-`host_id: unattributed` with `reason: lease has no host claim`. Counts include
+`unattributed_burn`, and optional `reason`. Driver leases with no host claim
+(`holder_host_id` null, empty, or the launcher fail-safe `local`) appear under
+`host_id: unattributed` with `reason: lease has no host claim` — never silently
+attributed to the API host. Counts include
 `live`, `hosts_unknown`, `workers_total`, `skipped` (malformed or oversized
 source ids dropped without 500), and `attention` items (for example
 `unreported:host-teacher`). Read path is cache-only — never probes SSH or

--- a/scripts/api/fleet_workers_collect.py
+++ b/scripts/api/fleet_workers_collect.py
@@ -223,6 +223,16 @@ def collect_delegate_workers(
     return rows
 
 
+def _driver_holder_host_id(raw: Any) -> str | None:
+    """Opaque host id from a lease, or None when the lease has no host claim."""
+    if raw is None:
+        return None
+    text = str(raw).strip().lower()
+    if not text or text == "local":
+        return None
+    return text
+
+
 def _read_driver_leases(
     *,
     db_path: Path | None = None,
@@ -294,7 +304,7 @@ def collect_driver_workers(
         collected = CollectedWorker(
             source="driver",
             row=row,
-            host_id=str(lease.get("holder_host_id") or "").strip().lower() or None,
+            host_id=_driver_holder_host_id(lease.get("holder_host_id")),
             identity=WorkerIdentity("driver", "driver", instance_id),
             instance_id=instance_id,
             task_id=task_id,
@@ -634,9 +644,7 @@ def workers_payload(
             if canonical is not None:
                 job_rows, _ = collect_job_workers(canonical_host=canonical, now=clock, tally=tally)
                 host_workers.extend(job_rows)
-            host_workers.extend(
-                collect_marker_workers(host_id=opaque, root=markers_root, now=clock, tally=tally)
-            )
+            host_workers.extend(collect_marker_workers(host_id=opaque, root=markers_root, now=clock, tally=tally))
             selected_map = {item: reverse.get(item) for item in selected if item != CLOUD_OBSERVER_HOST_ID}
             driver_read: OccupancyRead = read_session_streams(
                 host_id=opaque,

--- a/tests/api/test_fleet_workers.py
+++ b/tests/api/test_fleet_workers.py
@@ -316,11 +316,33 @@ def test_delegate_adapter_liveness_matrix(tmp_path: Path) -> None:
     tasks.mkdir()
     now = datetime.now(UTC)
     cases = [
-        ("spawning.json", {"task_id": "spawning-1", "agent": "cursor", "status": "spawning", "started_at": now.isoformat()}, "starting"),
-        ("live.json", {"task_id": "live-1", "agent": "cursor", "status": "running", "pid": 1, "started_at": now.isoformat()}, "live"),
-        ("zombie.json", {"task_id": "zombie-1", "agent": "cursor", "status": "running", "pid": 999999, "started_at": now.isoformat()}, "zombie"),
+        (
+            "spawning.json",
+            {"task_id": "spawning-1", "agent": "cursor", "status": "spawning", "started_at": now.isoformat()},
+            "starting",
+        ),
+        (
+            "live.json",
+            {"task_id": "live-1", "agent": "cursor", "status": "running", "pid": 1, "started_at": now.isoformat()},
+            "live",
+        ),
+        (
+            "zombie.json",
+            {
+                "task_id": "zombie-1",
+                "agent": "cursor",
+                "status": "running",
+                "pid": 999999,
+                "started_at": now.isoformat(),
+            },
+            "zombie",
+        ),
         ("done.json", {"task_id": "done-1", "agent": "cursor", "status": "done", "started_at": now.isoformat()}, None),
-        ("failed.json", {"task_id": "failed-1", "agent": "cursor", "status": "failed", "started_at": now.isoformat()}, None),
+        (
+            "failed.json",
+            {"task_id": "failed-1", "agent": "cursor", "status": "failed", "started_at": now.isoformat()},
+            None,
+        ),
     ]
     for name, payload, _expected in cases:
         (tasks / name).write_text(json.dumps(payload), encoding="utf-8")
@@ -335,6 +357,19 @@ def test_delegate_adapter_liveness_matrix(tmp_path: Path) -> None:
 
 
 def test_driver_hostless_lease_unattributed_bucket(tmp_path: Path) -> None:
+    db = _driver_lease_db(tmp_path)
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    _insert_driver_lease(db, holder_host_id=None, heartbeat=heartbeat, expires=expires, instance_id="inst-alpha")
+    _, unattributed = collect_mod.collect_driver_workers(db_path=db)
+    assert len(unattributed) == 1
+    assert unattributed[0].row.id == "inst-alpha"
+    payload = workers_payload(session_db=db, host_id=UNATTRIBUTED_HOST_ID)
+    host = _host_by_id(payload, UNATTRIBUTED_HOST_ID)
+    assert host["reason"] == "lease has no host claim"
+
+
+def _driver_lease_db(tmp_path: Path) -> Path:
     db = tmp_path / "streams.db"
     conn = sqlite3.connect(db)
     conn.executescript(
@@ -359,28 +394,101 @@ def test_driver_hostless_lease_unattributed_bucket(tmp_path: Path) -> None:
         );
         """
     )
-    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
-    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-    conn.execute(
-        "INSERT INTO sessions VALUES ('epic:7177', 'sess-1', 'open')"
-    )
+    conn.execute("INSERT INTO sessions VALUES ('epic:7177', 'sess-1', 'open')")
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _insert_driver_lease(
+    db: Path,
+    *,
+    holder_host_id: str | None,
+    heartbeat: str,
+    expires: str,
+    instance_id: str = "inst-alpha",
+    stream_id: str = "epic:7177",
+    session_id: str = "sess-1",
+) -> None:
+    conn = sqlite3.connect(db)
     conn.execute(
         """
         INSERT INTO stream_leases VALUES (
-            'epic:7177', 'sess-1', 'active', 'claude', 'claude-tools',
-            'inst-alpha', 'task-1', NULL, ?, ?
+            ?, ?, 'active', 'claude', 'claude-tools',
+            ?, 'task-1', ?, ?, ?
         )
         """,
-        (heartbeat, expires),
+        (stream_id, session_id, instance_id, holder_host_id, heartbeat, expires),
     )
     conn.commit()
     conn.close()
-    _, unattributed = collect_mod.collect_driver_workers(db_path=db)
+
+
+@pytest.mark.parametrize("holder_host_id", [None, "", "local"])
+def test_driver_missing_host_claim_unattributed_bucket(
+    tmp_path: Path,
+    holder_host_id: str | None,
+) -> None:
+    db = _driver_lease_db(tmp_path)
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    suffix = holder_host_id if holder_host_id is not None else "null"
+    instance_id = f"inst-{suffix}"
+    _insert_driver_lease(
+        db,
+        holder_host_id=holder_host_id,
+        heartbeat=heartbeat,
+        expires=expires,
+        instance_id=instance_id,
+    )
+    attributed, unattributed = collect_mod.collect_driver_workers(db_path=db)
+    assert attributed == []
     assert len(unattributed) == 1
-    assert unattributed[0].row.id == "inst-alpha"
-    payload = workers_payload(session_db=db, host_id=UNATTRIBUTED_HOST_ID)
+    assert unattributed[0].row.id == instance_id
+    payload = workers_payload(session_db=db)
     host = _host_by_id(payload, UNATTRIBUTED_HOST_ID)
     assert host["reason"] == "lease has no host claim"
+    worker_ids = {row["id"] for row in host["workers"]}
+    assert worker_ids == {instance_id}
+    assert payload["counts"]["live"] == 1
+
+
+def test_driver_opaque_host_claim_not_unattributed(tmp_path: Path) -> None:
+    db = _driver_lease_db(tmp_path)
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    _insert_driver_lease(
+        db,
+        holder_host_id="host-job",
+        heartbeat=heartbeat,
+        expires=expires,
+        instance_id="inst-real",
+    )
+    attributed, unattributed = collect_mod.collect_driver_workers(db_path=db)
+    assert unattributed == []
+    assert len(attributed) == 1
+    assert attributed[0].host_id == "host-job"
+    assert attributed[0].row.id == "inst-real"
+    payload = workers_payload(session_db=db)
+    assert UNATTRIBUTED_HOST_ID not in {host["host_id"] for host in payload["hosts"]}
+
+
+def test_driver_local_host_id_fails_without_host_claim_normalization(tmp_path: Path) -> None:
+    """Mutation guard: treating 'local' as a real host drops the lease from unattributed."""
+    db = _driver_lease_db(tmp_path)
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    _insert_driver_lease(
+        db,
+        holder_host_id="local",
+        heartbeat=heartbeat,
+        expires=expires,
+        instance_id="inst-local",
+    )
+    _, unattributed = collect_mod.collect_driver_workers(db_path=db)
+    assert len(unattributed) == 1
+    broken = [item for item in unattributed if item.host_id == "local"]
+    assert broken == []
 
 
 def test_related_links_equal_instance_id(tmp_path: Path) -> None:
@@ -447,9 +555,7 @@ def test_related_links_equal_instance_id(tmp_path: Path) -> None:
 
 
 def test_observer_adapter_identity() -> None:
-    upsert_presence(
-        PresenceRequest(agent="cursor", task_id="observe-1", status="working", epic="7177")
-    )
+    upsert_presence(PresenceRequest(agent="cursor", task_id="observe-1", status="working", epic="7177"))
     rows = collect_mod.collect_observer_workers()
     assert len(rows) == 1
     assert rows[0].row.id == "cursor"

--- a/tests/api/test_fleet_workers_unmocked.py
+++ b/tests/api/test_fleet_workers_unmocked.py
@@ -1,14 +1,16 @@
-"""Unmocked TestClient probe for /api/fleet/workers/v1 (#7187)."""
+"""Unmocked TestClient probe for /api/fleet/workers/v1 (#7187, #7265)."""
 
 from __future__ import annotations
 
 import json
 import os
-from datetime import UTC, datetime
+import sqlite3
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from scripts.api.fleet_workers_collect import UNATTRIBUTED_HOST_ID
 from scripts.api.main import app
 from scripts.api.observer_presence import PresenceRequest, reset_observer_presence, upsert_presence
 from scripts.api.occupancy_local import write_marker
@@ -71,4 +73,75 @@ def test_unmocked_workers_route_with_fixture_stores(tmp_path: Path, monkeypatch)
     observer = _host_by_id(client.get("/api/fleet/workers/v1?host_id=cloud-observer").json(), "cloud-observer")
     assert any(row["kind"] == "observer" for row in observer["workers"])
 
-    print("UNMOCKED_WORKERS_PROBE_OK", json.dumps({"delegate_kinds": sorted(kinds), "observer_count": len(observer["workers"])}))
+    print(
+        "UNMOCKED_WORKERS_PROBE_OK",
+        json.dumps({"delegate_kinds": sorted(kinds), "observer_count": len(observer["workers"])}),
+    )
+
+
+def _seed_local_driver_lease(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            stream_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            PRIMARY KEY (stream_id, session_id)
+        );
+        CREATE TABLE IF NOT EXISTS stream_leases (
+            stream_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            holder_agent TEXT,
+            holder_harness TEXT,
+            holder_instance_id TEXT,
+            holder_task_id TEXT,
+            holder_host_id TEXT,
+            heartbeat_at TEXT,
+            expires_at TEXT
+        );
+        """
+    )
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    heartbeat = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    conn.execute("INSERT OR REPLACE INTO sessions VALUES ('epic:7265', 'sess-local', 'open')")
+    conn.execute(
+        """
+        INSERT INTO stream_leases VALUES (
+            'epic:7265', 'sess-local', 'active', 'grok', 'grok-tools',
+            'inst-local-7265', 'task-local', 'local', ?, ?
+        )
+        """,
+        (heartbeat, expires),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_unmocked_local_host_driver_lease_in_unattributed_bucket(tmp_path: Path, monkeypatch) -> None:
+    """Driver lease with holder_host_id local must surface under unattributed, not vanish."""
+    reset_project_state_store()
+    reset_observer_presence()
+
+    db = tmp_path / "session_streams.db"
+    _seed_local_driver_lease(db)
+    monkeypatch.setattr("scripts.api.fleet_workers_collect.session_streams_db_path", lambda: db)
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", "teach-box=host-teacher,job-box=host-job")
+    monkeypatch.setenv("LU_MONITOR_HOST_ID", "host-teacher")
+
+    response = client.get("/api/fleet/workers/v1")
+    assert response.status_code == 200
+    payload = response.json()
+    unattributed = _host_by_id(payload, UNATTRIBUTED_HOST_ID)
+    assert unattributed["reason"] == "lease has no host claim"
+    worker_ids = {row["id"] for row in unattributed["workers"]}
+    assert worker_ids == {"inst-local-7265"}
+    assert payload["counts"]["live"] >= 1
+    teacher = _host_by_id(payload, "host-teacher")
+    assert not any(row.get("id") == "inst-local-7265" for row in teacher["workers"])
+
+    print(
+        "UNMOCKED_LOCAL_LEASE_PROBE_OK",
+        json.dumps({"live": payload["counts"]["live"], "worker_ids": sorted(worker_ids)}),
+    )


### PR DESCRIPTION
Parent: #7177. Closes #7265.

## Summary
- Driver leases with `holder_host_id` null, empty, or launcher fail-safe `local` now appear under `unattributed` with `reason: lease has no host claim` and count toward `counts.live`.
- `fleet.html` shows an explicit banner for the unattributed bucket; `MONITOR-API.md` documents the rule.

## Evidence
```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check scripts/api/fleet_workers_collect.py tests/api/test_fleet_workers.py tests/api/test_fleet_workers_unmocked.py
# All checks passed!

/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/api/test_fleet_workers.py tests/api/test_fleet_workers_unmocked.py tests/test_lint_test_assertions.py tests/api/test_import_pinning.py tests/test_subprocess_timeout_guard.py
# 58 passed

/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/api
# 308 passed, 1 failed (pre-existing release_snapshot live-server 503), 1 skipped
```

## Test plan
- [x] Parametrized collector tests for null / "" / `local` host claims
- [x] Opaque host claim unaffected
- [x] Unmocked TestClient GET with `local` lease fixture
- [x] Mutation guard: `local` must not retain `host_id=local` on collected worker