### PR TITLE
feat(rollover): cross-host rollover bundle — export/upload, API store, import, SessionStart hook (#7260)

### DIFF
--- a/agents_extensions/shared/hooks/context-monitor.sh
+++ b/agents_extensions/shared/hooks/context-monitor.sh
@@ -143,7 +143,23 @@ else
   HANDOFF_AGENT="claude"
 fi
 
+HANDOFF_IDENTITY_SH="${CLAUDE_HANDOFF_IDENTITY_SH:-$PROJECT_DIR/scripts/lib/handoff_identity.sh}"
+if [ -f "$HANDOFF_IDENTITY_SH" ]; then
+  # shellcheck disable=SC1090
+  source "$HANDOFF_IDENTITY_SH"
+fi
+ROLLOVER_STREAM=""
+ROLLOVER_STREAM_EPIC=""
+if [ -n "${SESSION_EPIC:-}" ] && declare -f launcher_selector_stream >/dev/null 2>&1; then
+  ROLLOVER_STREAM="$(launcher_selector_stream "$SESSION_EPIC" 2>/dev/null || true)"
+  case "$ROLLOVER_STREAM" in
+    epic:*) ROLLOVER_STREAM_EPIC="${ROLLOVER_STREAM#epic:}" ;;
+    *) ROLLOVER_STREAM=""; ROLLOVER_STREAM_EPIC="" ;;
+  esac
+fi
 PREPARE_CMD=".venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent ${HANDOFF_AGENT} --context-percent ${PCT}"
+[ -n "$ROLLOVER_STREAM" ] && PREPARE_CMD="$PREPARE_CMD --stream $ROLLOVER_STREAM --stream-epic $ROLLOVER_STREAM_EPIC"
+unset HANDOFF_IDENTITY_SH ROLLOVER_STREAM ROLLOVER_STREAM_EPIC
 BOOTSTRAP_FILE=".agent/${HANDOFF_AGENT}-thread-bootstrap.md"
 HANDOFF_FILE=".agent/${HANDOFF_AGENT}-thread-handoff.md"
 CONTEXT_FACT="${PCT}% of the ${WINDOW}-token context window [~${TOKENS}/${WINDOW}; ${USAGE_SOURCE}; capacity: ${WINDOW_PROVENANCE}]"

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -149,11 +149,20 @@ else
   fi
 fi
 
-# Interpreter for bounded session-record calls: the CANONICAL checkout owns the
+# Interpreter for bounded session-record calls: the canonical checkout owns the
 # shared venv — linked worktrees have none (formal CF r4 F001 on #5896: the
