### PR TITLE
ci(fastlane): run workflow-pinning tests on PR-tier workflow changes (#7274)

### DIFF
--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -62,7 +62,7 @@ def is_repo_invariant_trigger(path: str) -> bool:
         candidate.suffix == ".py"
         or path == "pyproject.toml"
         or fnmatchcase(candidate.name, "requirements*.txt")
-        or path == ".github/workflows/ci.yml"
+        or path.startswith(".github/workflows/")
         or path == "scripts/ci/fastlane_always_tests.txt"
         or candidate.suffix == ".sh"
         or path == "services.sh"

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -3,6 +3,7 @@ tests/api/test_import_pinning.py
 tests/test_ask_opencode.py
 tests/test_bio_preparation_ci_routing.py
 tests/test_ci_changed_tests.py
+tests/test_ci_queue_starvation.py
 tests/test_cyrillic_roundtrip_invariant.py
 tests/test_fleet_routing_open_model_data_import_guard.py
 tests/test_frontend_change_scope.py

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -80,12 +80,26 @@ def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:
         "pyproject.toml",
         "requirements-dev.txt",
         ".github/workflows/ci.yml",
+        ".github/workflows/hygiene.yml",
         "scripts/ci/fastlane_always_tests.txt",
         "site/src/data/lexicon-manifest.fingerprint.json",
         "site/src/data/lexicon-manifest.pointer.json",
         "tests/fixtures/example.json",
     ):
         assert changed_tests.select_test_modules([path], include_repo_invariants=True) == sorted(_manifest())
+
+
+def test_workflow_changes_trigger_repo_invariant_manifest_and_select_queue_starvation() -> None:
+    for path in (
+        ".github/workflows/ci.yml",
+        ".github/workflows/hygiene.yml",
+        ".github/workflows/ci-gate-queue-recovery.yml",
+        ".github/workflows/security-audit.yml",
+        ".github/workflows/ui-policy-gate.yml",
+    ):
+        selected = changed_tests.select_test_modules([path], include_repo_invariants=True)
+        assert selected == sorted(_manifest())
+        assert "tests/test_ci_queue_starvation.py" in selected
 
 
 def test_repo_invariant_manifest_entries_are_not_duplicated() -> None:

--- a/tests/test_ci_queue_starvation.py
+++ b/tests/test_ci_queue_starvation.py
@@ -23,6 +23,8 @@ from scripts.ci.queue_starvation_recovery import (
     select_candidate_runs,
 )
 
+pytestmark = pytest.mark.repo_invariant
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CI = _REPO_ROOT / ".github/workflows/ci.yml"
 _HYGIENE = _REPO_ROOT / ".github/workflows/hygiene.yml"

--- a/tests/test_repo_invariant_fastlane.py
+++ b/tests/test_repo_invariant_fastlane.py
@@ -53,6 +53,10 @@ ADJUDICATIONS: dict[str, tuple[str, str]] = {
         "listed",
         "cheap deterministic scan of the script-path bridge package",
     ),
+    "tests/test_ci_queue_starvation.py": (
+        "listed",
+        "pins workflow structure and queue starvation mitigations",
+    ),
     "tests/test_work_privacy.py": (
         "exempt",
         "private-boundary canary sweep stays out of the public PR fastlane",


### PR DESCRIPTION
## Summary
- Treat every path under `.github/workflows/` as a PR-tier repo-invariant trigger (not only `ci.yml`).
- Add `tests/test_ci_queue_starvation.py` to the fastlane always-list so workflow-pinning tests run on the PR tier.
- Mutation check (quoted in the worker result): `timeout-minutes: 8` → `assert 8 <= 7` red on that test when selected via the new trigger.

Fixes the class that let #7272 look PR-tier green while merge-group failed (`assert 7 <= 2` before the bound was raised).

Closes #7274. Refs #7263, #7272, #4811, #7250.

## Driver verification (primary venv, worktree)
```
36 passed in 18.88s  (test_ci_changed_tests + test_ci_queue_starvation + test_repo_invariant_fastlane)
ruff: All checks passed!
selector smoke: `.github/workflows/ci.yml` and `hygiene.yml` both select test_ci_queue_starvation.py (15 invariant modules)
```

Author lane: agy (Cursor first-pick was unauthenticated on this host; NOTE substitution). CF: kimi (outside Gemini).

CLOBBER SELF-AUDIT: one line replaced (`path == ".github/workflows/ci.yml"` → `path.startswith(".github/workflows/")`); nothing else deleted.