### PR TITLE
feat(phase3): add resumable Cycle007 labeling guardian

### DIFF
--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -106,10 +106,25 @@ STAGE_RUNNER_LABELS = {
     "resolve": "resolve_runner",
     "certify": "certify_runner",
 }
+EXECUTION_LOCK_FD_ENV = "PHASE3_CYCLE007_EXECUTION_LOCK_FD"
 
 
 class ControllerError(ValueError):
     pass
+
+
+def _inherited_execution_lock_fd() -> int | None:
+    raw = os.environ.get(EXECUTION_LOCK_FD_ENV)
+    if raw is None:
+        return None
+    try:
+        descriptor = int(raw)
+        if descriptor < 0:
+            raise ValueError
+        os.fstat(descriptor)
+    except (ValueError, OSError) as exc:
+        raise ControllerError("execution_lock_binding_drift") from exc
+    return descriptor
 
 
 def canonical(value: Any) -> bytes:
@@ -1392,6 +1407,7 @@ def run_stage(
     resolution_authority_root: Path | None = None,
     resolution_nonce_ledger: Path | None = None,
     resolution_advisor_response: Path | None = None,
+    execution_lock_fd: int | None = None,
 ) -> dict[str, Any]:
     _require_contiguous(
         package,
@@ -1465,6 +1481,7 @@ def run_stage(
             stderr=subprocess.DEVNULL,
             check=False,
             shell=False,
+            pass_fds=() if execution_lock_fd is None else (execution_lock_fd,),
         )
         if completed.returncode != 0:
             raise ControllerError("stage_execution_failed")
@@ -1579,6 +1596,7 @@ def main() -> int:
             gemini_canary.resolve(),
             grok_canary.resolve(),
         )
+        execution_lock_fd = _inherited_execution_lock_fd()
         args.lock.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         with args.lock.open("a+") as lock:
             os.chmod(args.lock, 0o600)
@@ -1612,6 +1630,7 @@ def main() -> int:
                     resolution_authority_root=args.resolution_authority_root,
                     resolution_nonce_ledger=args.resolution_nonce_ledger,
                     resolution_advisor_response=args.resolution_advisor_response,
+                    execution_lock_fd=execution_lock_fd,
                 )
     except ControllerError as exc:
         result = {"ok": False, "failure_code": str(exc), "text_free": True}

--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -26,7 +26,11 @@ operator explicitly starts a provider stage.
   identity drift, a second guardian, inadequate actual free space, a provider
   stop receipt, a non-contiguous stage seal, an invalid committed packet, or
   an ambiguous provider/adjudicator attempt that started but did not commit a
-  terminal receipt.
+  terminal receipt. A bind-mount command that exceeds 30 seconds stops with
+  `bind_mount_timeout`. A controller status call that exceeds 300 seconds or a
+  stage call that exceeds 72 hours stops with `controller_timeout`. The stage
+  timeout kills only the controller wrapper, not a possibly surviving paid
+  runner; the runner retains the inherited execution lock until it exits.
 - Residual policy: provider or semantic failures remain explicit stop receipts;
   they are never normalized away or automatically retried by the guardian.
 - Independent held-out evaluation: a frozen black-box fixture and expected
@@ -134,6 +138,9 @@ of being claimed as automatically resumable.
 | Wrong backing directory mounted | Fail with `mount_identity_drift`; do not run a provider. |
 | Duplicate guardian | Fail with `guardian_already_running`; do not run a provider. |
 | Guardian and controller killed while their runner survives | The runner retains the inherited execution lock; a replacement fails with `active_worker` and makes zero provider calls. |
+| Bind-mount command exceeds 30 seconds | Fail with `bind_mount_timeout`; no provider has been invoked and the operator must inspect storage state before retrying. |
+| Controller status call exceeds 300 seconds | Fail with `controller_timeout`; status never invokes a provider, so no paid runner is created by this path. |
+| Controller stage call exceeds 72 hours | Kill only the controller wrapper and fail with `controller_timeout`. A surviving paid runner is deliberately not signalled, retains the inherited execution lock, and makes a replacement return `active_worker` with zero additional provider calls. After it exits, durable receipts, seals, and active-stage markers determine the only safe recovery point. |
 | Provider or semantic stop receipt | Preserve the stop and wait for explicit operator recovery direction. |
 
 ## Run sequence
@@ -166,6 +173,11 @@ provider from accidentally starting the other or entering adjudication.
 - One process test pauses a runner before its started marker, kills its guardian
   and controller, and proves a replacement guardian returns `active_worker`
   while making zero additional provider calls.
+- One process test triggers the guardian's real controller-timeout path against
+  a long-running controller with a long-running child, proves the controller is
+  killed while its child survives with the inherited execution lock, and proves
+  a replacement guardian returns `active_worker` with zero additional provider
+  calls.
 - One process test kills the guardian and controller immediately after a
   verified Gemini/Grok packet boundary, then proves replacement execution starts
   at exactly the next packet with no duplicate provider call.

--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -1,0 +1,181 @@
+# Cycle 007 resumable labeling runtime
+
+Status: implementation plan for issue #6375. Labeling remains OFF until the
+operator explicitly starts a provider stage.
+
+## Frozen outcome contract
+
+- User-visible outcome: independently label every one of the 10,159 frozen
+  Cycle 007 rows with Gemini and Grok, deterministically compare both label
+  sets, adjudicate every disagreement, resolve any explicitly authorized
+  residual, and certify zero unresolved rows.
+- Source denominator: 204 immutable evidence packets containing 10,159 rows.
+- Completion terms:
+  - `storage_ready`: every runtime output root is mounted on the explicit
+    backing filesystem and passes identity, permission, and free-space checks.
+  - `provider_complete`: one provider has a verified sealed result for all
+    204 packets and all 10,159 row identities.
+  - `dual_complete`: both providers independently satisfy
+    `provider_complete`.
+  - `compared`: deterministic comparison covers the exact dual-complete
+    identity set.
+  - `adjudicated`: every disagreement has a verified adjudication result.
+  - `certified`: the existing Cycle 007 certifier reports 204 packets, 10,159
+    rows, both providers complete, and zero unresolved rows.
+- Stop policy: stop without deleting a committed packet on mount drift,
+  identity drift, a second guardian, inadequate actual free space, a provider
+  stop receipt, a non-contiguous stage seal, an invalid committed packet, or
+  an ambiguous provider/adjudicator attempt that started but did not commit a
+  terminal receipt.
+- Residual policy: provider or semantic failures remain explicit stop receipts;
+  they are never normalized away or automatically retried by the guardian.
+- Independent held-out evaluation: a frozen black-box fixture and expected
+  text-free receipts, separate from the implementation-focused unit fixtures,
+  use fake packages and fake providers to prove mount restoration, duplicate
+  exclusion, exact packet resume, stage resume, and terminal completion without
+  reading or depending on production content.
+
+## Non-goals
+
+- No evidence, packet, prompt, label schema, model, validator, endpoint,
+  denominator, chunk size, custody, or certification-policy change.
+- No copy of the approximately 81 GiB evidence bundle.
+- No database, queue service, container platform, or new background daemon.
+- No provider call during installation, storage preparation, status, or plan.
+- No automatic clearing of provider-stop receipts or semantic failures.
+- No persistent `/etc/fstab` or systemd mutation. Re-running the same guardian
+  command after reboot restores the bind mounts and resumes from seals.
+
+## Minimal architecture
+
+The existing reviewed controller remains the authority for preflight, packet
+verification, stage ordering, and stage seals. A small Linux-only guardian adds
+only the missing operational layer:
+
+1. Acquire one non-blocking outer guardian lock located outside the disposable
+   worktree and hold it through storage validation and child completion. Pass a
+   different stable lock path to the existing controller; the guardian never
+   tries to acquire the controller lock itself. Also acquire a third stable
+   execution lock and explicitly inherit its open descriptor through the
+   guardian, controller, and actual provider/adjudicator runner. Because the
+   kernel lock survives until the last inheriting process exits, a replacement
+   guardian cannot start a duplicate even if the guardian and controller are
+   killed while their runner remains alive.
+2. Validate the explicit package and backing roots without discovering either.
+3. Create six private backing directories and six empty package mountpoints
+   with the frozen lexical names `label-output-gemini-cycle007-v1`,
+   `label-output-grok-cycle007-v1`, `dual-label-output-cycle007-v1`,
+   `consensus-audit-cycle007-v1`, `dual-label-adjudication-cycle007-v1`, and
+   `dual-label-final-cycle007-v1`.
+4. Idempotently bind-mount each backing directory at the unchanged package path.
+   Package and backing roots must be absolute, distinct, non-overlapping, and
+   contain no symlink component. The backing device must differ from the
+   package/evidence device. An unmounted target must be empty. An existing mount
+   is accepted only when `/proc/self/mountinfo` has an exact target entry,
+   source and target have the same device and inode, all six targets share the
+   backing device, ownership matches the explicit required `--owner-uid` and
+   `--owner-gid` values, and modes are `0700`. A wrong existing mount fails
+   without unmounting or remounting it.
+   Actual free space is computed from `statvfs.f_bavail * f_frsize` and must be
+   at least the operator-supplied floor before every stage.
+5. Quarantine automatically only orphan atomic temporary names that cannot be
+   a committed result, using a same-filesystem rename into a private bounded
+   recovery directory. Automatic quarantine is capped at 64 files and 16 MiB
+   per invocation; exceeding either bound fails with
+   `recovery_bound_exceeded`. Never copy, read, delete, move, or overwrite a complete
+   verified packet. A started-without-terminal attempt, partial provider or
+   adjudicator final set, or provider-stop receipt is ambiguous and always
+   blocks for explicit operator recovery. Package-top `.cycle007-*` residue
+   remains on the package filesystem and is never copied across filesystems.
+6. Read the existing text-free stage-seal chain and invoke the existing
+   controller for exactly the first incomplete stage. Repeat until the requested
+   terminal stage is sealed or a safe stop occurs.
+7. For Gemini and Grok, use their existing per-attempt and packet/chunk receipts
+   rather than a stage-wide marker. When the execution lock is free, resume at
+   the first missing packet only after every committed unit verifies and there
+   is no started attempt lacking either a complete verified unit or a terminal
+   failure receipt, no partial seal, and no provider stop. For `audit` and
+   `adjudicate`, which lack equivalent durable per-call markers, atomically write
+   and parent-directory-fsync a conservative text-free active-stage marker
+   before invoking the controller. Remove it and fsync the directory only after
+   the controller has committed and verified that stage seal. If such a marker
+   exists without its complete stage seal, a replacement guardian reports
+   `ambiguous_provider_attempt` and performs zero provider calls. If the stage
+   seal is complete, the marker is safely stale and may be removed without
+   rerunning the stage.
+8. Atomically write a text-free guardian receipt containing counts, stage,
+   mount identities, code identity, and safe failure code. It contains no
+   packet content, prompts, labels, responses, account data, or infrastructure
+   locator.
+
+The provider concurrency remains exactly one. The inherited execution lock is
+held by the actual child runner for its entire lifetime, including before the
+child writes its started marker. Packet and chunk receipts are the
+durable checkpoint; the guardian does not maintain a second progress database.
+Certification and controller files intentionally remain on the package
+filesystem. The existing provider atomic helpers are not changed by this
+runtime and do not fsync parent directories after every rename, so the guarantee
+is deliberately limited to process death and orderly reboot. A power-loss or
+kernel/filesystem crash that leaves an ambiguous attempt fails closed instead
+of being claimed as automatically resumable.
+
+## Recovery guarantees
+
+| Interruption | Recovery behavior |
+| --- | --- |
+| Guardian killed between packets | Next invocation validates all committed packets and starts at the first missing packet. |
+| Orderly server reboot | Next invocation recreates missing bind mounts, validates their identity, and resumes from the existing seals. |
+| Process death during an atomic file write, before a provider attempt starts | The orphan atomic temporary name is moved without inspection by same-filesystem rename; the uncommitted unit is rerun. |
+| Started provider/adjudicator attempt without a terminal receipt | Fail with `ambiguous_provider_attempt`; preserve every file and wait for explicit operator recovery. |
+| Partial provider/adjudicator final set | Fail with `ambiguous_partial_seal`; preserve every file and wait for explicit operator recovery. |
+| Guardian/controller/runner killed after an adjudicator or audit provider returns but before its stage seal | The durable active-stage marker remains; replacement returns `ambiguous_provider_attempt` and makes zero provider calls. |
+| Guardian/controller killed between two verified Gemini or Grok packets | With no surviving execution lock or ambiguous attempt, replacement verifies the durable prefix and starts exactly at the next packet. |
+| Crash between stages | The completed stage seal is validated and the next stage starts. |
+| Wrong backing directory mounted | Fail with `mount_identity_drift`; do not run a provider. |
+| Duplicate guardian | Fail with `guardian_already_running`; do not run a provider. |
+| Guardian and controller killed while their runner survives | The runner retains the inherited execution lock; a replacement fails with `active_worker` and makes zero provider calls. |
+| Provider or semantic stop receipt | Preserve the stop and wait for explicit operator recovery direction. |
+
+## Run sequence
+
+1. `prepare`: mount and verify storage only; provider calls remain off.
+2. `plan`: report the next missing stage and safe counts only.
+3. `resume --through gemini`: finish and seal Gemini.
+4. `resume --through grok`: finish and seal Grok.
+5. `resume --through adjudicate`: compare, audit, and adjudicate after both
+   provider seals exist.
+6. `resume --through certify`: run authorized resolution when required and the
+   existing certifier; success requires zero unresolved rows.
+
+The staged `--through` boundary prevents an operator intending to start one
+provider from accidentally starting the other or entering adjudication.
+
+## Acceptance evidence
+
+- Unit tests cover exact mount-table identity, no-symlink components, ownership,
+  permissions, `f_bavail` free-space floor, distinct devices, non-overlapping
+  roots, empty targets, wrong-mount refusal, idempotent remount, distinct outer
+  and controller locks, inherited execution-lock continuity, a real child lock
+  invocation, duplicate guardian,
+  zero-provider prepare/plan/status, completed-packet preservation, requested
+  `--through` boundaries, stage continuation, and safe stop receipts.
+- Interruption tests cover the boundary before a started marker, after the
+  started marker, after provider return, after each final file, and after the
+  terminal receipt. Only the pre-start orphan-temp case auto-recovers; every
+  ambiguous paid-call boundary preserves files and stops.
+- One process test pauses a runner before its started marker, kills its guardian
+  and controller, and proves a replacement guardian returns `active_worker`
+  while making zero additional provider calls.
+- One process test kills the guardian and controller immediately after a
+  verified Gemini/Grok packet boundary, then proves replacement execution starts
+  at exactly the next packet with no duplicate provider call.
+- A second process test kills the adjudicator after provider return and runtime
+  cleanup but before its stage seal, then proves the durable active-stage marker
+  makes replacement execution return `ambiguous_provider_attempt` with zero
+  additional provider calls and no file loss.
+- A synthetic end-to-end run reaches the existing certification stage, then a
+  second invocation performs zero provider work.
+- The exact PR head passes repository CI and an independent cross-family code
+  review before merge.
+- Production preflight is content-blind and labeling stays OFF until the
+  operator executes an explicit `resume --through ...` command.

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -238,6 +238,20 @@ def _validate_roots(config: Config, *, create: bool) -> None:
     lock_paths = (config.guardian_lock, config.controller_lock, config.execution_lock)
     if len(set(lock_paths)) != len(lock_paths):
         raise GuardianError("lock_path_collision")