-# PROJECT_DIR default 127s every worktree session). Hermetic tests inject
-# CLAUDE_SESSION_RECORD_PYTHON explicitly instead.
-BOUNDED_PYTHON="${CLAUDE_SESSION_RECORD_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
+# PROJECT_DIR default 127s every worktree session). If an explicit canonical
+# root points at a linked worktree, resolve the shared interpreter from its Git
+# common directory instead of creating or looking for a worktree venv.
+SHARED_VENV_ROOT="$CANONICAL_ROOT"
+if [ ! -x "$SHARED_VENV_ROOT/.venv/bin/python" ]; then
+  SHARED_GIT_COMMON_DIR=$(_hook_deadline 2 git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -n "$SHARED_GIT_COMMON_DIR" ] && [ "$(basename "$SHARED_GIT_COMMON_DIR")" = ".git" ]; then
+    SHARED_VENV_ROOT=$(dirname "$SHARED_GIT_COMMON_DIR")
+  fi
+fi
+SHARED_PYTHON="$SHARED_VENV_ROOT/.venv/bin/python"
+BOUNDED_PYTHON="${CLAUDE_SESSION_RECORD_PYTHON:-$SHARED_PYTHON}"
 BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
 SESSION_START_BUDGET_SECONDS="${SESSION_START_BUDGET_SECONDS:-12}"
 if ! [[ "$SESSION_START_BUDGET_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
@@ -238,7 +247,7 @@ fi
 # The resolver's own interpreter default is $PROJECT_DIR/.venv — absent in
 # linked worktrees (F001 r5 class). Point it at the canonical venv here; an
 # explicit CLAUDE_PROFILE_RESOLVER_PYTHON still wins.
-export CLAUDE_PROFILE_RESOLVER_PYTHON="${CLAUDE_PROFILE_RESOLVER_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
+export CLAUDE_PROFILE_RESOLVER_PYTHON="${CLAUDE_PROFILE_RESOLVER_PYTHON:-$SHARED_PYTHON}"
 # shellcheck disable=SC1090
 source "$PROFILE_RESOLVER_SH"
 if ! resolve_context_profile "$REQUESTED_PROFILE_ID" "$OBSERVED_MODEL"; then
@@ -259,7 +268,7 @@ fi
 # to Claude Code's official SessionStart id before any rollover can be requested.
 if [ -n "${LEARN_UKRAINIAN_CLAUDEX_RUN_ID:-}" ]; then
   CLAUDEX_SUPERVISOR_SCRIPT="${CLAUDEX_SUPERVISOR_SCRIPT:-$PROJECT_DIR/scripts/orchestration/claudex_supervisor.py}"
-  CLAUDEX_SUPERVISOR_PYTHON="${CLAUDEX_SUPERVISOR_PYTHON:-$PROJECT_DIR/.venv/bin/python}"
+  CLAUDEX_SUPERVISOR_PYTHON="${CLAUDEX_SUPERVISOR_PYTHON:-$SHARED_PYTHON}"
   if [ -z "$SESSION_ID" ] || [ ! -f "$CLAUDEX_SUPERVISOR_SCRIPT" ] || [ ! -x "$CLAUDEX_SUPERVISOR_PYTHON" ]; then
     ISSUES+=("CLAUDEX SUPERVISOR BIND FAILED: official session identity or runtime helper is unavailable.")
   else
@@ -281,7 +290,7 @@ fi
 
 # 1. Venv-missing is checked in shell (the gate itself needs the venv python);
 # the exact version pin comparison happens inside the gate, in-process.
-if [ ! -x "$CANONICAL_ROOT/.venv/bin/python" ]; then
+if [ ! -x "$SHARED_PYTHON" ]; then
   ISSUES+=("VENV MISSING: canonical .venv/bin/python not found. Recreate it with the version in .python-version.")
 fi
 
@@ -412,7 +421,7 @@ fi
 # 13. Session handoff. Claude uses the official SessionStart session id; Codex
 # retains its documented environment fallback for non-Claude fixtures.
 CURRENT_THREAD_ID="${SESSION_ID:-${CODEX_THREAD_ID:-${CODEX_SESSION_ID:-}}}"
-ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"  # canonical: worktrees carry no venv (F001 r5)
+ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$SHARED_PYTHON}"  # canonical: worktrees carry no venv (F001 r5)
 ROLLOVER_SCRIPT="${THREAD_ROLLOVER_SCRIPT:-$PROJECT_DIR/scripts/orchestration/thread_handoff.py}"
 HANDOFF_CONTEXT=""
 HANDOFF_WARNINGS=""
@@ -681,6 +690,15 @@ fi
 if [ ${#TASK_FAMILY_ARGS[@]} -gt 0 ]; then
   GATE_ARGS+=(--task-family "$SESSION_EPIC")
 fi
+ROLLOVER_BUNDLE_STREAM=""
+if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ] \
+  && declare -f launcher_selector_stream >/dev/null 2>&1; then
+  ROLLOVER_BUNDLE_STREAM="$(launcher_selector_stream "$SESSION_EPIC" 2>/dev/null || true)"
+  case "$ROLLOVER_BUNDLE_STREAM" in
+    epic:*) GATE_ARGS+=(--import-bundle --stream "$ROLLOVER_BUNDLE_STREAM") ;;
+    *) ROLLOVER_BUNDLE_STREAM="" ;;
+  esac
+fi
 
 GATE_RC=0
 GATE_JSON=$(run_bounded 9 env "PYTHONPATH=$PROJECT_DIR" "$BOUNDED_PYTHON" \
@@ -698,7 +716,8 @@ if [ "$GATE_RC" -eq 0 ] && [ -n "$GATE_JSON" ]; then
       (.thread_lease.status // ""), (.thread_lease.context // ""),
       (.thread_lease.generation // ""), (.thread_lease.takeover_banner // ""),
       (.rollover_detect.status // ""), (.rollover_detect.context // ""),
-      (.rollover_detect.detect_status // "")
+      (.rollover_detect.detect_status // ""),
+      (.rollover_import.warning // .rollover_import.error // "")
     ] | .[] | tostring, ([0] | implode)' 2>/dev/null)
   unset _gate_field
 fi
@@ -756,6 +775,9 @@ else
       fi
       ;;
   esac
+  if [ ${#GATE_FIELDS[@]} -ge 14 ]; then
+    [ -n "${GATE_FIELDS[13]}" ] && ISSUES+=("${GATE_FIELDS[13]}")
+  fi
 fi
 unset GATE_JSON GATE_FIELDS GATE_RC
 
@@ -828,7 +850,7 @@ fi
 # established thread-handoff path under the aggregate startup budget.
 if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ] \
   && declare -f launcher_selector_stream >/dev/null 2>&1; then
-  REMOTE_EPIC_STREAM="$(launcher_selector_stream "$SESSION_EPIC" 2>/dev/null || true)"
+  REMOTE_EPIC_STREAM="$ROLLOVER_BUNDLE_STREAM"
   case "$REMOTE_EPIC_STREAM" in
     epic:*)
       REMOTE_EPIC_NUMBER="${REMOTE_EPIC_STREAM#epic:}"
@@ -841,6 +863,7 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ] \
   esac
   unset REMOTE_EPIC_STREAM
 fi
+unset ROLLOVER_BUNDLE_STREAM
 
 # Epic assignment banner
 EPIC_BANNER=""

--- a/agents_extensions/shared/session_streams/inventory.py
+++ b/agents_extensions/shared/session_streams/inventory.py
@@ -23,9 +23,15 @@ MAX_EPIC_NUMBER = 9_999_999_999
 
 # Optional explicit handoff path overrides (relative to repo root).
 # First existing path wins when resolving a live mirror source.
-# Keys are stream ids ``epic:<number>`` or issue-stream names. Infra is keyed
-# by stream name so the harness-epic paths survive epic succession (#6949).
+# Keys are stream ids ``epic:<number>`` or issue-stream names. The infra
+# successor has an explicit stream-id override; the legacy stream-name entry
+# keeps harness-epic paths available for older assignments (#6949).
 HANDOFF_PATH_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "epic:6943": (
+        ".claude/infra-epic/CLAUDE-DRIVER-HANDOFF.md",
+        ".claude/harness-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-infra.md",
+    ),
     "epic:4387": (
         ".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
         ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md",

--- a/agents_extensions/shared/session_streams/migrations/0005_rollover_bundles.sql
+++ b/agents_extensions/shared/session_streams/migrations/0005_rollover_bundles.sql
@@ -1,0 +1,22 @@
+-- Cross-host strict rollover continuity bundles.  Rows are immutable while
+-- retained; the store removes only rows beyond the per-lineage five-row cap.
+CREATE TABLE rollover_bundles (
+    bundle_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    agent TEXT NOT NULL,
+    lineage_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    rollover_id TEXT NOT NULL,
+    bundle_sha256 TEXT NOT NULL CHECK (length(bundle_sha256) = 64) UNIQUE,
+    manifest_json TEXT NOT NULL CHECK (json_valid(manifest_json)),
+    blob BLOB NOT NULL CHECK (length(blob) > 0),
+    uploaded_at TEXT NOT NULL,
+    uploaded_by_lease_id TEXT NOT NULL REFERENCES stream_leases(lease_id),
+    UNIQUE (stream_id, agent, lineage_id, rollover_id)
+) STRICT;
+
+CREATE INDEX rollover_bundles_lineage_order
+    ON rollover_bundles(stream_id, agent, lineage_id, bundle_id DESC);
+
+CREATE INDEX rollover_bundles_stream_order
+    ON rollover_bundles(stream_id, bundle_id DESC);

--- a/agents_extensions/shared/session_streams/migrations/0006_rollover_bundle_status_binding.sql
+++ b/agents_extensions/shared/session_streams/migrations/0006_rollover_bundle_status_binding.sql
@@ -1,0 +1,51 @@
+-- Permit one immutable row for each status/prepared-time tuple while keeping
+-- the bundle digest globally unique.  Migration 0005 is already fingerprinted
+-- by schema_migrations, so rebuild rather than editing that applied DDL.
+DROP INDEX IF EXISTS rollover_bundles_lineage_order;
+DROP INDEX IF EXISTS rollover_bundles_stream_order;
+
+ALTER TABLE rollover_bundles RENAME TO rollover_bundles_v5;
+
+CREATE TABLE rollover_bundles (
+    bundle_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    agent TEXT NOT NULL,
+    lineage_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    rollover_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    prepared_at TEXT NOT NULL,
+    bundle_sha256 TEXT NOT NULL CHECK (length(bundle_sha256) = 64),
+    manifest_json TEXT NOT NULL CHECK (json_valid(manifest_json)),
+    blob BLOB NOT NULL CHECK (length(blob) > 0),
+    uploaded_at TEXT NOT NULL,
+    uploaded_by_lease_id TEXT NOT NULL REFERENCES stream_leases(lease_id)
+) STRICT;
+
+INSERT INTO rollover_bundles(
+    bundle_id, stream_id, agent, lineage_id, generation, rollover_id,
+    status, prepared_at, bundle_sha256, manifest_json, blob, uploaded_at,
+    uploaded_by_lease_id
+)
+SELECT
+    bundle_id, stream_id, agent, lineage_id, generation, rollover_id,
+    json_extract(manifest_json, '$.status'),
+    json_extract(manifest_json, '$.prepared_at'),
+    bundle_sha256, manifest_json, blob, uploaded_at, uploaded_by_lease_id
+FROM rollover_bundles_v5;
+
+DROP TABLE rollover_bundles_v5;
+
+CREATE UNIQUE INDEX rollover_bundles_bundle_sha256_unique
+    ON rollover_bundles(bundle_sha256);
+
+CREATE UNIQUE INDEX rollover_bundles_identity_unique
+    ON rollover_bundles(
+        stream_id, agent, lineage_id, rollover_id, status, prepared_at
+    );
+
+CREATE INDEX rollover_bundles_lineage_order
+    ON rollover_bundles(stream_id, agent, lineage_id, bundle_id DESC);
+
+CREATE INDEX rollover_bundles_stream_order
+    ON rollover_bundles(stream_id, bundle_id DESC);

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
 import uuid
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta
 from typing import Any
@@ -35,6 +36,9 @@ from .model import (
 
 MAX_ENTRY_BYTES = 65_536
 MAX_TTL_SECONDS = 86_400
+MAX_ROLLOVER_BUNDLE_BYTES = 4 * 1024 * 1024
+ROLLOVER_BUNDLE_SCHEMA = "rollover-bundle.v1"
+ROLLOVER_BUNDLE_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 SECRET_PATTERNS = (
     ("private-key", re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |PGP )?PRIVATE KEY-----")),
     ("credential-token", re.compile(r"(?:sk-|gh[pousr]_|AIza)[A-Za-z0-9_-]{16,}")),
@@ -1536,6 +1540,248 @@ class SessionStreamStore:
             if row is None:
                 raise SessionStreamError("entry insert did not produce a readable row")
             return self._entry_from_row(connection, row)
+
+    def upload_rollover_bundle(
+        self,
+        lease: Lease,
+        *,
+        manifest: Mapping[str, Any],
+        blob: bytes,
+        now: datetime | None = None,
+        app_proof: VerifiedAppLifecycleProof | None = None,
+    ) -> dict[str, Any]:
+        """Store one verified rollover bundle under the exact fenced lease.
+
+        This deliberately mirrors ``append_entry``'s lease and app-proof
+        contract.  Process holders use the ordinary fenced lease path;
+        app-thread holders must carry the same verified lifecycle receipt used
+        by other immutable mutations.
+        """
+        if not isinstance(manifest, Mapping):
+            raise ValueError("rollover bundle manifest must be an object")
+        if not isinstance(blob, bytes) or not blob:
+            raise ContentRejectedError("rollover bundle blob must be non-empty bytes")
+        if len(blob) > MAX_ROLLOVER_BUNDLE_BYTES:
+            raise ContentRejectedError("rollover bundle exceeds the 4 MiB cap")
+        manifest_value = dict(manifest)
+        if manifest_value.get("schema") != ROLLOVER_BUNDLE_SCHEMA:
+            raise ValueError("rollover bundle manifest schema is invalid")
+        stream_id = validate_stream_id(lease.stream_id)
+        if manifest_value.get("stream_id") != stream_id:
+            raise ValueError("rollover bundle stream_id does not match the lease")
+        for field in ("agent", "lineage_id", "rollover_id"):
+            value = manifest_value.get(field)
+            if not isinstance(value, str) or not value or not self._identity_is_safe(value):
+                raise ValueError(f"rollover bundle {field} is malformed")
+        try:
+            generation = int(manifest_value["generation"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("rollover bundle generation is malformed") from exc
+        if generation < 1:
+            raise ValueError("rollover bundle generation must be positive")
+        if manifest_value.get("status") not in {"pending_start", "resumed", "started", "confirmed", "superseded"}:
+            raise ValueError("rollover bundle status is invalid")
+        prepared_at = manifest_value.get("prepared_at")
+        if not isinstance(prepared_at, str):
+            raise ValueError("rollover bundle prepared_at is malformed")
+        parse_timestamp(prepared_at)
+        bundle_sha256 = manifest_value.get("bundle_sha256")
+        if not isinstance(bundle_sha256, str) or not ROLLOVER_BUNDLE_SHA256_RE.fullmatch(bundle_sha256):
+            raise ValueError("rollover bundle fingerprint is malformed")
+        files = manifest_value.get("files")
+        if not isinstance(files, list) or not files:
+            raise ValueError("rollover bundle manifest has no files")
+        current_time = now or utc_now()
+        self._require_app_proof(
+            app_proof,
+            operation="append",
+            holder=lease.holder,
+            stream_id=stream_id,
+            session_id=lease.session_id,
+            lease_id=lease.lease_id,
+            generation=lease.generation,
+            fencing_token=lease.fencing_token,
+            now=current_time,
+        )
+        uploaded_at = isoformat_z(current_time)
+        manifest_json = canonical_json(manifest_value)
+        try:
+            with self._transaction(now=current_time) as connection:
+                lease_row = self._require_current_lease(connection, lease, require_valid_at=current_time)
+                existing_by_sha = connection.execute(
+                    "SELECT * FROM rollover_bundles WHERE bundle_sha256 = ?",
+                    (bundle_sha256,),
+                ).fetchone()
+                if existing_by_sha is not None:
+                    if (
+                        existing_by_sha["stream_id"] != stream_id
+                        or existing_by_sha["agent"] != manifest_value["agent"]
+                        or existing_by_sha["lineage_id"] != manifest_value["lineage_id"]
+                        or existing_by_sha["rollover_id"] != manifest_value["rollover_id"]
+                    ):
+                        raise LeaseConflictError("bundle fingerprint is already bound to another lineage")
+                    return self._rollover_bundle_payload(existing_by_sha, include_blob=True)
+                existing_by_rollover = connection.execute(
+                    "SELECT bundle_sha256 FROM rollover_bundles "
+                    "WHERE stream_id = ? AND agent = ? AND lineage_id = ? AND rollover_id = ?",
+                    (stream_id, manifest_value["agent"], manifest_value["lineage_id"], manifest_value["rollover_id"]),
+                ).fetchone()
+                if existing_by_rollover is not None:
+                    raise LeaseConflictError("rollover id already binds different immutable bundle content")
+                cursor = connection.execute(
+                    "INSERT INTO rollover_bundles("
+                    "stream_id, agent, lineage_id, generation, rollover_id, bundle_sha256, "
+                    "manifest_json, blob, uploaded_at, uploaded_by_lease_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        stream_id,
+                        manifest_value["agent"],
+                        manifest_value["lineage_id"],
+                        generation,
+                        manifest_value["rollover_id"],
+                        bundle_sha256,
+                        manifest_json,
+                        blob,
+                        uploaded_at,
+                        lease.lease_id,
+                    ),
+                )
+                bundle_id = int(cursor.lastrowid)
+                if app_proof is not None:
+                    event_id = self._insert_lease_event_from_row(
+                        connection,
+                        row=lease_row,
+                        event_type="appended",
+                        timestamp=uploaded_at,
+                        proof={
+                            "kind": "session_stream_rollover_bundle_upload.v1",
+                            "bundle_sha256": bundle_sha256,
+                            **self._proof_payload(app_proof),
+                        },
+                        reason="verified GUI-native rollover bundle upload",
+                    )
+                    connection.execute(
+                        "UPDATE stream_leases SET version = version + 1, last_event_id = ? WHERE stream_id = ?",
+                        (event_id, stream_id),
+                    )
+                old_rows = connection.execute(
+                    "SELECT bundle_id FROM rollover_bundles "
+                    "WHERE stream_id = ? AND agent = ? AND lineage_id = ? "
+                    "ORDER BY bundle_id DESC LIMIT -1 OFFSET 5",
+                    (stream_id, manifest_value["agent"], manifest_value["lineage_id"]),
+                ).fetchall()
+                if old_rows:
+                    connection.executemany(
+                        "DELETE FROM rollover_bundles WHERE bundle_id = ?",
+                        ((int(row["bundle_id"]),) for row in old_rows),
+                    )
+                row = connection.execute(
+                    "SELECT * FROM rollover_bundles WHERE bundle_id = ?",
+                    (bundle_id,),
+                ).fetchone()
+                if row is None:
+                    raise SessionStreamError("rollover bundle insert did not produce a readable row")
+                return self._rollover_bundle_payload(row, include_blob=True)
+        except sqlite3.IntegrityError as exc:
+            raise LeaseConflictError("rollover bundle conflicts with an existing immutable row") from exc
+
+    def list_rollover_bundles(
+        self,
+        stream_id: str,
+        *,
+        agent: str | None = None,
+        lineage_id: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        stream_id = validate_stream_id(stream_id)
+        if limit < 1 or limit > 100:
+            raise ValueError("rollover bundle limit must be between 1 and 100")
+        if agent is not None:
+            self._validate_identity("agent", agent)
+        if lineage_id is not None:
+            self._validate_identity("lineage_id", lineage_id)
+        with self._read_snapshot() as connection:
+            if connection.execute("SELECT 1 FROM streams WHERE stream_id = ?", (stream_id,)).fetchone() is None:
+                raise NotFoundError(f"stream not found: {stream_id}")
+            clauses = ["stream_id = ?"]
+            values: list[Any] = [stream_id]
+            if agent is not None:
+                clauses.append("agent = ?")
+                values.append(agent)
+            if lineage_id is not None:
+                clauses.append("lineage_id = ?")
+                values.append(lineage_id)
+            values.append(limit)
+            rows = connection.execute(
+                "SELECT * FROM rollover_bundles WHERE " + " AND ".join(clauses) + " "
+                "ORDER BY bundle_id DESC LIMIT ?",
+                tuple(values),
+            ).fetchall()
+            return [self._rollover_bundle_payload(row, include_blob=False) for row in rows]
+
+    def upload_bundle(
+        self,
+        lease: Lease,
+        *,
+        manifest: Mapping[str, Any],
+        blob: bytes,
+        now: datetime | None = None,
+        app_proof: VerifiedAppLifecycleProof | None = None,
+    ) -> dict[str, Any]:
+        """Compatibility name for callers that treat bundles as uploads."""
+        return self.upload_rollover_bundle(
+            lease,
+            manifest=manifest,
+            blob=blob,
+            now=now,
+            app_proof=app_proof,
+        )
+
+    def latest_rollover_bundle(
+        self,
+        stream_id: str,
+        *,
+        agent: str,
+        lineage_id: str | None = None,
+    ) -> dict[str, Any]:
+        stream_id = validate_stream_id(stream_id)
+        self._validate_identity("agent", agent)
+        if lineage_id is not None:
+            self._validate_identity("lineage_id", lineage_id)
+        with self._read_snapshot() as connection:
+            clauses = ["stream_id = ?", "agent = ?"]
+            values: list[Any] = [stream_id, agent]
+            if lineage_id is not None:
+                clauses.append("lineage_id = ?")
+                values.append(lineage_id)
+            row = connection.execute(
+                "SELECT * FROM rollover_bundles WHERE " + " AND ".join(clauses) + " "
+                "ORDER BY bundle_id DESC LIMIT 1",
+                tuple(values),
+            ).fetchone()
+            if row is None:
+                raise NotFoundError("no rollover bundle exists for the requested lineage")
+            return self._rollover_bundle_payload(row, include_blob=True)
+
+    @staticmethod
+    def _identity_is_safe(value: str) -> bool:
+        return bool(value) and len(value) <= 256 and all(char.isalnum() or char in "._:/-" for char in value)
+
+    @staticmethod
+    def _rollover_bundle_payload(row: sqlite3.Row, *, include_blob: bool) -> dict[str, Any]:
+        manifest = json.loads(str(row["manifest_json"]))
+        manifest["upload_seq"] = int(row["bundle_id"])
+        payload: dict[str, Any] = {
+            "manifest": manifest,
+            "upload_seq": int(row["bundle_id"]),
+            "bundle_sha256": str(row["bundle_sha256"]),
+            "bytes": len(row["blob"]),
+            "uploaded_at": str(row["uploaded_at"]),
+            "uploaded_by_lease_id": str(row["uploaded_by_lease_id"]),
+        }
+        if include_blob:
+            payload["blob"] = bytes(row["blob"])
+        return payload
 
     def load_digest(self, stream_id: str, *, limit: int) -> StreamDigest:
         """Load all pinned entries first, then the last N non-pinned entries."""

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -1790,6 +1790,20 @@ class SessionStreamStore:
                 raise NotFoundError("no rollover bundle exists for the requested lineage")
             return self._rollover_bundle_payload(row, include_blob=True)
 
+    def rollover_bundle_by_upload_seq(self, stream_id: str, upload_seq: int) -> dict[str, Any]:
+        """Load one immutable rollover bundle by its stream upload sequence."""
+        stream_id = validate_stream_id(stream_id)
+        if upload_seq < 1:
+            raise ValueError("rollover bundle upload sequence must be positive")
+        with self._read_snapshot() as connection:
+            row = connection.execute(
+                "SELECT * FROM rollover_bundles WHERE stream_id = ? AND bundle_id = ?",
+                (stream_id, upload_seq),
+            ).fetchone()
+            if row is None:
+                raise NotFoundError("rollover bundle not found")
+            return self._rollover_bundle_payload(row, include_blob=True)
+
     @staticmethod
     def _identity_is_safe(value: str) -> bool:
         return bool(value) and len(value) <= 256 and all(char.isalnum() or char in "._:/-" for char in value)

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -1756,22 +1756,34 @@ class SessionStreamStore:
         self,
         stream_id: str,
         *,
-        agent: str,
+        agent: str | None = None,
         lineage_id: str | None = None,
     ) -> dict[str, Any]:
         stream_id = validate_stream_id(stream_id)
-        self._validate_identity("agent", agent)
+        if agent is not None:
+            self._validate_identity("agent", agent)
         if lineage_id is not None:
             self._validate_identity("lineage_id", lineage_id)
         with self._read_snapshot() as connection:
-            clauses = ["stream_id = ?", "agent = ?"]
-            values: list[Any] = [stream_id, agent]
+            clauses = ["stream_id = ?"]
+            values: list[Any] = [stream_id]
+            if agent is not None:
+                clauses.append("agent = ?")
+                values.append(agent)
             if lineage_id is not None:
                 clauses.append("lineage_id = ?")
                 values.append(lineage_id)
             row = connection.execute(
                 "SELECT * FROM rollover_bundles WHERE " + " AND ".join(clauses) + " "
-                "ORDER BY bundle_id DESC LIMIT 1",
+                "ORDER BY generation DESC, "
+                "CASE status "
+                "WHEN 'superseded' THEN 0 "
+                "WHEN 'pending_start' THEN 1 "
+                "WHEN 'resumed' THEN 2 "
+                "WHEN 'started' THEN 3 "
+                "WHEN 'confirmed' THEN 3 "
+                "ELSE -1 END DESC, "
+                "prepared_at DESC, rollover_id DESC, bundle_id DESC LIMIT 1",
                 tuple(values),
             ).fetchone()
             if row is None:

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -1618,27 +1618,42 @@ class SessionStreamStore:
                         or existing_by_sha["agent"] != manifest_value["agent"]
                         or existing_by_sha["lineage_id"] != manifest_value["lineage_id"]
                         or existing_by_sha["rollover_id"] != manifest_value["rollover_id"]
+                        or int(existing_by_sha["generation"]) != generation
+                        or existing_by_sha["status"] != manifest_value["status"]
+                        or existing_by_sha["prepared_at"] != prepared_at
                     ):
                         raise LeaseConflictError("bundle fingerprint is already bound to another lineage")
                     return self._rollover_bundle_payload(existing_by_sha, include_blob=True)
                 existing_by_rollover = connection.execute(
                     "SELECT bundle_sha256 FROM rollover_bundles "
-                    "WHERE stream_id = ? AND agent = ? AND lineage_id = ? AND rollover_id = ?",
-                    (stream_id, manifest_value["agent"], manifest_value["lineage_id"], manifest_value["rollover_id"]),
+                    "WHERE stream_id = ? AND agent = ? AND lineage_id = ? AND rollover_id = ? "
+                    "AND status = ? AND prepared_at = ?",
+                    (
+                        stream_id,
+                        manifest_value["agent"],
+                        manifest_value["lineage_id"],
+                        manifest_value["rollover_id"],
+                        manifest_value["status"],
+                        prepared_at,
+                    ),
                 ).fetchone()
                 if existing_by_rollover is not None:
-                    raise LeaseConflictError("rollover id already binds different immutable bundle content")
+                    raise LeaseConflictError(
+                        "rollover tuple already binds different immutable bundle content"
+                    )
                 cursor = connection.execute(
                     "INSERT INTO rollover_bundles("
-                    "stream_id, agent, lineage_id, generation, rollover_id, bundle_sha256, "
-                    "manifest_json, blob, uploaded_at, uploaded_by_lease_id) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "stream_id, agent, lineage_id, generation, rollover_id, status, prepared_at, "
+                    "bundle_sha256, manifest_json, blob, uploaded_at, uploaded_by_lease_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         stream_id,
                         manifest_value["agent"],
                         manifest_value["lineage_id"],
                         generation,
                         manifest_value["rollover_id"],
+                        manifest_value["status"],
+                        prepared_at,
                         bundle_sha256,
                         manifest_json,
                         blob,

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -279,6 +279,9 @@ boundary for another machine.
 | POST | `/api/epics/v1/epic:<N>/claim` | Client-supplied IDs; same IDs plus same holder replay; expired recovery increments generation and fence atomically |
 | POST | `/api/epics/v1/epic:<N>/heartbeat` | Exact fenced lease heartbeat; `409 LEASE LOST` fences the client |
 | POST | `/api/epics/v1/epic:<N>/handoff` | Appends one existing entry type with an idempotency key |
+| POST | `/api/epics/v1/epic:<N>/bundles` | Uploads one verified `rollover-bundle.v1`; loopback mutation, fenced lease, secret scan, SHA idempotency, and 4 MiB cap |
+| GET | `/api/epics/v1/epic:<N>/bundles` | Lists retained bundle manifests and receipts without blobs; optional `agent`, `lineage_id`, and `limit` |
+| GET | `/api/epics/v1/epic:<N>/bundles/latest` | Returns the newest matching manifest plus base64 blob; `agent` is required and `lineage_id` is optional |
 | POST | `/api/epics/v1/epic:<N>/release` | Exact release is idempotent; `force` requires actor host and reason |
 
 Driver leases are claimed on the API host through this surface. Remote mode is
@@ -286,6 +289,28 @@ the default; `--local` is an offline-only fallback that prints a warning and
 does not create a fleet-visible lease. A driver on any machine resumes by
 claiming the same stream, and a typed handoff is appended with
 `POST /api/epics/v1/epic:<N>/handoff`.
+
+### Rollover bundle routes
+
+Bundles are agent-to-agent, gitignored continuity artifacts. The upload body
+contains the same lease fields accepted by `heartbeat`/`handoff`, a manifest,
+and a base64 tarball. The server validates archive member fingerprints and the
+canonical `bundle_sha256`, rejects secret-pattern hits with the member and rule
+identified, and assigns a monotonic `upload_seq` from the SQLite row id. The
+same SHA re-upload returns the existing row. Retention keeps the latest five
+rows per `(stream, agent, lineage)`.
+
+Only text members are root-tokenised; the manifest's `tokenized_members` makes
+that explicit. JSON artifacts are byte-exact. `.native-intent.lock` is excluded;
+present semantic-snapshot templates, all strict JSON artifacts, identity
+receipts, and `canary-pass.json` are included. The list route omits blobs; the
+latest route returns the manifest and blob for import.
+
+All three bundle routes use the same API-host loopback boundary as claim and
+handoff. A remote machine reaches the API through its SSH tunnel; a direct
+non-loopback POST is rejected. If the API or tunnel is unavailable, launcher
+and SessionStart imports warn loudly and continue fail-open; the `--file`
+export/import path is the scp/rsync fallback.
 
 ### Registry and lease fields
 

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -103,11 +103,12 @@ SESSION_HANDOFF_AGENT=claude-infra .venv/bin/python scripts/orchestration/thread
   import-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
 ```
 
-When the successor is a different agent, the lane handoff transfers with the
-newest stream bundle and the strict packet binds only same-harness successors,
-who receive it from their own agent's bundle; a different-harness successor
-keeps the foreign lineage under its recorded agent namespace and must not treat
-that packet as its own.
+When the successor is a different agent, the lane handoff follows the newest
+**upload** across agents, while the successor's own packet is selected separately
+from the newest upload in its own agent namespace; the strict packet binds only
+same-harness successors, who receive it from that own namespace. A
+different-harness successor keeps any foreign lineage under its recorded agent
+namespace and must not treat that packet as its own.
 
 The API host stores at most the five newest bundles for each
 `(stream, agent, lineage)`. Re-uploading the same `bundle_sha256` is idempotent.
@@ -116,8 +117,8 @@ The manifest fingerprints the tokenised member bytes and records
 `{{REPO_ROOT}}`, while JSON members are copied byte-for-byte. The bundle tar
 hash is deterministic, `.native-intent.lock` is excluded, and present semantic
 snapshot templates, strict JSON artifacts, identity receipts, and canary
-receipts are included. Secret-pattern hits name the member and rule, write the
-local file, and skip upload.
+receipts are included. Secret-pattern hits log only the rule id, write the local
+file, and skip upload.
 
 Import compares `(generation, status rank, prepared_at, rollover_id,
 upload_seq)`, where confirmed/started outranks resumed, which outranks

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -77,6 +77,65 @@ LU_MONITOR_HOST_ID="<opaque id>" \
 The driver launcher normally performs the claim. `--local` is the explicit
 offline fallback and prints its warning; it is not a remote handoff path.
 
+## Cross-host rollover bundle (#7260)
+
+The launcher-derived `epic:<N>` stream now carries the gitignored thread packet
+and the lane handoff as one bounded `rollover-bundle.v1` tarball. `prepare` and
+`confirm-replacement` write the local bundle and best-effort upload it after
+their durable mutation when the fenced `SESSION_STREAM_*` lease envelope is
+present. Upload failure is loud and fail-open: it never blocks close or start.
+
+The automatic launcher import runs before provider pre-lease checks and packet
+scans. The consolidated SessionStart gate repeats the import as a <=3-second
+backstop before `detect`; an unavailable API is a warning, not a start blocker.
+The Python caller receives `--stream` from `launcher_selector_stream
+"$SESSION_EPIC"`; there is no `SESSION_STREAM_ID` guessing path.
+
+```bash
+# Explicit export to a local file (the source root is the current checkout).
+.venv/bin/python scripts/orchestration/thread_handoff.py \
+  export-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
+
+# Import from the API authority, or use the file after scp/rsync.
+.venv/bin/python scripts/orchestration/thread_handoff.py \
+  import-bundle --agent claude-infra --from-api epic:6943
+.venv/bin/python scripts/orchestration/thread_handoff.py \
+  import-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
+```
+
+The API host stores at most the five newest bundles for each
+`(stream, agent, lineage)`. Re-uploading the same `bundle_sha256` is idempotent.
+The manifest fingerprints the tokenised member bytes and records
+`tokenized_members`; `bootstrap.md`, `handoff.md`, and other text members carry
+`{{REPO_ROOT}}`, while JSON members are copied byte-for-byte. The bundle tar
+hash is deterministic, `.native-intent.lock` is excluded, and present semantic
+snapshot templates, strict JSON artifacts, identity receipts, and canary
+receipts are included. Secret-pattern hits name the member and rule, write the
+local file, and skip upload.
+
+Import compares `(generation, status rank, prepared_at, rollover_id,
+upload_seq)`, where confirmed/started outranks resumed, which outranks
+pending_start. A newer remote copy archives the local lineage and marks stale
+pending/resumed replacements `superseded`; a newer local copy is refused with
+exit 2 unless `--force` is explicit. A confirmed local replacement is never
+archived for a remote pending copy. Differing existing lane handoffs are kept
+beside the target as `CLAUDE-DRIVER-HANDOFF.<utc>.superseded.md` before install.
+
+The bundle API is loopback-mutation protected just like claim and handoff. A
+remote host reaches it through the SSH tunnel to the API host. If tunnelling is
+not available, export to a file and copy only that file:
+
+```bash
+scp /path/to/rollover.tgz target-host:/tmp/rollover.tgz
+ssh target-host -- .venv/bin/python scripts/orchestration/thread_handoff.py \
+  import-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
+```
+
+After import, run `detect --agent claude-infra --format session-start` and
+follow the exact packet's `bootstrap-replacement` / `confirm-replacement` card.
+Archived copies under `.agent/thread-rollovers/<agent>/_archive/` are retained
+for operator review and are never swept automatically.
+
 ## Manual checklist (until CLI is habitual)
 
 1. Read `GET /api/epics/v1/epic:<N>` or the equivalent SessionStart remote state.

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -97,11 +97,17 @@ The Python caller receives `--stream` from `launcher_selector_stream
   export-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
 
 # Import from the API authority, or use the file after scp/rsync.
-.venv/bin/python scripts/orchestration/thread_handoff.py \
-  import-bundle --agent claude-infra --from-api epic:6943
+SESSION_HANDOFF_AGENT=claude-infra .venv/bin/python scripts/orchestration/thread_handoff.py \
+  import-bundle --from-api epic:6943
 .venv/bin/python scripts/orchestration/thread_handoff.py \
   import-bundle --agent claude-infra --stream epic:6943 --file /tmp/rollover.tgz
 ```
+
+When the successor is a different agent, the lane handoff transfers with the
+newest stream bundle and the strict packet binds only same-harness successors,
+who receive it from their own agent's bundle; a different-harness successor
+keeps the foreign lineage under its recorded agent namespace and must not treat
+that packet as its own.
 
 The API host stores at most the five newest bundles for each
 `(stream, agent, lineage)`. Re-uploading the same `bundle_sha256` is idempotent.

--- a/scripts/api/epics_router.py
+++ b/scripts/api/epics_router.py
@@ -598,14 +598,14 @@ def remote_claim(stream_id: str, request: Request, body: dict[str, Any]) -> JSON
         response = _stream_response(store, stream_id, limit)
         response["outcome"] = outcome
         return JSONResponse(content=response, headers={"Cache-Control": "no-store"})
-    except LeaseConflictError as exc:
+    except LeaseConflictError:
         try:
             projection = _stream_response(store, stream_id, limit)
         except Exception:
-            return _error(409, str(exc))
+            return _error(409, "lease conflict")
         lease = projection.get("lease")
         if not isinstance(lease, dict) or lease.get("state") != "active":
-            return _error(409, str(exc))
+            return _error(409, "lease conflict")
         holder = lease.get("holder") or {}
         return _error(
             409,
@@ -729,8 +729,8 @@ def remote_bundle_upload(stream_id: str, request: Request, body: dict[str, Any])
             content={"schema": SCHEMA, **_bundle_api_payload(stored, include_blob=False)},
             headers={"Cache-Control": "no-store"},
         )
-    except LeaseConflictError as exc:
-        return _error(409, str(exc))
+    except LeaseConflictError:
+        return _error(409, "lease conflict")
     except (ValueError, ContentRejectedError, binascii.Error):
         return _error(400, "invalid rollover bundle upload request")
     except Exception:
@@ -777,6 +777,23 @@ def remote_bundle_latest(stream_id: str, agent: str | None = None, lineage_id: s
         return _error(404, "rollover bundle not found")
     except (ValueError, ContentRejectedError):
         return _error(400, "invalid latest rollover bundle request")
+    except Exception:
+        return _server_error()
+
+
+@router.get("/v1/{stream_id}/bundles/{upload_seq}")
+def remote_bundle_by_upload_seq(stream_id: str, upload_seq: int) -> JSONResponse:
+    try:
+        stream_id = _epic_stream(stream_id)
+        stored = _store().rollover_bundle_by_upload_seq(stream_id, upload_seq)
+        return JSONResponse(
+            content={"schema": SCHEMA, "stream_id": stream_id, **_bundle_api_payload(stored, include_blob=True)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except NotFoundError:
+        return _error(404, "rollover bundle not found")
+    except (ValueError, ContentRejectedError):
+        return _error(400, "invalid rollover bundle sequence request")
     except Exception:
         return _server_error()
 

--- a/scripts/api/epics_router.py
+++ b/scripts/api/epics_router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import re
 from datetime import datetime
@@ -29,6 +31,7 @@ from agents_extensions.shared.session_streams.model import (
 )
 from agents_extensions.shared.session_streams.receipts import register_manifest_inventory
 from agents_extensions.shared.session_streams.store import (
+    MAX_ROLLOVER_BUNDLE_BYTES,
     ContentRejectedError,
     LeaseConflictError,
     NotFoundError,
@@ -38,6 +41,7 @@ from agents_extensions.shared.session_streams.store import (
 from scripts.api.config import LIVE_REPO_ROOT
 from scripts.api.observer_presence import _direct_loopback_peer
 from scripts.api.occupancy_sanitize import opaque_host_id, safe_field
+from scripts.orchestration.thread_handoff import _bundle_extract, _bundle_secret_hits
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -461,6 +465,29 @@ def _check_mutation_peer(request: Request) -> JSONResponse | None:
     return None
 
 
+def _bundle_blob_from_body(body: dict[str, Any]) -> bytes:
+    encoded = body.get("blob")
+    if not isinstance(encoded, str) or not encoded:
+        raise ValueError("bundle blob must be base64 text")
+    try:
+        blob = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, binascii.Error, ValueError) as exc:
+        raise ValueError("bundle blob is not valid base64") from exc
+    if not blob or len(blob) > MAX_ROLLOVER_BUNDLE_BYTES:
+        raise ContentRejectedError("rollover bundle exceeds the 4 MiB cap")
+    return blob
+
+
+def _bundle_api_payload(row: dict[str, Any], *, include_blob: bool) -> dict[str, Any]:
+    payload = dict(row)
+    blob = payload.pop("blob", None)
+    if include_blob:
+        if not isinstance(blob, bytes):
+            raise ValueError("stored rollover bundle blob is malformed")
+        payload["blob"] = base64.b64encode(blob).decode("ascii")
+    return payload
+
+
 def _claim_values(body: dict[str, Any]) -> tuple[str, str, str, LeaseHolder, int, int]:
     session_id = _token(body.get("session_id"), "session_id")
     lease_id = _token(body.get("lease_id"), "lease_id")
@@ -672,6 +699,84 @@ def remote_handoff(stream_id: str, request: Request, body: dict[str, Any]) -> JS
         return _error(409, "LEASE LOST")
     except (ValueError, ContentRejectedError):
         return _error(400, "invalid epic handoff request")
+    except Exception:
+        return _server_error()
+
+
+@router.post("/v1/{stream_id}/bundles")
+def remote_bundle_upload(stream_id: str, request: Request, body: dict[str, Any]) -> JSONResponse:
+    """Upload one cross-host bundle through the same fenced loopback mutation path."""
+    denied = _check_mutation_peer(request)
+    if denied is not None:
+        return denied
+    try:
+        stream_id = _epic_stream(stream_id)
+        lease = _lease_from_payload({**body, "stream_id": stream_id})
+        if lease.stream_id != stream_id:
+            raise ValueError("stream mismatch")
+        manifest = body.get("manifest")
+        if not isinstance(manifest, dict):
+            raise ValueError("bundle manifest must be an object")
+        blob = _bundle_blob_from_body(body)
+        _, members = _bundle_extract(blob, manifest_override=manifest)
+        secret_hits = _bundle_secret_hits(members)
+        if secret_hits:
+            member, rule = secret_hits[0]
+            raise ContentRejectedError(f"bundle member {member} matched {rule} rule")
+        store = _store()
+        stored = store.upload_bundle(lease, manifest=manifest, blob=blob)
+        return JSONResponse(
+            content={"schema": SCHEMA, **_bundle_api_payload(stored, include_blob=False)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except LeaseConflictError as exc:
+        return _error(409, str(exc))
+    except (ValueError, ContentRejectedError, binascii.Error):
+        return _error(400, "invalid rollover bundle upload request")
+    except Exception:
+        return _server_error()
+
+
+@router.get("/v1/{stream_id}/bundles")
+def remote_bundle_list(
+    stream_id: str,
+    agent: str | None = None,
+    lineage_id: str | None = None,
+    limit: int = 20,
+) -> JSONResponse:
+    try:
+        stream_id = _epic_stream(stream_id)
+        bundles = _store().list_rollover_bundles(
+            stream_id,
+            agent=agent,
+            lineage_id=lineage_id,
+            limit=limit,
+        )
+        return JSONResponse(
+            content={"schema": SCHEMA, "stream_id": stream_id, "bundles": bundles},
+            headers={"Cache-Control": "no-store"},
+        )
+    except NotFoundError:
+        return _error(404, "epic stream not found")
+    except (ValueError, ContentRejectedError):
+        return _error(400, "invalid rollover bundle list request")
+    except Exception:
+        return _server_error()
+
+
+@router.get("/v1/{stream_id}/bundles/latest")
+def remote_bundle_latest(stream_id: str, agent: str, lineage_id: str | None = None) -> JSONResponse:
+    try:
+        stream_id = _epic_stream(stream_id)
+        stored = _store().latest_rollover_bundle(stream_id, agent=agent, lineage_id=lineage_id)
+        return JSONResponse(
+            content={"schema": SCHEMA, "stream_id": stream_id, **_bundle_api_payload(stored, include_blob=True)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except NotFoundError:
+        return _error(404, "rollover bundle not found")
+    except (ValueError, ContentRejectedError):
+        return _error(400, "invalid latest rollover bundle request")
     except Exception:
         return _server_error()
 

--- a/scripts/api/epics_router.py
+++ b/scripts/api/epics_router.py
@@ -765,7 +765,7 @@ def remote_bundle_list(
 
 
 @router.get("/v1/{stream_id}/bundles/latest")
-def remote_bundle_latest(stream_id: str, agent: str, lineage_id: str | None = None) -> JSONResponse:
+def remote_bundle_latest(stream_id: str, agent: str | None = None, lineage_id: str | None = None) -> JSONResponse:
     try:
         stream_id = _epic_stream(stream_id)
         stored = _store().latest_rollover_bundle(stream_id, agent=agent, lineage_id=lineage_id)

--- a/scripts/hooks/session_start_gate.py
+++ b/scripts/hooks/session_start_gate.py
@@ -30,7 +30,10 @@ import contextlib
 import io
 import json
 import platform
+import signal
 import sys
+import threading
+import time
 import traceback
 from pathlib import Path
 from typing import Any
@@ -289,6 +292,9 @@ def phase_rollover_detect(args: argparse.Namespace) -> dict[str, Any]:
     family_args: list[str] = []
     if args.task_family:
         family_args = ["--task-family", args.task_family]
+    stream_args: list[str] = []
+    if getattr(args, "stream", ""):
+        stream_args = ["--stream", args.stream]
     base = [
         "--repo-root",
         args.repo_root,
@@ -298,6 +304,7 @@ def phase_rollover_detect(args: argparse.Namespace) -> dict[str, Any]:
         "--current-thread-id",
         args.session_id or "",
         *family_args,
+        *stream_args,
     ]
     try:
         thread_handoff = _import_thread_handoff()
@@ -365,6 +372,71 @@ def phase_rollover_detect(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def phase_rollover_import(args: argparse.Namespace) -> dict[str, Any]:
+    """Fetch the newest remote packet before detect, without blocking startup."""
+    if not getattr(args, "import_bundle", False):
+        return {"status": "skipped", "reason": "bundle backstop not requested"}
+    if not getattr(args, "stream", ""):
+        return {"status": "skipped", "reason": "no launcher-derived stream"}
+    started = time.monotonic()
+    import_timeout = 2.8
+    previous_handler: Any = None
+    previous_timer: tuple[float, float] | None = None
+    alarm_enabled = threading.current_thread() is threading.main_thread()
+    try:
+        thread_handoff = _import_thread_handoff()
+        if alarm_enabled:
+            previous_handler = signal.getsignal(signal.SIGALRM)
+            previous_timer = signal.setitimer(signal.ITIMER_REAL, import_timeout)
+
+            def _alarm_timeout(_signum: int, _frame: Any) -> None:
+                raise TimeoutError("rollover bundle import exceeded its 3-second sub-budget")
+
+            signal.signal(signal.SIGALRM, _alarm_timeout)
+        rc, out, err = _run_cli_inprocess(
+            thread_handoff.main,
+            [
+                "--repo-root",
+                args.repo_root,
+                "import-bundle",
+                "--agent",
+                args.agent,
+                "--from-api",
+                args.stream,
+                "--stream",
+                args.stream,
+            ],
+        )
+    except TimeoutError as exc:
+        return {
+            "status": "issue",
+            "warning": f"WARNING: rollover bundle import skipped (fail-open): {exc}; detect continues.",
+        }
+    except Exception as exc:
+        return _crash(exc)
+    finally:
+        if alarm_enabled:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            if previous_timer is not None:
+                signal.setitimer(signal.ITIMER_REAL, *previous_timer)
+            if previous_handler is not None:
+                signal.signal(signal.SIGALRM, previous_handler)
+    elapsed = time.monotonic() - started
+    payload = _parse_protocol_payload(out, err)
+    if elapsed > 3.0:
+        return {
+            "status": "issue",
+            "warning": f"WARNING: rollover bundle import exceeded its 3-second sub-budget ({elapsed:.2f}s); detect continues.",
+        }
+    if rc == 0 and isinstance(payload, dict) and payload.get("status") not in {"warning", "refused"}:
+        return {"status": "ok", "elapsed_seconds": round(elapsed, 3)}
+    detail = " ".join((out or err).split()) or "no structured output"
+    return {
+        "status": "issue",
+        "warning": f"WARNING: rollover bundle import skipped (fail-open): {detail}",
+    }
+
+
 # --- entrypoint ---------------------------------------------------------------
 
 
@@ -392,6 +464,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--task-family", default="")
     parser.add_argument("--claim-lease", action="store_true")
     parser.add_argument("--detect", action="store_true")
+    parser.add_argument("--import-bundle", action="store_true")
+    parser.add_argument("--stream", default="")
     args = parser.parse_args(argv)
 
     # Imports must resolve against the session checkout, matching the old
@@ -410,8 +484,10 @@ def main(argv: list[str] | None = None) -> int:
     # and detect must not run (never replace a lease verdict with detect output).
     lease_status = result["thread_lease"]["status"]
     if lease_status in {"stop", "crashed"}:
+        result["rollover_import"] = {"status": "skipped", "reason": "lease verdict is authoritative"}
         result["rollover_detect"] = {"status": "skipped", "reason": "lease verdict is authoritative"}
     else:
+        result["rollover_import"] = phase_rollover_import(args)
         result["rollover_detect"] = phase_rollover_detect(args)
 
     json.dump(result, sys.stdout, ensure_ascii=False)

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -409,6 +409,31 @@ launcher_prepare_driver_identity() {
   export SESSION_HANDOFF_AGENT="$LC_DRIVER_HANDOFF"
 }
 
+launcher_import_rollover_bundle() {
+  local stream helper_root python script output rc
+  stream="$(launcher_selector_stream "$LC_EPIC" 2>/dev/null || true)"
+  case "$stream" in
+    epic:*) ;;
+    *) return 0 ;;
+  esac
+  helper_root="${LC_DURABLE_HELPER_ROOT:-$LC_ROOT}"
+  python="$helper_root/.venv/bin/python"
+  script="$helper_root/scripts/orchestration/thread_handoff.py"
+  if [ ! -x "$python" ] || [ ! -f "$script" ]; then
+    printf 'WARNING: rollover bundle pre-lease import unavailable; continuing fail-open (helper=%s).\n' "$helper_root" >&2
+    return 0
+  fi
+  output=""
+  rc=0
+  output="$("$python" "$script" \
+    --repo-root "$helper_root" \
+    --monitor-base-url "${LU_MONITOR_LOOPBACK:-http://127.0.0.1:8765}" \
+    import-bundle --agent "$LC_DRIVER_HANDOFF" --from-api "$stream" --stream "$stream" 2>&1)" || rc=$?
+  if [ "$rc" -ne 0 ] || [[ "$output" == *WARNING:* ]]; then
+    printf 'WARNING: rollover bundle pre-lease import refused or failed (fail-open); launcher continues.\n%s\n' "$output" >&2
+  fi
+}
+
 launcher_claim_driver_lease() {
   local stream task_id instance_id
   stream="$(launcher_selector_stream "$LC_EPIC")"
@@ -694,6 +719,11 @@ launcher_main() {
   if [ "$LC_MODE" = "driver" ] && [ "$LC_GOVERNOR" = "0" ]; then
     local canary_rc=0
     launcher_prepare_driver_identity
+    if [ "$LC_DRY_RUN" != "1" ]; then
+      # This is deliberately before adapter prelease and before any provider
+      # packet scan: every driver must see an imported packet at cold start.
+      launcher_import_rollover_bundle
+    fi
     if [ "$LC_DRY_RUN" != "1" ] && declare -F launcher_adapter_prelease >/dev/null 2>&1; then
       # Continuity refusal (rollover ambiguity / already-resumed packet) is the
       # legacy public exit 1 — NOT 5, which is reserved for transport

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -428,7 +428,7 @@ launcher_import_rollover_bundle() {
   output="$("$python" "$script" \
     --repo-root "$helper_root" \
     --monitor-base-url "${LU_MONITOR_LOOPBACK:-http://127.0.0.1:8765}" \
-    import-bundle --agent "$LC_DRIVER_HANDOFF" --from-api "$stream" --stream "$stream" 2>&1)" || rc=$?
+    import-bundle --from-api "$stream" --stream "$stream" 2>&1)" || rc=$?
   if [ "$rc" -ne 0 ] || [[ "$output" == *WARNING:* ]]; then
     printf 'WARNING: rollover bundle pre-lease import refused or failed (fail-open); launcher continues.\n%s\n' "$output" >&2
   fi

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -971,6 +971,7 @@ def _bundle_commit_install(
     staged_lineage: Path,
     staged_repo: Mapping[str, Path],
     local_lineage_exists: bool,
+    install_handoff: bool = True,
 ) -> tuple[Path | None, list[str]]:
     """Commit a staged bundle with exact rollback around archive+rename."""
     agent = normalize_agent_name(str(manifest["agent"]))
@@ -988,8 +989,10 @@ def _bundle_commit_install(
     try:
         if local_lineage_exists:
             shutil.copytree(lineage_root, original_backup)
-        candidates = set(_bundle_handoff_candidates_for_agent(repo_root, str(manifest["stream_id"]), agent))
+        handoff_candidates = set(_bundle_handoff_candidates_for_agent(repo_root, str(manifest["stream_id"]), agent))
         for name, source in sorted(staged_repo.items()):
+            if not install_handoff and name in handoff_candidates:
+                continue
             target = (repo_root / name).resolve()
             target.relative_to(repo_root.resolve())
             if target.exists() and not target.is_file():
@@ -997,7 +1000,7 @@ def _bundle_commit_install(
             old_payload = target.read_bytes() if target.is_file() else None
             repo_backups[target] = old_payload
             installed = source.read_bytes()
-            if name in candidates and old_payload is not None and old_payload != installed:
+            if name in handoff_candidates and old_payload is not None and old_payload != installed:
                 superseded = _bundle_preserved_path(target)
                 write_bytes_atomic(superseded, old_payload)
                 created_preserved.append(superseded)
@@ -1074,6 +1077,10 @@ class RolloverBundleAPIUnavailable(RuntimeError):
     """The optional remote bundle authority cannot be reached."""
 
 
+class RolloverBundleNotFound(RuntimeError):
+    """The remote bundle authority has no matching bundle."""
+
+
 def _bundle_monitor_url(base_url: str) -> str:
     value = str(base_url or DEFAULT_MONITOR_BASE_URL).rstrip("/")
     parsed = urlparse(value)
@@ -1139,7 +1146,11 @@ def _bundle_api_request(
         with urllib.request.urlopen(request, timeout=timeout_s) as response:
             raw = response.read().decode("utf-8")
             status = int(getattr(response, "status", 200))
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+    except urllib.error.HTTPError as exc:
+        if method == "GET" and exc.code == 404 and path.split("?", 1)[0].endswith("/bundles/latest"):
+            raise RolloverBundleNotFound("bundle API has no matching bundle") from exc
+        raise RolloverBundleAPIUnavailable(f"bundle API unavailable: HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
         raise RolloverBundleAPIUnavailable(f"bundle API unavailable: {type(exc).__name__}") from exc
     try:
         value = json.loads(raw)
@@ -1147,6 +1158,8 @@ def _bundle_api_request(
         raise RolloverBundleAPIUnavailable("bundle API returned non-JSON data") from exc
     if status >= 400:
         detail = value.get("detail", "request refused") if isinstance(value, dict) else "request refused"
+        if status == 404:
+            raise RolloverBundleNotFound(f"bundle API has no matching bundle: {detail}")
         raise RuntimeError(f"bundle API refused request ({status}): {detail}")
     if not isinstance(value, dict):
         raise RuntimeError("bundle API returned a non-object JSON document")
@@ -1169,12 +1182,18 @@ def _bundle_api_upload(args: argparse.Namespace, *, stream_id: str, manifest: Ma
     )
 
 
-def _bundle_api_latest(args: argparse.Namespace, *, stream_id: str, agent: str) -> tuple[dict[str, Any], bytes]:
-    query = urlencode({"agent": agent})
+def _bundle_api_latest(
+    args: argparse.Namespace,
+    *,
+    stream_id: str,
+    agent: str | None = None,
+) -> tuple[dict[str, Any], bytes]:
+    query = urlencode({"agent": agent}) if agent is not None else ""
+    suffix = f"?{query}" if query else ""
     payload = _bundle_api_request(
         args.monitor_base_url,
         method="GET",
-        path=f"/api/epics/v1/{stream_id}/bundles/latest?{query}",
+        path=f"/api/epics/v1/{stream_id}/bundles/latest{suffix}",
     )
     manifest = payload.get("manifest")
     encoded = payload.get("blob")
@@ -5438,124 +5457,102 @@ def _bundle_import_error(reason: str) -> int:
     return 2
 
 
-def cmd_import_bundle(args: argparse.Namespace) -> int:
-    try:
-        repo_root, state_root = resolve_roots(args.repo_root)
-        agent = normalize_agent_name(args.agent)
-    except (OSError, ValueError) as exc:
-        return _bundle_import_error(str(exc))
+def _bundle_import_candidate(
+    repo_root: Path,
+    state_root: Path,
+    *,
+    manifest: Mapping[str, Any],
+    members: Mapping[str, bytes],
+    force: bool,
+    install_handoff: bool,
+) -> dict[str, Any]:
+    """Install one bundle while keeping packet and lane precedence separate."""
+    agent = normalize_agent_name(str(manifest.get("agent") or ""))
+    lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
+    stream_id = str(manifest.get("stream_id") or "")
+    _bundle_validate_lease_member(
+        state_root,
+        agent=agent,
+        lineage_id=lineage_id,
+        manifest=manifest,
+        members=members,
+    )
+    remote_order = _bundle_order(manifest)
+    local_manifest, local_members, local_lineage_exists = _bundle_local_lineage_snapshot(
+        repo_root,
+        state_root,
+        agent=agent,
+        lineage_id=lineage_id,
+        stream_id=stream_id,
+    )
+    if local_manifest is not None and local_members is not None:
+        local_order = _bundle_order(local_manifest)
+        if local_order > remote_order and not force:
+            return {
+                "status": "refused",
+                "error": "local rollover copy is newer; refusing to clobber it",
+                "agent": agent,
+                "lineage_id": lineage_id,
+                "rollover_id": manifest["rollover_id"],
+                "local": {
+                    "generation": local_order[0],
+                    "status_rank": local_order[1],
+                    "prepared_at": isoformat_z(local_order[2]),
+                    "rollover_id": local_order[3],
+                },
+                "remote": {
+                    "generation": remote_order[0],
+                    "status_rank": remote_order[1],
+                    "prepared_at": isoformat_z(remote_order[2]),
+                    "rollover_id": remote_order[3],
+                },
+            }
+        if local_order == remote_order and not force:
+            handoff_names = set(_bundle_handoff_candidates_for_agent(repo_root, stream_id, agent))
+            remote_compare = {
+                name: payload
+                for name, payload in members.items()
+                if install_handoff or name not in handoff_names
+            }
+            local_compare = {
+                name: payload
+                for name, payload in local_members.items()
+                if install_handoff or name not in handoff_names
+            }
+            if local_compare == remote_compare and local_manifest.get("generation") == manifest.get("generation"):
+                return {
+                    "status": "noop",
+                    "reason": "identical bundle content",
+                    "agent": agent,
+                    "lineage_id": lineage_id,
+                    "rollover_id": manifest["rollover_id"],
+                }
+            return {
+                "status": "refused",
+                "error": "bundle order ties but content differs; refusing to choose a copy",
+                "agent": agent,
+                "lineage_id": lineage_id,
+                "rollover_id": manifest["rollover_id"],
+                "generation": manifest["generation"],
+            }
 
-    api_manifest: dict[str, Any] | None = None
-    try:
-        if args.file is not None:
-            blob = args.file.expanduser().resolve().read_bytes()
-        else:
-            stream_id = str(args.from_api)
-            api_manifest, blob = _bundle_api_latest(args, stream_id=stream_id, agent=agent)
-        manifest, members = _bundle_extract(blob, manifest_override=api_manifest)
-        if manifest.get("agent") != agent:
-            raise ValueError("bundle agent does not match --agent")
-        stream_id = str(manifest.get("stream_id") or "")
-        if args.from_api is not None and stream_id != str(args.from_api):
-            raise ValueError("bundle stream does not match --from-api")
-        if args.stream is not None and stream_id != str(args.stream):
-            raise ValueError("bundle stream does not match --stream")
-        if not stream_id:
-            raise ValueError("bundle stream_id is missing")
-    except RolloverBundleAPIUnavailable as exc:
-        print(f"WARNING: rollover bundle import skipped (fail-open): {exc}", file=sys.stderr)
-        print(json.dumps({"status": "warning", "action": "import-bundle", "reason": str(exc)}, separators=(",", ":")))
-        return 0
-    except (OSError, ValueError, KeyError, TypeError) as exc:
-        return _bundle_import_error(str(exc))
-    try:
-        lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
-        _bundle_validate_lease_member(
-            state_root,
-            agent=agent,
-            lineage_id=lineage_id,
-            manifest=manifest,
-            members=members,
-        )
-        remote_order = _bundle_order(manifest)
-        local_manifest, local_members, local_lineage_exists = _bundle_local_lineage_snapshot(
-            repo_root,
-            state_root,
-            agent=agent,
-            lineage_id=lineage_id,
-            stream_id=stream_id,
-        )
-        if local_manifest is not None and local_members is not None:
-            local_order = _bundle_order(local_manifest)
-            if local_order > remote_order and not args.force:
-                print(
-                    json.dumps(
-                        {
-                            "status": "refused",
-                            "error": "local rollover copy is newer; refusing to clobber it",
-                            "local": {
-                                "generation": local_order[0],
-                                "status_rank": local_order[1],
-                                "prepared_at": isoformat_z(local_order[2]),
-                                "rollover_id": local_order[3],
-                            },
-                            "remote": {
-                                "generation": remote_order[0],
-                                "status_rank": remote_order[1],
-                                "prepared_at": isoformat_z(remote_order[2]),
-                                "rollover_id": remote_order[3],
-                            },
-                        },
-                        separators=(",", ":"),
-                    )
-                )
-                return 2
-            if local_order == remote_order and not args.force:
-                if local_members == members and local_manifest.get("generation") == manifest.get("generation"):
-                    print(
-                        json.dumps(
-                            {
-                                "status": "noop",
-                                "reason": "identical bundle content",
-                                "agent": agent,
-                                "lineage_id": lineage_id,
-                                "rollover_id": manifest["rollover_id"],
-                            },
-                            separators=(",", ":"),
-                        )
-                    )
-                    return 0
-                print(
-                    json.dumps(
-                        {
-                            "status": "refused",
-                            "error": "bundle order ties but content differs; refusing to choose a copy",
-                            "generation": manifest["generation"],
-                            "rollover_id": manifest["rollover_id"],
-                        },
-                        separators=(",", ":"),
-                    )
-                )
-                return 2
-
-        stage_root, staged_lineage, staged_repo = _bundle_stage_install(
-            repo_root,
-            state_root,
-            manifest=manifest,
-            members=members,
-        )
-        archived, preserved = _bundle_commit_install(
-            repo_root,
-            state_root,
-            manifest=manifest,
-            stage_root=stage_root,
-            staged_lineage=staged_lineage,
-            staged_repo=staged_repo,
-            local_lineage_exists=local_lineage_exists,
-        )
-    except Exception as exc:
-        return _bundle_import_error(str(exc))
-    result = {
+    stage_root, staged_lineage, staged_repo = _bundle_stage_install(
+        repo_root,
+        state_root,
+        manifest=manifest,
+        members=members,
+    )
+    archived, preserved = _bundle_commit_install(
+        repo_root,
+        state_root,
+        manifest=manifest,
+        stage_root=stage_root,
+        staged_lineage=staged_lineage,
+        staged_repo=staged_repo,
+        local_lineage_exists=local_lineage_exists,
+        install_handoff=install_handoff,
+    )
+    return {
         "status": "installed",
         "agent": agent,
         "lineage_id": lineage_id,
@@ -5565,9 +5562,91 @@ def cmd_import_bundle(args: argparse.Namespace) -> int:
         "archived": str(archived.relative_to(state_root)) if archived is not None else None,
         "preserved_handoffs": preserved,
         "upload_seq": manifest.get("upload_seq", 0),
+        "install_handoff": install_handoff,
     }
+
+
+def cmd_import_bundle(args: argparse.Namespace) -> int:
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+    except (OSError, ValueError) as exc:
+        return _bundle_import_error(str(exc))
+
+    candidates: list[tuple[dict[str, Any], dict[str, bytes]]] = []
+    try:
+        if args.file is not None:
+            blob = args.file.expanduser().resolve().read_bytes()
+            manifest, members = _bundle_extract(blob)
+            if manifest.get("agent") != agent:
+                raise ValueError("bundle agent does not match --agent")
+            candidates.append((manifest, members))
+        else:
+            stream_id = str(args.from_api)
+            any_manifest, any_blob = _bundle_api_latest(args, stream_id=stream_id)
+            any_manifest, any_members = _bundle_extract(any_blob, manifest_override=any_manifest)
+            candidates.append((any_manifest, any_members))
+            try:
+                own_manifest, own_blob = _bundle_api_latest(args, stream_id=stream_id, agent=agent)
+            except RolloverBundleNotFound:
+                own_manifest = None
+            except RolloverBundleAPIUnavailable as exc:
+                own_manifest = None
+                print(f"WARNING: own-agent rollover bundle lookup skipped (fail-open): {exc}", file=sys.stderr)
+            if own_manifest is not None:
+                own_manifest, own_members = _bundle_extract(own_blob, manifest_override=own_manifest)
+                if _bundle_order(own_manifest) > _bundle_order(any_manifest):
+                    candidates.append((own_manifest, own_members))
+
+        for manifest, _ in candidates:
+            stream_id = str(manifest.get("stream_id") or "")
+            if not stream_id:
+                raise ValueError("bundle stream_id is missing")
+            if args.from_api is not None and stream_id != str(args.from_api):
+                raise ValueError("bundle stream does not match --from-api")
+            if args.stream is not None and stream_id != str(args.stream):
+                raise ValueError("bundle stream does not match --stream")
+    except RolloverBundleAPIUnavailable as exc:
+        print(f"WARNING: rollover bundle import skipped (fail-open): {exc}", file=sys.stderr)
+        print(json.dumps({"status": "warning", "action": "import-bundle", "reason": str(exc)}, separators=(",", ":")))
+        return 0
+    except RolloverBundleNotFound as exc:
+        return _bundle_import_error(str(exc))
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        return _bundle_import_error(str(exc))
+
+    handoff_winner = max(candidates, key=lambda item: int(item[0].get("upload_seq", 0))) if len(candidates) > 1 else None
+    results: list[dict[str, Any]] = []
+    try:
+        for candidate in candidates:
+            results.append(
+                _bundle_import_candidate(
+                    repo_root,
+                    state_root,
+                    manifest=candidate[0],
+                    members=candidate[1],
+                    force=args.force,
+                    install_handoff=handoff_winner is None or candidate is handoff_winner,
+                )
+            )
+    except Exception as exc:
+        return _bundle_import_error(str(exc))
+
+    if len(results) == 1:
+        result = results[0]
+    else:
+        statuses = {item["status"] for item in results}
+        aggregate_status = "refused" if "refused" in statuses else "installed" if "installed" in statuses else "noop"
+        result = {
+            "status": aggregate_status,
+            "agent": agent,
+            "stream_id": str(args.from_api),
+            "bundles": results,
+            "handoff_source": handoff_winner[0].get("agent") if handoff_winner is not None else None,
+            "handoff_upload_seq": handoff_winner[0].get("upload_seq", 0) if handoff_winner is not None else None,
+        }
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    return 0
+    return 2 if any(item["status"] == "refused" for item in results) else 0
 
 
 def rollover_identity_snapshot(state_root: Path, agent: str | None = None) -> dict[str, Any]:
@@ -6346,7 +6425,11 @@ def build_parser() -> argparse.ArgumentParser:
         "import-bundle",
         help="Install a newer cross-host rollover bundle without silently clobbering local state.",
     )
-    import_bundle.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    import_bundle.add_argument(
+        "--agent",
+        type=argparse_agent_name,
+        default=os.environ.get("SESSION_HANDOFF_AGENT", DEFAULT_AGENT),
+    )
     import_source = import_bundle.add_mutually_exclusive_group(required=True)
     import_source.add_argument("--from-api", metavar="STREAM", help="Fetch the latest bundle for this stream.")
     import_source.add_argument("--file", type=Path, help="Read a local/scp/rsync .tgz bundle.")

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -11,15 +11,23 @@ until the replacement thread is explicitly confirmed.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import copy
+import gzip
 import hashlib
+import io
 import json
 import os
 import re
 import shlex
+import shutil
 import socket
 import sqlite3
 import subprocess
 import sys
+import tarfile
+import tempfile
 import urllib.error
 import urllib.request
 import uuid
@@ -29,6 +37,15 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode, urlparse
+
+# Script-by-path execution under the shared primary interpreter can expose the
+# primary checkout through a site-packages ``.pth`` file before this linked
+# worktree.  Prefer the code that is actually being executed without asking
+# callers to mutate PYTHONPATH.
+_LOCAL_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _LOCAL_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _LOCAL_REPO_ROOT)
 
 try:
     from scripts import context_canary
@@ -69,6 +86,18 @@ ROLLOVER_ID_RE = re.compile(r"^rollover-[a-z0-9]+(?:-[a-z0-9]+)*$")
 DEFAULT_ROUTER_PATH = Path("docs/session-state/current.md")
 ORCHESTRATOR_HANDOFF_PATH = Path("docs/session-state/codex-orchestrator-handoff.md")
 DEFAULT_STALE_HOURS = 12
+ROLLOVER_BUNDLE_SCHEMA = "rollover-bundle.v1"
+ROLLOVER_BUNDLE_MANIFEST_NAME = "manifest.json"
+ROLLOVER_BUNDLE_MAX_BYTES = 4 * 1024 * 1024
+ROLLOVER_BUNDLE_REPO_TOKEN = "{{REPO_ROOT}}"
+ROLLOVER_BUNDLE_STATUS_RANK = {
+    "superseded": 0,
+    "pending_start": 1,
+    "resumed": 2,
+    "confirmed": 3,
+    # The existing state machine calls the confirmed replacement ``started``.
+    "started": 3,
+}
 # Default warning threshold (percentage of window)
 DEFAULT_CONTEXT_THRESHOLD = 88.0
 THREAD_LEASE_SCHEMA_VERSION = 2
@@ -169,6 +198,13 @@ def normalize_rollover_id(value: str) -> str:
 def argparse_lineage_id(value: str) -> str:
     try:
         return normalize_lineage_id(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def argparse_rollover_id(value: str) -> str:
+    try:
+        return normalize_rollover_id(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
@@ -405,6 +441,550 @@ def http_get_json(base_url: str, path: str, timeout_s: float = 3.0) -> dict[str,
     except json.JSONDecodeError as exc:
         return {"_error": f"JSONDecodeError: {exc}"}
     return data if isinstance(data, dict) else {"value": data}
+
+
+def _bundle_json(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _bundle_member_path(value: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError("bundle member path is malformed")
+    path = Path(value)
+    if not path.parts or path.is_absolute() or ".." in path.parts or path.parts[0] == ROLLOVER_BUNDLE_MANIFEST_NAME:
+        raise ValueError(f"bundle member path is unsafe: {value!r}")
+    return path.as_posix()
+
+
+def _bundle_archive(members: Mapping[str, bytes], manifest: Mapping[str, Any]) -> bytes:
+    """Build a deterministic gzip tar; deterministic bytes make the receipt verifiable."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as archive:
+        manifest_info = tarfile.TarInfo(ROLLOVER_BUNDLE_MANIFEST_NAME)
+        manifest_bytes = _bundle_json(manifest)
+        manifest_info.size = len(manifest_bytes)
+        manifest_info.mode = 0o600
+        manifest_info.mtime = 0
+        manifest_info.uid = 0
+        manifest_info.gid = 0
+        manifest_info.uname = ""
+        manifest_info.gname = ""
+        archive.addfile(manifest_info, io.BytesIO(manifest_bytes))
+        for name in sorted(members):
+            member_name = _bundle_member_path(name)
+            payload = members[name]
+            info = tarfile.TarInfo(member_name)
+            info.size = len(payload)
+            info.mode = 0o600
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            archive.addfile(info, io.BytesIO(payload))
+    return gzip.compress(raw.getvalue(), compresslevel=9, mtime=0)
+
+
+def _bundle_digest(members: Mapping[str, bytes], manifest: Mapping[str, Any]) -> str:
+    unsigned = copy.deepcopy(dict(manifest))
+    unsigned["bundle_sha256"] = ""
+    return hashlib.sha256(_bundle_archive(members, unsigned)).hexdigest()
+
+
+def _bundle_text_member(name: str) -> bool:
+    return Path(name).suffix.lower() in {".md", ".txt"}
+
+
+def _bundle_tokenize(data: bytes, *, repo_root: Path, state_root: Path) -> bytes:
+    text = data.decode("utf-8")
+    for root in (repo_root.resolve(), state_root.resolve()):
+        text = text.replace(str(root), ROLLOVER_BUNDLE_REPO_TOKEN)
+    return text.encode("utf-8")
+
+
+def _bundle_rewrite(data: bytes, *, repo_root: Path) -> bytes:
+    return data.replace(ROLLOVER_BUNDLE_REPO_TOKEN.encode("utf-8"), str(repo_root.resolve()).encode("utf-8"))
+
+
+def _bundle_replacement_status(replacement: Mapping[str, Any]) -> str:
+    status = str(replacement.get("status") or "")
+    if status not in ROLLOVER_BUNDLE_STATUS_RANK:
+        raise ValueError(f"replacement status is not bundle-orderable: {status!r}")
+    return status
+
+
+def _bundle_order(manifest: Mapping[str, Any]) -> tuple[int, int, datetime, str, int]:
+    try:
+        generation = int(manifest["generation"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("bundle generation is malformed") from exc
+    status = _bundle_replacement_status(manifest)
+    prepared_at = parse_iso_datetime(str(manifest.get("prepared_at") or ""))
+    if prepared_at is None:
+        raise ValueError("bundle prepared_at is malformed")
+    rollover_id = normalize_rollover_id(str(manifest.get("rollover_id") or ""))
+    try:
+        upload_seq = int(manifest.get("upload_seq", 0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("bundle upload_seq is malformed") from exc
+    if generation < 1 or upload_seq < 0:
+        raise ValueError("bundle generation or upload_seq is out of range")
+    return generation, ROLLOVER_BUNDLE_STATUS_RANK[status], prepared_at, rollover_id, upload_seq
+
+
+def _bundle_state_manifest(state: Mapping[str, Any], *, stream_id: str, upload_seq: int | None = None) -> dict[str, Any]:
+    replacement = state.get("replacement")
+    if not isinstance(replacement, dict):
+        raise ValueError("rollover state has no replacement")
+    agent = normalize_agent_name(str(state.get("agent") or ""))
+    lineage_id = normalize_lineage_id(str(state.get("lineage_id") or replacement.get("lineage_id") or ""))
+    status = _bundle_replacement_status(replacement)
+    generation = int(replacement.get("generation"))
+    rollover_id = normalize_rollover_id(str(replacement.get("rollover_id") or ""))
+    prepared_at = str(replacement.get("prepared_at") or "")
+    if parse_iso_datetime(prepared_at) is None:
+        raise ValueError("rollover replacement prepared_at is malformed")
+    if upload_seq is None:
+        upload_seq = int(state.get("bundle_upload_seq", 0))
+    return {
+        "schema": ROLLOVER_BUNDLE_SCHEMA,
+        "agent": agent,
+        "stream_id": stream_id,
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+        "generation": generation,
+        "status": status,
+        "prepared_at": prepared_at,
+        "source_root": ROLLOVER_BUNDLE_REPO_TOKEN,
+        "exported_at": isoformat_z(utc_now()),
+        "files": [],
+        "tokenized_members": [],
+        "upload_seq": upload_seq,
+        "bundle_sha256": "",
+    }
+
+
+def _bundle_state_candidates(state_root: Path, agent: str) -> list[tuple[Path, dict[str, Any]]]:
+    root = state_root / ".agent" / "thread-rollovers" / agent
+    candidates: list[tuple[Path, dict[str, Any]]] = []
+    if not root.is_dir():
+        return candidates
+    for path in sorted(root.glob("*/lease.json")):
+        state = load_state(path)
+        replacement = state.get("replacement")
+        if not isinstance(replacement, dict) or replacement.get("status") not in ROLLOVER_BUNDLE_STATUS_RANK:
+            continue
+        candidates.append((path, state))
+    return candidates
+
+
+def _select_bundle_state(
+    state_root: Path,
+    *,
+    agent: str,
+    lineage_id: str | None,
+    rollover_id: str | None,
+) -> tuple[Path, dict[str, Any]]:
+    candidates = _bundle_state_candidates(state_root, agent)
+    if lineage_id is not None:
+        wanted_lineage = normalize_lineage_id(lineage_id)
+        candidates = [item for item in candidates if item[1].get("lineage_id") == wanted_lineage]
+    if rollover_id is not None:
+        wanted_rollover = normalize_rollover_id(rollover_id)
+        candidates = [
+            item for item in candidates if (item[1].get("replacement") or {}).get("rollover_id") == wanted_rollover
+        ]
+    if not candidates:
+        raise ValueError("no matching rollover lineage exists")
+    if len(candidates) == 1:
+        return candidates[0]
+    ranked = sorted(
+        candidates,
+        key=lambda item: _bundle_order(
+            _bundle_state_manifest(item[1], stream_id="shared:rollover")
+        ),
+        reverse=True,
+    )
+    return ranked[0]
+
+
+def _bundle_handoff_candidates(repo_root: Path, stream_id: str) -> tuple[str, ...]:
+    try:
+        from agents_extensions.shared.session_streams.inventory import epic_handoff_map
+
+        return tuple(epic_handoff_map(repo_root).get(stream_id, ()))
+    except (OSError, ValueError, ImportError):
+        return ()
+
+
+def _bundle_handoff_candidates_for_agent(repo_root: Path, stream_id: str, agent: str) -> tuple[str, ...]:
+    """Resolve the inventory lane first, then the canonical agent-slug template."""
+    candidates = list(_bundle_handoff_candidates(repo_root, stream_id))
+    if agent.startswith("claude-"):
+        candidates.append(f".claude/{agent.removeprefix('claude-')}-epic/CLAUDE-DRIVER-HANDOFF.md")
+    return tuple(dict.fromkeys(candidates))
+
+
+def _bundle_source_members(
+    repo_root: Path,
+    state_root: Path,
+    *,
+    agent: str,
+    state: Mapping[str, Any],
+    stream_id: str,
+) -> dict[str, bytes]:
+    lineage_id = normalize_lineage_id(str(state.get("lineage_id") or ""))
+    lineage_root = state_root / ".agent" / "thread-rollovers" / agent / lineage_id
+    if not lineage_root.is_dir():
+        raise ValueError(f"rollover lineage directory is missing: {lineage_id}")
+    members: dict[str, bytes] = {}
+    for path in sorted(lineage_root.rglob("*")):
+        if not path.is_file() or path.is_symlink() or path.name == ".native-intent.lock" or path.name.endswith(".bundle.tgz"):
+            continue
+        member_name = (Path(".agent") / "thread-rollovers" / agent / lineage_id / path.relative_to(lineage_root)).as_posix()
+        payload = path.read_bytes()
+        if _bundle_text_member(member_name):
+            payload = _bundle_tokenize(payload, repo_root=repo_root, state_root=state_root)
+        members[_bundle_member_path(member_name)] = payload
+
+    for candidate in _bundle_handoff_candidates_for_agent(repo_root, stream_id, agent):
+        path = repo_root / candidate
+        if path.is_file() and not path.is_symlink():
+            payload = _bundle_tokenize(path.read_bytes(), repo_root=repo_root, state_root=state_root)
+            members[_bundle_member_path(candidate)] = payload
+            break
+    return members
+
+
+def _bundle_secret_hits(members: Mapping[str, bytes]) -> list[tuple[str, str]]:
+    try:
+        from agents_extensions.shared.session_streams.store import SECRET_PATTERNS
+    except ImportError:
+        return []
+    hits: list[tuple[str, str]] = []
+    for name, payload in members.items():
+        try:
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            hits.append((name, "invalid-utf8-text"))
+            continue
+        for rule, pattern in SECRET_PATTERNS:
+            if pattern.search(text):
+                hits.append((name, rule))
+    return hits
+
+
+def _build_rollover_bundle(
+    repo_root: Path,
+    state_root: Path,
+    *,
+    agent: str,
+    state: Mapping[str, Any],
+    stream_id: str,
+) -> tuple[dict[str, Any], bytes, list[tuple[str, str]]]:
+    stream_id = str(stream_id)
+    if not stream_id:
+        raise ValueError("--stream is required for a rollover bundle")
+    manifest = _bundle_state_manifest(state, stream_id=stream_id)
+    members = _bundle_source_members(repo_root, state_root, agent=agent, state=state, stream_id=stream_id)
+    files = []
+    tokenized_members: list[str] = []
+    for name in sorted(members):
+        tokenized = _bundle_text_member(name)
+        if tokenized:
+            tokenized_members.append(name)
+        files.append({"path": name, "sha256": hashlib.sha256(members[name]).hexdigest(), "bytes": len(members[name]), "tokenized": tokenized})
+    manifest["files"] = files
+    manifest["tokenized_members"] = tokenized_members
+    manifest["bundle_sha256"] = _bundle_digest(members, manifest)
+    archive = _bundle_archive(members, manifest)
+    if len(archive) > ROLLOVER_BUNDLE_MAX_BYTES:
+        raise ValueError("rollover bundle exceeds the 4 MiB cap")
+    return manifest, archive, _bundle_secret_hits(members)
+
+
+def _bundle_extract(blob: bytes, *, manifest_override: Mapping[str, Any] | None = None) -> tuple[dict[str, Any], dict[str, bytes]]:
+    if len(blob) > ROLLOVER_BUNDLE_MAX_BYTES:
+        raise ValueError("rollover bundle exceeds the 4 MiB cap")
+    members: dict[str, bytes] = {}
+    manifest: dict[str, Any] | None = None
+    try:
+        with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as archive:
+            for info in archive.getmembers():
+                if info.name == ROLLOVER_BUNDLE_MANIFEST_NAME:
+                    if manifest is not None or not info.isfile():
+                        raise ValueError("bundle manifest is malformed")
+                    raw_manifest = archive.extractfile(info)
+                    if raw_manifest is None:
+                        raise ValueError("bundle manifest is unreadable")
+                    value = json.loads(raw_manifest.read().decode("utf-8"))
+                    if not isinstance(value, dict):
+                        raise ValueError("bundle manifest must be an object")
+                    manifest = value
+                    continue
+                name = _bundle_member_path(info.name)
+                if name in members or not info.isfile():
+                    raise ValueError("bundle contains a duplicate or non-regular member")
+                payload = archive.extractfile(info)
+                if payload is None:
+                    raise ValueError("bundle member is unreadable")
+                members[name] = payload.read()
+    except (tarfile.TarError, OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"rollover bundle is not a valid tar.gz: {exc}") from exc
+    if manifest is None or manifest.get("schema") != ROLLOVER_BUNDLE_SCHEMA:
+        raise ValueError("rollover bundle manifest schema is invalid")
+    declared_files = manifest.get("files")
+    if not isinstance(declared_files, list) or not declared_files:
+        raise ValueError("rollover bundle manifest has no files")
+    declared_names: set[str] = set()
+    declared_tokenized: set[str] = set()
+    for item in declared_files:
+        if not isinstance(item, dict):
+            raise ValueError("rollover bundle file manifest is malformed")
+        name = _bundle_member_path(item.get("path"))
+        if name in declared_names or name not in members:
+            raise ValueError("rollover bundle file manifest does not match the tar")
+        declared_names.add(name)
+        payload = members[name]
+        tokenized = item.get("tokenized")
+        if not isinstance(tokenized, bool) or tokenized != _bundle_text_member(name):
+            raise ValueError(f"rollover bundle tokenization declaration is invalid: {name}")
+        if tokenized:
+            declared_tokenized.add(name)
+        if item.get("bytes") != len(payload) or item.get("sha256") != hashlib.sha256(payload).hexdigest():
+            raise ValueError(f"rollover bundle member fingerprint mismatch: {name}")
+    if declared_names != set(members):
+        raise ValueError("rollover bundle tar contains an unmanifested member")
+    tokenized_members = manifest.get("tokenized_members")
+    if not isinstance(tokenized_members, list) or set(tokenized_members) != declared_tokenized:
+        raise ValueError("rollover bundle tokenized_members does not match its file manifest")
+    _bundle_order(manifest)
+    expected_digest = _bundle_digest(members, manifest)
+    if manifest.get("bundle_sha256") != expected_digest:
+        raise ValueError("rollover bundle fingerprint mismatch")
+    if manifest_override is not None:
+        outer = dict(manifest_override)
+        if outer.get("schema") != ROLLOVER_BUNDLE_SCHEMA or outer.get("bundle_sha256") != manifest.get("bundle_sha256"):
+            raise ValueError("API manifest does not match the bundle")
+        for key in ("agent", "stream_id", "lineage_id", "rollover_id", "generation", "status", "prepared_at"):
+            if outer.get(key) != manifest.get(key):
+                raise ValueError(f"API manifest differs from bundle at {key}")
+        manifest = {**manifest, "upload_seq": outer.get("upload_seq", manifest.get("upload_seq", 0))}
+        _bundle_order(manifest)
+    return manifest, members
+
+
+def _bundle_local_members(repo_root: Path, state_root: Path, *, agent: str, lineage_id: str, stream_id: str) -> dict[str, bytes]:
+    state_path = state_root / ".agent" / "thread-rollovers" / agent / lineage_id / "lease.json"
+    state = load_state(state_path)
+    return _bundle_source_members(repo_root, state_root, agent=agent, state=state, stream_id=stream_id)
+
+
+def _bundle_write_member(repo_root: Path, state_root: Path, name: str, payload: bytes) -> None:
+    target_root = state_root if name.startswith(".agent/thread-rollovers/") else repo_root
+    target = (target_root / name).resolve()
+    target.relative_to(target_root.resolve())
+    if _bundle_text_member(name):
+        payload = _bundle_rewrite(payload, repo_root=repo_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    write_bytes_atomic(target, payload)
+
+
+def _bundle_archive_local_lineage(
+    state_root: Path,
+    *,
+    agent: str,
+    lineage_id: str,
+    remote_manifest: Mapping[str, Any],
+) -> Path | None:
+    lineage_root = state_root / ".agent" / "thread-rollovers" / agent / lineage_id
+    if not lineage_root.exists():
+        return None
+    timestamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+    archive_root = state_root / ".agent" / "thread-rollovers" / agent / "_archive" / f"{lineage_id}-{timestamp}"
+    suffix = 1
+    while archive_root.exists():
+        archive_root = state_root / ".agent" / "thread-rollovers" / agent / "_archive" / f"{lineage_id}-{timestamp}-{suffix}"
+        suffix += 1
+    archive_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(os.fspath(lineage_root), os.fspath(archive_root))
+    archived_state_path = archive_root / "lease.json"
+    archived_state = load_state(archived_state_path)
+    replacement = archived_state.get("replacement")
+    if isinstance(replacement, dict) and replacement.get("status") in {"pending_start", "resumed"}:
+        replacement["status"] = "superseded"
+        replacement["superseded_by"] = {
+            "lineage_id": remote_manifest.get("lineage_id"),
+            "generation": remote_manifest.get("generation"),
+            "rollover_id": remote_manifest.get("rollover_id"),
+        }
+        archived_state["replacement"] = replacement
+        write_rollover_state(archived_state_path, state_root, archived_state)
+    return archive_root
+
+
+def _bundle_install(
+    repo_root: Path,
+    state_root: Path,
+    *,
+    manifest: Mapping[str, Any],
+    members: Mapping[str, bytes],
+) -> None:
+    agent = normalize_agent_name(str(manifest["agent"]))
+    lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
+    lineage_prefix = f".agent/thread-rollovers/{agent}/{lineage_id}/"
+    if not any(name.startswith(lineage_prefix) for name in members):
+        raise ValueError("bundle has no lineage state members")
+    scratch_root = state_root / ".agent"
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="rollover-import-", dir=os.fspath(scratch_root)) as scratch:
+        staging = Path(scratch)
+        for name, payload in members.items():
+            destination = staging / name if name.startswith(lineage_prefix) else staging / "repo" / name
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(_bundle_rewrite(payload, repo_root=repo_root) if _bundle_text_member(name) else payload)
+        names = sorted(members, key=lambda name: ("identity-receipt.json" not in name, name == "lease.json", name))
+        for name in names:
+            source = staging / name if name.startswith(lineage_prefix) else staging / "repo" / name
+            target_root = state_root if name.startswith(".agent/thread-rollovers/") else repo_root
+            target = (target_root / name).resolve()
+            target.relative_to(target_root.resolve())
+            target.parent.mkdir(parents=True, exist_ok=True)
+            write_bytes_atomic(target, source.read_bytes())
+
+
+def _bundle_status_manifest(state_root: Path, *, agent: str, lineage_id: str) -> dict[str, Any] | None:
+    state_path = state_root / ".agent" / "thread-rollovers" / agent / lineage_id / "lease.json"
+    if not state_path.is_file():
+        return None
+    state = load_state(state_path)
+    try:
+        receipt_path = state_root / ".agent" / "thread-rollovers" / agent / "_bundle-receipts" / f"{lineage_id}.json"
+        receipt = load_state(receipt_path) if receipt_path.is_file() else {}
+        return _bundle_state_manifest(
+            state,
+            stream_id="shared:rollover",
+            upload_seq=int(receipt.get("upload_seq", 0)),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+class RolloverBundleAPIUnavailable(RuntimeError):
+    """The optional remote bundle authority cannot be reached."""
+
+
+def _bundle_monitor_url(base_url: str) -> str:
+    value = str(base_url or DEFAULT_MONITOR_BASE_URL).rstrip("/")
+    parsed = urlparse(value)
+    if parsed.scheme != "http" or parsed.hostname not in {"localhost", "127.0.0.1"}:
+        raise ValueError("bundle API URL must be an HTTP loopback URL")
+    return f"http://127.0.0.1:{parsed.port or 8765}"
+
+
+def _bundle_lease_payload(stream_id: str) -> dict[str, Any] | None:
+    session_id = os.environ.get("SESSION_STREAM_SESSION_ID", "").strip()
+    lease_id = os.environ.get("SESSION_STREAM_LEASE_ID", "").strip()
+    if not session_id or not lease_id:
+        return None
+    try:
+        generation = int(os.environ.get("SESSION_STREAM_GENERATION", ""))
+        fencing_token = int(os.environ.get("SESSION_STREAM_FENCING_TOKEN", ""))
+    except ValueError:
+        return None
+    holder_kind = os.environ.get("SESSION_STREAM_HOLDER_KIND", "process")
+    process_id: int | None
+    if holder_kind == "app_thread":
+        process_id = None
+    else:
+        try:
+            process_id = int(os.environ.get("SESSION_STREAM_PROCESS_ID", str(os.getpid())))
+        except ValueError:
+            return None
+    task_id = os.environ.get("SESSION_STREAM_TASK_ID") or None
+    return {
+        "stream_id": stream_id,
+        "session_id": session_id,
+        "lease_id": lease_id,
+        "generation": generation,
+        "fencing_token": fencing_token,
+        "holder": {
+            "agent": os.environ.get("SESSION_STREAM_AGENT", ""),
+            "harness": os.environ.get("SESSION_STREAM_HARNESS", ""),
+            "instance_id": os.environ.get("SESSION_STREAM_INSTANCE_ID", ""),
+            "task_id": task_id,
+            "process_id": process_id,
+            "holder_kind": holder_kind,
+            "host_id": os.environ.get("LU_MONITOR_HOST_ID") or None,
+        },
+    }
+
+
+def _bundle_api_request(
+    base_url: str,
+    *,
+    method: str,
+    path: str,
+    payload: Mapping[str, Any] | None = None,
+    timeout_s: float = 3.0,
+) -> dict[str, Any]:
+    body = None if payload is None else _bundle_json(payload)
+    request = urllib.request.Request(
+        f"{_bundle_monitor_url(base_url)}{path}",
+        data=body,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            raw = response.read().decode("utf-8")
+            status = int(getattr(response, "status", 200))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+        raise RolloverBundleAPIUnavailable(f"bundle API unavailable: {type(exc).__name__}") from exc
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RolloverBundleAPIUnavailable("bundle API returned non-JSON data") from exc
+    if status >= 400:
+        detail = value.get("detail", "request refused") if isinstance(value, dict) else "request refused"
+        raise RuntimeError(f"bundle API refused request ({status}): {detail}")
+    if not isinstance(value, dict):
+        raise RuntimeError("bundle API returned a non-object JSON document")
+    return value
+
+
+def _bundle_api_upload(args: argparse.Namespace, *, stream_id: str, manifest: Mapping[str, Any], blob: bytes) -> dict[str, Any]:
+    lease = _bundle_lease_payload(stream_id)
+    if lease is None:
+        raise RolloverBundleAPIUnavailable("SESSION_STREAM_* fenced lease envelope is unavailable")
+    return _bundle_api_request(
+        args.monitor_base_url,
+        method="POST",
+        path=f"/api/epics/v1/{stream_id}/bundles",
+        payload={
+            **lease,
+            "manifest": dict(manifest),
+            "blob": base64.b64encode(blob).decode("ascii"),
+        },
+    )
+
+
+def _bundle_api_latest(args: argparse.Namespace, *, stream_id: str, agent: str) -> tuple[dict[str, Any], bytes]:
+    query = urlencode({"agent": agent})
+    payload = _bundle_api_request(
+        args.monitor_base_url,
+        method="GET",
+        path=f"/api/epics/v1/{stream_id}/bundles/latest?{query}",
+    )
+    manifest = payload.get("manifest")
+    encoded = payload.get("blob")
+    if not isinstance(manifest, dict) or not isinstance(encoded, str):
+        raise ValueError("bundle API latest response omitted its manifest or blob")
+    try:
+        blob = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("bundle API latest blob is not valid base64") from exc
+    return manifest, blob
 
 
 def gh_json(repo_root: Path, args: list[str], timeout_s: int = 15) -> Any:
@@ -1745,6 +2325,13 @@ def write_text_atomic(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
     tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_bytes_atomic(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_bytes(payload)
     os.replace(tmp, path)
 
 
@@ -3320,6 +3907,16 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
         )
         return 2
 
+    bundle_upload: dict[str, Any] = {"status": "not-requested"}
+    if getattr(args, "stream", None):
+        bundle_upload = _maybe_auto_upload_bundle(
+            args,
+            repo_root=repo_root,
+            state_root=state_root,
+            agent=agent,
+            state=prepared_state,
+        )
+
     if agent == "claude" or agent.startswith("claude-"):
         # The packet is sealed and every fallible prepare step (including the
         # Claudex rollover request above) has already succeeded: only now is
@@ -3392,6 +3989,7 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
     }
     if claudex_request is not None:
         output["claudex_rollover_request"] = claudex_request
+    output["bundle_upload"] = bundle_upload
     print(json.dumps(output, indent=2))
     return 0
 
@@ -4080,6 +4678,13 @@ def _cmd_confirm_started_locked(args: argparse.Namespace) -> int:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
     write_rollover_state(state_path, state_root, confirmed, already_locked=True)
+    bundle_upload = _maybe_auto_upload_bundle(
+        args,
+        repo_root=repo_root,
+        state_root=state_root,
+        agent=agent,
+        state=confirmed,
+    ) if getattr(args, "stream", None) else {"status": "not-requested"}
     print(
         json.dumps(
             {
@@ -4096,6 +4701,7 @@ def _cmd_confirm_started_locked(args: argparse.Namespace) -> int:
                 "identity_receipt_file": confirmed["replacement"]["identity_receipt_path"],
                 "old_automation_ready_to_delete": confirmed["cleanup"]["old_automation_ready_to_delete"],
                 "next_native_action": "Run native-action --action archive with authoritative idle and unpinned app evidence; unknown state preserves the predecessor.",
+                "bundle_upload": bundle_upload,
             },
             indent=2,
         )
@@ -4394,6 +5000,7 @@ def cmd_confirm_replacement(args: argparse.Namespace) -> int:
         strict_probe=probe_path,
         strict_verdict=verdict_path,
         confirmed_by=args.confirmed_by,
+        stream=getattr(args, "stream", None),
     )
     return cmd_confirm_started(confirm_args)
 
@@ -4443,6 +5050,309 @@ def cmd_audit(args: argparse.Namespace) -> int:
     except ValueError as exc:
         audit["task_identity"] = {"error": str(exc)}
     print(json.dumps(audit, indent=2))
+    return 0
+
+
+def _bundle_output_path(state_root: Path, *, agent: str, lineage_id: str, rollover_id: str, supplied: Path | None) -> Path:
+    if supplied is not None:
+        return supplied.expanduser().resolve()
+    return (
+        state_root
+        / ".agent"
+        / "thread-rollovers"
+        / agent
+        / lineage_id
+        / f"{rollover_id}.bundle.tgz"
+    )
+
+
+def cmd_export_bundle(args: argparse.Namespace) -> int:
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+        state_path, state = _select_bundle_state(
+            state_root,
+            agent=agent,
+            lineage_id=args.lineage_id,
+            rollover_id=args.rollover_id,
+        )
+        stream_id = str(args.stream or "")
+        manifest, blob, secret_hits = _build_rollover_bundle(
+            repo_root,
+            state_root,
+            agent=agent,
+            state=state,
+            stream_id=stream_id,
+        )
+        output_path = _bundle_output_path(
+            state_root,
+            agent=agent,
+            lineage_id=str(manifest["lineage_id"]),
+            rollover_id=str(manifest["rollover_id"]),
+            supplied=args.file,
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_bytes_atomic(output_path, blob)
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(json.dumps({"error": str(exc), "action": "export-bundle"}, indent=2))
+        return 2
+
+    result: dict[str, Any] = {
+        "status": "exported",
+        "agent": agent,
+        "lineage_id": manifest["lineage_id"],
+        "rollover_id": manifest["rollover_id"],
+        "generation": manifest["generation"],
+        "stream_id": stream_id,
+        "file": rel(output_path, repo_root) if output_path.is_relative_to(repo_root) else str(output_path),
+        "bytes": len(blob),
+        "bundle_sha256": manifest["bundle_sha256"],
+        "source_state": rel(state_path, state_root),
+        "upload": "not-requested",
+    }
+    for member, rule in secret_hits:
+        print(
+            f"WARNING: rollover bundle secret scan hit member={member} rule={rule}; "
+            "local bundle was written but upload was skipped.",
+            file=sys.stderr,
+        )
+    if args.upload:
+        if secret_hits:
+            result["upload"] = "skipped-secret-scan"
+        else:
+            try:
+                response = _bundle_api_upload(args, stream_id=stream_id, manifest=manifest, blob=blob)
+                result["upload"] = "uploaded"
+                result["upload_seq"] = response.get("upload_seq")
+            except (RolloverBundleAPIUnavailable, RuntimeError, ValueError) as exc:
+                result["upload"] = "skipped"
+                print(f"WARNING: rollover bundle upload skipped (fail-open): {exc}", file=sys.stderr)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _maybe_auto_upload_bundle(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path,
+    state_root: Path,
+    agent: str,
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    """Best-effort prepare/confirm upload; never changes the lifecycle result."""
+    stream_id = str(getattr(args, "stream", "") or "").strip()
+    if not stream_id:
+        return {"status": "not-requested"}
+    try:
+        manifest, blob, secret_hits = _build_rollover_bundle(
+            repo_root,
+            state_root,
+            agent=agent,
+            state=state,
+            stream_id=stream_id,
+        )
+        output_path = _bundle_output_path(
+            state_root,
+            agent=agent,
+            lineage_id=str(manifest["lineage_id"]),
+            rollover_id=str(manifest["rollover_id"]),
+            supplied=None,
+        )
+        write_bytes_atomic(output_path, blob)
+        for member, rule in secret_hits:
+            print(
+                f"WARNING: rollover bundle secret scan hit member={member} rule={rule}; "
+                "local bundle was written but upload was skipped.",
+                file=sys.stderr,
+            )
+        if secret_hits:
+            return {
+                "status": "skipped-secret-scan",
+                "file": rel(output_path, repo_root) if output_path.is_relative_to(repo_root) else str(output_path),
+                "bundle_sha256": manifest["bundle_sha256"],
+            }
+        response = _bundle_api_upload(args, stream_id=stream_id, manifest=manifest, blob=blob)
+        upload_seq = response.get("upload_seq")
+        if isinstance(upload_seq, int) and upload_seq >= 0:
+            receipt_path = (
+                state_root
+                / ".agent"
+                / "thread-rollovers"
+                / agent
+                / "_bundle-receipts"
+                / f"{manifest['lineage_id']}.json"
+            )
+            write_json_atomic(
+                receipt_path,
+                {"schema": "rollover-bundle-receipt.v1", "upload_seq": upload_seq},
+            )
+        return {
+            "status": "uploaded",
+            "file": rel(output_path, repo_root) if output_path.is_relative_to(repo_root) else str(output_path),
+            "bundle_sha256": manifest["bundle_sha256"],
+            "upload_seq": upload_seq,
+        }
+    except Exception as exc:
+        print(f"WARNING: automatic rollover bundle upload skipped (fail-open): {exc}", file=sys.stderr)
+        return {"status": "skipped", "reason": str(exc)}
+
+
+def _bundle_preserve_handoff_files(
+    repo_root: Path,
+    *,
+    agent: str,
+    stream_id: str,
+    members: Mapping[str, bytes],
+) -> list[str]:
+    preserved: list[str] = []
+    candidates = set(_bundle_handoff_candidates_for_agent(repo_root, stream_id, agent))
+    for name, payload in members.items():
+        if name.startswith(".agent/") or name not in candidates:
+            continue
+        target = repo_root / name
+        if not target.is_file():
+            continue
+        installed = _bundle_rewrite(payload, repo_root=repo_root) if _bundle_text_member(name) else payload
+        if target.read_bytes() == installed:
+            continue
+        timestamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+        superseded = target.with_name(f"{target.stem}.{timestamp}.superseded{target.suffix}")
+        suffix = 1
+        while superseded.exists():
+            superseded = target.with_name(f"{target.stem}.{timestamp}-{suffix}.superseded{target.suffix}")
+            suffix += 1
+        write_bytes_atomic(superseded, target.read_bytes())
+        preserved.append(superseded.as_posix())
+    return preserved
+
+
+def cmd_import_bundle(args: argparse.Namespace) -> int:
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
+        return 2
+
+    api_manifest: dict[str, Any] | None = None
+    try:
+        if args.file is not None:
+            blob = args.file.expanduser().resolve().read_bytes()
+        else:
+            stream_id = str(args.from_api)
+            api_manifest, blob = _bundle_api_latest(args, stream_id=stream_id, agent=agent)
+        manifest, members = _bundle_extract(blob, manifest_override=api_manifest)
+        if manifest.get("agent") != agent:
+            raise ValueError("bundle agent does not match --agent")
+        stream_id = str(manifest.get("stream_id") or "")
+        if args.from_api is not None and stream_id != str(args.from_api):
+            raise ValueError("bundle stream does not match --from-api")
+        if args.stream is not None and stream_id != str(args.stream):
+            raise ValueError("bundle stream does not match --stream")
+        if not stream_id:
+            raise ValueError("bundle stream_id is missing")
+    except RolloverBundleAPIUnavailable as exc:
+        print(f"WARNING: rollover bundle import skipped (fail-open): {exc}", file=sys.stderr)
+        print(json.dumps({"status": "warning", "action": "import-bundle", "reason": str(exc)}, indent=2))
+        return 0
+    except FileNotFoundError as exc:
+        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
+        return 2
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
+        return 2
+
+    lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
+    remote_order = _bundle_order(manifest)
+    local_manifest = _bundle_status_manifest(state_root, agent=agent, lineage_id=lineage_id)
+    if local_manifest is not None:
+        local_members = _bundle_local_members(
+            repo_root,
+            state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            stream_id=stream_id,
+        )
+        if local_members == members and local_manifest.get("generation") == manifest.get("generation"):
+            print(
+                json.dumps(
+                    {
+                        "status": "noop",
+                        "reason": "identical bundle content",
+                        "agent": agent,
+                        "lineage_id": lineage_id,
+                        "rollover_id": manifest["rollover_id"],
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+        local_order = _bundle_order(local_manifest)
+        if local_order > remote_order and not args.force:
+            print(
+                json.dumps(
+                    {
+                        "status": "refused",
+                        "error": "local rollover copy is newer; refusing to clobber it",
+                        "local": {
+                            "generation": local_order[0],
+                            "status_rank": local_order[1],
+                            "prepared_at": isoformat_z(local_order[2]),
+                            "rollover_id": local_order[3],
+                        },
+                        "remote": {
+                            "generation": remote_order[0],
+                            "status_rank": remote_order[1],
+                            "prepared_at": isoformat_z(remote_order[2]),
+                            "rollover_id": remote_order[3],
+                        },
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+        if local_order == remote_order and not args.force:
+            print(
+                json.dumps(
+                    {
+                        "status": "refused",
+                        "error": "bundle order ties but content differs; refusing to choose a copy",
+                        "generation": manifest["generation"],
+                        "rollover_id": manifest["rollover_id"],
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+        archived = _bundle_archive_local_lineage(
+            state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            remote_manifest=manifest,
+        )
+    else:
+        archived = None
+
+    preserved = _bundle_preserve_handoff_files(repo_root, agent=agent, stream_id=stream_id, members=members)
+    try:
+        _bundle_install(repo_root, state_root, manifest=manifest, members=members)
+        receipt_path = state_root / ".agent" / "thread-rollovers" / agent / "_bundle-receipts" / f"{lineage_id}.json"
+        write_json_atomic(receipt_path, {"schema": "rollover-bundle-receipt.v1", "upload_seq": int(manifest.get("upload_seq", 0))})
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
+        return 2
+    result = {
+        "status": "installed",
+        "agent": agent,
+        "lineage_id": lineage_id,
+        "rollover_id": manifest["rollover_id"],
+        "generation": manifest["generation"],
+        "stream_id": stream_id,
+        "archived": str(archived.relative_to(state_root)) if archived is not None else None,
+        "preserved_handoffs": preserved,
+        "upload_seq": manifest.get("upload_seq", 0),
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
     return 0
 
 
@@ -4506,7 +5416,13 @@ def rollover_identity_snapshot(state_root: Path, agent: str | None = None) -> di
 
 
 
-def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str, current_thread_id: str) -> str:
+def render_session_start_context(
+    candidate: dict[str, Any] | None,
+    *,
+    agent: str,
+    current_thread_id: str,
+    stream_id: str | None = None,
+) -> str:
     """Render the only SessionStart handoff text; shell hooks never parse leases."""
     if candidate is None or candidate.get("status") == "none":
         facts_path = ".agent/orientation-health-facts.json"
@@ -4535,18 +5451,19 @@ def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str
     thread_id = current_thread_id or "<current-codex-thread-id>"
     lineage_id = candidate["lineage_id"]
     rollover_id = candidate["rollover_id"]
+    stream_arg = f" --stream {stream_id}" if stream_id else ""
     if candidate["status"] == "resumed":
         title = "RESUMED THREAD ROLLOVER DETECTED"
     else:
         title = "PENDING THREAD ROLLOVER DETECTED"
-    lines = [title, "```bash"]
+    lines = [title, f"Replacement generation: {candidate.get('generation', 'unknown')}", "```bash"]
     if candidate["status"] == "pending_start":
         lines.append(
             f".venv/bin/python scripts/orchestration/thread_handoff.py bootstrap-replacement -a {agent} -l {lineage_id} -r {rollover_id} -t {thread_id} -e <binding>"
         )
     lines.extend(
         [
-            f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-replacement -a {agent} -l {lineage_id} -r {rollover_id}",
+            f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-replacement -a {agent} -l {lineage_id} -r {rollover_id}{stream_arg}",
             "```",
             "Fill snapshot; first confirm emits questions. Failure keeps cleanup locked.",
         ]
@@ -4718,7 +5635,12 @@ def cmd_detect(args: argparse.Namespace) -> int:
         if registry_errors:
             output["registry_errors"] = registry_errors
         print(
-            render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
+            render_session_start_context(
+                output,
+                agent=agent,
+                current_thread_id=args.current_thread_id,
+                stream_id=getattr(args, "stream", None),
+            )
             if args.format == "session-start"
             else json.dumps(output, indent=2)
         )
@@ -4803,6 +5725,7 @@ def cmd_detect(args: argparse.Namespace) -> int:
         "packet_agent": scan_agent,
         "lineage_id": state.get("lineage_id"),
         "rollover_id": replacement.get("rollover_id"),
+        "generation": replacement.get("generation"),
         "status": replacement.get("status"),
         "state_file": rel(path, state_root),
         "state": "live",
@@ -4828,7 +5751,12 @@ def cmd_detect(args: argparse.Namespace) -> int:
         output["registry_errors"] = registry_errors
 
     print(
-        render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
+        render_session_start_context(
+            output,
+            agent=agent,
+            current_thread_id=args.current_thread_id,
+            stream_id=getattr(args, "stream", None),
+        )
         if args.format == "session-start"
         else json.dumps(output, indent=2)
     )
@@ -4981,7 +5909,10 @@ def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path)
-    parser.add_argument("--monitor-base-url", default=os.environ.get("MONITOR_API_BASE_URL", DEFAULT_MONITOR_BASE_URL))
+    parser.add_argument(
+        "--monitor-base-url",
+        default=os.environ.get("LU_MONITOR_LOOPBACK", os.environ.get("MONITOR_API_BASE_URL", DEFAULT_MONITOR_BASE_URL)),
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     prepare = subparsers.add_parser("prepare", help="Prepare a rollover handoff and bootstrap prompt.")
@@ -5026,6 +5957,7 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--context-percent", type=float)
     prepare.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
     prepare.add_argument("--force-new-replacement", action="store_true")
+    prepare.add_argument("--stream", help="Explicit session stream id used for an optional bundle upload.")
     prepare.add_argument(
         "--migrate-v1", action="store_true", help="Explicitly migrate a v1 lease into a fresh v2 rollover."
     )
@@ -5141,6 +6073,7 @@ def build_parser() -> argparse.ArgumentParser:
     confirm.add_argument("--strict-probe", type=Path, required=True)
     confirm.add_argument("--strict-verdict", type=Path, required=True)
     confirm.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
+    confirm.add_argument("--stream", help="Explicit session stream id used for an optional bundle upload.")
     confirm.set_defaults(func=cmd_confirm_started)
 
     resume = subparsers.add_parser(
@@ -5180,7 +6113,32 @@ def build_parser() -> argparse.ArgumentParser:
     )
     confirm_replacement.add_argument("--new-automation-id")
     confirm_replacement.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
+    confirm_replacement.add_argument("--stream", help="Explicit session stream id used for an optional bundle upload.")
     confirm_replacement.set_defaults(func=cmd_confirm_replacement)
+
+    export_bundle = subparsers.add_parser(
+        "export-bundle",
+        help="Export one lineage rollover packet and its stream-lane handoff as a bounded bundle.",
+    )
+    export_bundle.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    export_bundle.add_argument("--lineage-id", type=argparse_lineage_id)
+    export_bundle.add_argument("--rollover-id", type=argparse_rollover_id)
+    export_bundle.add_argument("--stream", help="Explicit launcher-derived stream id for the lane handoff/API.")
+    export_bundle.add_argument("--file", type=Path, help="Write the local .tgz to this path.")
+    export_bundle.add_argument("--upload", action="store_true", help="Upload through the loopback Monitor API.")
+    export_bundle.set_defaults(func=cmd_export_bundle)
+
+    import_bundle = subparsers.add_parser(
+        "import-bundle",
+        help="Install a newer cross-host rollover bundle without silently clobbering local state.",
+    )
+    import_bundle.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    import_source = import_bundle.add_mutually_exclusive_group(required=True)
+    import_source.add_argument("--from-api", metavar="STREAM", help="Fetch the latest bundle for this stream.")
+    import_source.add_argument("--file", type=Path, help="Read a local/scp/rsync .tgz bundle.")
+    import_bundle.add_argument("--stream", help="Expected stream id for a file import.")
+    import_bundle.add_argument("--force", action="store_true", help="Archive a newer local copy before installing.")
+    import_bundle.set_defaults(func=cmd_import_bundle)
 
     check = subparsers.add_parser("check", help="Detect stale or unsafe handoff state.")
     check.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
@@ -5203,6 +6161,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     detect.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
     detect.add_argument("--current-thread-id", default="")
+    detect.add_argument("--stream", help="Explicit launcher-derived stream id for the confirm/upload card.")
     detect.add_argument(
         "--task-family",
         default="",

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
-import copy
 import gzip
 import hashlib
 import io
@@ -32,7 +31,7 @@ import urllib.error
 import urllib.request
 import uuid
 from collections.abc import Callable, Mapping
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -98,6 +97,19 @@ ROLLOVER_BUNDLE_STATUS_RANK = {
     # The existing state machine calls the confirmed replacement ``started``.
     "started": 3,
 }
+# Only these manifest fields affect bundle identity.  Host paths, export
+# clocks, and server-assigned upload sequence numbers are informational or
+# transport metadata and must not turn an identical state into new content.
+ROLLOVER_BUNDLE_DIGEST_FIELDS = (
+    "agent",
+    "stream_id",
+    "lineage_id",
+    "rollover_id",
+    "generation",
+    "status",
+    "prepared_at",
+    "tokenized_members",
+)
 # Default warning threshold (percentage of window)
 DEFAULT_CONTEXT_THRESHOLD = 88.0
 THREAD_LEASE_SCHEMA_VERSION = 2
@@ -486,7 +498,28 @@ def _bundle_archive(members: Mapping[str, bytes], manifest: Mapping[str, Any]) -
 
 
 def _bundle_digest(members: Mapping[str, bytes], manifest: Mapping[str, Any]) -> str:
-    unsigned = copy.deepcopy(dict(manifest))
+    digest_manifest = {
+        field: (
+            sorted(manifest[field])
+            if field == "tokenized_members" and isinstance(manifest.get(field), list)
+            else manifest.get(field)
+        )
+        for field in ROLLOVER_BUNDLE_DIGEST_FIELDS
+    }
+    digest_members = [
+        {
+            "path": name,
+            "sha256": hashlib.sha256(members[name]).hexdigest(),
+            "bytes": len(members[name]),
+        }
+        for name in sorted(members)
+    ]
+    return hashlib.sha256(_bundle_json({"manifest": digest_manifest, "members": digest_members})).hexdigest()
+
+
+def _bundle_legacy_digest(members: Mapping[str, bytes], manifest: Mapping[str, Any]) -> str:
+    """Verify v1 archives emitted before the deterministic identity digest fix."""
+    unsigned = dict(manifest)
     unsigned["bundle_sha256"] = ""
     return hashlib.sha256(_bundle_archive(members, unsigned)).hexdigest()
 
@@ -760,7 +793,9 @@ def _bundle_extract(blob: bytes, *, manifest_override: Mapping[str, Any] | None 
         raise ValueError("rollover bundle tokenized_members does not match its file manifest")
     _bundle_order(manifest)
     expected_digest = _bundle_digest(members, manifest)
-    if manifest.get("bundle_sha256") != expected_digest:
+    if manifest.get("bundle_sha256") != expected_digest and manifest.get("bundle_sha256") != _bundle_legacy_digest(
+        members, manifest
+    ):
         raise ValueError("rollover bundle fingerprint mismatch")
     if manifest_override is not None:
         outer = dict(manifest_override)
@@ -807,50 +842,215 @@ def _bundle_archive_local_lineage(
         archive_root = state_root / ".agent" / "thread-rollovers" / agent / "_archive" / f"{lineage_id}-{timestamp}-{suffix}"
         suffix += 1
     archive_root.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(os.fspath(lineage_root), os.fspath(archive_root))
-    archived_state_path = archive_root / "lease.json"
-    archived_state = load_state(archived_state_path)
-    replacement = archived_state.get("replacement")
-    if isinstance(replacement, dict) and replacement.get("status") in {"pending_start", "resumed"}:
-        replacement["status"] = "superseded"
-        replacement["superseded_by"] = {
-            "lineage_id": remote_manifest.get("lineage_id"),
-            "generation": remote_manifest.get("generation"),
-            "rollover_id": remote_manifest.get("rollover_id"),
-        }
-        archived_state["replacement"] = replacement
-        write_rollover_state(archived_state_path, state_root, archived_state)
+    original_lease = (lineage_root / "lease.json").read_bytes()
+    try:
+        shutil.move(os.fspath(lineage_root), os.fspath(archive_root))
+        archived_state_path = archive_root / "lease.json"
+        archived_state = load_state(archived_state_path)
+        replacement = archived_state.get("replacement")
+        if isinstance(replacement, dict) and replacement.get("status") in {"pending_start", "resumed"}:
+            replacement["status"] = "superseded"
+            replacement["superseded_by"] = {
+                "lineage_id": remote_manifest.get("lineage_id"),
+                "generation": remote_manifest.get("generation"),
+                "rollover_id": remote_manifest.get("rollover_id"),
+            }
+            archived_state["replacement"] = replacement
+            # The identity receipt already describes the same lineage identity;
+            # only the archived lease projection changes here.  Keep this final
+            # archive update local so a failed import can remove the transaction's
+            # archive without leaving a second registry mutation to roll back.
+            write_json_atomic(archived_state_path, archived_state)
+    except Exception:
+        if archive_root.exists():
+            with suppress(OSError):
+                write_bytes_atomic(archive_root / "lease.json", original_lease)
+            with suppress(OSError):
+                shutil.move(os.fspath(archive_root), os.fspath(lineage_root))
+        raise
     return archive_root
 
 
-def _bundle_install(
+def _bundle_validate_lease_member(
+    state_root: Path,
+    *,
+    agent: str,
+    lineage_id: str,
+    manifest: Mapping[str, Any],
+    members: Mapping[str, bytes],
+) -> None:
+    """Validate the imported lease before staging or replacing local state."""
+    lease_name = f".agent/thread-rollovers/{agent}/{lineage_id}/lease.json"
+    payload = members.get(lease_name)
+    if payload is None:
+        raise ValueError("bundle has no lease state member")
+    try:
+        state = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("bundle lease state is not valid JSON") from exc
+    if not isinstance(state, dict):
+        raise ValueError("bundle lease state must be an object")
+    replacement, error = validate_live_lease(
+        state,
+        agent=agent,
+        state_path=state_root / ".agent" / "thread-rollovers" / agent / lineage_id / "lease.json",
+    )
+    if error:
+        raise ValueError(f"bundle lease is invalid: {error}")
+    assert replacement is not None
+    if state.get("lineage_id") != lineage_id or state.get("rollover_id") != manifest.get("rollover_id"):
+        raise ValueError("bundle lease identity does not match its manifest")
+    try:
+        generation = int(manifest["generation"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("bundle manifest generation is malformed") from exc
+    if replacement.get("generation") != generation:
+        raise ValueError("bundle lease generation does not match its manifest")
+    if replacement.get("prepared_at") != manifest.get("prepared_at"):
+        raise ValueError("bundle lease prepared_at does not match its manifest")
+    lease_status = str(replacement.get("status") or "")
+    manifest_status = str(manifest.get("status") or "")
+    if lease_status != manifest_status and {lease_status, manifest_status} != {"started", "confirmed"}:
+        raise ValueError("bundle lease status does not match its manifest")
+
+
+def _bundle_stage_install(
     repo_root: Path,
     state_root: Path,
     *,
     manifest: Mapping[str, Any],
     members: Mapping[str, bytes],
-) -> None:
+) -> tuple[Path, Path, dict[str, Path]]:
+    """Stage every imported file beside its target lineage, without clobbering it."""
     agent = normalize_agent_name(str(manifest["agent"]))
     lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
     lineage_prefix = f".agent/thread-rollovers/{agent}/{lineage_id}/"
     if not any(name.startswith(lineage_prefix) for name in members):
         raise ValueError("bundle has no lineage state members")
-    scratch_root = state_root / ".agent"
-    scratch_root.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="rollover-import-", dir=os.fspath(scratch_root)) as scratch:
-        staging = Path(scratch)
+    lineage_parent = state_root / ".agent" / "thread-rollovers" / agent
+    lineage_parent.mkdir(parents=True, exist_ok=True)
+    stage_root = Path(tempfile.mkdtemp(prefix=f".{lineage_id}.import-", dir=os.fspath(lineage_parent)))
+    staged_lineage = stage_root / "lineage"
+    staged_repo: dict[str, Path] = {}
+    try:
         for name, payload in members.items():
-            destination = staging / name if name.startswith(lineage_prefix) else staging / "repo" / name
+            if name.startswith(".agent/thread-rollovers/"):
+                if not name.startswith(lineage_prefix):
+                    raise ValueError("bundle contains a foreign lineage member")
+                destination = staged_lineage / name.removeprefix(lineage_prefix)
+            else:
+                destination = stage_root / "repo" / name
+                staged_repo[name] = destination
+            destination.relative_to(stage_root.resolve())
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes(_bundle_rewrite(payload, repo_root=repo_root) if _bundle_text_member(name) else payload)
-        names = sorted(members, key=lambda name: ("identity-receipt.json" not in name, name == "lease.json", name))
-        for name in names:
-            source = staging / name if name.startswith(lineage_prefix) else staging / "repo" / name
-            target_root = state_root if name.startswith(".agent/thread-rollovers/") else repo_root
-            target = (target_root / name).resolve()
-            target.relative_to(target_root.resolve())
-            target.parent.mkdir(parents=True, exist_ok=True)
-            write_bytes_atomic(target, source.read_bytes())
+            destination.write_bytes(
+                _bundle_rewrite(payload, repo_root=repo_root) if _bundle_text_member(name) else payload
+            )
+    except Exception:
+        shutil.rmtree(stage_root, ignore_errors=True)
+        raise
+    return stage_root, staged_lineage, staged_repo
+
+
+def _bundle_preserved_path(target: Path) -> Path:
+    timestamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+    preserved = target.with_name(f"{target.stem}.{timestamp}.superseded{target.suffix}")
+    suffix = 1
+    while preserved.exists():
+        preserved = target.with_name(f"{target.stem}.{timestamp}-{suffix}.superseded{target.suffix}")
+        suffix += 1
+    return preserved
+
+
+def _bundle_commit_install(
+    repo_root: Path,
+    state_root: Path,
+    *,
+    manifest: Mapping[str, Any],
+    stage_root: Path,
+    staged_lineage: Path,
+    staged_repo: Mapping[str, Path],
+    local_lineage_exists: bool,
+) -> tuple[Path | None, list[str]]:
+    """Commit a staged bundle with exact rollback around archive+rename."""
+    agent = normalize_agent_name(str(manifest["agent"]))
+    lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
+    lineage_root = state_root / ".agent" / "thread-rollovers" / agent / lineage_id
+    receipt_path = state_root / ".agent" / "thread-rollovers" / agent / "_bundle-receipts" / f"{lineage_id}.json"
+    original_backup = stage_root / "original-lineage"
+
+    repo_backups: dict[Path, bytes | None] = {}
+    created_preserved: list[Path] = []
+    preserved: list[str] = []
+    old_receipt = receipt_path.read_bytes() if receipt_path.is_file() else None
+    archived: Path | None = None
+    lineage_replaced = False
+    try:
+        if local_lineage_exists:
+            shutil.copytree(lineage_root, original_backup)
+        candidates = set(_bundle_handoff_candidates_for_agent(repo_root, str(manifest["stream_id"]), agent))
+        for name, source in sorted(staged_repo.items()):
+            target = (repo_root / name).resolve()
+            target.relative_to(repo_root.resolve())
+            if target.exists() and not target.is_file():
+                raise ValueError(f"bundle target is not a regular file: {name}")
+            old_payload = target.read_bytes() if target.is_file() else None
+            repo_backups[target] = old_payload
+            installed = source.read_bytes()
+            if name in candidates and old_payload is not None and old_payload != installed:
+                superseded = _bundle_preserved_path(target)
+                write_bytes_atomic(superseded, old_payload)
+                created_preserved.append(superseded)
+                preserved.append(superseded.as_posix())
+            write_bytes_atomic(target, installed)
+
+        write_json_atomic(
+            receipt_path,
+            {"schema": "rollover-bundle-receipt.v1", "upload_seq": int(manifest.get("upload_seq", 0))},
+        )
+
+        # No operation that can select a different copy occurs before all
+        # validation and staging above.  Archive and rename are the final
+        # lineage transition, and every failure below restores the original.
+        if lineage_root.exists():
+            archived = _bundle_archive_local_lineage(
+                state_root,
+                agent=agent,
+                lineage_id=lineage_id,
+                remote_manifest=manifest,
+            )
+        os.replace(staged_lineage, lineage_root)
+        lineage_replaced = True
+        return archived, preserved
+    except Exception:
+        if lineage_replaced and lineage_root.exists():
+            shutil.rmtree(lineage_root, ignore_errors=True)
+        if archived is not None and archived.exists():
+            shutil.rmtree(archived, ignore_errors=True)
+        if local_lineage_exists and original_backup.exists() and not lineage_root.exists():
+            shutil.copytree(original_backup, lineage_root)
+
+        for target, old_payload in repo_backups.items():
+            try:
+                if old_payload is None:
+                    target.unlink(missing_ok=True)
+                else:
+                    write_bytes_atomic(target, old_payload)
+            except OSError:
+                pass
+        for path in created_preserved:
+            path.unlink(missing_ok=True)
+        try:
+            if old_receipt is None:
+                receipt_path.unlink(missing_ok=True)
+            else:
+                write_bytes_atomic(receipt_path, old_receipt)
+        except OSError:
+            pass
+        raise
+    finally:
+        if stage_root.exists():
+            shutil.rmtree(stage_root, ignore_errors=True)
 
 
 def _bundle_status_manifest(state_root: Path, *, agent: str, lineage_id: str) -> dict[str, Any] | None:
@@ -5197,33 +5397,45 @@ def _maybe_auto_upload_bundle(
         return {"status": "skipped", "reason": str(exc)}
 
 
-def _bundle_preserve_handoff_files(
+def _bundle_local_lineage_snapshot(
     repo_root: Path,
+    state_root: Path,
     *,
     agent: str,
+    lineage_id: str,
     stream_id: str,
-    members: Mapping[str, bytes],
-) -> list[str]:
-    preserved: list[str] = []
-    candidates = set(_bundle_handoff_candidates_for_agent(repo_root, stream_id, agent))
-    for name, payload in members.items():
-        if name.startswith(".agent/") or name not in candidates:
-            continue
-        target = repo_root / name
-        if not target.is_file():
-            continue
-        installed = _bundle_rewrite(payload, repo_root=repo_root) if _bundle_text_member(name) else payload
-        if target.read_bytes() == installed:
-            continue
-        timestamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
-        superseded = target.with_name(f"{target.stem}.{timestamp}.superseded{target.suffix}")
-        suffix = 1
-        while superseded.exists():
-            superseded = target.with_name(f"{target.stem}.{timestamp}-{suffix}.superseded{target.suffix}")
-            suffix += 1
-        write_bytes_atomic(superseded, target.read_bytes())
-        preserved.append(superseded.as_posix())
-    return preserved
+) -> tuple[dict[str, Any] | None, dict[str, bytes] | None, bool]:
+    """Read and validate the local copy before any import filesystem mutation."""
+    lineage_root = state_root / ".agent" / "thread-rollovers" / agent / lineage_id
+    if not lineage_root.exists():
+        return None, None, False
+    if lineage_root.is_symlink() or not lineage_root.is_dir():
+        raise ValueError("local rollover lineage is not a regular directory")
+    state_path = lineage_root / "lease.json"
+    state = load_state(state_path)
+    _, error = validate_live_lease(state, agent=agent, state_path=state_path)
+    if error:
+        raise ValueError(f"local rollover lease is invalid: {error}")
+    receipt_path = state_root / ".agent" / "thread-rollovers" / agent / "_bundle-receipts" / f"{lineage_id}.json"
+    receipt = load_state(receipt_path) if receipt_path.is_file() else {}
+    try:
+        upload_seq = int(receipt.get("upload_seq", 0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("local rollover bundle receipt has a malformed upload_seq") from exc
+    local_manifest = _bundle_state_manifest(state, stream_id=stream_id, upload_seq=upload_seq)
+    local_members = _bundle_local_members(
+        repo_root,
+        state_root,
+        agent=agent,
+        lineage_id=lineage_id,
+        stream_id=stream_id,
+    )
+    return local_manifest, local_members, True
+
+
+def _bundle_import_error(reason: str) -> int:
+    print(json.dumps({"error": reason, "action": "import-bundle"}, separators=(",", ":")))
+    return 2
 
 
 def cmd_import_bundle(args: argparse.Namespace) -> int:
@@ -5231,8 +5443,7 @@ def cmd_import_bundle(args: argparse.Namespace) -> int:
         repo_root, state_root = resolve_roots(args.repo_root)
         agent = normalize_agent_name(args.agent)
     except (OSError, ValueError) as exc:
-        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
-        return 2
+        return _bundle_import_error(str(exc))
 
     api_manifest: dict[str, Any] | None = None
     try:
@@ -5253,94 +5464,97 @@ def cmd_import_bundle(args: argparse.Namespace) -> int:
             raise ValueError("bundle stream_id is missing")
     except RolloverBundleAPIUnavailable as exc:
         print(f"WARNING: rollover bundle import skipped (fail-open): {exc}", file=sys.stderr)
-        print(json.dumps({"status": "warning", "action": "import-bundle", "reason": str(exc)}, indent=2))
+        print(json.dumps({"status": "warning", "action": "import-bundle", "reason": str(exc)}, separators=(",", ":")))
         return 0
-    except FileNotFoundError as exc:
-        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
-        return 2
     except (OSError, ValueError, KeyError, TypeError) as exc:
-        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
-        return 2
-
-    lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
-    remote_order = _bundle_order(manifest)
-    local_manifest = _bundle_status_manifest(state_root, agent=agent, lineage_id=lineage_id)
-    if local_manifest is not None:
-        local_members = _bundle_local_members(
+        return _bundle_import_error(str(exc))
+    try:
+        lineage_id = normalize_lineage_id(str(manifest["lineage_id"]))
+        _bundle_validate_lease_member(
+            state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            manifest=manifest,
+            members=members,
+        )
+        remote_order = _bundle_order(manifest)
+        local_manifest, local_members, local_lineage_exists = _bundle_local_lineage_snapshot(
             repo_root,
             state_root,
             agent=agent,
             lineage_id=lineage_id,
             stream_id=stream_id,
         )
-        if local_members == members and local_manifest.get("generation") == manifest.get("generation"):
-            print(
-                json.dumps(
-                    {
-                        "status": "noop",
-                        "reason": "identical bundle content",
-                        "agent": agent,
-                        "lineage_id": lineage_id,
-                        "rollover_id": manifest["rollover_id"],
-                    },
-                    indent=2,
-                )
-            )
-            return 0
-        local_order = _bundle_order(local_manifest)
-        if local_order > remote_order and not args.force:
-            print(
-                json.dumps(
-                    {
-                        "status": "refused",
-                        "error": "local rollover copy is newer; refusing to clobber it",
-                        "local": {
-                            "generation": local_order[0],
-                            "status_rank": local_order[1],
-                            "prepared_at": isoformat_z(local_order[2]),
-                            "rollover_id": local_order[3],
+        if local_manifest is not None and local_members is not None:
+            local_order = _bundle_order(local_manifest)
+            if local_order > remote_order and not args.force:
+                print(
+                    json.dumps(
+                        {
+                            "status": "refused",
+                            "error": "local rollover copy is newer; refusing to clobber it",
+                            "local": {
+                                "generation": local_order[0],
+                                "status_rank": local_order[1],
+                                "prepared_at": isoformat_z(local_order[2]),
+                                "rollover_id": local_order[3],
+                            },
+                            "remote": {
+                                "generation": remote_order[0],
+                                "status_rank": remote_order[1],
+                                "prepared_at": isoformat_z(remote_order[2]),
+                                "rollover_id": remote_order[3],
+                            },
                         },
-                        "remote": {
-                            "generation": remote_order[0],
-                            "status_rank": remote_order[1],
-                            "prepared_at": isoformat_z(remote_order[2]),
-                            "rollover_id": remote_order[3],
+                        separators=(",", ":"),
+                    )
+                )
+                return 2
+            if local_order == remote_order and not args.force:
+                if local_members == members and local_manifest.get("generation") == manifest.get("generation"):
+                    print(
+                        json.dumps(
+                            {
+                                "status": "noop",
+                                "reason": "identical bundle content",
+                                "agent": agent,
+                                "lineage_id": lineage_id,
+                                "rollover_id": manifest["rollover_id"],
+                            },
+                            separators=(",", ":"),
+                        )
+                    )
+                    return 0
+                print(
+                    json.dumps(
+                        {
+                            "status": "refused",
+                            "error": "bundle order ties but content differs; refusing to choose a copy",
+                            "generation": manifest["generation"],
+                            "rollover_id": manifest["rollover_id"],
                         },
-                    },
-                    indent=2,
+                        separators=(",", ":"),
+                    )
                 )
-            )
-            return 2
-        if local_order == remote_order and not args.force:
-            print(
-                json.dumps(
-                    {
-                        "status": "refused",
-                        "error": "bundle order ties but content differs; refusing to choose a copy",
-                        "generation": manifest["generation"],
-                        "rollover_id": manifest["rollover_id"],
-                    },
-                    indent=2,
-                )
-            )
-            return 2
-        archived = _bundle_archive_local_lineage(
-            state_root,
-            agent=agent,
-            lineage_id=lineage_id,
-            remote_manifest=manifest,
-        )
-    else:
-        archived = None
+                return 2
 
-    preserved = _bundle_preserve_handoff_files(repo_root, agent=agent, stream_id=stream_id, members=members)
-    try:
-        _bundle_install(repo_root, state_root, manifest=manifest, members=members)
-        receipt_path = state_root / ".agent" / "thread-rollovers" / agent / "_bundle-receipts" / f"{lineage_id}.json"
-        write_json_atomic(receipt_path, {"schema": "rollover-bundle-receipt.v1", "upload_seq": int(manifest.get("upload_seq", 0))})
-    except (OSError, ValueError, KeyError, TypeError) as exc:
-        print(json.dumps({"error": str(exc), "action": "import-bundle"}, indent=2))
-        return 2
+        stage_root, staged_lineage, staged_repo = _bundle_stage_install(
+            repo_root,
+            state_root,
+            manifest=manifest,
+            members=members,
+        )
+        archived, preserved = _bundle_commit_install(
+            repo_root,
+            state_root,
+            manifest=manifest,
+            stage_root=stage_root,
+            staged_lineage=staged_lineage,
+            staged_repo=staged_repo,
+            local_lineage_exists=local_lineage_exists,
+        )
+    except Exception as exc:
+        return _bundle_import_error(str(exc))
     result = {
         "status": "installed",
         "agent": agent,

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -1147,7 +1147,10 @@ def _bundle_api_request(
             raw = response.read().decode("utf-8")
             status = int(getattr(response, "status", 200))
     except urllib.error.HTTPError as exc:
-        if method == "GET" and exc.code == 404 and path.split("?", 1)[0].endswith("/bundles/latest"):
+        if method == "GET" and exc.code == 404 and (
+            path.split("?", 1)[0].endswith("/bundles/latest")
+            or "/bundles/" in path.split("?", 1)[0]
+        ):
             raise RolloverBundleNotFound("bundle API has no matching bundle") from exc
         raise RolloverBundleAPIUnavailable(f"bundle API unavailable: HTTP {exc.code}") from exc
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
@@ -1203,6 +1206,51 @@ def _bundle_api_latest(
         blob = base64.b64decode(encoded.encode("ascii"), validate=True)
     except (ValueError, binascii.Error) as exc:
         raise ValueError("bundle API latest blob is not valid base64") from exc
+    return manifest, blob
+
+
+def _bundle_api_list(
+    args: argparse.Namespace,
+    *,
+    stream_id: str,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """List bundle metadata in upload-sequence order without downloading blobs."""
+    if limit < 1 or limit > 100:
+        raise ValueError("bundle API list limit must be between 1 and 100")
+    payload = _bundle_api_request(
+        args.monitor_base_url,
+        method="GET",
+        path=f"/api/epics/v1/{stream_id}/bundles?{urlencode({'limit': limit})}",
+    )
+    bundles = payload.get("bundles")
+    if not isinstance(bundles, list) or not all(isinstance(bundle, dict) for bundle in bundles):
+        raise ValueError("bundle API list response omitted valid bundle metadata")
+    return bundles
+
+
+def _bundle_api_by_seq(
+    args: argparse.Namespace,
+    *,
+    stream_id: str,
+    upload_seq: int,
+) -> tuple[dict[str, Any], bytes]:
+    """Fetch one bundle's manifest and blob by its immutable upload sequence."""
+    if upload_seq < 1:
+        raise ValueError("bundle API upload sequence must be positive")
+    payload = _bundle_api_request(
+        args.monitor_base_url,
+        method="GET",
+        path=f"/api/epics/v1/{stream_id}/bundles/{upload_seq}",
+    )
+    manifest = payload.get("manifest")
+    encoded = payload.get("blob")
+    if not isinstance(manifest, dict) or not isinstance(encoded, str):
+        raise ValueError("bundle API sequence response omitted its manifest or blob")
+    try:
+        blob = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("bundle API sequence blob is not valid base64") from exc
     return manifest, blob
 
 
@@ -5329,9 +5377,9 @@ def cmd_export_bundle(args: argparse.Namespace) -> int:
         "source_state": rel(state_path, state_root),
         "upload": "not-requested",
     }
-    for member, rule in secret_hits:
+    for _member, rule in secret_hits:
         print(
-            f"WARNING: rollover bundle secret scan hit member={member} rule={rule}; "
+            f"WARNING: rollover bundle secret scan hit rule={rule}; "
             "local bundle was written but upload was skipped.",
             file=sys.stderr,
         )
@@ -5378,9 +5426,9 @@ def _maybe_auto_upload_bundle(
             supplied=None,
         )
         write_bytes_atomic(output_path, blob)
-        for member, rule in secret_hits:
+        for _member, rule in secret_hits:
             print(
-                f"WARNING: rollover bundle secret scan hit member={member} rule={rule}; "
+                f"WARNING: rollover bundle secret scan hit rule={rule}; "
                 "local bundle was written but upload was skipped.",
                 file=sys.stderr,
             )
@@ -5583,20 +5631,38 @@ def cmd_import_bundle(args: argparse.Namespace) -> int:
             candidates.append((manifest, members))
         else:
             stream_id = str(args.from_api)
-            any_manifest, any_blob = _bundle_api_latest(args, stream_id=stream_id)
-            any_manifest, any_members = _bundle_extract(any_blob, manifest_override=any_manifest)
-            candidates.append((any_manifest, any_members))
-            try:
-                own_manifest, own_blob = _bundle_api_latest(args, stream_id=stream_id, agent=agent)
-            except RolloverBundleNotFound:
-                own_manifest = None
-            except RolloverBundleAPIUnavailable as exc:
-                own_manifest = None
-                print(f"WARNING: own-agent rollover bundle lookup skipped (fail-open): {exc}", file=sys.stderr)
-            if own_manifest is not None:
-                own_manifest, own_members = _bundle_extract(own_blob, manifest_override=own_manifest)
-                if _bundle_order(own_manifest) > _bundle_order(any_manifest):
-                    candidates.append((own_manifest, own_members))
+            listed = _bundle_api_list(args, stream_id=stream_id)
+            if not listed:
+                raise RolloverBundleNotFound("bundle API has no matching bundle")
+
+            def upload_seq(row: Mapping[str, Any]) -> int:
+                try:
+                    return int(row.get("upload_seq", (row.get("manifest") or {}).get("upload_seq", 0)))
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("bundle API list upload sequence is malformed") from exc
+
+            def row_agent(row: Mapping[str, Any]) -> str:
+                if row.get("agent") is not None:
+                    return str(row["agent"])
+                manifest = row.get("manifest")
+                if not isinstance(manifest, Mapping):
+                    raise ValueError("bundle API list manifest is malformed")
+                return str(manifest.get("agent") or "")
+
+            own_row = next((row for row in listed if row_agent(row) == agent), None)
+            handoff_row = max(listed, key=upload_seq)
+            selected_sequences = {
+                upload_seq(row)
+                for row in (own_row, handoff_row)
+                if row is not None
+            }
+            for row in listed:
+                sequence = upload_seq(row)
+                if sequence not in selected_sequences:
+                    continue
+                manifest, blob = _bundle_api_by_seq(args, stream_id=stream_id, upload_seq=sequence)
+                manifest, members = _bundle_extract(blob, manifest_override=manifest)
+                candidates.append((manifest, members))
 
         for manifest, _ in candidates:
             stream_id = str(manifest.get("stream_id") or "")

--- a/tests/api/test_rollover_bundle_router.py
+++ b/tests/api/test_rollover_bundle_router.py
@@ -50,16 +50,17 @@ def _bundle(
     *,
     rollover_id: str,
     body: bytes,
+    agent: str = "claude-infra",
     status: str = "pending_start",
     prepared_at: str = "2026-08-24T16:00:00Z",
     lineage_id: str = "bundle-lineage",
     generation: int = 3,
 ) -> tuple[dict, bytes]:
-    name = f".agent/thread-rollovers/claude-infra/{lineage_id}/generation-{generation:04d}/{rollover_id}/handoff.md"
+    name = f".agent/thread-rollovers/{agent}/{lineage_id}/generation-{generation:04d}/{rollover_id}/handoff.md"
     members = {name: body}
     manifest = {
         "schema": "rollover-bundle.v1",
-        "agent": "claude-infra",
+        "agent": agent,
         "stream_id": "epic:7178",
         "lineage_id": lineage_id,
         "rollover_id": rollover_id,
@@ -116,6 +117,38 @@ def test_bundle_upload_list_latest_idempotency_and_secret_refusal(tmp_path: Path
         json={**lease, "manifest": secret_manifest, "blob": base64.b64encode(secret_blob).decode("ascii")},
     )
     assert secret_response.status_code == 400
+
+
+def test_bundle_latest_without_agent_selects_highest_order_across_agents(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+    lease = _claim(client)
+
+    own_manifest, own_blob = _bundle(
+        rollover_id="rollover-grok-newer",
+        body=b"grok packet\n",
+        agent="grok-infra",
+        lineage_id="grok-lineage",
+        generation=4,
+    )
+    foreign_manifest, foreign_blob = _bundle(
+        rollover_id="rollover-claude-older",
+        body=b"claude packet\n",
+        agent="claude-infra",
+        lineage_id="claude-lineage",
+        generation=3,
+    )
+    for manifest, blob in ((own_manifest, own_blob), (foreign_manifest, foreign_blob)):
+        response = client.post(
+            "/api/epics/v1/epic:7178/bundles",
+            json={**lease, "manifest": manifest, "blob": base64.b64encode(blob).decode("ascii")},
+        )
+        assert response.status_code == 200, response.text
+
+    latest = client.get("/api/epics/v1/epic:7178/bundles/latest")
+    assert latest.status_code == 200, latest.text
+    assert latest.json()["manifest"]["agent"] == "grok-infra"
+    assert latest.json()["manifest"]["generation"] == 4
+    assert latest.json()["manifest"]["upload_seq"] == 1
 
 
 def test_bundle_upload_allows_status_evolution_and_rejects_same_tuple_contradiction(

--- a/tests/api/test_rollover_bundle_router.py
+++ b/tests/api/test_rollover_bundle_router.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
+import sqlite3
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import LeaseHolder
 from agents_extensions.shared.session_streams.store import SessionStreamStore
 from scripts.api import epics_router
 from scripts.orchestration import thread_handoff as th
@@ -42,18 +46,26 @@ def _claim(client: TestClient) -> dict:
     return response.json()["lease"]
 
 
-def _bundle(*, rollover_id: str, body: bytes) -> tuple[dict, bytes]:
-    name = ".agent/thread-rollovers/claude-infra/bundle-lineage/generation-0003/" + rollover_id + "/handoff.md"
+def _bundle(
+    *,
+    rollover_id: str,
+    body: bytes,
+    status: str = "pending_start",
+    prepared_at: str = "2026-08-24T16:00:00Z",
+    lineage_id: str = "bundle-lineage",
+    generation: int = 3,
+) -> tuple[dict, bytes]:
+    name = f".agent/thread-rollovers/claude-infra/{lineage_id}/generation-{generation:04d}/{rollover_id}/handoff.md"
     members = {name: body}
     manifest = {
         "schema": "rollover-bundle.v1",
         "agent": "claude-infra",
         "stream_id": "epic:7178",
-        "lineage_id": "bundle-lineage",
+        "lineage_id": lineage_id,
         "rollover_id": rollover_id,
-        "generation": 3,
-        "status": "pending_start",
-        "prepared_at": "2026-08-24T16:00:00Z",
+        "generation": generation,
+        "status": status,
+        "prepared_at": prepared_at,
         "source_root": "{{REPO_ROOT}}",
         "exported_at": "2026-08-24T16:00:00Z",
         "files": [
@@ -104,6 +116,116 @@ def test_bundle_upload_list_latest_idempotency_and_secret_refusal(tmp_path: Path
         json={**lease, "manifest": secret_manifest, "blob": base64.b64encode(secret_blob).decode("ascii")},
     )
     assert secret_response.status_code == 400
+
+
+def test_bundle_upload_allows_status_evolution_and_rejects_same_tuple_contradiction(
+    tmp_path: Path, monkeypatch
+) -> None:
+    client = _client(tmp_path, monkeypatch)
+    lease = _claim(client)
+    pending_manifest, pending_blob = _bundle(rollover_id="rollover-evolve", body=b"pending\n")
+    pending_request = {
+        **lease,
+        "manifest": pending_manifest,
+        "blob": base64.b64encode(pending_blob).decode("ascii"),
+    }
+    pending = client.post("/api/epics/v1/epic:7178/bundles", json=pending_request)
+    assert pending.status_code == 200
+    assert pending.json()["upload_seq"] == 1
+
+    started_manifest, started_blob = _bundle(
+        rollover_id="rollover-evolve",
+        body=b"pending\n",
+        status="started",
+    )
+    started = client.post(
+        "/api/epics/v1/epic:7178/bundles",
+        json={
+            **lease,
+            "manifest": started_manifest,
+            "blob": base64.b64encode(started_blob).decode("ascii"),
+        },
+    )
+    assert started.status_code == 200, started.text
+    assert started.json()["upload_seq"] == 2
+
+    contradiction_manifest, contradiction_blob = _bundle(
+        rollover_id="rollover-evolve",
+        body=b"different\n",
+    )
+    contradiction = client.post(
+        "/api/epics/v1/epic:7178/bundles",
+        json={
+            **lease,
+            "manifest": contradiction_manifest,
+            "blob": base64.b64encode(contradiction_blob).decode("ascii"),
+        },
+    )
+    assert contradiction.status_code == 409
+
+    latest = client.get(
+        "/api/epics/v1/epic:7178/bundles/latest",
+        params={"agent": "claude-infra", "lineage_id": "bundle-lineage"},
+    )
+    assert latest.status_code == 200
+    assert latest.json()["manifest"]["status"] == "started"
+    assert latest.json()["manifest"]["upload_seq"] == 2
+
+
+def test_rollover_schema_has_both_unique_indexes_and_raw_digest_constraint(
+    tmp_path: Path,
+) -> None:
+    database = SessionStreamDatabase(tmp_path / "api.sqlite3")
+    store = SessionStreamStore(database)
+    lease = store.open_session(
+        stream_id="epic:7178",
+        holder=LeaseHolder(agent="codex", harness="codex-cli", instance_id="raw", process_id=1234),
+        lineage_id="raw-lineage",
+        ttl_seconds=900,
+    )
+    connection = database.connect()
+    try:
+        unique_indexes = {
+            str(row[1])
+            for row in connection.execute("PRAGMA index_list('rollover_bundles')").fetchall()
+            if int(row[2]) == 1
+        }
+        assert "rollover_bundles_bundle_sha256_unique" in unique_indexes
+        assert "rollover_bundles_identity_unique" in unique_indexes
+
+        manifest_json = json.dumps(
+            {
+                "schema": "rollover-bundle.v1",
+                "status": "pending_start",
+                "prepared_at": "2026-08-24T16:00:00Z",
+            }
+        )
+        row = (
+            "epic:7178",
+            "claude-infra",
+            "raw-lineage",
+            3,
+            "rollover-raw-a",
+            "pending_start",
+            "2026-08-24T16:00:00Z",
+            "a" * 64,
+            manifest_json,
+            b"raw",
+            "2026-08-24T16:00:00Z",
+            lease.lease_id,
+        )
+        columns = (
+            "stream_id, agent, lineage_id, generation, rollover_id, status, prepared_at, "
+            "bundle_sha256, manifest_json, blob, uploaded_at, uploaded_by_lease_id"
+        )
+        connection.execute(f"INSERT INTO rollover_bundles({columns}) VALUES ({','.join('?' for _ in row)})", row)
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                f"INSERT INTO rollover_bundles({columns}) VALUES ({','.join('?' for _ in row)})",
+                (*row[:4], "rollover-raw-b", *row[5:]),
+            )
+    finally:
+        connection.close()
 
 
 def test_bundle_upload_enforces_four_mib_cap(tmp_path: Path, monkeypatch) -> None:

--- a/tests/api/test_rollover_bundle_router.py
+++ b/tests/api/test_rollover_bundle_router.py
@@ -108,6 +108,13 @@ def test_bundle_upload_list_latest_idempotency_and_secret_refusal(tmp_path: Path
     assert latest.json()["manifest"]["upload_seq"] == 1
     assert base64.b64decode(latest.json()["blob"]) == blob
 
+    by_sequence = client.get("/api/epics/v1/epic:7178/bundles/1")
+    assert by_sequence.status_code == 200
+    assert by_sequence.json()["manifest"]["upload_seq"] == 1
+    assert base64.b64decode(by_sequence.json()["blob"]) == blob
+    missing_sequence = client.get("/api/epics/v1/epic:7178/bundles/99")
+    assert missing_sequence.status_code == 404
+
     secret_manifest, secret_blob = _bundle(
         rollover_id="rollover-api2",
         body=b"api-key: secret-value\n",

--- a/tests/api/test_rollover_bundle_router.py
+++ b/tests/api/test_rollover_bundle_router.py
@@ -1,0 +1,116 @@
+"""Loopback API contract for cross-host rollover bundle storage."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+from scripts.api import epics_router
+from scripts.orchestration import thread_handoff as th
+
+
+def _client(tmp_path: Path, monkeypatch) -> TestClient:
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "api.sqlite3"))
+    monkeypatch.setattr(epics_router, "_store", lambda: store)
+    app = FastAPI()
+    app.include_router(epics_router.router, prefix="/api/epics")
+    return TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 8765))
+
+
+def _claim(client: TestClient) -> dict:
+    response = client.post(
+        "/api/epics/v1/epic:7178/claim",
+        json={
+            "session_id": "bundle-session",
+            "lease_id": "bundle-lease",
+            "lineage_id": "bundle-lineage",
+            "agent": "codex",
+            "harness": "codex-cli",
+            "instance_id": "bundle-instance",
+            "process_id": 1234,
+            "host_id": "api-host",
+            "ttl_seconds": 900,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["lease"]
+
+
+def _bundle(*, rollover_id: str, body: bytes) -> tuple[dict, bytes]:
+    name = ".agent/thread-rollovers/claude-infra/bundle-lineage/generation-0003/" + rollover_id + "/handoff.md"
+    members = {name: body}
+    manifest = {
+        "schema": "rollover-bundle.v1",
+        "agent": "claude-infra",
+        "stream_id": "epic:7178",
+        "lineage_id": "bundle-lineage",
+        "rollover_id": rollover_id,
+        "generation": 3,
+        "status": "pending_start",
+        "prepared_at": "2026-08-24T16:00:00Z",
+        "source_root": "{{REPO_ROOT}}",
+        "exported_at": "2026-08-24T16:00:00Z",
+        "files": [
+            {
+                "path": name,
+                "sha256": hashlib.sha256(body).hexdigest(),
+                "bytes": len(body),
+                "tokenized": True,
+            }
+        ],
+        "tokenized_members": [name],
+        "upload_seq": 0,
+        "bundle_sha256": "",
+    }
+    manifest["bundle_sha256"] = th._bundle_digest(members, manifest)
+    return manifest, th._bundle_archive(members, manifest)
+
+
+def test_bundle_upload_list_latest_idempotency_and_secret_refusal(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+    lease = _claim(client)
+    manifest, blob = _bundle(rollover_id="rollover-api1", body=b"safe handoff\n")
+    request = {**lease, "manifest": manifest, "blob": base64.b64encode(blob).decode("ascii")}
+
+    uploaded = client.post("/api/epics/v1/epic:7178/bundles", json=request)
+    assert uploaded.status_code == 200, uploaded.text
+    assert uploaded.json()["upload_seq"] == 1
+    replay = client.post("/api/epics/v1/epic:7178/bundles", json=request)
+    assert replay.status_code == 200
+    assert replay.json()["upload_seq"] == 1
+
+    listed = client.get("/api/epics/v1/epic:7178/bundles", params={"agent": "claude-infra"})
+    assert listed.status_code == 200
+    assert len(listed.json()["bundles"]) == 1
+    assert "blob" not in listed.json()["bundles"][0]
+
+    latest = client.get("/api/epics/v1/epic:7178/bundles/latest", params={"agent": "claude-infra"})
+    assert latest.status_code == 200
+    assert latest.json()["manifest"]["upload_seq"] == 1
+    assert base64.b64decode(latest.json()["blob"]) == blob
+
+    secret_manifest, secret_blob = _bundle(
+        rollover_id="rollover-api2",
+        body=b"api-key: secret-value\n",
+    )
+    secret_response = client.post(
+        "/api/epics/v1/epic:7178/bundles",
+        json={**lease, "manifest": secret_manifest, "blob": base64.b64encode(secret_blob).decode("ascii")},
+    )
+    assert secret_response.status_code == 400
+
+
+def test_bundle_upload_enforces_four_mib_cap(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+    lease = _claim(client)
+    response = client.post(
+        "/api/epics/v1/epic:7178/bundles",
+        json={**lease, "manifest": {}, "blob": base64.b64encode(b"x" * (4 * 1024 * 1024 + 1)).decode("ascii")},
+    )
+    assert response.status_code == 400

--- a/tests/test_rollover_bundles.py
+++ b/tests/test_rollover_bundles.py
@@ -22,11 +22,13 @@ def _seed_state(
     root: Path,
     *,
     thread_id: str,
+    agent: str = AGENT,
     generation: int = 3,
     rollover_id: str | None = None,
     prepared_at: str = "2026-08-24T16:00:00Z",
+    harness: str = "claude-code",
 ) -> dict:
-    lineage_id = th.lineage_id_for(AGENT, thread_id)
+    lineage_id = th.lineage_id_for(agent, thread_id)
     state = th.prepare_state(
         {
             "schema_version": th.SCHEMA_VERSION,
@@ -38,20 +40,20 @@ def _seed_state(
                 "started_at": prepared_at,
             },
         },
-        agent=AGENT,
+        agent=agent,
         now=datetime(2026, 8, 24, 16, 0, tzinfo=UTC),
         active_thread_id=thread_id,
         active_automation_id="old-auto",
         context_percent=80.0,
         force_new_replacement=False,
-        harness="claude-code",
+        harness=harness,
     )
     replacement = state["replacement"]
     del rollover_id
     assert replacement["generation"] == generation
     replacement["prepared_at"] = prepared_at
     replacement["source_checkout"] = {"full_head": "a" * 40, "clean": True}
-    state_path = root / th.default_state_path(AGENT, state["lineage_id"])
+    state_path = root / th.default_state_path(agent, state["lineage_id"])
     th.write_rollover_state(state_path, root, state)
     bootstrap = root / replacement["bootstrap_prompt_path"]
     handoff = root / replacement["handoff_path"]
@@ -67,13 +69,20 @@ def _seed_state(
     return state
 
 
-def _export_args(root: Path, state: dict, output: Path, *, upload: bool = False) -> SimpleNamespace:
+def _export_args(
+    root: Path,
+    state: dict,
+    output: Path,
+    *,
+    upload: bool = False,
+    stream: str = STREAM,
+) -> SimpleNamespace:
     return SimpleNamespace(
         repo_root=root,
-        agent=AGENT,
+        agent=state["agent"],
         lineage_id=state["lineage_id"],
         rollover_id=None,
-        stream=STREAM,
+        stream=stream,
         file=output,
         upload=upload,
         monitor_base_url="http://127.0.0.1:1",
@@ -93,12 +102,19 @@ def _mark_confirmed(root: Path, state: dict) -> None:
     th.write_json_atomic(root / th.default_state_path(AGENT, state["lineage_id"]), state)
 
 
-def _import_args(root: Path, bundle: Path, *, force: bool = False) -> SimpleNamespace:
+def _import_args(
+    root: Path,
+    bundle: Path | None,
+    *,
+    agent: str = AGENT,
+    force: bool = False,
+    from_api: str | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         repo_root=root,
-        agent=AGENT,
+        agent=agent,
         file=bundle,
-        from_api=None,
+        from_api=from_api,
         stream=STREAM,
         force=force,
         monitor_base_url="http://127.0.0.1:1",
@@ -323,6 +339,130 @@ def test_import_newer_lineage_supersedes_one_of_two_pending_detect_candidates(
     detected = json.loads(capsys.readouterr().out)
     assert detected["status"] == "pending_start"
     assert detected["lineage_id"] != remote["lineage_id"]
+
+
+def test_from_api_cross_agent_import_keeps_foreign_lineage_and_upload_ordered_handoff(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_foreign = tmp_path / "source-claude"
+    source_own = tmp_path / "source-grok"
+    target = tmp_path / "target"
+    source_foreign.mkdir()
+    source_own.mkdir()
+    target.mkdir()
+
+    foreign = _seed_state(source_foreign, thread_id="foreign-thread", agent="claude-infra", generation=3)
+    own = _seed_state(
+        source_own,
+        thread_id="own-thread",
+        agent="grok-infra",
+        generation=4,
+        harness="grok-tui",
+        prepared_at="2026-08-24T17:00:00Z",
+    )
+    (source_foreign / HANDOFF_PATH).write_text("foreign lane handoff\n", encoding="utf-8")
+    (source_own / HANDOFF_PATH).write_text("own lane handoff\n", encoding="utf-8")
+
+    foreign_bundle = tmp_path / "foreign.tgz"
+    own_bundle = tmp_path / "own.tgz"
+    assert th.cmd_export_bundle(_export_args(source_foreign, foreign, foreign_bundle)) == 0
+    capsys.readouterr()
+    assert th.cmd_export_bundle(_export_args(source_own, own, own_bundle)) == 0
+    capsys.readouterr()
+    foreign_manifest, _ = th._bundle_extract(foreign_bundle.read_bytes())
+    own_manifest, _ = th._bundle_extract(own_bundle.read_bytes())
+    foreign_blob = foreign_bundle.read_bytes()
+    own_blob = own_bundle.read_bytes()
+    foreign_manifest["upload_seq"] = 10
+    own_manifest["upload_seq"] = 9
+
+    def latest(_args: SimpleNamespace, *, stream_id: str, agent: str | None = None):
+        assert stream_id == STREAM
+        return (foreign_manifest, foreign_blob) if agent is None else (own_manifest, own_blob)
+
+    monkeypatch.setattr(th, "_bundle_api_latest", latest)
+    args = _import_args(target, None, agent="grok-infra", from_api=STREAM)
+    assert th.cmd_import_bundle(args) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert [item["agent"] for item in result["bundles"]] == ["claude-infra", "grok-infra"]
+    assert result["handoff_source"] == "claude-infra"
+    assert result["handoff_upload_seq"] == 10
+
+    foreign_lineage = target / th.default_state_path("claude-infra", foreign["lineage_id"])
+    own_lineage = target / th.default_state_path("grok-infra", own["lineage_id"])
+    assert foreign_lineage.is_file()
+    assert own_lineage.is_file()
+    assert (target / HANDOFF_PATH).read_text(encoding="utf-8") == "foreign lane handoff\n"
+
+    detect_args = SimpleNamespace(
+        repo_root=target,
+        agent="grok-infra",
+        current_thread_id=None,
+        format=None,
+        stream=None,
+        task_family=None,
+    )
+    assert th.cmd_detect(detect_args) == 0
+    grok_detected = json.loads(capsys.readouterr().out)
+    assert grok_detected["agent"] == "grok-infra"
+    assert grok_detected["status"] == "pending_start"
+    assert grok_detected["generation"] == 4
+    detect_args.agent = "claude-infra"
+    assert th.cmd_detect(detect_args) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["agent"] == "claude-infra"
+    assert detected["status"] == "pending_start"
+    assert detected["generation"] == 3
+
+
+def test_from_api_foreign_lineage_is_ignored_by_driver_detect(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    foreign = _seed_state(source, thread_id="foreign-only", agent="claude-infra", generation=3)
+    (source / HANDOFF_PATH).write_text("foreign lane handoff\n", encoding="utf-8")
+    bundle = tmp_path / "foreign-only.tgz"
+    assert th.cmd_export_bundle(_export_args(source, foreign, bundle)) == 0
+    capsys.readouterr()
+    manifest, _ = th._bundle_extract(bundle.read_bytes())
+    manifest["upload_seq"] = 3
+    blob = bundle.read_bytes()
+
+    def latest(_args: SimpleNamespace, *, stream_id: str, agent: str | None = None):
+        assert stream_id == STREAM
+        if agent is None:
+            return manifest, blob
+        raise th.RolloverBundleNotFound("no own-agent bundle")
+
+    monkeypatch.setattr(th, "_bundle_api_latest", latest)
+    assert th.cmd_import_bundle(_import_args(target, None, agent="grok-infra", from_api=STREAM)) == 0
+    capsys.readouterr()
+
+    detect_args = SimpleNamespace(
+        repo_root=target,
+        agent="grok-infra",
+        current_thread_id=None,
+        format=None,
+        stream=None,
+        task_family=None,
+    )
+    assert th.cmd_detect(detect_args) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "grok-infra", "status": "none"}
+    detect_args.agent = "claude-infra"
+    assert th.cmd_detect(detect_args) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["agent"] == "claude-infra"
+    assert detected["status"] == "pending_start"
+    assert detected["generation"] == 3
 
 
 def test_api_down_import_is_fail_open_and_secret_prose_is_not_a_hit(

--- a/tests/test_rollover_bundles.py
+++ b/tests/test_rollover_bundles.py
@@ -341,20 +341,27 @@ def test_import_newer_lineage_supersedes_one_of_two_pending_detect_candidates(
     assert detected["lineage_id"] != remote["lineage_id"]
 
 
-def test_from_api_cross_agent_import_keeps_foreign_lineage_and_upload_ordered_handoff(
+def test_from_api_cross_agent_import_uses_max_upload_seq_for_handoff(
     tmp_path: Path,
     handoff_candidates: None,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    source_foreign = tmp_path / "source-claude"
+    source_foreign_old = tmp_path / "source-claude-old"
     source_own = tmp_path / "source-grok"
+    source_foreign_new = tmp_path / "source-claude-new"
     target = tmp_path / "target"
-    source_foreign.mkdir()
+    source_foreign_old.mkdir()
     source_own.mkdir()
+    source_foreign_new.mkdir()
     target.mkdir()
 
-    foreign = _seed_state(source_foreign, thread_id="foreign-thread", agent="claude-infra", generation=3)
+    foreign_old = _seed_state(
+        source_foreign_old,
+        thread_id="foreign-old-thread",
+        agent="claude-infra",
+        generation=3,
+    )
     own = _seed_state(
         source_own,
         thread_id="own-thread",
@@ -363,39 +370,69 @@ def test_from_api_cross_agent_import_keeps_foreign_lineage_and_upload_ordered_ha
         harness="grok-tui",
         prepared_at="2026-08-24T17:00:00Z",
     )
-    (source_foreign / HANDOFF_PATH).write_text("foreign lane handoff\n", encoding="utf-8")
+    foreign_new = _seed_state(
+        source_foreign_new,
+        thread_id="foreign-new-thread",
+        agent="claude-infra",
+        generation=3,
+        prepared_at="2026-08-24T18:00:00Z",
+    )
+    (source_foreign_old / HANDOFF_PATH).write_text("stale foreign lane handoff\n", encoding="utf-8")
     (source_own / HANDOFF_PATH).write_text("own lane handoff\n", encoding="utf-8")
+    (source_foreign_new / HANDOFF_PATH).write_text("fresh foreign lane handoff\n", encoding="utf-8")
 
-    foreign_bundle = tmp_path / "foreign.tgz"
+    foreign_old_bundle = tmp_path / "foreign-old.tgz"
     own_bundle = tmp_path / "own.tgz"
-    assert th.cmd_export_bundle(_export_args(source_foreign, foreign, foreign_bundle)) == 0
+    foreign_new_bundle = tmp_path / "foreign-new.tgz"
+    assert th.cmd_export_bundle(_export_args(source_foreign_old, foreign_old, foreign_old_bundle)) == 0
     capsys.readouterr()
     assert th.cmd_export_bundle(_export_args(source_own, own, own_bundle)) == 0
     capsys.readouterr()
-    foreign_manifest, _ = th._bundle_extract(foreign_bundle.read_bytes())
+    assert th.cmd_export_bundle(_export_args(source_foreign_new, foreign_new, foreign_new_bundle)) == 0
+    capsys.readouterr()
+    foreign_old_manifest, _ = th._bundle_extract(foreign_old_bundle.read_bytes())
     own_manifest, _ = th._bundle_extract(own_bundle.read_bytes())
-    foreign_blob = foreign_bundle.read_bytes()
+    foreign_new_manifest, _ = th._bundle_extract(foreign_new_bundle.read_bytes())
+    foreign_old_blob = foreign_old_bundle.read_bytes()
     own_blob = own_bundle.read_bytes()
-    foreign_manifest["upload_seq"] = 10
-    own_manifest["upload_seq"] = 9
+    foreign_new_blob = foreign_new_bundle.read_bytes()
+    foreign_old_manifest["upload_seq"] = 1
+    own_manifest["upload_seq"] = 2
+    foreign_new_manifest["upload_seq"] = 3
 
-    def latest(_args: SimpleNamespace, *, stream_id: str, agent: str | None = None):
+    bundles = {
+        1: (foreign_old_manifest, foreign_old_blob),
+        2: (own_manifest, own_blob),
+        3: (foreign_new_manifest, foreign_new_blob),
+    }
+
+    def bundle_list(_args: SimpleNamespace, *, stream_id: str, limit: int = 20):
         assert stream_id == STREAM
-        return (foreign_manifest, foreign_blob) if agent is None else (own_manifest, own_blob)
+        assert limit == 20
+        return [
+            {"manifest": manifest, "upload_seq": sequence}
+            for sequence, (manifest, _blob) in sorted(bundles.items(), reverse=True)
+        ]
 
-    monkeypatch.setattr(th, "_bundle_api_latest", latest)
+    def bundle_by_seq(_args: SimpleNamespace, *, stream_id: str, upload_seq: int):
+        assert stream_id == STREAM
+        return bundles[upload_seq]
+
+    monkeypatch.setattr(th, "_bundle_api_list", bundle_list)
+    monkeypatch.setattr(th, "_bundle_api_by_seq", bundle_by_seq)
     args = _import_args(target, None, agent="grok-infra", from_api=STREAM)
     assert th.cmd_import_bundle(args) == 0
     result = json.loads(capsys.readouterr().out)
     assert [item["agent"] for item in result["bundles"]] == ["claude-infra", "grok-infra"]
     assert result["handoff_source"] == "claude-infra"
-    assert result["handoff_upload_seq"] == 10
+    assert result["handoff_upload_seq"] == 3
 
-    foreign_lineage = target / th.default_state_path("claude-infra", foreign["lineage_id"])
+    foreign_lineage = target / th.default_state_path("claude-infra", foreign_new["lineage_id"])
     own_lineage = target / th.default_state_path("grok-infra", own["lineage_id"])
     assert foreign_lineage.is_file()
     assert own_lineage.is_file()
-    assert (target / HANDOFF_PATH).read_text(encoding="utf-8") == "foreign lane handoff\n"
+    handoff_text = (target / HANDOFF_PATH).read_text(encoding="utf-8")
+    assert handoff_text == "fresh foreign lane handoff\n"
 
     detect_args = SimpleNamespace(
         repo_root=target,
@@ -416,6 +453,8 @@ def test_from_api_cross_agent_import_keeps_foreign_lineage_and_upload_ordered_ha
     assert detected["agent"] == "claude-infra"
     assert detected["status"] == "pending_start"
     assert detected["generation"] == 3
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(handoff_text, end="")
 
 
 def test_from_api_foreign_lineage_is_ignored_by_driver_detect(
@@ -437,13 +476,13 @@ def test_from_api_foreign_lineage_is_ignored_by_driver_detect(
     manifest["upload_seq"] = 3
     blob = bundle.read_bytes()
 
-    def latest(_args: SimpleNamespace, *, stream_id: str, agent: str | None = None):
+    def bundle_list(_args: SimpleNamespace, *, stream_id: str, limit: int = 20):
         assert stream_id == STREAM
-        if agent is None:
-            return manifest, blob
-        raise th.RolloverBundleNotFound("no own-agent bundle")
+        assert limit == 20
+        return [{"manifest": manifest, "upload_seq": 3}]
 
-    monkeypatch.setattr(th, "_bundle_api_latest", latest)
+    monkeypatch.setattr(th, "_bundle_api_list", bundle_list)
+    monkeypatch.setattr(th, "_bundle_api_by_seq", lambda _args, *, stream_id, upload_seq: (manifest, blob))
     assert th.cmd_import_bundle(_import_args(target, None, agent="grok-infra", from_api=STREAM)) == 0
     capsys.readouterr()
 
@@ -506,7 +545,21 @@ def test_api_down_import_is_fail_open_and_secret_prose_is_not_a_hit(
     assert th.cmd_export_bundle(_export_args(source, state, bundle, upload=True)) == 0
     assert not called
     assert bundle.is_file()
-    assert "member=" in capsys.readouterr().err
+    warning = capsys.readouterr().err
+    assert "rule=credential-assignment" in warning
+    assert "supersecret-value" not in warning
+
+    auto_result = th._maybe_auto_upload_bundle(
+        _export_args(source, state, bundle),
+        repo_root=source,
+        state_root=source,
+        agent=state["agent"],
+        state=state,
+    )
+    assert auto_result["status"] == "skipped-secret-scan"
+    auto_warning = capsys.readouterr().err
+    assert "rule=credential-assignment" in auto_warning
+    assert "supersecret-value" not in auto_warning
 
 
 def test_retention_keeps_latest_five_and_store_false_positive_contract(tmp_path: Path) -> None:

--- a/tests/test_rollover_bundles.py
+++ b/tests/test_rollover_bundles.py
@@ -1,0 +1,316 @@
+"""Cross-host rollover bundle round-trip and ordering contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agents_extensions.shared.session_streams.store import ContentRejectedError, validate_entry_body
+from scripts.orchestration import thread_handoff as th
+
+HANDOFF_PATH = ".claude/infra-epic/CLAUDE-DRIVER-HANDOFF.md"
+AGENT = "claude-infra"
+STREAM = "epic:9999"
+
+
+def _seed_state(
+    root: Path,
+    *,
+    thread_id: str,
+    generation: int = 3,
+    rollover_id: str | None = None,
+    prepared_at: str = "2026-08-24T16:00:00Z",
+) -> dict:
+    lineage_id = th.lineage_id_for(AGENT, thread_id)
+    state = th.prepare_state(
+        {
+            "schema_version": th.SCHEMA_VERSION,
+            "lineage_id": lineage_id,
+            "active": {
+                "thread_id": thread_id,
+                "generation": generation - 1,
+                "lineage_id": lineage_id,
+                "started_at": prepared_at,
+            },
+        },
+        agent=AGENT,
+        now=datetime(2026, 8, 24, 16, 0, tzinfo=UTC),
+        active_thread_id=thread_id,
+        active_automation_id="old-auto",
+        context_percent=80.0,
+        force_new_replacement=False,
+        harness="claude-code",
+    )
+    replacement = state["replacement"]
+    del rollover_id
+    assert replacement["generation"] == generation
+    replacement["prepared_at"] = prepared_at
+    replacement["source_checkout"] = {"full_head": "a" * 40, "clean": True}
+    state_path = root / th.default_state_path(AGENT, state["lineage_id"])
+    th.write_rollover_state(state_path, root, state)
+    bootstrap = root / replacement["bootstrap_prompt_path"]
+    handoff = root / replacement["handoff_path"]
+    bootstrap.parent.mkdir(parents=True, exist_ok=True)
+    bootstrap.write_text(
+        f"source checkout: {root}\nThe credential-assignment rule is prose here.\n",
+        encoding="utf-8",
+    )
+    handoff.write_text(f"handoff source checkout: {root}\n", encoding="utf-8")
+    lane_handoff = root / HANDOFF_PATH
+    lane_handoff.parent.mkdir(parents=True, exist_ok=True)
+    lane_handoff.write_text(f"lane handoff source checkout: {root}\n", encoding="utf-8")
+    return state
+
+
+def _export_args(root: Path, state: dict, output: Path, *, upload: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        repo_root=root,
+        agent=AGENT,
+        lineage_id=state["lineage_id"],
+        rollover_id=None,
+        stream=STREAM,
+        file=output,
+        upload=upload,
+        monitor_base_url="http://127.0.0.1:1",
+    )
+
+
+def _mark_confirmed(root: Path, state: dict) -> None:
+    replacement = state["replacement"]
+    replacement.update(
+        {
+            "status": "started",
+            "thread_id": "confirmed-replacement",
+            "resumed_thread_id": "confirmed-replacement",
+            "confirmed_at": "2026-08-24T17:00:00Z",
+        }
+    )
+    th.write_json_atomic(root / th.default_state_path(AGENT, state["lineage_id"]), state)
+
+
+def _import_args(root: Path, bundle: Path, *, force: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        repo_root=root,
+        agent=AGENT,
+        file=bundle,
+        from_api=None,
+        stream=STREAM,
+        force=force,
+        monitor_base_url="http://127.0.0.1:1",
+    )
+
+
+@pytest.fixture
+def handoff_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(th, "_bundle_handoff_candidates", lambda _root, _stream: (HANDOFF_PATH,))
+
+
+def test_round_trip_rewrites_root_and_identical_import_is_noop(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    state = _seed_state(source, thread_id="source-thread")
+    bundle = tmp_path / "rollover.tgz"
+
+    assert th.cmd_export_bundle(_export_args(source, state, bundle)) == 0
+    export_output = capsys.readouterr()
+    assert "secret scan" not in export_output.err
+    assert bundle.is_file()
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 0
+    first_import = json.loads(capsys.readouterr().out)
+    assert first_import["status"] == "installed"
+
+    imported_bootstrap = target / state["replacement"]["bootstrap_prompt_path"]
+    imported_text = imported_bootstrap.read_text(encoding="utf-8")
+    assert str(target) in imported_text
+    assert str(source) not in imported_text
+    assert (target / HANDOFF_PATH).is_file()
+
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "noop"
+
+
+def test_newer_remote_archives_stale_local_and_preserves_different_handoff(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    state = _seed_state(source, thread_id="source-thread", generation=4)
+    bundle = tmp_path / "remote4.tgz"
+    assert th.cmd_export_bundle(_export_args(source, state, bundle)) == 0
+    capsys.readouterr()
+
+    _seed_state(target, thread_id="source-thread", generation=2)
+    (target / HANDOFF_PATH).write_text("local handoff differs\n", encoding="utf-8")
+
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "installed"
+    assert output["archived"]
+    assert output["preserved_handoffs"]
+    archive_root = target / output["archived"]
+    archived_state = json.loads((archive_root / "lease.json").read_text(encoding="utf-8"))
+    assert archived_state["replacement"]["status"] == "superseded"
+    assert list((target / HANDOFF_PATH).parent.glob("CLAUDE-DRIVER-HANDOFF.*.superseded.md"))
+
+
+def test_newer_local_refuses_and_force_archives_then_installs(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    state = _seed_state(source, thread_id="source-thread", generation=3)
+    bundle = tmp_path / "remote3.tgz"
+    assert th.cmd_export_bundle(_export_args(source, state, bundle)) == 0
+    capsys.readouterr()
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 0
+    capsys.readouterr()
+
+    _seed_state(target, thread_id="source-thread", generation=4, prepared_at="2026-08-25T00:00:00Z")
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 2
+    refused = json.loads(capsys.readouterr().out)
+    assert refused["status"] == "refused"
+    assert refused["local"]["generation"] == 4
+    assert refused["remote"]["generation"] == 3
+
+    assert th.cmd_import_bundle(_import_args(target, bundle, force=True)) == 0
+    forced = json.loads(capsys.readouterr().out)
+    assert forced["status"] == "installed"
+    assert forced["archived"]
+
+
+def test_import_newer_lineage_supersedes_one_of_two_pending_detect_candidates(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    remote = _seed_state(source, thread_id="lineage-a", generation=3)
+    _mark_confirmed(source, remote)
+    bundle = tmp_path / "lineage-a.tgz"
+    assert th.cmd_export_bundle(_export_args(source, remote, bundle)) == 0
+    capsys.readouterr()
+
+    _seed_state(target, thread_id="lineage-a", generation=2)
+    _seed_state(target, thread_id="lineage-b")
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 0
+    capsys.readouterr()
+
+    args = SimpleNamespace(repo_root=target, agent=AGENT, current_thread_id="", task_family="", format="json")
+    assert th.cmd_detect(args) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["status"] == "pending_start"
+    assert detected["lineage_id"] != remote["lineage_id"]
+
+
+def test_api_down_import_is_fail_open_and_secret_prose_is_not_a_hit(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    state = _seed_state(source, thread_id="source-thread")
+    assert th.cmd_import_bundle(
+        SimpleNamespace(
+            repo_root=tmp_path / "empty",
+            agent=AGENT,
+            file=None,
+            from_api=STREAM,
+            stream=STREAM,
+            force=False,
+            monitor_base_url="http://127.0.0.1:1",
+        )
+    ) == 0
+    assert "WARNING: rollover bundle import skipped" in capsys.readouterr().err
+
+    validate_entry_body("The credential-assignment rule is discussed as prose, not a secret assignment.")
+    assert th._bundle_secret_hits(
+        {".agent/thread-rollovers/claude-infra/source-lineage/semantic-snapshot.json": b"api-key: secret-value\n"}
+    ) == [
+        (".agent/thread-rollovers/claude-infra/source-lineage/semantic-snapshot.json", "credential-assignment")
+    ]
+    bundle = tmp_path / "secret.tgz"
+    (source / HANDOFF_PATH).write_text("api-key: supersecret-value\n", encoding="utf-8")
+    called = False
+
+    def unexpected_upload(*_args: object, **_kwargs: object) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(th, "_bundle_api_upload", unexpected_upload)
+    assert th.cmd_export_bundle(_export_args(source, state, bundle, upload=True)) == 0
+    assert not called
+    assert bundle.is_file()
+    assert "member=" in capsys.readouterr().err
+
+
+def test_retention_keeps_latest_five_and_store_false_positive_contract(tmp_path: Path) -> None:
+    from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+    from agents_extensions.shared.session_streams.model import LeaseHolder
+    from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    lease = store.open_session(
+        stream_id=STREAM,
+        holder=LeaseHolder(agent="claude", harness="claude-code", instance_id="instance", process_id=1234),
+        lineage_id="lineage-retention",
+        ttl_seconds=900,
+    )
+    for index in range(6):
+        payload = f"packet-{index}".encode()
+        name = f".agent/thread-rollovers/claude/lineage-retention/generation-0001/rollover-r{index}/handoff.md"
+        members = {name: payload}
+        manifest = {
+            "schema": "rollover-bundle.v1",
+            "agent": "claude",
+            "stream_id": STREAM,
+            "lineage_id": "lineage-retention",
+            "rollover_id": f"rollover-r{index}",
+            "generation": index + 1,
+            "status": "pending_start",
+            "prepared_at": f"2026-08-24T16:0{index}:00Z",
+            "source_root": "{{REPO_ROOT}}",
+            "exported_at": "2026-08-24T16:00:00Z",
+            "files": [
+                {
+                    "path": name,
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "bytes": len(payload),
+                    "tokenized": True,
+                }
+            ],
+            "tokenized_members": [name],
+            "upload_seq": 0,
+            "bundle_sha256": "",
+        }
+        manifest["bundle_sha256"] = th._bundle_digest(members, manifest)
+        store.upload_rollover_bundle(lease, manifest=manifest, blob=th._bundle_archive(members, manifest))
+    rows = store.list_rollover_bundles(STREAM, agent="claude", lineage_id="lineage-retention")
+    assert len(rows) == 5
+    assert rows[0]["manifest"]["generation"] == 6
+    with pytest.raises(ContentRejectedError):
+        validate_entry_body("password: definitely-a-secret")

--- a/tests/test_rollover_bundles.py
+++ b/tests/test_rollover_bundles.py
@@ -140,6 +140,107 @@ def test_round_trip_rewrites_root_and_identical_import_is_noop(
     assert json.loads(capsys.readouterr().out)["status"] == "noop"
 
 
+def test_export_digest_is_stable_across_export_clock_and_changes_with_status(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    state = _seed_state(source, thread_id="source-thread")
+    first_path = tmp_path / "first.tgz"
+    second_path = tmp_path / "second.tgz"
+
+    export_times = iter(
+        (
+            datetime(2026, 8, 24, 18, 0, tzinfo=UTC),
+            datetime(2026, 8, 24, 18, 1, tzinfo=UTC),
+        )
+    )
+    monkeypatch.setattr(th, "utc_now", lambda: next(export_times))
+    assert th.cmd_export_bundle(_export_args(source, state, first_path)) == 0
+    first_output = json.loads(capsys.readouterr().out)
+    assert th.cmd_export_bundle(_export_args(source, state, second_path)) == 0
+    second_output = json.loads(capsys.readouterr().out)
+
+    first_manifest, _ = th._bundle_extract(first_path.read_bytes())
+    second_manifest, _ = th._bundle_extract(second_path.read_bytes())
+    assert first_manifest["exported_at"] != second_manifest["exported_at"]
+    assert first_output["bundle_sha256"] == second_output["bundle_sha256"]
+    assert first_manifest["bundle_sha256"] == second_manifest["bundle_sha256"]
+    assert [item["sha256"] for item in first_manifest["files"]] == [
+        item["sha256"] for item in second_manifest["files"]
+    ]
+
+    monkeypatch.setattr(th, "utc_now", lambda: datetime(2026, 8, 24, 18, 2, tzinfo=UTC))
+    _mark_confirmed(source, state)
+    confirmed_path = tmp_path / "confirmed.tgz"
+    assert th.cmd_export_bundle(_export_args(source, state, confirmed_path)) == 0
+    confirmed_output = json.loads(capsys.readouterr().out)
+    assert confirmed_output["bundle_sha256"] != first_output["bundle_sha256"]
+
+
+def test_confirmed_local_copy_refuses_older_pending_remote_at_rank_level(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    remote = _seed_state(source, thread_id="source-thread", generation=3)
+    bundle = tmp_path / "pending.tgz"
+    assert th.cmd_export_bundle(_export_args(source, remote, bundle)) == 0
+    capsys.readouterr()
+
+    local = _seed_state(target, thread_id="source-thread", generation=3)
+    _mark_confirmed(target, local)
+    local_lease = target / th.default_state_path(AGENT, local["lineage_id"])
+    before = local_lease.read_bytes()
+
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 2
+    refused = json.loads(capsys.readouterr().out)
+    assert refused["status"] == "refused"
+    assert refused["local"]["status_rank"] > refused["remote"]["status_rank"]
+    assert local_lease.read_bytes() == before
+    archive_root = target / ".agent" / "thread-rollovers" / AGENT / "_archive"
+    assert not archive_root.exists() or not any(archive_root.iterdir())
+
+
+def test_inconsistent_local_lease_refuses_without_archive_or_lineage_mutation(
+    tmp_path: Path,
+    handoff_candidates: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    remote = _seed_state(source, thread_id="source-thread", generation=4)
+    bundle = tmp_path / "remote.tgz"
+    assert th.cmd_export_bundle(_export_args(source, remote, bundle)) == 0
+    capsys.readouterr()
+
+    local = _seed_state(target, thread_id="source-thread", generation=3)
+    local_path = target / th.default_state_path(AGENT, local["lineage_id"])
+    broken = json.loads(local_path.read_bytes())
+    broken["rollover_id"] = "rollover-inconsistent"
+    th.write_json_atomic(local_path, broken)
+    broken_before_import = local_path.read_bytes()
+
+    assert th.cmd_import_bundle(_import_args(target, bundle)) == 2
+    output = capsys.readouterr()
+    reason = json.loads(output.out)
+    assert reason["action"] == "import-bundle"
+    assert "local rollover lease is invalid" in reason["error"]
+    assert "Traceback" not in output.out
+    assert local_path.read_bytes() == broken_before_import
+    archive_root = target / ".agent" / "thread-rollovers" / AGENT / "_archive"
+    assert not archive_root.exists() or not any(archive_root.iterdir())
+
+
 def test_newer_remote_archives_stale_local_and_preserves_different_handoff(
     tmp_path: Path,
     handoff_candidates: None,

--- a/tests/test_session_start_gate.py
+++ b/tests/test_session_start_gate.py
@@ -320,6 +320,50 @@ def test_detect_pending_returns_formatted_stop(monkeypatch: pytest.MonkeyPatch) 
     assert result["detect_status"] == "pending_start"
 
 
+def test_import_bundle_runs_before_detect_and_is_fail_open(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    events: list[str] = []
+
+    class FakeTH:
+        @staticmethod
+        def main(argv: list[str]) -> int:
+            if "import-bundle" in argv:
+                events.append("import")
+                print(json.dumps({"status": "warning", "reason": "API unavailable"}))
+                return 0
+            if "detect" in argv:
+                events.append("detect")
+                print(json.dumps({"status": "none"}))
+                return 0
+            raise AssertionError(f"unexpected thread_handoff invocation: {argv}")
+
+    monkeypatch.setattr(gate, "_import_thread_handoff", lambda: FakeTH)
+    monkeypatch.setattr(gate, "phase_session_record", lambda _args: {"status": "ok"})
+    monkeypatch.setattr(gate, "phase_python_version", lambda _args: {"status": "ok"})
+    monkeypatch.setattr(gate, "phase_primary_main", lambda _args: {"status": "ok"})
+    monkeypatch.setattr(gate, "phase_thread_lease", lambda _args: {"status": "skipped"})
+    rc = gate.main(
+        [
+            "--repo-root",
+            str(REPO_ROOT),
+            "--project-dir",
+            str(REPO_ROOT),
+            "--agent",
+            "claude-testlane",
+            "--session-id",
+            "s-1",
+            "--import-bundle",
+            "--stream",
+            "epic:6943",
+            "--detect",
+        ]
+    )
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    assert events == ["import", "detect"]
+    assert result["rollover_import"]["status"] == "issue"
+    assert result["rollover_detect"] == {"status": "ok", "detect_status": "none"}
+
+
 def test_python_version_matches_pin() -> None:
     # The suite runs on the canonical venv python, which must match the pin.
     result = gate.phase_python_version(_args())

--- a/tests/test_session_streams_inventory_receipts.py
+++ b/tests/test_session_streams_inventory_receipts.py
@@ -83,21 +83,23 @@ def test_inventory_does_not_use_hard_coded_exclusive_list(tmp_path: Path) -> Non
 
 def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
     migrations = load_migrations()
-    assert [m.version for m in migrations] == [1, 2, 3, 4]
+    assert [m.version for m in migrations] == [1, 2, 3, 4, 5]
     assert "inventory_receipts" in migrations[1].name
     assert "app_thread_holders" in migrations[2].name
     assert "remote_epic_lifecycle" in migrations[3].name
+    assert "rollover_bundles" in migrations[4].name
     db = SessionStreamDatabase(tmp_path / "streams.sqlite3")
     conn = db.connect()
     try:
         versions = [int(r[0]) for r in conn.execute("SELECT version FROM schema_migrations ORDER BY 1")]
-        assert versions == [1, 2, 3, 4]
+        assert versions == [1, 2, 3, 4, 5]
         for table in (
             "stream_migration_state",
             "stream_inventory_receipts",
             "legacy_import_receipts",
             "legacy_projection_receipts",
             "stream_control_events",
+            "rollover_bundles",
         ):
             row = conn.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",

--- a/tests/test_session_streams_inventory_receipts.py
+++ b/tests/test_session_streams_inventory_receipts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -83,7 +84,7 @@ def test_inventory_does_not_use_hard_coded_exclusive_list(tmp_path: Path) -> Non
 
 def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
     migrations = load_migrations()
-    assert [m.version for m in migrations] == [1, 2, 3, 4, 5]
+    assert [m.version for m in migrations] == [1, 2, 3, 4, 5, 6]
     assert "inventory_receipts" in migrations[1].name
     assert "app_thread_holders" in migrations[2].name
     assert "remote_epic_lifecycle" in migrations[3].name
@@ -92,7 +93,7 @@ def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
     conn = db.connect()
     try:
         versions = [int(r[0]) for r in conn.execute("SELECT version FROM schema_migrations ORDER BY 1")]
-        assert versions == [1, 2, 3, 4, 5]
+        assert versions == [1, 2, 3, 4, 5, 6]
         for table in (
             "stream_migration_state",
             "stream_inventory_receipts",
@@ -108,6 +109,83 @@ def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
             assert row is not None, table
     finally:
         conn.close()
+
+
+def test_rollover_bundle_v5_receipt_upgrades_to_status_binding_schema(tmp_path: Path) -> None:
+    path = tmp_path / "v5.sqlite3"
+    migrations = load_migrations()
+    timestamp = "2026-08-24T10:00:00Z"
+    manifest = {
+        "schema": "rollover-bundle.v1",
+        "status": "pending_start",
+        "prepared_at": timestamp,
+    }
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        for migration in migrations[:5]:
+            connection.executescript(migration.sql)
+            connection.execute(
+                "INSERT INTO schema_migrations VALUES (?, ?, ?, ?)",
+                (migration.version, migration.name, migration.sha256, timestamp),
+            )
+        connection.execute("INSERT INTO streams VALUES ('epic:7260', 'epic', 7260, ?)", (timestamp,))
+        connection.execute(
+            "INSERT INTO sessions("
+            "session_id, stream_id, state, lineage_id, opened_at, updated_at, closed_at, state_version, expired_at"
+            ") VALUES ('session-v5', 'epic:7260', 'open', 'lineage-v5', ?, ?, NULL, 1, NULL)",
+            (timestamp, timestamp),
+        )
+        event = connection.execute(
+            "INSERT INTO lease_events("
+            "stream_id, session_id, lease_id, generation, fencing_token, event_type, "
+            "holder_kind, holder_agent, holder_harness, holder_instance_id, holder_task_id, holder_process_id, "
+            "ttl_seconds, ts, proof_json, reason, holder_host_id) VALUES ("
+            "'epic:7260', 'session-v5', 'lease-v5', 3, 7, 'acquired', 'process', "
+            "'codex', 'codex-cli', 'instance-v5', 'task-v5', 4321, 900, ?, '{}', 'fixture', NULL)",
+            (timestamp,),
+        )
+        connection.execute(
+            "INSERT INTO stream_leases("
+            "stream_id, session_id, lease_id, generation, fencing_token, state, holder_kind, holder_agent, "
+            "holder_harness, holder_instance_id, holder_task_id, holder_process_id, heartbeat_at, expires_at, "
+            "ttl_seconds, version, last_event_id, holder_host_id) VALUES ("
+            "'epic:7260', 'session-v5', 'lease-v5', 3, 7, 'active', 'process', 'codex', 'codex-cli', "
+            "'instance-v5', 'task-v5', 4321, ?, ?, 900, 1, ?, NULL)",
+            (timestamp, "2026-08-24T10:15:00Z", int(event.lastrowid)),
+        )
+        connection.execute(
+            "INSERT INTO rollover_bundles("
+            "stream_id, agent, lineage_id, generation, rollover_id, bundle_sha256, "
+            "manifest_json, blob, uploaded_at, uploaded_by_lease_id) VALUES ("
+            "'epic:7260', 'codex', 'lineage-v5', 3, 'rollover-v5', ?, ?, ?, ?, 'lease-v5')",
+            (
+                "a" * 64,
+                json.dumps(manifest, separators=(",", ":")),
+                b"v5-bundle",
+                timestamp,
+            ),
+        )
+
+    connection = SessionStreamDatabase(path).connect()
+    try:
+        row = connection.execute(
+            "SELECT status, prepared_at FROM rollover_bundles WHERE rollover_id = 'rollover-v5'"
+        ).fetchone()
+        assert row["status"] == "pending_start"
+        assert row["prepared_at"] == timestamp
+        unique_indexes = {
+            str(item[1])
+            for item in connection.execute("PRAGMA index_list('rollover_bundles')").fetchall()
+            if int(item[2]) == 1
+        }
+        assert unique_indexes == {
+            "rollover_bundles_bundle_sha256_unique",
+            "rollover_bundles_identity_unique",
+        }
+        versions = [int(item[0]) for item in connection.execute("SELECT version FROM schema_migrations ORDER BY 1")]
+        assert versions == [1, 2, 3, 4, 5, 6]
+    finally:
+        connection.close()
 
 
 def test_app_holder_migration_preserves_legacy_process_projection_and_indexes(tmp_path: Path) -> None:

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -106,6 +106,8 @@ fi
 if [[ "${{1:-}}" == */scripts/orchestration/thread_handoff.py && "$*" == *" import-bundle "* ]]; then
   if [[ -n "${{CODEX_LAUNCHER_TEST_ORDER:-}}" ]]; then
     printf '%s\n' 'import-bundle' >> "$CODEX_LAUNCHER_TEST_ORDER"
+    [[ "$*" == *"--from-api"* ]] && printf '%s\n' 'from-api' >> "$CODEX_LAUNCHER_TEST_ORDER"
+    [[ "$*" != *"--agent"* ]] && printf '%s\n' 'agent-unpinned' >> "$CODEX_LAUNCHER_TEST_ORDER"
   fi
   exit 0
 fi
@@ -314,6 +316,8 @@ def test_launcher_imports_bundle_before_prelease_scan_and_lease_claim(tmp_path: 
     )
     assert order_capture.read_text(encoding="utf-8").splitlines() == [
         "import-bundle",
+        "from-api",
+        "agent-unpinned",
         "prelease-scan",
         "lease-claim",
     ]

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_PROJECT_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
+# Tests spawn the same prescribed project interpreter that is running pytest;
+# dispatch worktrees intentionally do not contain a private .venv.
+_PROJECT_PYTHON = Path(sys.executable)
 _LAUNCHER_FILES = (
     Path("start-codex.sh"),
     Path("start-codex-driver.sh"),
@@ -74,6 +77,9 @@ def _prepare_repo(
         venv_bin / "python",
         f'''#!/usr/bin/env bash
 if [[ "${{1:-}}" == */scripts/orchestration/thread_handoff.py && "$*" == *" detect "* ]]; then
+  if [[ -n "${{CODEX_LAUNCHER_TEST_ORDER:-}}" ]]; then
+    printf '%s\n' 'prelease-scan' >> "$CODEX_LAUNCHER_TEST_ORDER"
+  fi
   case "${{CODEX_LAUNCHER_TEST_ROLLOVER:-none}}" in
     none)
       printf '%s\\n' '{{"agent":"codex-test","status":"none"}}'
@@ -97,11 +103,20 @@ JSON
       ;;
   esac
 fi
+if [[ "${{1:-}}" == */scripts/orchestration/thread_handoff.py && "$*" == *" import-bundle "* ]]; then
+  if [[ -n "${{CODEX_LAUNCHER_TEST_ORDER:-}}" ]]; then
+    printf '%s\n' 'import-bundle' >> "$CODEX_LAUNCHER_TEST_ORDER"
+  fi
+  exit 0
+fi
 if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.orchestration.codex_transport_health" ]]; then
   printf '%s\\n' '{{"status":"healthy","fresh":true}}'
   exit 0
 fi
 if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" ]]; then
+  if [[ -n "${{CODEX_LAUNCHER_TEST_ORDER:-}}" && "$*" == *" open "* ]]; then
+    printf '%s\n' 'lease-claim' >> "$CODEX_LAUNCHER_TEST_ORDER"
+  fi
   cat <<'JSON'
 {{"identity":{{"lease":{{"session_id":"session-test","lease_id":"lease-test","generation":1,"fencing_token":1,"expires_at":"2026-07-23T00:00:00Z"}}}}}}
 JSON
@@ -154,6 +169,7 @@ def _launch(
     provide_canonical_root: bool = False,
     ambient_profile: tuple[str, str] | None = None,
     rollover: str = "none",
+    order_capture: Path | None = None,
     expect_success: bool = True,
 ) -> tuple[dict[str, str], list[str], subprocess.CompletedProcess[str], Path, Path]:
     primary, linked = _prepare_repo(tmp_path, separate_git_dir=separate_git_dir)
@@ -202,6 +218,8 @@ def _launch(
             "CODEX_LAUNCHER_TEST_ROLLOVER": rollover,
         }
     )
+    if order_capture is not None:
+        env["CODEX_LAUNCHER_TEST_ORDER"] = os.fspath(order_capture)
     if provide_canonical_root:
         env["CODEX_CANONICAL_REPO_ROOT"] = os.fspath(primary)
     if ambient_profile is not None:
@@ -284,6 +302,21 @@ def test_launcher_binds_epic_and_strips_private_flag(tmp_path: Path) -> None:
     assert "orchestrate this epic" in forwarded
     assert "--epic" not in forwarded
     assert any("already claimed the hramatka lease" in arg for arg in forwarded)
+
+
+def test_launcher_imports_bundle_before_prelease_scan_and_lease_claim(tmp_path: Path) -> None:
+    order_capture = tmp_path / "launcher-order.txt"
+    _launch(
+        tmp_path,
+        ["--epic", "hramatka", "--model", "gpt-5.6-sol"],
+        driver=True,
+        order_capture=order_capture,
+    )
+    assert order_capture.read_text(encoding="utf-8").splitlines() == [
+        "import-bundle",
+        "prelease-scan",
+        "lease-claim",
+    ]
 
 
 def test_launcher_binds_epic_when_no_codex_args_remain(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- A: Added deterministic export bundles, tokenized text paths, manifest fingerprints, secret scanning, 4 MiB cap, and optional upload.
- B: Added migration 0005, SQLite retention/idempotency, and loopback-fenced list/latest/upload API routes.
- C: Added verified file/API import with newest-wins ordering, refusal/force behavior, stale supersession, handoff preservation, and `{{REPO_ROOT}}` rewriting.
- D: Added launcher pre-lease import, SessionStart fail-open backstop, and automatic prepare/confirm uploads.
- Updated cross-host runbook and Monitor API documentation.

## Acceptance evidence

- Focused suite: `244 passed in 28.20s`
- Required guards: `28 passed in 16.62s`
- Ruff: `All checks passed!`
- Shell syntax and `git diff --check`: clean.
- Local E2E:
  - generation 2 archived;
  - differing lane handoff preserved as `.superseded.md`;
  - `detect` exposed generation 3;
  - import-side strict continuity scored `SCORE 10/10 = 1.000  ->  PASS (strict 10/10)`;
  - newer local generation 4 refused with `refuse_rc=2`.
- API-down import remains fail-open with a loud warning and exit 0.

The design-note test paths were absent in this checkout; equivalent repository paths were used (`tests/orchestration/test_thread_handoff.py` and `tests/test_session_streams*.py`).

CLOBBER SELF-AUDIT: every deleted line intentional.

## Driver notes
- Design + kimi critique (GO-WITH-CHANGES) + ten binding amendments: #7260 comments. Author lane: codex; CF: kimi at exact head.
- Driver re-ran acceptance in the primary env at 5a5ec5d8a7: focused suites 191 passed (-n 4); session_streams + epics 75 passed; repo invariants (fastlane meta-test, lint-assertions, subprocess guard, path-safety) 43 passed; ruff clean; `bash -n` clean on the three touched shell files.
- After merge: #M-19 deploy on the API host (pull + `services.sh restart api`), then the live cross-host transfer test for the infra lane (export on the Mac with `--upload`, import on the target host, strict 10/10 there).

Closes #7260. Refs #7228 #7185 #6159.