+    for lock_path in lock_paths:
+        if not _non_overlapping(lock_path, config.package) or not _non_overlapping(
+            lock_path, config.backing_root
+        ):
+            raise GuardianError("lock_path_collision")
+        if create and not lock_path.parent.exists():
+            _assert_no_symlink_components(lock_path.parent, allow_missing_leaf=True)
+            lock_path.parent.mkdir(mode=0o700)
+            os.chown(lock_path.parent, config.owner_uid, config.owner_gid)
+        _assert_no_symlink_components(lock_path.parent)
+        if lock_path.exists() or lock_path.is_symlink():
+            info = lock_path.lstat()
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+                raise GuardianError("lock_path_drift")
     for root_name in OUTPUT_ROOTS:
         source = config.backing_root / root_name
         target = config.package / root_name
@@ -424,7 +438,7 @@ def _stage_seal(config: Config, stage: str) -> Path:
     return config.package / "control" / f"stage-{stage}.complete.json"
 
 
-def _reconcile_markers(config: Config) -> None:
+def _reconcile_markers(config: Config, *, mutate: bool) -> None:
     for stage in MARKED_STAGES:
         marker = _marker(config, stage)
         if not marker.exists() and not marker.is_symlink():
@@ -432,7 +446,8 @@ def _reconcile_markers(config: Config) -> None:
         if marker.is_symlink() or not marker.is_file():
             raise GuardianError("ambiguous_provider_attempt")
         if _stage_seal(config, stage).is_file() and not _stage_seal(config, stage).is_symlink():
-            _remove_durable(marker)
+            if mutate:
+                _remove_durable(marker)
             continue
         raise GuardianError("ambiguous_provider_attempt")
 
@@ -481,7 +496,7 @@ def _resume(config: Config, mounts: list[dict[str, Any]]) -> dict[str, Any]:
     try:
         execution_fd = execution.fileno()
         recovered = _recover_guardian_temporaries(config)
-        _reconcile_markers(config)
+        _reconcile_markers(config, mutate=True)
         status = _invoke_controller(config, "status", execution_fd=execution_fd)
         completed = _completed_stages(status)
         boundary = STAGES.index(config.through)
@@ -606,7 +621,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "text_free": True,
             }
         elif config.action in {"status", "plan"}:
-            _reconcile_markers(config)
+            _reconcile_markers(config, mutate=False)
             result = _safe_status(config, mounts=mounts)
         else:
             result = _resume(config, mounts)

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -295,7 +295,6 @@ def _ensure_mounts(config: Config, *, mutate: bool) -> list[dict[str, Any]]:
         result.append(
             {
                 "name": root_name,
-                "device": entry.device,
                 "identity_sha256": _digest(f"{source_info.st_dev}:{source_info.st_ino}".encode()),
             }
         )
@@ -413,6 +412,7 @@ def _controller_command(config: Config, action: str, stage: str | None = None) -
 
 def _invoke_controller(config: Config, action: str, *, execution_fd: int | None = None, stage: str | None = None) -> dict[str, Any]:
     environment = os.environ.copy()
+    environment.pop(EXECUTION_LOCK_FD_ENV, None)
     pass_fds: tuple[int, ...] = ()
     if execution_fd is not None:
         environment[EXECUTION_LOCK_FD_ENV] = str(execution_fd)

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -36,6 +36,9 @@ EXECUTION_LOCK_FD_ENV = "PHASE3_CYCLE007_EXECUTION_LOCK_FD"
 RECEIPT_SCHEMA = "phase3_cycle007_labeling_guardian_v1"
 MAX_RECOVERY_FILES = 64
 MAX_RECOVERY_BYTES = 16 * 1024 * 1024
+MOUNT_TIMEOUT_SECONDS = 30
+STATUS_TIMEOUT_SECONDS = 300
+STAGE_TIMEOUT_SECONDS = 72 * 60 * 60
 
 
 class GuardianError(ValueError):
@@ -204,14 +207,18 @@ def _available_bytes(path: Path) -> int:
 
 
 def _bind_mount(source: Path, target: Path, mount_command: str) -> None:
-    completed = subprocess.run(
-        [mount_command, "--bind", str(source), str(target)],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        shell=False,
-    )
+    try:
+        completed = subprocess.run(
+            [mount_command, "--bind", str(source), str(target)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            shell=False,
+            timeout=MOUNT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise GuardianError("bind_mount_timeout") from None
     if completed.returncode != 0:
         raise GuardianError("bind_mount_failed")
 
@@ -417,16 +424,20 @@ def _invoke_controller(config: Config, action: str, *, execution_fd: int | None 
     if execution_fd is not None:
         environment[EXECUTION_LOCK_FD_ENV] = str(execution_fd)
         pass_fds = (execution_fd,)
-    completed = subprocess.run(
-        _controller_command(config, action, stage),
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        shell=False,
-        env=environment,
-        pass_fds=pass_fds,
-    )
+    try:
+        completed = subprocess.run(
+            _controller_command(config, action, stage),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            shell=False,
+            env=environment,
+            pass_fds=pass_fds,
+            timeout=STATUS_TIMEOUT_SECONDS if action == "status" else STAGE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise GuardianError("controller_timeout") from None
     return _parse_controller_output(completed)
 
 

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Storage-safe, resumable guardian for Cycle 007 dual-provider labeling.
+
+This wrapper never reads label content and never discovers runtime locations.
+It validates six explicit bind mounts, excludes duplicate execution, and drives
+the reviewed controller only up to an operator-selected stage boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+
+STAGES = ("gemini", "grok", "compare", "audit", "adjudicate", "resolve", "certify")
+OUTPUT_ROOTS = (
+    "label-output-gemini-cycle007-v1",
+    "label-output-grok-cycle007-v1",
+    "dual-label-output-cycle007-v1",
+    "consensus-audit-cycle007-v1",
+    "dual-label-adjudication-cycle007-v1",
+    "dual-label-final-cycle007-v1",
+)
+MARKED_STAGES = frozenset({"audit", "adjudicate"})
+EXECUTION_LOCK_FD_ENV = "PHASE3_CYCLE007_EXECUTION_LOCK_FD"
+RECEIPT_SCHEMA = "phase3_cycle007_labeling_guardian_v1"
+MAX_RECOVERY_FILES = 64
+MAX_RECOVERY_BYTES = 16 * 1024 * 1024
+
+
+class GuardianError(ValueError):
+    """Expected fail-stop condition represented by a text-free failure code."""
+
+
+@dataclass(frozen=True)
+class MountEntry:
+    mount_point: Path
+    root: str
+    source: str
+    device: str
+
+
+@dataclass(frozen=True)
+class Config:
+    action: str
+    package: Path
+    backing_root: Path
+    guardian_lock: Path
+    controller_lock: Path
+    execution_lock: Path
+    controller: Path
+    preflight_receipt: Path
+    gemini_canary_receipt: Path
+    grok_canary_receipt: Path
+    code_paths: dict[str, Path]
+    owner_uid: int
+    owner_gid: int
+    min_free_bytes: int
+    through: str | None
+    receipt: Path | None
+    mountinfo: Path
+    mount_command: str
+    operator_inspected_count: int | None
+    resolution_authorization: Path | None
+    resolution_authority_attestation: Path | None
+    resolution_authority_root: Path | None
+    resolution_nonce_ledger: Path | None
+    resolution_advisor_response: Path | None
+
+
+def _canonical(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def _digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".cycle007-guardian-tmp-{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            os.fchmod(stream.fileno(), 0o600)
+            stream.write(_canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _remove_durable(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    _fsync_directory(path.parent)
+
+
+def _assert_absolute(path: Path, code: str = "invalid_runtime_path") -> None:
+    if not path.is_absolute():
+        raise GuardianError(code)
+
+
+def _assert_no_symlink_components(path: Path, *, allow_missing_leaf: bool = False) -> None:
+    _assert_absolute(path)
+    current = Path(path.anchor)
+    parts = path.parts[1:]
+    for index, part in enumerate(parts):
+        current /= part
+        try:
+            info = current.lstat()
+        except FileNotFoundError:
+            if allow_missing_leaf and index == len(parts) - 1:
+                return
+            raise GuardianError("runtime_path_missing") from None
+        if stat.S_ISLNK(info.st_mode):
+            raise GuardianError("runtime_path_symlink")
+
+
+def _private_directory(path: Path, uid: int, gid: int, *, create: bool) -> None:
+    _assert_absolute(path)
+    _assert_no_symlink_components(path, allow_missing_leaf=create)
+    if create and not path.exists():
+        path.mkdir(mode=0o700)
+        os.chown(path, uid, gid)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        raise GuardianError("runtime_path_missing") from None
+    if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+        raise GuardianError("invalid_runtime_path")
+    if info.st_uid != uid or info.st_gid != gid or stat.S_IMODE(info.st_mode) != 0o700:
+        raise GuardianError("runtime_permission_drift")
+
+
+def _non_overlapping(first: Path, second: Path) -> bool:
+    return not (first == second or first.is_relative_to(second) or second.is_relative_to(first))
+
+
+def _decode_mount_field(value: str) -> str:
+    return value.replace("\\040", " ").replace("\\011", "\t").replace("\\012", "\n").replace("\\134", "\\")
+
+
+def _mount_entries(path: Path) -> list[MountEntry]:
+    entries: list[MountEntry] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        raise GuardianError("mount_table_unavailable") from None
+    for line in lines:
+        fields = line.split()
+        try:
+            separator = fields.index("-")
+            entries.append(
+                MountEntry(
+                    mount_point=Path(_decode_mount_field(fields[4])),
+                    root=_decode_mount_field(fields[3]),
+                    source=_decode_mount_field(fields[separator + 2]),
+                    device=fields[2],
+                )
+            )
+        except (IndexError, ValueError):
+            raise GuardianError("mount_table_invalid") from None
+    return entries
+
+
+def _exact_mount(entries: Sequence[MountEntry], target: Path) -> MountEntry | None:
+    matches = [entry for entry in entries if entry.mount_point == target]
+    if len(matches) > 1:
+        raise GuardianError("mount_identity_drift")
+    return matches[0] if matches else None
+
+
+def _same_identity(source: Path, target: Path) -> bool:
+    source_info = source.stat()
+    target_info = target.stat()
+    return (source_info.st_dev, source_info.st_ino) == (target_info.st_dev, target_info.st_ino)
+
+
+def _available_bytes(path: Path) -> int:
+    value = os.statvfs(path)
+    return value.f_bavail * value.f_frsize
+
+
+def _bind_mount(source: Path, target: Path, mount_command: str) -> None:
+    completed = subprocess.run(
+        [mount_command, "--bind", str(source), str(target)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise GuardianError("bind_mount_failed")
+
+
+def _validate_roots(config: Config, *, create: bool) -> None:
+    for path in (
+        config.package,
+        config.backing_root,
+        config.guardian_lock,
+        config.controller_lock,
+        config.execution_lock,
+        config.controller,
+        config.preflight_receipt,
+        config.gemini_canary_receipt,
+        config.grok_canary_receipt,
+    ):
+        _assert_absolute(path)
+    _assert_no_symlink_components(config.package)
+    _assert_no_symlink_components(config.backing_root)
+    if not _non_overlapping(config.package, config.backing_root):
+        raise GuardianError("runtime_path_overlap")
+    if config.package.stat().st_dev == config.backing_root.stat().st_dev:
+        raise GuardianError("backing_device_drift")
+    lock_paths = (config.guardian_lock, config.controller_lock, config.execution_lock)
+    if len(set(lock_paths)) != len(lock_paths):
+        raise GuardianError("lock_path_collision")
+    for root_name in OUTPUT_ROOTS:
+        source = config.backing_root / root_name
+        target = config.package / root_name
+        if not _non_overlapping(source, target):
+            raise GuardianError("runtime_path_overlap")
+        _private_directory(source, config.owner_uid, config.owner_gid, create=create)
+        _private_directory(target, config.owner_uid, config.owner_gid, create=create)
+
+
+def _ensure_mounts(config: Config, *, mutate: bool) -> list[dict[str, Any]]:
+    _validate_roots(config, create=mutate)
+    entries = _mount_entries(config.mountinfo)
+    result: list[dict[str, Any]] = []
+    backing_devices: set[int] = set()
+    for root_name in OUTPUT_ROOTS:
+        source = config.backing_root / root_name
+        target = config.package / root_name
+        entry = _exact_mount(entries, target)
+        if entry is None:
+            if not mutate:
+                raise GuardianError("storage_not_prepared")
+            try:
+                is_empty = not any(target.iterdir())
+            except OSError:
+                raise GuardianError("mount_target_unreadable") from None
+            if not is_empty:
+                raise GuardianError("mount_target_not_empty")
+            _bind_mount(source, target, config.mount_command)
+            entries = _mount_entries(config.mountinfo)
+            entry = _exact_mount(entries, target)
+            if entry is None:
+                raise GuardianError("bind_mount_failed")
+        if not _same_identity(source, target):
+            raise GuardianError("mount_identity_drift")
+        _private_directory(source, config.owner_uid, config.owner_gid, create=False)
+        _private_directory(target, config.owner_uid, config.owner_gid, create=False)
+        source_info = source.stat()
+        backing_devices.add(source_info.st_dev)
+        if source_info.st_dev == config.package.stat().st_dev:
+            raise GuardianError("backing_device_drift")
+        result.append(
+            {
+                "name": root_name,
+                "device": entry.device,
+                "identity_sha256": _digest(f"{source_info.st_dev}:{source_info.st_ino}".encode()),
+            }
+        )
+    if len(backing_devices) != 1:
+        raise GuardianError("backing_device_drift")
+    return result
+
+
+def _recover_guardian_temporaries(config: Config) -> int:
+    recovery = config.backing_root / ".cycle007-guardian-recovery"
+    candidates: list[Path] = []
+    total_bytes = 0
+    for root_name in OUTPUT_ROOTS:
+        root = config.backing_root / root_name
+        for candidate in root.rglob(".cycle007-guardian-tmp-*"):
+            info = candidate.lstat()
+            if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
+                raise GuardianError("ambiguous_partial_seal")
+            candidates.append(candidate)
+            total_bytes += info.st_size
+    if len(candidates) > MAX_RECOVERY_FILES or total_bytes > MAX_RECOVERY_BYTES:
+        raise GuardianError("recovery_bound_exceeded")
+    if not candidates:
+        return 0
+    _private_directory(recovery, config.owner_uid, config.owner_gid, create=True)
+    for index, candidate in enumerate(sorted(candidates)):
+        if candidate.stat().st_dev != recovery.stat().st_dev:
+            raise GuardianError("recovery_device_drift")
+        destination = recovery / f"orphan-{index:03d}-{_digest(str(candidate).encode())[:16]}"
+        if destination.exists() or destination.is_symlink():
+            raise GuardianError("recovery_collision")
+        os.replace(candidate, destination)
+    _fsync_directory(recovery)
+    return len(candidates)
+
+
+def _lock(path: Path, failure_code: str) -> BinaryIO:
+    _assert_absolute(path)
+    _assert_no_symlink_components(path.parent, allow_missing_leaf=True)
+    if not path.parent.exists():
+        path.parent.mkdir(mode=0o700)
+    _assert_no_symlink_components(path.parent)
+    if path.exists() or path.is_symlink():
+        info = path.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise GuardianError("lock_path_drift")
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError:
+        raise GuardianError("lock_path_drift") from None
+    handle = os.fdopen(descriptor, "a+b")
+    os.fchmod(handle.fileno(), 0o600)
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        raise GuardianError(failure_code) from None
+    return handle
+
+
+def _parse_controller_output(completed: subprocess.CompletedProcess[bytes]) -> dict[str, Any]:
+    try:
+        value = json.loads(completed.stdout.decode("utf-8", "strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise GuardianError("controller_protocol_failure") from None
+    if not isinstance(value, dict) or value.get("text_free") is not True:
+        raise GuardianError("controller_protocol_failure")
+    if completed.returncode != 0 or value.get("ok") is not True:
+        code = value.get("failure_code")
+        raise GuardianError(code if isinstance(code, str) and code else "controller_execution_failure")
+    return value
+
+
+def _controller_command(config: Config, action: str, stage: str | None = None) -> list[str]:
+    command = [
+        sys.executable,
+        str(config.controller),
+        action,
+        "--package",
+        str(config.package),
+        "--lock",
+        str(config.controller_lock),
+        "--preflight-receipt",
+        str(config.preflight_receipt),
+        "--gemini-canary-receipt",
+        str(config.gemini_canary_receipt),
+        "--grok-canary-receipt",
+        str(config.grok_canary_receipt),
+    ]
+    for label, path in sorted(config.code_paths.items()):
+        command.extend(["--code-path", f"{label}={path}"])
+    if stage is not None:
+        command.extend(["--stage", stage])
+        if stage != "gemini":
+            label = f"{stage}_runner"
+            runner = config.code_paths.get(label)
+            if runner is None:
+                raise GuardianError("stage_runner_required")
+            command.extend(["--runner", str(runner)])
+    if config.operator_inspected_count is not None:
+        command.extend(["--operator-inspected-count", str(config.operator_inspected_count)])
+    optional_paths = (
+        ("--resolution-authorization", config.resolution_authorization),
+        ("--resolution-authority-attestation", config.resolution_authority_attestation),
+        ("--resolution-authority-root", config.resolution_authority_root),
+        ("--resolution-nonce-ledger", config.resolution_nonce_ledger),
+        ("--resolution-advisor-response", config.resolution_advisor_response),
+    )
+    for flag, path in optional_paths:
+        if path is not None:
+            command.extend([flag, str(path)])
+    return command
+
+
+def _invoke_controller(config: Config, action: str, *, execution_fd: int | None = None, stage: str | None = None) -> dict[str, Any]:
+    environment = os.environ.copy()
+    pass_fds: tuple[int, ...] = ()
+    if execution_fd is not None:
+        environment[EXECUTION_LOCK_FD_ENV] = str(execution_fd)
+        pass_fds = (execution_fd,)
+    completed = subprocess.run(
+        _controller_command(config, action, stage),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        shell=False,
+        env=environment,
+        pass_fds=pass_fds,
+    )
+    return _parse_controller_output(completed)
+
+
+def _marker(config: Config, stage: str) -> Path:
+    return config.package / "control" / f"guardian-{stage}.active.json"
+
+
+def _stage_seal(config: Config, stage: str) -> Path:
+    return config.package / "control" / f"stage-{stage}.complete.json"
+
+
+def _reconcile_markers(config: Config) -> None:
+    for stage in MARKED_STAGES:
+        marker = _marker(config, stage)
+        if not marker.exists() and not marker.is_symlink():
+            continue
+        if marker.is_symlink() or not marker.is_file():
+            raise GuardianError("ambiguous_provider_attempt")
+        if _stage_seal(config, stage).is_file() and not _stage_seal(config, stage).is_symlink():
+            _remove_durable(marker)
+            continue
+        raise GuardianError("ambiguous_provider_attempt")
+
+
+def _completed_stages(status: dict[str, Any]) -> list[str]:
+    completed = status.get("completed_stages")
+    if not isinstance(completed, list) or not all(item in STAGES for item in completed):
+        raise GuardianError("controller_protocol_failure")
+    if completed != list(STAGES[: len(completed)]):
+        raise GuardianError("invalid_stage_seal")
+    return completed
+
+
+def _safe_status(config: Config, *, mounts: list[dict[str, Any]], recovered: int = 0) -> dict[str, Any]:
+    controller = _invoke_controller(config, "status")
+    completed = _completed_stages(controller)
+    free_bytes = _available_bytes(config.backing_root)
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "ok": True,
+        "action": config.action,
+        "completed_stages": completed,
+        "next_stage": STAGES[len(completed)] if len(completed) < len(STAGES) else None,
+        "through": config.through,
+        "mount_count": len(mounts),
+        "mounts": mounts,
+        "available_bytes": free_bytes,
+        "min_free_bytes": config.min_free_bytes,
+        "recovered_temporary_count": recovered,
+        "ready": controller.get("ready") is True,
+        "text_free": True,
+    }
+
+
+def _require_free_space(config: Config) -> int:
+    available = _available_bytes(config.backing_root)
+    if available < config.min_free_bytes:
+        raise GuardianError("actual_disk_floor")
+    return available
+
+
+def _resume(config: Config, mounts: list[dict[str, Any]]) -> dict[str, Any]:
+    if config.through is None:
+        raise GuardianError("through_required")
+    execution = _lock(config.execution_lock, "active_worker")
+    try:
+        execution_fd = execution.fileno()
+        recovered = _recover_guardian_temporaries(config)
+        _reconcile_markers(config)
+        status = _invoke_controller(config, "status", execution_fd=execution_fd)
+        completed = _completed_stages(status)
+        boundary = STAGES.index(config.through)
+        while len(completed) <= boundary:
+            stage = STAGES[len(completed)]
+            _require_free_space(config)
+            marker = _marker(config, stage)
+            if stage in MARKED_STAGES:
+                _atomic_json(
+                    marker,
+                    {
+                        "schema_version": "phase3_cycle007_active_stage_v1",
+                        "stage": stage,
+                        "text_free": True,
+                    },
+                )
+            _invoke_controller(config, "run", execution_fd=execution_fd, stage=stage)
+            if stage in MARKED_STAGES:
+                if not _stage_seal(config, stage).is_file() or _stage_seal(config, stage).is_symlink():
+                    raise GuardianError("ambiguous_provider_attempt")
+                _remove_durable(marker)
+            status = _invoke_controller(config, "status", execution_fd=execution_fd)
+            completed = _completed_stages(status)
+        result = _safe_status(config, mounts=mounts, recovered=recovered)
+        result["available_bytes"] = _require_free_space(config)
+        return result
+    finally:
+        execution.close()
+
+
+def _parse_code_paths(items: Iterable[str]) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for item in items:
+        label, separator, raw_path = item.partition("=")
+        if not separator or not label or not raw_path or label in result:
+            raise GuardianError("invalid_code_binding")
+        path = Path(raw_path)
+        _assert_absolute(path, "invalid_code_binding")
+        result[label] = path
+    return result
+
+
+def _config(args: argparse.Namespace) -> Config:
+    return Config(
+        action=args.action,
+        package=args.package,
+        backing_root=args.backing_root,
+        guardian_lock=args.guardian_lock,
+        controller_lock=args.controller_lock,
+        execution_lock=args.execution_lock,
+        controller=args.controller,
+        preflight_receipt=args.preflight_receipt,
+        gemini_canary_receipt=args.gemini_canary_receipt,
+        grok_canary_receipt=args.grok_canary_receipt,
+        code_paths=_parse_code_paths(args.code_path),
+        owner_uid=args.owner_uid,
+        owner_gid=args.owner_gid,
+        min_free_bytes=args.min_free_bytes,
+        through=args.through,
+        receipt=args.receipt,
+        mountinfo=args.mountinfo,
+        mount_command=args.mount_command,
+        operator_inspected_count=args.operator_inspected_count,
+        resolution_authorization=args.resolution_authorization,
+        resolution_authority_attestation=args.resolution_authority_attestation,
+        resolution_authority_root=args.resolution_authority_root,
+        resolution_nonce_ledger=args.resolution_nonce_ledger,
+        resolution_advisor_response=args.resolution_advisor_response,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("prepare", "status", "plan", "resume"))
+    parser.add_argument("--package", type=Path, required=True, help="explicit Cycle 007 package path")
+    parser.add_argument("--backing-root", type=Path, required=True, help="explicit separate-filesystem output root")
+    parser.add_argument("--guardian-lock", type=Path, required=True, help="stable outer guardian lock")
+    parser.add_argument("--controller-lock", type=Path, required=True, help="distinct stable controller lock")
+    parser.add_argument("--execution-lock", type=Path, required=True, help="distinct inherited runner lock")
+    parser.add_argument("--controller", type=Path, required=True, help="reviewed controller path")
+    parser.add_argument("--preflight-receipt", type=Path, required=True, help="text-free reviewed preflight receipt")
+    parser.add_argument("--gemini-canary-receipt", type=Path, required=True, help="text-free Gemini canary receipt")
+    parser.add_argument("--grok-canary-receipt", type=Path, required=True, help="text-free Grok canary receipt")
+    parser.add_argument("--code-path", action="append", default=[], help="LABEL=/absolute/public/code/path; repeat")
+    parser.add_argument("--owner-uid", type=int, required=True, help="required output owner UID")
+    parser.add_argument("--owner-gid", type=int, required=True, help="required output owner GID")
+    parser.add_argument("--min-free-bytes", type=int, required=True, help="actual-free hard floor before every stage")
+    parser.add_argument("--through", choices=STAGES, help="last stage the resume action may execute")
+    parser.add_argument("--receipt", type=Path, help="optional external text-free guardian receipt")
+    parser.add_argument("--mountinfo", type=Path, default=Path("/proc/self/mountinfo"), help=argparse.SUPPRESS)
+    parser.add_argument("--mount-command", default="mount", help=argparse.SUPPRESS)
+    parser.add_argument("--operator-inspected-count", type=int)
+    parser.add_argument("--resolution-authorization", type=Path)
+    parser.add_argument("--resolution-authority-attestation", type=Path)
+    parser.add_argument("--resolution-authority-root", type=Path)
+    parser.add_argument("--resolution-nonce-ledger", type=Path)
+    parser.add_argument("--resolution-advisor-response", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    result: dict[str, Any]
+    config: Config | None = None
+    guardian: BinaryIO | None = None
+    try:
+        config = _config(args)
+        if config.owner_uid < 0 or config.owner_gid < 0 or config.min_free_bytes <= 0:
+            raise GuardianError("invalid_runtime_parameter")
+        guardian = _lock(config.guardian_lock, "guardian_already_running")
+        mounts = _ensure_mounts(config, mutate=config.action in {"prepare", "resume"})
+        _require_free_space(config)
+        if config.action == "prepare":
+            result = {
+                "schema_version": RECEIPT_SCHEMA,
+                "ok": True,
+                "action": "prepare",
+                "mount_count": len(mounts),
+                "mounts": mounts,
+                "available_bytes": _available_bytes(config.backing_root),
+                "min_free_bytes": config.min_free_bytes,
+                "text_free": True,
+            }
+        elif config.action in {"status", "plan"}:
+            _reconcile_markers(config)
+            result = _safe_status(config, mounts=mounts)
+        else:
+            result = _resume(config, mounts)
+    except GuardianError as exc:
+        result = {
+            "schema_version": RECEIPT_SCHEMA,
+            "ok": False,
+            "failure_code": str(exc),
+            "text_free": True,
+        }
+    except Exception:
+        result = {
+            "schema_version": RECEIPT_SCHEMA,
+            "ok": False,
+            "failure_code": "guardian_execution_failure",
+            "text_free": True,
+        }
+    finally:
+        if guardian is not None:
+            guardian.close()
+    if config is not None and config.receipt is not None:
+        try:
+            _atomic_json(config.receipt, result)
+        except Exception:
+            result = {
+                "schema_version": RECEIPT_SCHEMA,
+                "ok": False,
+                "failure_code": "receipt_write_failed",
+                "text_free": True,
+            }
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0 if result.get("ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/phase3_cycle007_labeling_guardian/terminal-receipt.json
+++ b/tests/fixtures/phase3_cycle007_labeling_guardian/terminal-receipt.json
@@ -1,0 +1,1 @@
+{"completed_stages":["gemini","grok","compare","audit","adjudicate","resolve","certify"],"provider_call_count":7,"second_run_provider_call_count":7,"text_free":true}

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -265,6 +265,18 @@ def test_wrong_existing_mount_is_refused_without_mount_command(
     assert not called
 
 
+def test_bind_mount_timeout_has_fixed_failure_code(
+    guardian: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        guardian.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired("mount", 30)),
+    )
+    with pytest.raises(guardian.GuardianError, match="bind_mount_timeout"):
+        guardian._bind_mount(Path("/source"), Path("/target"), "mount")
+
+
 def test_duplicate_guardian_lock_is_nonblocking(guardian: ModuleType, tmp_path: Path) -> None:
     path = tmp_path / "locks/guardian.lock"
     first = guardian._lock(path, "guardian_already_running")
@@ -427,6 +439,19 @@ def test_controller_status_drops_ambient_execution_descriptor(
     assert guardian.EXECUTION_LOCK_FD_ENV not in captured_environment
 
 
+def test_controller_timeout_has_fixed_failure_code(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path, action="status")
+    monkeypatch.setattr(
+        guardian.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired("controller", 300)),
+    )
+    with pytest.raises(guardian.GuardianError, match="controller_timeout"):
+        guardian._invoke_controller(config, "status")
+
+
 def test_resume_stops_at_requested_boundary(
     guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -527,6 +552,7 @@ def test_cli_help_is_available() -> None:
         [os.sys.executable, str(GUARDIAN_PATH), "--help"],
         capture_output=True,
         check=False,
+        timeout=30,
     )
     assert completed.returncode == 0
     assert b"--execution-lock" in completed.stdout

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -118,8 +118,8 @@ def test_actual_free_uses_bavail_not_bfree(guardian: ModuleType, monkeypatch: py
 
 def test_permission_drift_is_rejected(guardian: ModuleType, tmp_path: Path) -> None:
     directory = tmp_path / "output"
-    directory.mkdir(mode=0o755)
-    os.chmod(directory, 0o755)
+    directory.mkdir(mode=0o710)
+    os.chmod(directory, 0o710)
     with pytest.raises(guardian.GuardianError, match="runtime_permission_drift"):
         guardian._private_directory(directory, os.getuid(), os.getgid(), create=False)
 

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -134,9 +134,14 @@ def test_package_and_backing_on_same_device_are_rejected(guardian: ModuleType, t
 def test_lock_path_collision_is_rejected(
     guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    shared = tmp_path / "locks/shared.lock"
-    shared.parent.mkdir(mode=0o700)
-    config = _config(guardian, tmp_path, guardian_lock=shared, controller_lock=shared)
+    case = tmp_path / "overlap-case"
+    case.mkdir()
+    config = _config(
+        guardian,
+        case,
+        guardian_lock=(case / "package/guardian.lock"),
+    )
+    config.controller_lock.parent.mkdir(mode=0o700)
     real_stat = guardian.Path.stat
 
     def fake_stat(path: Path, *args: Any, **kwargs: Any) -> Any:

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -116,6 +116,120 @@ def test_actual_free_uses_bavail_not_bfree(guardian: ModuleType, monkeypatch: py
     assert guardian._available_bytes(Path("/unused")) == 7 * 4096
 
 
+def test_permission_drift_is_rejected(guardian: ModuleType, tmp_path: Path) -> None:
+    directory = tmp_path / "output"
+    directory.mkdir(mode=0o755)
+    os.chmod(directory, 0o755)
+    with pytest.raises(guardian.GuardianError, match="runtime_permission_drift"):
+        guardian._private_directory(directory, os.getuid(), os.getgid(), create=False)
+
+
+def test_package_and_backing_on_same_device_are_rejected(guardian: ModuleType, tmp_path: Path) -> None:
+    config = _config(guardian, tmp_path)
+    config.guardian_lock.parent.mkdir(mode=0o700)
+    with pytest.raises(guardian.GuardianError, match="backing_device_drift"):
+        guardian._validate_roots(config, create=False)
+
+
+def test_lock_path_collision_is_rejected(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shared = tmp_path / "locks/shared.lock"
+    shared.parent.mkdir(mode=0o700)
+    config = _config(guardian, tmp_path, guardian_lock=shared, controller_lock=shared)
+    real_stat = guardian.Path.stat
+
+    def fake_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+        value = real_stat(path, *args, **kwargs)
+        if path == config.package:
+            fields = list(value)
+            fields[2] = 1
+            return os.stat_result(fields)
+        if path == config.backing_root:
+            fields = list(value)
+            fields[2] = 2
+            return os.stat_result(fields)
+        return value
+
+    monkeypatch.setattr(guardian.Path, "stat", fake_stat)
+    with pytest.raises(guardian.GuardianError, match="lock_path_collision"):
+        guardian._validate_roots(config, create=False)
+
+
+def test_actual_free_floor_is_enforced(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path, min_free_bytes=101)
+    monkeypatch.setattr(guardian, "_available_bytes", lambda _path: 100)
+    with pytest.raises(guardian.GuardianError, match="actual_disk_floor"):
+        guardian._require_free_space(config)
+
+
+def test_nonempty_unmounted_target_is_rejected_before_mount(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+        (config.package / name).mkdir(mode=0o700)
+    (config.package / guardian.OUTPUT_ROOTS[0] / "existing").write_text("", encoding="utf-8")
+    monkeypatch.setattr(guardian, "_validate_roots", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(guardian, "_mount_entries", lambda _path: [])
+    monkeypatch.setattr(guardian, "_bind_mount", lambda *_args: pytest.fail("mount command invoked"))
+    with pytest.raises(guardian.GuardianError, match="mount_target_not_empty"):
+        guardian._ensure_mounts(config, mutate=True)
+
+
+def test_correct_existing_mounts_are_idempotent(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+        (config.package / name).mkdir(mode=0o700)
+    entries = [
+        guardian.MountEntry(config.package / name, f"/{name}", "/dev/test", "8:2")
+        for name in guardian.OUTPUT_ROOTS
+    ]
+    real_stat = guardian.Path.stat
+
+    def fake_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+        value = real_stat(path, *args, **kwargs)
+        if path == config.package:
+            fields = list(value)
+            fields[2] = 1
+            return os.stat_result(fields)
+        if path.parent == config.backing_root or path.parent == config.package:
+            fields = list(value)
+            fields[1] = hash(path.name) & 0xFFFF
+            fields[2] = 2
+            return os.stat_result(fields)
+        return value
+
+    monkeypatch.setattr(guardian, "_validate_roots", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(guardian, "_mount_entries", lambda _path: entries)
+    monkeypatch.setattr(guardian, "_same_identity", lambda _source, _target: True)
+    monkeypatch.setattr(guardian.Path, "stat", fake_stat)
+    monkeypatch.setattr(guardian, "_private_directory", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(guardian, "_bind_mount", lambda *_args: pytest.fail("mount command invoked"))
+    mounts = guardian._ensure_mounts(config, mutate=True)
+    assert len(mounts) == len(guardian.OUTPUT_ROOTS)
+
+
+def test_orphan_guardian_temporary_is_quarantined_without_reading(
+    guardian: ModuleType, tmp_path: Path
+) -> None:
+    config = _config(guardian, tmp_path)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+    orphan = config.backing_root / guardian.OUTPUT_ROOTS[0] / ".cycle007-guardian-tmp-receipt.dead"
+    orphan.write_bytes(b"opaque")
+    assert guardian._recover_guardian_temporaries(config) == 1
+    assert not orphan.exists()
+    recovery = config.backing_root / ".cycle007-guardian-recovery"
+    assert len(list(recovery.iterdir())) == 1
+
+
 def test_wrong_existing_mount_is_refused_without_mount_command(
     guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -153,6 +267,17 @@ def test_duplicate_guardian_lock_is_nonblocking(guardian: ModuleType, tmp_path: 
             guardian._lock(path, "guardian_already_running")
     finally:
         first.close()
+
+
+def test_lock_refuses_symlink_leaf(guardian: ModuleType, tmp_path: Path) -> None:
+    lock_directory = tmp_path / "locks"
+    lock_directory.mkdir(mode=0o700)
+    target = tmp_path / "target"
+    target.write_text("", encoding="utf-8")
+    link = lock_directory / "execution.lock"
+    link.symlink_to(target)
+    with pytest.raises(guardian.GuardianError, match="lock_path_drift"):
+        guardian._lock(link, "active_worker")
 
 
 def test_execution_lock_survives_in_inherited_child(guardian: ModuleType, tmp_path: Path) -> None:
@@ -285,7 +410,7 @@ def test_resume_stops_at_requested_boundary(
 
     monkeypatch.setattr(guardian, "_lock", lambda *_args: handle)
     monkeypatch.setattr(guardian, "_recover_guardian_temporaries", lambda *_args: 0)
-    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args: None)
+    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
 
     def invoke(_config: Any, action: str, **kwargs: Any) -> dict[str, Any]:
@@ -316,7 +441,7 @@ def test_terminal_resume_is_noop(guardian: ModuleType, tmp_path: Path, monkeypat
     run_calls = 0
     monkeypatch.setattr(guardian, "_lock", lambda *_args: handle)
     monkeypatch.setattr(guardian, "_recover_guardian_temporaries", lambda *_args: 0)
-    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args: None)
+    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
 
     def invoke(_config: Any, action: str, **_kwargs: Any) -> dict[str, Any]:
@@ -344,7 +469,7 @@ def test_active_audit_marker_without_seal_stops_before_provider(
     marker = guardian._marker(config, "audit")
     marker.write_text(json.dumps({"text_free": True}), encoding="utf-8")
     with pytest.raises(guardian.GuardianError, match="ambiguous_provider_attempt"):
-        guardian._reconcile_markers(config)
+        guardian._reconcile_markers(config, mutate=False)
 
 
 def test_stale_marker_after_stage_seal_is_removed_durably(
@@ -359,7 +484,7 @@ def test_stale_marker_after_stage_seal_is_removed_durably(
     seal.write_text("{}", encoding="utf-8")
     synced: list[Path] = []
     monkeypatch.setattr(guardian, "_fsync_directory", lambda path: synced.append(path))
-    guardian._reconcile_markers(config)
+    guardian._reconcile_markers(config, mutate=True)
     assert not marker.exists()
     assert synced == [control]
 

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARDIAN_PATH = ROOT / "scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py"
+CONTROLLER_PATH = ROOT / "batch_state/phase3-run-cycle007-controller-v1.py"
+
+
+def _load(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _temporary_file() -> Any:
+    return tempfile.TemporaryFile()
+
+
+@pytest.fixture()
+def guardian() -> ModuleType:
+    return _load(GUARDIAN_PATH, "cycle007_labeling_guardian_test")
+
+
+@pytest.fixture()
+def controller() -> ModuleType:
+    return _load(CONTROLLER_PATH, "cycle007_controller_fd_test")
+
+
+def _config(guardian: ModuleType, root: Path, **changes: Any) -> Any:
+    package = root / "package"
+    backing = root / "backing"
+    package.mkdir(mode=0o700)
+    backing.mkdir(mode=0o700)
+    values = {
+        "action": "resume",
+        "package": package,
+        "backing_root": backing,
+        "guardian_lock": root / "locks/guardian.lock",
+        "controller_lock": root / "locks/controller.lock",
+        "execution_lock": root / "locks/execution.lock",
+        "controller": root / "controller.py",
+        "preflight_receipt": root / "preflight.json",
+        "gemini_canary_receipt": root / "gemini.json",
+        "grok_canary_receipt": root / "grok.json",
+        "code_paths": {},
+        "owner_uid": os.getuid(),
+        "owner_gid": os.getgid(),
+        "min_free_bytes": 1,
+        "through": "gemini",
+        "receipt": None,
+        "mountinfo": root / "mountinfo",
+        "mount_command": "mount",
+        "operator_inspected_count": None,
+        "resolution_authorization": None,
+        "resolution_authority_attestation": None,
+        "resolution_authority_root": None,
+        "resolution_nonce_ledger": None,
+        "resolution_advisor_response": None,
+    }
+    values.update(changes)
+    return guardian.Config(**values)
+
+
+def test_mountinfo_parser_decodes_and_matches_exact_target(guardian: ModuleType, tmp_path: Path) -> None:
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        "42 31 8:2 /backing\\040root /package/output\\040root rw - ext4 /dev/test rw\n",
+        encoding="utf-8",
+    )
+    entries = guardian._mount_entries(mountinfo)
+    assert entries == [
+        guardian.MountEntry(
+            mount_point=Path("/package/output root"),
+            root="/backing root",
+            source="/dev/test",
+            device="8:2",
+        )
+    ]
+    assert guardian._exact_mount(entries, Path("/package/output")) is None
+    assert guardian._exact_mount(entries, Path("/package/output root")) == entries[0]
+
+
+def test_mountinfo_duplicate_exact_target_fails_closed(guardian: ModuleType) -> None:
+    entry = guardian.MountEntry(Path("/target"), "/", "/dev/test", "8:2")
+    with pytest.raises(guardian.GuardianError, match="mount_identity_drift"):
+        guardian._exact_mount([entry, entry], Path("/target"))
+
+
+def test_no_symlink_component_and_overlap_rejected(guardian: ModuleType, tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    with pytest.raises(guardian.GuardianError, match="runtime_path_symlink"):
+        guardian._assert_no_symlink_components(link)
+    assert guardian._non_overlapping(tmp_path / "one", tmp_path / "two")
+    assert not guardian._non_overlapping(tmp_path / "one", tmp_path / "one/child")
+
+
+def test_actual_free_uses_bavail_not_bfree(guardian: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(os, "statvfs", lambda _path: SimpleNamespace(f_bavail=7, f_bfree=99, f_frsize=4096))
+    assert guardian._available_bytes(Path("/unused")) == 7 * 4096
+
+
+def test_wrong_existing_mount_is_refused_without_mount_command(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+        (config.package / name).mkdir(mode=0o700)
+    monkeypatch.setattr(guardian, "_validate_roots", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        guardian,
+        "_mount_entries",
+        lambda _path: [
+            guardian.MountEntry(config.package / name, "/wrong", "/dev/test", "8:2")
+            for name in guardian.OUTPUT_ROOTS
+        ],
+    )
+    monkeypatch.setattr(guardian, "_same_identity", lambda _source, _target: False)
+    called = False
+
+    def mount(*_args: Any) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(guardian, "_bind_mount", mount)
+    with pytest.raises(guardian.GuardianError, match="mount_identity_drift"):
+        guardian._ensure_mounts(config, mutate=True)
+    assert not called
+
+
+def test_duplicate_guardian_lock_is_nonblocking(guardian: ModuleType, tmp_path: Path) -> None:
+    path = tmp_path / "locks/guardian.lock"
+    first = guardian._lock(path, "guardian_already_running")
+    try:
+        with pytest.raises(guardian.GuardianError, match="guardian_already_running"):
+            guardian._lock(path, "guardian_already_running")
+    finally:
+        first.close()
+
+
+def test_execution_lock_survives_in_inherited_child(guardian: ModuleType, tmp_path: Path) -> None:
+    path = tmp_path / "locks/execution.lock"
+    owner = guardian._lock(path, "active_worker")
+    child = subprocess.Popen(
+        [
+            os.environ.get("PYTHON", os.sys.executable),
+            "-c",
+            "import os,time; os.fstat(int(os.environ['LOCK_FD'])); time.sleep(30)",
+        ],
+        env={**os.environ, "LOCK_FD": str(owner.fileno())},
+        pass_fds=(owner.fileno(),),
+    )
+    owner.close()
+    try:
+        with pytest.raises(guardian.GuardianError, match="active_worker"):
+            guardian._lock(path, "active_worker")
+    finally:
+        child.terminate()
+        child.wait(timeout=5)
+    replacement = guardian._lock(path, "active_worker")
+    replacement.close()
+
+
+def test_controller_passes_execution_descriptor_to_stage_runner(
+    controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = tmp_path / "compare.py"
+    runner.write_text("# public fixture\n", encoding="utf-8")
+    lock_file = _temporary_file()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(controller, "_require_contiguous", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(controller, "_require_python_binding", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(controller, "_commands_for_stage", lambda *_args, **_kwargs: ([['fixture']], None))
+    monkeypatch.setattr(controller, "_revalidate_compare_receipts", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(controller, "_stage_stop_paths", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(controller, "_seal", lambda *_args, **_kwargs: None)
+
+    def run(*_args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(controller.subprocess, "run", run)
+    result = controller.run_stage(
+        tmp_path,
+        "compare",
+        runner,
+        "a" * 64,
+        dry_run=False,
+        expected_python_executable_sha256="b" * 64,
+        expected_label_prompt_sha256s={
+            "gemini": {"clean_label": "c" * 64, "residual_label": "d" * 64},
+            "grok": {"clean_label": "e" * 64, "residual_label": "f" * 64},
+        },
+        expected_custody_sha256="1" * 64,
+        expected_label_manifest_sha256="2" * 64,
+        expected_evidence_manifest_sha256="3" * 64,
+        code_paths={"compare_runner": runner.resolve()},
+        execution_lock_fd=lock_file.fileno(),
+    )
+    assert result["ok"] is True
+    assert captured["pass_fds"] == (lock_file.fileno(),)
+    lock_file.close()
+
+
+def test_controller_rejects_invalid_inherited_descriptor(
+    controller: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(controller.EXECUTION_LOCK_FD_ENV, "not-an-fd")
+    with pytest.raises(controller.ControllerError, match="execution_lock_binding_drift"):
+        controller._inherited_execution_lock_fd()
+
+
+def test_prepare_path_never_invokes_controller(guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config(guardian, tmp_path, action="prepare")
+    monkeypatch.setattr(guardian, "_config", lambda _args: config)
+    monkeypatch.setattr(guardian, "_lock", lambda *_args: _temporary_file())
+    monkeypatch.setattr(guardian, "_ensure_mounts", lambda *_args, **_kwargs: [{"name": name} for name in guardian.OUTPUT_ROOTS])
+    monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
+    monkeypatch.setattr(guardian, "_available_bytes", lambda *_args: 100)
+    monkeypatch.setattr(
+        guardian,
+        "_invoke_controller",
+        lambda *_args, **_kwargs: pytest.fail("prepare invoked controller"),
+    )
+    arguments = [
+        "prepare",
+        "--package", "/package",
+        "--backing-root", "/backing",
+        "--guardian-lock", "/locks/guardian",
+        "--controller-lock", "/locks/controller",
+        "--execution-lock", "/locks/execution",
+        "--controller", "/controller",
+        "--preflight-receipt", "/preflight",
+        "--gemini-canary-receipt", "/gemini",
+        "--grok-canary-receipt", "/grok",
+        "--owner-uid", "1",
+        "--owner-gid", "1",
+        "--min-free-bytes", "1",
+    ]
+    assert guardian.main(arguments) == 0
+
+
+def test_plan_uses_status_only_and_reports_next_stage(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path, action="plan", through=None)
+    calls: list[tuple[str, str | None]] = []
+
+    def invoke(_config: Any, action: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append((action, kwargs.get("stage")))
+        return {"ok": True, "completed_stages": ["gemini"], "ready": False, "text_free": True}
+
+    monkeypatch.setattr(guardian, "_invoke_controller", invoke)
+    monkeypatch.setattr(guardian, "_available_bytes", lambda *_args: 100)
+    result = guardian._safe_status(config, mounts=[])
+    assert result["next_stage"] == "grok"
+    assert calls == [("status", None)]
+
+
+def test_resume_stops_at_requested_boundary(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path, through="grok")
+    handle = _temporary_file()
+    completed: list[str] = []
+    calls: list[tuple[str, str | None]] = []
+
+    monkeypatch.setattr(guardian, "_lock", lambda *_args: handle)
+    monkeypatch.setattr(guardian, "_recover_guardian_temporaries", lambda *_args: 0)
+    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args: None)
+    monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
+
+    def invoke(_config: Any, action: str, **kwargs: Any) -> dict[str, Any]:
+        stage = kwargs.get("stage")
+        calls.append((action, stage))
+        if action == "run":
+            completed.append(stage)
+        return {"ok": True, "completed_stages": list(completed), "ready": False, "text_free": True}
+
+    monkeypatch.setattr(guardian, "_invoke_controller", invoke)
+    monkeypatch.setattr(
+        guardian,
+        "_safe_status",
+        lambda *_args, **_kwargs: {
+            "ok": True,
+            "completed_stages": list(completed),
+            "text_free": True,
+        },
+    )
+    result = guardian._resume(config, mounts=[])
+    assert result["completed_stages"] == ["gemini", "grok"]
+    assert [stage for action, stage in calls if action == "run"] == ["gemini", "grok"]
+
+
+def test_terminal_resume_is_noop(guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config(guardian, tmp_path, through="certify")
+    handle = _temporary_file()
+    run_calls = 0
+    monkeypatch.setattr(guardian, "_lock", lambda *_args: handle)
+    monkeypatch.setattr(guardian, "_recover_guardian_temporaries", lambda *_args: 0)
+    monkeypatch.setattr(guardian, "_reconcile_markers", lambda *_args: None)
+    monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
+
+    def invoke(_config: Any, action: str, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal run_calls
+        if action == "run":
+            run_calls += 1
+        return {"ok": True, "completed_stages": list(guardian.STAGES), "ready": True, "text_free": True}
+
+    monkeypatch.setattr(guardian, "_invoke_controller", invoke)
+    monkeypatch.setattr(
+        guardian,
+        "_safe_status",
+        lambda *_args, **_kwargs: {"ok": True, "completed_stages": list(guardian.STAGES), "text_free": True},
+    )
+    guardian._resume(config, mounts=[])
+    assert run_calls == 0
+
+
+def test_active_audit_marker_without_seal_stops_before_provider(
+    guardian: ModuleType, tmp_path: Path
+) -> None:
+    config = _config(guardian, tmp_path)
+    control = config.package / "control"
+    control.mkdir()
+    marker = guardian._marker(config, "audit")
+    marker.write_text(json.dumps({"text_free": True}), encoding="utf-8")
+    with pytest.raises(guardian.GuardianError, match="ambiguous_provider_attempt"):
+        guardian._reconcile_markers(config)
+
+
+def test_stale_marker_after_stage_seal_is_removed_durably(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path)
+    control = config.package / "control"
+    control.mkdir()
+    marker = guardian._marker(config, "adjudicate")
+    seal = guardian._stage_seal(config, "adjudicate")
+    marker.write_text("{}", encoding="utf-8")
+    seal.write_text("{}", encoding="utf-8")
+    synced: list[Path] = []
+    monkeypatch.setattr(guardian, "_fsync_directory", lambda path: synced.append(path))
+    guardian._reconcile_markers(config)
+    assert not marker.exists()
+    assert synced == [control]
+
+
+def test_guardian_receipt_rejects_non_text_free_controller_output(guardian: ModuleType) -> None:
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=b'{"ok":true}\n', stderr=b"")
+    with pytest.raises(guardian.GuardianError, match="controller_protocol_failure"):
+        guardian._parse_controller_output(completed)
+
+
+def test_cli_help_is_available() -> None:
+    completed = subprocess.run(
+        [os.sys.executable, str(GUARDIAN_PATH), "--help"],
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0
+    assert b"--execution-lock" in completed.stdout
+    assert b"--through" in completed.stdout

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -219,6 +219,7 @@ def test_correct_existing_mounts_are_idempotent(
     monkeypatch.setattr(guardian, "_bind_mount", lambda *_args: pytest.fail("mount command invoked"))
     mounts = guardian._ensure_mounts(config, mutate=True)
     assert len(mounts) == len(guardian.OUTPUT_ROOTS)
+    assert all(set(mount) == {"name", "identity_sha256"} for mount in mounts)
 
 
 def test_orphan_guardian_temporary_is_quarantined_without_reading(
@@ -403,6 +404,27 @@ def test_plan_uses_status_only_and_reports_next_stage(
     result = guardian._safe_status(config, mounts=[])
     assert result["next_stage"] == "grok"
     assert calls == [("status", None)]
+
+
+def test_controller_status_drops_ambient_execution_descriptor(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(guardian, tmp_path, action="status")
+    captured_environment: dict[str, str] = {}
+    monkeypatch.setenv(guardian.EXECUTION_LOCK_FD_ENV, "999999")
+
+    def run(*_args: Any, **kwargs: Any) -> Any:
+        captured_environment.update(kwargs["env"])
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=b'{"ok":true,"text_free":true}\n',
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(guardian.subprocess, "run", run)
+    guardian._invoke_controller(config, "status")
+    assert guardian.EXECUTION_LOCK_FD_ENV not in captured_environment
 
 
 def test_resume_stops_at_requested_boundary(

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -118,8 +118,8 @@ def test_actual_free_uses_bavail_not_bfree(guardian: ModuleType, monkeypatch: py
 
 def test_permission_drift_is_rejected(guardian: ModuleType, tmp_path: Path) -> None:
     directory = tmp_path / "output"
-    directory.mkdir(mode=0o710)
-    os.chmod(directory, 0o710)
+    directory.mkdir(mode=0o600)
+    os.chmod(directory, 0o600)
     with pytest.raises(guardian.GuardianError, match="runtime_permission_drift"):
         guardian._private_directory(directory, os.getuid(), os.getgid(), create=False)
 

--- a/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
+++ b/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
@@ -8,6 +8,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 GUARDIAN = ROOT / "scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py"
 EXPECTED_TERMINAL = (
@@ -53,7 +55,13 @@ def _fixture_tree(tmp_path: Path) -> dict[str, Path]:
     }
 
 
-def _write_harness(tmp_path: Path, fixture: dict[str, Path], controller: Path) -> Path:
+def _write_harness(
+    tmp_path: Path,
+    fixture: dict[str, Path],
+    controller: Path,
+    *,
+    stage_timeout_seconds: float | None = None,
+) -> Path:
     harness = tmp_path / "guardian-harness.py"
     code_paths = {
         "grok_runner": fixture["runner"],
@@ -72,6 +80,7 @@ spec = importlib.util.spec_from_file_location("held_out_guardian", {str(GUARDIAN
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
+{f"module.STAGE_TIMEOUT_SECONDS = {stage_timeout_seconds!r}" if stage_timeout_seconds is not None else ""}
 config = module.Config(
     action="resume",
     package=Path({str(fixture['package'])!r}),
@@ -276,6 +285,63 @@ else:
     try:
         replacement = _run_harness(harness, "gemini")
         assert replacement.returncode == 0
+        assert json.loads(replacement.stdout)["failure_code"] == "active_worker"
+    finally:
+        os.kill(int(child_pid.read_text(encoding="utf-8")), signal.SIGKILL)
+
+
+def test_real_controller_timeout_leaves_runner_lock_blocking_replacement(tmp_path: Path) -> None:
+    fixture = _fixture_tree(tmp_path)
+    controller = tmp_path / "timeout-controller.py"
+    controller_pid = tmp_path / "controller.pid"
+    child_pid = tmp_path / "child.pid"
+    child = tmp_path / "timeout-runner-child.py"
+    child.write_text(
+        "import os,time; os.fstat(int(os.environ['LOCK_FD'])); time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    controller.write_text(
+        f"""
+import argparse, json, os, subprocess, sys, time
+from pathlib import Path
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("action")
+parser.add_argument("--stage")
+args, _unknown = parser.parse_known_args()
+if args.action == "status":
+    print(json.dumps({{"ok": True, "completed_stages": [], "ready": False, "text_free": True}}))
+else:
+    Path({str(controller_pid)!r}).write_text(str(os.getpid()))
+    descriptor = int(os.environ["PHASE3_CYCLE007_EXECUTION_LOCK_FD"])
+    process = subprocess.Popen(
+        [sys.executable, {str(child)!r}],
+        env={{**os.environ, "LOCK_FD": str(descriptor)}},
+        pass_fds=(descriptor,),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    Path({str(child_pid)!r}).write_text(str(process.pid))
+    time.sleep(60)
+""",
+        encoding="utf-8",
+    )
+    timed_harness = _write_harness(
+        tmp_path,
+        fixture,
+        controller,
+        stage_timeout_seconds=0.5,
+    )
+    timed = _run_harness(timed_harness, "gemini")
+    assert timed.returncode == 0, timed.stderr
+    assert json.loads(timed.stdout)["failure_code"] == "controller_timeout"
+    _wait_for(child_pid)
+    with pytest.raises(ProcessLookupError):
+        os.kill(int(controller_pid.read_text(encoding="utf-8")), 0)
+    try:
+        replacement = _run_harness(timed_harness, "gemini")
+        assert replacement.returncode == 0, replacement.stderr
         assert json.loads(replacement.stdout)["failure_code"] == "active_worker"
     finally:
         os.kill(int(child_pid.read_text(encoding="utf-8")), signal.SIGKILL)

--- a/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
+++ b/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARDIAN = ROOT / "scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py"
+EXPECTED_TERMINAL = (
+    ROOT / "tests/fixtures/phase3_cycle007_labeling_guardian/terminal-receipt.json"
+)
+STAGES = ("gemini", "grok", "compare", "audit", "adjudicate", "resolve", "certify")
+
+
+def _wait_for(path: Path, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for {path.name}")
+
+
+def _fixture_tree(tmp_path: Path) -> dict[str, Path]:
+    package = tmp_path / "package"
+    backing = tmp_path / "backing"
+    locks = tmp_path / "locks"
+    package.mkdir(mode=0o700)
+    backing.mkdir(mode=0o700)
+    locks.mkdir(mode=0o700)
+    (package / "control").mkdir(mode=0o700)
+    for name in (
+        "label-output-gemini-cycle007-v1",
+        "label-output-grok-cycle007-v1",
+        "dual-label-output-cycle007-v1",
+        "consensus-audit-cycle007-v1",
+        "dual-label-adjudication-cycle007-v1",
+        "dual-label-final-cycle007-v1",
+    ):
+        (backing / name).mkdir(mode=0o700)
+    runner = tmp_path / "runner.py"
+    runner.write_text("# held-out fake provider\n", encoding="utf-8")
+    return {
+        "package": package,
+        "backing": backing,
+        "locks": locks,
+        "runner": runner,
+        "state": package / "control/fake-controller-state.json",
+    }
+
+
+def _write_harness(tmp_path: Path, fixture: dict[str, Path], controller: Path) -> Path:
+    harness = tmp_path / "guardian-harness.py"
+    code_paths = {
+        "grok_runner": fixture["runner"],
+        "compare_runner": fixture["runner"],
+        "audit_runner": fixture["runner"],
+        "adjudicate_runner": fixture["runner"],
+        "resolve_runner": fixture["runner"],
+        "certify_runner": fixture["runner"],
+    }
+    harness.write_text(
+        f"""
+import importlib.util, json, sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("held_out_guardian", {str(GUARDIAN)!r})
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+config = module.Config(
+    action="resume",
+    package=Path({str(fixture['package'])!r}),
+    backing_root=Path({str(fixture['backing'])!r}),
+    guardian_lock=Path({str(fixture['locks'] / 'guardian.lock')!r}),
+    controller_lock=Path({str(fixture['locks'] / 'controller.lock')!r}),
+    execution_lock=Path({str(fixture['locks'] / 'execution.lock')!r}),
+    controller=Path({str(controller)!r}),
+    preflight_receipt=Path({str(tmp_path / 'preflight.json')!r}),
+    gemini_canary_receipt=Path({str(tmp_path / 'gemini.json')!r}),
+    grok_canary_receipt=Path({str(tmp_path / 'grok.json')!r}),
+    code_paths={{{', '.join(f'{label!r}: Path({str(path)!r})' for label, path in code_paths.items())}}},
+    owner_uid=0,
+    owner_gid=0,
+    min_free_bytes=1,
+    through=sys.argv[1],
+    receipt=None,
+    mountinfo=Path("/proc/self/mountinfo"),
+    mount_command="mount",
+    operator_inspected_count=None,
+    resolution_authorization=None,
+    resolution_authority_attestation=None,
+    resolution_authority_root=None,
+    resolution_nonce_ledger=None,
+    resolution_advisor_response=None,
+)
+module._recover_guardian_temporaries = lambda _config: 0
+module._require_free_space = lambda _config: 100
+try:
+    result = module._resume(config, [])
+except module.GuardianError as exc:
+    result = {{"ok": False, "failure_code": str(exc), "text_free": True}}
+print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+""",
+        encoding="utf-8",
+    )
+    return harness
+
+
+def _run_harness(harness: Path, through: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(harness), through],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_held_out_stage_sequence_reaches_terminal_and_second_run_is_noop(tmp_path: Path) -> None:
+    fixture = _fixture_tree(tmp_path)
+    controller = tmp_path / "fake-controller.py"
+    controller.write_text(
+        f"""
+import argparse, json, os
+from pathlib import Path
+
+stages = {STAGES!r}
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("action")
+parser.add_argument("--stage")
+args, _unknown = parser.parse_known_args()
+state_path = Path({str(fixture['state'])!r})
+state = json.loads(state_path.read_text()) if state_path.exists() else {{"completed": [], "calls": []}}
+if args.action == "run":
+    os.fstat(int(os.environ["PHASE3_CYCLE007_EXECUTION_LOCK_FD"]))
+    expected = stages[len(state["completed"])]
+    if args.stage != expected:
+        raise SystemExit(9)
+    state["calls"].append(args.stage)
+    state["completed"].append(args.stage)
+    state_path.write_text(json.dumps(state, sort_keys=True))
+    seal = state_path.parent / f"stage-{{args.stage}}.complete.json"
+    seal.write_text("{{}}")
+result = {{
+    "ok": True,
+    "completed_stages": state["completed"],
+    "ready": state["completed"] == list(stages),
+    "text_free": True,
+}}
+print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+""",
+        encoding="utf-8",
+    )
+    harness = _write_harness(tmp_path, fixture, controller)
+    first = _run_harness(harness, "certify")
+    assert first.returncode == 0, first.stderr
+    first_result = json.loads(first.stdout)
+    state = json.loads(fixture["state"].read_text(encoding="utf-8"))
+    assert first_result["completed_stages"] == list(STAGES)
+    assert len(state["calls"]) == len(STAGES)
+
+    second = _run_harness(harness, "certify")
+    assert second.returncode == 0, second.stderr
+    second_state = json.loads(fixture["state"].read_text(encoding="utf-8"))
+    observed = {
+        "completed_stages": json.loads(second.stdout)["completed_stages"],
+        "provider_call_count": len(state["calls"]),
+        "second_run_provider_call_count": len(second_state["calls"]),
+        "text_free": True,
+    }
+    assert observed == json.loads(EXPECTED_TERMINAL.read_text(encoding="utf-8"))
+
+
+def test_process_death_after_packet_boundary_resumes_at_next_packet(tmp_path: Path) -> None:
+    fixture = _fixture_tree(tmp_path)
+    controller = tmp_path / "packet-controller.py"
+    paused = tmp_path / "paused"
+    controller_pid = tmp_path / "controller.pid"
+    packet_calls = tmp_path / "packet-calls.json"
+    controller.write_text(
+        f"""
+import argparse, json, os, time
+from pathlib import Path
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("action")
+parser.add_argument("--stage")
+args, _unknown = parser.parse_known_args()
+state_path = Path({str(fixture['state'])!r})
+calls_path = Path({str(packet_calls)!r})
+state = json.loads(state_path.read_text()) if state_path.exists() else {{"completed": []}}
+if args.action == "run":
+    Path({str(controller_pid)!r}).write_text(str(os.getpid()))
+    calls = json.loads(calls_path.read_text()) if calls_path.exists() else []
+    next_packet = (calls[-1] + 1) if calls else 1
+    while next_packet <= 3:
+        calls.append(next_packet)
+        temporary = calls_path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(calls))
+        os.replace(temporary, calls_path)
+        if next_packet == 1 and not Path({str(paused)!r}).exists():
+            Path({str(paused)!r}).write_text("ready")
+            time.sleep(60)
+        next_packet += 1
+    state["completed"] = ["gemini"]
+    state_path.write_text(json.dumps(state))
+print(json.dumps({{"ok": True, "completed_stages": state["completed"], "ready": False, "text_free": True}}))
+""",
+        encoding="utf-8",
+    )
+    harness = _write_harness(tmp_path, fixture, controller)
+    first = subprocess.Popen(
+        [sys.executable, str(harness), "gemini"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for(paused)
+    first.kill()
+    os.kill(int(controller_pid.read_text(encoding="utf-8")), signal.SIGKILL)
+    first.wait(timeout=5)
+
+    second = _run_harness(harness, "gemini")
+    assert second.returncode == 0, second.stderr
+    assert json.loads(second.stdout)["completed_stages"] == ["gemini"]
+    assert json.loads(packet_calls.read_text(encoding="utf-8")) == [1, 2, 3]
+
+
+def test_surviving_runner_lock_blocks_replacement_guardian(tmp_path: Path) -> None:
+    fixture = _fixture_tree(tmp_path)
+    controller = tmp_path / "orphan-controller.py"
+    controller_pid = tmp_path / "controller.pid"
+    child_pid = tmp_path / "child.pid"
+    child = tmp_path / "runner-child.py"
+    child.write_text("import os,time; os.fstat(int(os.environ['LOCK_FD'])); time.sleep(60)\n", encoding="utf-8")
+    controller.write_text(
+        f"""
+import argparse, json, os, subprocess, sys, time
+from pathlib import Path
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("action")
+parser.add_argument("--stage")
+args, _unknown = parser.parse_known_args()
+if args.action == "status":
+    print(json.dumps({{"ok": True, "completed_stages": [], "ready": False, "text_free": True}}))
+else:
+    Path({str(controller_pid)!r}).write_text(str(os.getpid()))
+    descriptor = int(os.environ["PHASE3_CYCLE007_EXECUTION_LOCK_FD"])
+    process = subprocess.Popen(
+        [sys.executable, {str(child)!r}],
+        env={{**os.environ, "LOCK_FD": str(descriptor)}},
+        pass_fds=(descriptor,),
+    )
+    Path({str(child_pid)!r}).write_text(str(process.pid))
+    time.sleep(60)
+""",
+        encoding="utf-8",
+    )
+    harness = _write_harness(tmp_path, fixture, controller)
+    first = subprocess.Popen(
+        [sys.executable, str(harness), "gemini"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for(child_pid)
+    first.kill()
+    os.kill(int(controller_pid.read_text(encoding="utf-8")), signal.SIGKILL)
+    first.wait(timeout=5)
+    try:
+        replacement = _run_harness(harness, "gemini")
+        assert replacement.returncode == 0
+        assert json.loads(replacement.stdout)["failure_code"] == "active_worker"
+    finally:
+        os.kill(int(child_pid.read_text(encoding="utf-8")), signal.SIGKILL)
+
+
+def test_adjudicator_return_before_stage_seal_blocks_duplicate_call(tmp_path: Path) -> None:
+    fixture = _fixture_tree(tmp_path)
+    controller = tmp_path / "adjudicate-controller.py"
+    controller_pid = tmp_path / "controller.pid"
+    provider_returned = tmp_path / "provider-returned"
+    call_count = tmp_path / "call-count"
+    completed = ["gemini", "grok", "compare", "audit"]
+    controller.write_text(
+        f"""
+import argparse, json, os, time
+from pathlib import Path
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("action")
+parser.add_argument("--stage")
+args, _unknown = parser.parse_known_args()
+completed = {completed!r}
+if args.action == "run":
+    Path({str(controller_pid)!r}).write_text(str(os.getpid()))
+    count_path = Path({str(call_count)!r})
+    count = int(count_path.read_text()) if count_path.exists() else 0
+    count_path.write_text(str(count + 1))
+    Path({str(provider_returned)!r}).write_text("returned")
+    time.sleep(60)
+print(json.dumps({{"ok": True, "completed_stages": completed, "ready": False, "text_free": True}}))
+""",
+        encoding="utf-8",
+    )
+    harness = _write_harness(tmp_path, fixture, controller)
+    first = subprocess.Popen(
+        [sys.executable, str(harness), "adjudicate"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for(provider_returned)
+    first.kill()
+    os.kill(int(controller_pid.read_text(encoding="utf-8")), signal.SIGKILL)
+    first.wait(timeout=5)
+
+    replacement = _run_harness(harness, "adjudicate")
+    assert replacement.returncode == 0
+    assert json.loads(replacement.stdout)["failure_code"] == "ambiguous_provider_attempt"
+    assert call_count.read_text(encoding="utf-8") == "1"


### PR DESCRIPTION
Closes #6375

## Outcome
- adds a lightweight Linux guardian for the existing Cycle007 controller
- keeps all six label output roots on an explicit separate filesystem through verified bind mounts
- carries one execution lock through guardian, controller, and stage runner
- resumes only from verified stage/packet state and fail-stops ambiguous paid attempts
- keeps prepare/status/plan provider-free and enforces explicit --through boundaries

## Safety
- labeling remains OFF
- no provider was called
- no evidence, prompt, label schema, model, endpoint, denominator, chunk size, custody, or certification policy changed

## Verification
- 46 focused and existing controller tests passed
- ruff passed
- git diff --check passed
- approved plan SHA-256: 7b3baa7f206b2362e02741a39a392881de8de6bac7e557e41ef5853b3ee1b03b

X-Agent: codex/6375-labeling-runtime