### PR TITLE
fix(opsec): remove session-streams/orient/authority path fields — burn-down family 1 (#7182)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -4,7 +4,7 @@ Base URL: `http://localhost:8765`
 
 FastAPI auto-docs: `http://localhost:8765/docs` (Swagger UI)
 
-**Definition authority for the public surface**: `GET /api/contracts/routes` (returns the full `route_contracts` + `page_contracts` registry with `purpose`, `source_of_truth`, `freshness`, `consumers`, `overlap`, `stale_risk`, `recommendation`, `mutates`, `replacement` for every endpoint family and every `dashboards/*.html` page).
+**Definition authority for the public surface**: `GET /api/contracts/routes` (returns the full `route_contracts` + `page_contracts` registry with `purpose`, `source_of_truth`, `freshness`, `consumers`, `overlap`, `stale_risk`, `recommendation`, `mutates`, `replacement`, and `response_schema_version` for every endpoint family and every `dashboards/*.html` page).
 
 This (plus the live `meta` objects returned by many endpoints) is the enforced, machine-readable definition of the declared API surface. The running code in `scripts/api/*.py` is the ultimate behavioral authority. `docs/MONITOR-API.md` is the human narrative. Dashboards are consumers/visualizers that should (and increasingly do) derive from the contracts. See `scripts/api/route_contracts.py` and `tests/test_monitor_route_contracts.py`. The 2026-06-07 Monitor API/UI Audit (#2794) is the origin of this registry.
 
@@ -142,9 +142,9 @@ canaries. It exempts SHA values, RFC3339 timestamps, `epic:<N>` identifiers,
 corpus protects those boundaries.
 
 Each exercised record derives success and redirect statuses from OpenAPI and
-also permits the explicit isolated-fixture error contract: 200, 400, 401,
-403, 404, 409, 410, 422, 500, and 503. Any other returned status fails the
-invariant.
+permits the documented isolated-fixture 4xx contract. A 5xx is refused unless
+the registry record carries a route-specific reason and explicitly expects it;
+any other returned status fails the invariant.
 
 PR-A is intentionally green with a shrinking exception table at
 [`tests/api/opsec_sweep/known_leaks.toml`](../tests/api/opsec_sweep/known_leaks.toml).
@@ -156,11 +156,11 @@ atomically; the following manifest is the record of those boundaries:
 
 | Emitter family | Current path-bearing fields | Known consumers | PR-B shape | Schema version |
 | --- | --- | --- | --- | --- |
-| `session_streams_router.py` | `repo_root`, `db_path` | `tests/test_session_streams_api.py` | `repo: {role, sha}`, `store: {reachable, schema_versions}` | `session-streams.v2` |
-| `repository_authority.py`, `preparation_state.py`, `state_router.py` | checkout and authority roots | `tests/test_orient_api.py` and preparation/state clients | `primary_checkout: {role, head_sha, dirty_count}`, `cwd_role` | `authority.v2` |
+| `session_streams_router.py` | `repo_root`, `db_path` (removed) | `tests/test_session_streams_api.py` | `repo: {role, sha}`, `store: {reachable, schema_versions}` | `session-streams.v2 — DONE` |
+| `repository_authority.py`, `preparation_state.py`, `state_router.py` | checkout and authority roots (removed) | `tests/test_orient_api.py` and preparation/state clients | `primary_checkout: {role, head_sha, dirty_count}`, `cwd_role` | `authority.v2 — DONE` |
 | `worktrees_router.py` | worktree filesystem paths | worktree dashboards and guardrail consumers | opaque worktree id, branch, role | `worktrees.v2` |
 | `comms_router.py`, fleet facade collectors | broker/fleet database paths | comms and fleet dashboards | `store: {reachable, kind}` | `comms.v2` |
-| `main.py` orient collectors | Git roots and diagnostic paths | orient clients and `tests/test_orient_api.py` | role/head metadata only | `orient.v2` |
+| `main.py` orient collectors | Git roots and diagnostic paths (removed) | orient clients and `tests/test_orient_api.py` | role/head metadata only | `orient.v2 — DONE` |
 | `telemetry.response` | transcript filenames | Monitor telemetry consumers | retain context/window/source; drop filename | `telemetry.v2` |
 
 The global error handlers preserve status codes and return
@@ -2456,7 +2456,8 @@ Query params:
     "head": "cb5f47d19",
     "authority": {
       "repository": "learn-ukrainian/learn-ukrainian.github.io",
-      "data_checkout": {"role": "live_primary", "root": "/fixed/repo", "branch": "main", "head_sha": "<40-hex>"},
+      "primary_checkout": {"role": "live_primary", "head_sha": "<40-hex>", "dirty_count": 0},
+      "cwd_role": "primary",
       "service_code": {"mode": "release", "commit_sha": "<40-hex>", "tree_sha256": "<64-hex>"}
     }
   },

--- a/docs/runbooks/session-streams-monitor-api.md
+++ b/docs/runbooks/session-streams-monitor-api.md
@@ -31,7 +31,7 @@ bootstrap attempt.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| GET | `/api/session-streams/v1/health` | DB presence / repo root |
+| GET | `/api/session-streams/v1/health` | DB reachability / repo identity |
 | GET | `/api/session-streams/v1/status/{stream_id}` | Lease/handoff diagnosis (`epic:N`) |
 | GET | `/api/session-streams/v1/digest/{stream_id}?limit=20` | Pinned + recent entries |
 | GET | `/api/session-streams/v1/dual-write-status` | Handoff file inventory existence |

--- a/schemas/agent-preparation-state.v1.schema.json
+++ b/schemas/agent-preparation-state.v1.schema.json
@@ -21,20 +21,20 @@
     "authority": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repository", "data_checkout", "service_code", "manifest"],
+      "required": ["repository", "primary_checkout", "cwd_role", "service_code", "manifest"],
       "properties": {
         "repository": {"type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$"},
-        "data_checkout": {
+        "primary_checkout": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["role", "root", "branch", "head_sha"],
+          "required": ["role", "head_sha", "dirty_count"],
           "properties": {
             "role": {"enum": ["live_primary", "dispatch_worktree", "linked_worktree"]},
-            "root": {"type": "string", "minLength": 1},
-            "branch": {"type": ["string", "null"]},
-            "head_sha": {"$ref": "#/$defs/commitSha"}
+            "head_sha": {"$ref": "#/$defs/commitSha"},
+            "dirty_count": {"type": "integer", "minimum": 0}
           }
         },
+        "cwd_role": {"enum": ["primary", "worktree", "other"]},
         "service_code": {
           "type": "object",
           "additionalProperties": false,

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -95,7 +95,7 @@ from .ops_router import router as ops_router
 from .preload import preload_all
 from .project_state_router import router as project_state_router
 from .rag_router import router as sources_router
-from .repository_authority import build_repository_authority
+from .repository_authority import build_repository_authority, cwd_role
 from .resilience import get_resilience_snapshot, resilience_middleware
 from .reviewer_ghosts_router import router as reviewer_ghosts_router
 from .rollover_router import collect_rollover_orient_data
@@ -498,6 +498,7 @@ def _run_command(args: list[str], *, timeout: float = 2.0) -> subprocess.Complet
 def _collect_git_orient_data() -> dict:
     branch_proc = _run_command(["git", "branch", "--show-current"])
     head_proc = _run_command(["git", "rev-parse", "--short=9", "HEAD"])
+    full_head_proc = _run_command(["git", "rev-parse", "HEAD"])
     ahead_proc = _run_command(["git", "rev-list", "--count", "origin/main..HEAD"])
     log_proc = _run_command(["git", "log", "--oneline", "-5"])
 
@@ -524,20 +525,19 @@ def _collect_git_orient_data() -> dict:
             ahead_value = 0
     try:
         primary_status = worktree_containment.primary_checkout_dirty_status(LIVE_REPO_ROOT)
-    except Exception as exc:
+    except Exception:
         branch = branch_proc.stdout.strip()
         primary_status = {
-            "main_root": str(LIVE_REPO_ROOT),
+            "role": "primary",
+            "head_sha": (
+                full_head_proc.stdout.strip()
+                if full_head_proc.returncode == 0
+                else None
+            ),
             "branch": branch,
             "protected_branch": branch in worktree_containment.PROTECTED_BRANCHES,
             "dirty": False,
             "dirty_count": 0,
-            "tracked_dirty_count": 0,
-            "untracked_dirty_count": 0,
-            "entries": [],
-            "checked_cwd": str(LIVE_REPO_ROOT),
-            "checked_command": "git status --porcelain=v1 -z --untracked-files=all",
-            "error": str(exc),
         }
 
     branch = branch_proc.stdout.strip()
@@ -552,7 +552,13 @@ def _collect_git_orient_data() -> dict:
         "ahead_of_origin": ahead_value,
         "recent_commits": recent_commits,
         "primary_checkout_dirty": primary_status["dirty"],
-        "primary_checkout": primary_status,
+        "primary_checkout": {
+            "role": primary_status.get("role", "primary"),
+            "head_sha": primary_status.get("head_sha")
+            or (full_head_proc.stdout.strip() if full_head_proc.returncode == 0 else None),
+            "dirty_count": int(primary_status.get("dirty_count", 0)),
+        },
+        "cwd_role": cwd_role(Path(LIVE_REPO_ROOT)),
         "authority": authority,
     }
 

--- a/scripts/api/repository_authority.py
+++ b/scripts/api/repository_authority.py
@@ -38,6 +38,18 @@ def _checkout_role(root: Path) -> str:
     return "live_primary"
 
 
+def cwd_role(root: Path) -> str:
+    """Classify the serving cwd without returning its filesystem location."""
+    if is_release_root(root):
+        return "other"
+    git_entry = root / ".git"
+    if git_entry.is_file():
+        return "worktree"
+    if git_entry.is_dir():
+        return "primary"
+    return "other"
+
+
 def _git(cwd: Path, *args: str) -> str:
     try:
         result = subprocess.run(
@@ -103,6 +115,28 @@ def _release_identity(project_root: Path) -> dict[str, str | None]:
     }
 
 
+def _dirty_count(root: Path) -> int:
+    """Return only the number of non-ignored dirty entries."""
+    status = _git(root, "status", "--porcelain=v1", "--untracked-files=all")
+    return sum(1 for line in status.splitlines() if line)
+
+
+def build_repository_identity(root: Path) -> dict[str, str | None]:
+    """Return the stable live/release identity used by session-stream routes."""
+    resolved = root.resolve()
+    try:
+        candidate = _git(resolved, "rev-parse", "HEAD")
+        sha = candidate if _FULL_SHA_RE.fullmatch(candidate) else None
+    except Exception:
+        # Health and inventory remain useful when the configured checkout is
+        # unavailable; the absence of a SHA is explicit and path-free.
+        sha = None
+    return {
+        "role": "release" if is_release_root(resolved) else "live",
+        "sha": sha,
+    }
+
+
 def build_repository_authority(
     *,
     project_root: Path,
@@ -112,8 +146,9 @@ def build_repository_authority(
 ) -> dict[str, object]:
     """Build the single authority envelope used by agent-facing API routes.
 
-    The only filesystem path exposed is the configured, fixed live-data root.
-    Callers cannot select another root, branch, commit, or worktree.
+    Callers receive stable repository identity and checkout metadata, never a
+    filesystem path. Callers cannot select another root, branch, commit, or
+    worktree.
     """
     try:
         data_root = live_repo_root.resolve(strict=True)
@@ -122,18 +157,17 @@ def build_repository_authority(
         raise RepositoryAuthorityError("configured repository root is unavailable") from exc
 
     remote = _git(data_root, "remote", "get-url", "origin")
-    branch = data_branch if data_branch is not None else _git(data_root, "branch", "--show-current")
     head_sha = data_head_sha if data_head_sha is not None else _git(data_root, "rev-parse", "HEAD")
     if not _FULL_SHA_RE.fullmatch(head_sha):
         raise RepositoryAuthorityError("live-data checkout SHA is invalid")
 
     return {
         "repository": _repository_slug(remote),
-        "data_checkout": {
+        "primary_checkout": {
             "role": _checkout_role(data_root),
-            "root": str(data_root),
-            "branch": branch or None,
             "head_sha": head_sha,
+            "dirty_count": _dirty_count(data_root),
         },
+        "cwd_role": cwd_role(code_root),
         "service_code": _release_identity(code_root),
     }

--- a/scripts/api/repository_authority.py
+++ b/scripts/api/repository_authority.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 from scripts.common.git_context import sanitized_git_env
 from scripts.common.release_layout import MANIFEST_NAME, is_release_root
+from scripts.guardrails.worktree_containment import classify_repo_path
 
 _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _HASH_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -32,10 +33,17 @@ def preparation_data_root(*, project_root: Path, live_repo_root: Path) -> Path:
 
 
 def _checkout_role(root: Path) -> str:
-    git_entry = root / ".git"
-    if git_entry.is_file():
-        return "dispatch_worktree" if ".worktrees/dispatch" in root.as_posix() else "linked_worktree"
-    return "live_primary"
+    """Return the stable public role for a real checkout's structural class."""
+    path_class = classify_repo_path(root, cwd=root)
+    return {
+        "primary_checkout": "live_primary",
+        "dispatch_worktree": "dispatch_worktree",
+        "other_worktree": "linked_worktree",
+        # ``build_repository_authority`` has already proved that this is a Git
+        # checkout. Preserve the historical fallback for unusual Git layouts
+        # that the containment classifier cannot anchor to a primary root.
+        "outside_repo": "live_primary",
+    }[path_class]
 
 
 def cwd_role(root: Path) -> str:

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -31,6 +31,7 @@ class RouteContract:
     recommendation: str
     mutates: bool = False
     replacement: str | None = None
+    response_schema_version: str | None = None
 
     def matches(self, path: str, kind: ContractKind) -> bool:
         if self.kind != kind:
@@ -83,6 +84,19 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         mutates=True,
     ),
     RouteContract(
+        "/api/session-streams",
+        "prefix",
+        "http",
+        "Read-only session-stream health, status, digest, dual-write, and projection-drift surfaces.",
+        "SessionStreamStore plus bounded legacy-handoff inventory and projection receipts.",
+        "Health and inventory are generated per request; store schema versions are read from the configured database.",
+        ("agents", "Monitor", "session-stream consumers"),
+        "Complements the remote /api/epics/v1 lifecycle projection; it never exposes filesystem paths.",
+        "medium if callers treat local inventory as remote lease authority",
+        "keep as the path-free session-stream observability contract",
+        response_schema_version="session-streams.v2",
+    ),
+    RouteContract(
         "/api/ops/entire-context",
         "prefix",
         "http",
@@ -130,6 +144,7 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "Replaces readiness inferences from legacy /api/state/summary, /module, and /ready-to-build telemetry.",
         "low — failures in manifest, readiness contracts, selectors, or repository authority fail closed",
         "keep as the canonical agent-facing curriculum preparation contract",
+        response_schema_version="authority.v2",
     ),
     RouteContract(
         "/api/state/ready-to-build",
@@ -656,6 +671,7 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "Aggregates many other API sections.",
         "low/medium when upstream collectors degrade",
         "keep cold-start source of truth",
+        response_schema_version="orient.v2",
     ),
     RouteContract(
         "/api/rollovers",

--- a/scripts/api/session_streams_router.py
+++ b/scripts/api/session_streams_router.py
@@ -22,7 +22,7 @@ from agents_extensions.shared.session_streams.projection import (
 from agents_extensions.shared.session_streams.store import NotFoundError, SessionStreamStore
 
 from .config import LIVE_REPO_ROOT, PROJECT_ROOT
-from .repository_authority import preparation_data_root
+from .repository_authority import build_repository_identity, preparation_data_root
 
 router = APIRouter(tags=["session-streams"])
 
@@ -50,20 +50,37 @@ def _db_path() -> Path:
 def _store() -> SessionStreamStore:
     db_path = _db_path()
     if not db_path.is_file():
-        raise FileNotFoundError(f"session-stream database does not exist: {db_path}")
+        raise FileNotFoundError("session-stream database is unavailable")
     return SessionStreamStore(SessionStreamDatabase(db_path))
+
+
+def _store_health() -> dict[str, Any]:
+    """Return store reachability and migration versions without its path."""
+    connection = None
+    try:
+        connection = SessionStreamDatabase(_db_path()).connect(read_only=True)
+        versions = [
+            int(row[0])
+            for row in connection.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        ]
+        return {"reachable": True, "schema_versions": versions}
+    except Exception:
+        return {"reachable": False, "schema_versions": []}
+    finally:
+        if connection is not None:
+            connection.close()
 
 
 @router.get("/v1/health")
 def session_streams_health() -> dict[str, Any]:
     """Liveness for the session-streams monitor surface (no cutover)."""
     root = _repo_root()
-    db_path = _db_path()
     return {
         "ok": True,
-        "repo_root": str(root),
-        "db_exists": db_path.is_file(),
-        "db_path": str(db_path),
+        "repo": build_repository_identity(root),
+        "store": _store_health(),
         "cutover": "operator-gated",
     }
 
@@ -78,7 +95,7 @@ def session_stream_status(stream_id: str) -> dict[str, Any]:
     except (NotFoundError, FileNotFoundError) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive API boundary
-        raise HTTPException(status_code=500, detail=f"status_failed:{exc}") from exc
+        raise HTTPException(status_code=500, detail="status_failed") from exc
     return status.as_dict()
 
 
@@ -95,7 +112,7 @@ def session_stream_digest(
     except (NotFoundError, FileNotFoundError) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
-        raise HTTPException(status_code=500, detail=f"digest_failed:{exc}") from exc
+        raise HTTPException(status_code=500, detail="digest_failed") from exc
     return {
         "stream_id": stream_id,
         "limit": limit,
@@ -116,14 +133,14 @@ def dual_write_status() -> dict[str, Any]:
             "stream_id": c.stream_id,
             "stream_name": c.stream_name,
             "title": c.title,
-            "path": str(c.path.relative_to(root)) if c.path.is_relative_to(root) else str(c.path),
             "exists": c.exists,
         }
         for c in candidates
     ]
     missing = sum(1 for r in rows if not r["exists"])
     return {
-        "repo_root": str(root),
+        "repo": build_repository_identity(root),
+        "store": _store_health(),
         "total": len(rows),
         "missing_files": missing,
         "candidates": rows,
@@ -163,7 +180,7 @@ def projection_drift(
     try:
         batch = detect_projection_drift(store, root, stream_ids=stream_ids)
     except Exception as exc:  # pragma: no cover
-        raise HTTPException(status_code=500, detail=f"drift_failed:{exc}") from exc
+        raise HTTPException(status_code=500, detail="drift_failed") from exc
     # ProjectionBatchResult may be a dataclass — best-effort serialization
     if hasattr(batch, "as_dict"):
         payload = batch.as_dict()

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1831,7 +1831,8 @@ def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
     return (
         "❌ primary checkout is dirty; refusing write-capable dispatch before "
         "creating branch/worktree residue.\n"
-        f"   cwd: {status.get('checked_cwd')}\n"
+        f"   checkout role: {status.get('role')}\n"
+        f"   head: {status.get('head_sha')}\n"
         f"   command: {status.get('checked_command')}\n"
         f"   branch: {status.get('branch')}\n"
         f"   dirty files: {_format_dirty_entries(entries)}\n"

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -465,6 +465,9 @@ def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
     branch = current_branch(main_root)
     heal = heal_primary_bare_if_needed(main_root)
 
+    head_proc = _run_git(main_root, "rev-parse", "HEAD")
+    head_sha = head_proc.stdout.strip() if head_proc.returncode == 0 else None
+
     command = ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all")
     proc = _run_git(main_root, *command[1:])
     if proc.returncode != 0:
@@ -478,7 +481,8 @@ def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
     tracked_count = sum(1 for entry in entries if entry["kind"] == "tracked")
     untracked_count = sum(1 for entry in entries if entry["kind"] == "untracked")
     return {
-        "main_root": str(main_root),
+        "role": "primary",
+        "head_sha": head_sha,
         "branch": branch,
         "protected_branch": branch in PROTECTED_BRANCHES if branch else False,
         "dirty": bool(entries),
@@ -486,7 +490,6 @@ def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
         "tracked_dirty_count": tracked_count,
         "untracked_dirty_count": untracked_count,
         "entries": entries,
-        "checked_cwd": str(main_root),
         "checked_command": " ".join(command),
         "bare_primary": False,
         "bare_healed": bool(heal.get("healed")),

--- a/tests/api/opsec_sweep/known_leaks.toml
+++ b/tests/api/opsec_sweep/known_leaks.toml
@@ -102,20 +102,6 @@ owner = "monitor-retention"
 expiry = "2026-09-23"
 
 [[known_leaks]]
-id = "session-health-repo-root"
-operation = "GET /api/session-streams/v1/health"
-field = "body.repo_root"
-owner = "monitor-session-streams"
-expiry = "2026-09-23"
-
-[[known_leaks]]
-id = "session-health-db-path"
-operation = "GET /api/session-streams/v1/health"
-field = "body.db_path"
-owner = "monitor-session-streams"
-expiry = "2026-09-23"
-
-[[known_leaks]]
 id = "dashboard-index-localhost"
 operation = "dashboard:index.html"
 field = "body"

--- a/tests/api/opsec_sweep/registry.py
+++ b/tests/api/opsec_sweep/registry.py
@@ -34,13 +34,29 @@ FROZEN_WEBSOCKET_ROUTE_COUNT = 1
 FROZEN_DENOMINATOR_SHA256 = "4876620305f8035f30103fc6f2d0f0d4f22e43dfb00247f1a7aa32604cbccd20"
 
 # The OpenAPI document records the successful response for most operations,
-# while the isolated PR-A fixture deliberately exercises empty stores,
-# denied subprocess seams, and invalid synthetic identifiers. These are the
-# documented framework/domain error outcomes accepted by every exercised
-# record; the route test still fails on any status outside this contract.
+# while the isolated fixture deliberately exercises empty stores, denied
+# subprocess seams, and invalid synthetic identifiers. Read records must not
+# silently bless a server error: an exercised 5xx needs a route-specific
+# record reason and explicit expected status.
 DOCUMENTED_EXERCISE_STATUSES = frozenset(
     {200, 400, 401, 403, 404, 409, 410, 422, 500, 503}
 )
+
+EXERCISED_READ_5XX_REASONS: dict[str, str] = {
+    "GET /api/comms/by-module/{track}/{slug}": "isolated fixture has no broker module rows",
+    "GET /api/comms/channels/{name}": "isolated fixture has no broker channel store",
+    "GET /api/comms/channels/{name}/deliveries": "isolated fixture has no broker delivery store",
+    "GET /api/comms/channels/{name}/messages": "isolated fixture has no broker message store",
+    "GET /api/comms/channels/{name}/threads/{thread_id}": "isolated fixture has no broker thread store",
+    "GET /api/dashboard/comms/conversation/{task_id}": "isolated fixture has no dashboard comms store",
+    "GET /api/dashboard/comms/message/{message_id}": "isolated fixture has no dashboard comms store",
+    "GET /api/dashboard/comms/messages": "isolated fixture has no dashboard comms store",
+    "GET /api/epics/v1": "isolated fixture has no seeded epic registry snapshot",
+    "GET /api/rules": "isolated fixture has no deployed rule files",
+    "GET /api/state/preparation": "sparse isolated fixture omits the curriculum tree",
+    "GET /api/state/preparation/{track}/{slug}": "sparse isolated fixture omits the curriculum tree",
+    "GET /api/work/v1/next": "isolated fixture has no warm work projection",
+}
 
 _CONVERTER_RE = re.compile(r"\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::[^}]+)?\}")
 _PATH_PARAM_RE = re.compile(r"\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::[^}]+)?\}")
@@ -359,6 +375,9 @@ def _record_for(operation: Operation, openapi_by_key: Mapping[str, Any]) -> Exer
         if str(status).isdigit()
     )
     statuses = tuple(sorted(set(statuses) | DOCUMENTED_EXERCISE_STATUSES))
+    explicit_5xx_reason = EXERCISED_READ_5XX_REASONS.get(operation.key)
+    if explicit_5xx_reason is None:
+        statuses = tuple(status for status in statuses if not 500 <= status < 600)
 
     if operation.path_template in {
         "/api/epics/v1/{stream_id}/bundles",
@@ -419,6 +438,7 @@ def _record_for(operation: Operation, openapi_by_key: Mapping[str, Any]) -> Exer
         path_values=path_values,
         query=_query_for(operation.path_template),
         body_factory=_body_factory(operation.path_template),
+        reason=explicit_5xx_reason,
         expected_statuses=statuses,
     )
 

--- a/tests/api/opsec_sweep/test_opsec_route_sweep.py
+++ b/tests/api/opsec_sweep/test_opsec_route_sweep.py
@@ -279,6 +279,7 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
     # values at the seam so the route exercises its normal response shaping.
     monkeypatch.setattr(project_state_collect, "_git", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(repository_authority, "_git", _fixture_authority_git)
+    monkeypatch.setattr(repository_authority, "classify_repo_path", lambda *_args, **_kwargs: "primary_checkout")
     monkeypatch.setattr(
         git_hygiene_router,
         "_run_git",

--- a/tests/api/opsec_sweep/test_opsec_route_sweep.py
+++ b/tests/api/opsec_sweep/test_opsec_route_sweep.py
@@ -24,6 +24,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.dual_write import HandoffCandidate
 from agents_extensions.shared.session_streams.store import SessionStreamStore
 from scripts.api import (
     docs_router,
@@ -37,6 +38,7 @@ from scripts.api import (
     project_state_collect,
     project_state_router,
     repository_authority,
+    route_contracts,
     session_streams_router,
     site_router,
     state_helpers,
@@ -45,6 +47,7 @@ from scripts.api import (
 )
 from scripts.api import main as api_main
 from scripts.fleet_comms import cold_start_board, message_plane
+from scripts.guardrails import worktree_containment
 from scripts.lexicon.runner import atlas_job
 from scripts.orchestration import reap_worktrees
 from scripts.wiki import sources_db
@@ -71,8 +74,6 @@ FROZEN_IDS = frozenset(
         "retention-plan-dir",
         "retention-archive-root",
         "session-digest-detail",
-        "session-health-repo-root",
-        "session-health-db-path",
         "session-status-detail",
         "dashboard-index-localhost",
         "dashboard-work-loopback",
@@ -215,10 +216,6 @@ def _fixture_cold_start_board(
     }
 
 
-def _fixture_session_inventory_unavailable(_root: Path) -> list[Any]:
-    raise FileNotFoundError("isolated OPSEC fixture has no session inventory")
-
-
 @pytest.fixture
 def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> IsolatedFixture:
     """Redirect existing API seams into a canary-planted disposable tree."""
@@ -241,6 +238,11 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
     monkeypatch.setattr(work_router, "_IN_FLIGHT_BUILDS", {})
     epics_store = SessionStreamStore(SessionStreamDatabase(root / "stores" / "epics.sqlite3"))
     monkeypatch.setattr(epics_router, "_store", lambda: epics_store)
+    session_database = SessionStreamDatabase(root / "stores" / "session-streams.sqlite3")
+    session_connection = session_database.connect()
+    session_connection.close()
+    handoff_path = root / "batch_state" / "session-handoff.md"
+    handoff_path.write_text("fixture handoff\n", encoding="utf-8")
     monkeypatch.setattr(api_main, "_health_instance_identity", _fixture_health_identity)
     monkeypatch.setattr(project_state_router, "allowed_reporter_host_ids", lambda: frozenset())
     monkeypatch.setattr(fleet_router, "build_cold_start_board", _fixture_cold_start_board)
@@ -331,7 +333,19 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
         lambda: root / "stores" / "session-streams.sqlite3",
     )
     monkeypatch.setattr(session_streams_router, "_store", lambda: _FixtureSessionStore())
-    monkeypatch.setattr(session_streams_router, "list_handoff_candidates", _fixture_session_inventory_unavailable)
+    monkeypatch.setattr(
+        session_streams_router,
+        "list_handoff_candidates",
+        lambda _root: [
+            HandoffCandidate(
+                stream_id="epic:4707",
+                path=handoff_path,
+                exists=True,
+                stream_name="fixture",
+                title="fixture handoff",
+            )
+        ],
+    )
     monkeypatch.setattr(
         session_streams_router,
         "diagnose_handoff",
@@ -342,6 +356,25 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
         session_streams_router,
         "detect_projection_drift",
         lambda *_args, **_kwargs: {"status": "fixture"},
+    )
+    monkeypatch.setattr(
+        worktree_containment,
+        "primary_checkout_dirty_status",
+        lambda _start: {
+            "role": "primary",
+            "head_sha": "0" * 40,
+            "branch": "opsec-fixture",
+            "protected_branch": False,
+            "dirty": False,
+            "dirty_count": 0,
+            "tracked_dirty_count": 0,
+            "untracked_dirty_count": 0,
+            "entries": [],
+            "checked_command": "git status --porcelain=v1 -z --untracked-files=all",
+            "bare_primary": False,
+            "bare_healed": False,
+            "bare_heal_message": None,
+        },
     )
 
     monkeypatch.setattr(cold_start_board, "_get_local_git_info", lambda: {
@@ -540,9 +573,55 @@ def test_route_registry_matches_openapi_and_classifies_every_operation() -> None
     assert by_key["GET /api/epics/v1/{stream_id}/bundles"].classification == "read"
     assert by_key["GET /api/epics/v1/{stream_id}/bundles/latest"].classification == "read"
     assert by_key["GET /api/epics/v1/{stream_id}/bundles/{upload_seq}"].classification == "read"
+    assert route_contracts.contract_for_route("/api/session-streams/v1/health").response_schema_version == "session-streams.v2"
+    assert route_contracts.contract_for_route("/api/state/preparation").response_schema_version == "authority.v2"
+    assert route_contracts.contract_for_route("/api/orient").response_schema_version == "orient.v2"
     for record in records:
         if record.fixture == "skip":
             assert record.owner and record.reason and record.expiry
+
+
+def test_exercised_read_registry_refuses_unexplained_5xx() -> None:
+    records = registry.build_registry(api_main.app)
+    unexplained = [
+        record.key
+        for record in records
+        if record.fixture != "skip"
+        and record.classification in {"read", "read-side-effect"}
+        and any(500 <= status < 600 for status in record.expected_statuses)
+        and not record.reason
+    ]
+    assert unexplained == []
+
+
+def test_family_one_fixture_reaches_dual_write_and_orient_git_happy_paths(
+    isolated_fixture: IsolatedFixture,
+) -> None:
+    client = TestClient(api_main.app, raise_server_exceptions=False)
+
+    dual = client.get("/api/session-streams/v1/dual-write-status")
+    assert dual.status_code == 200
+    dual_payload = dual.json()
+    assert dual_payload["total"] == 1
+    assert dual_payload["candidates"][0]["exists"] is True
+    assert "path" not in dual_payload["candidates"][0]
+    assert "repo_root" not in json.dumps(dual_payload)
+    assert "db_path" not in json.dumps(dual_payload)
+
+    orient = client.get("/api/orient", params={"sections": "git"})
+    assert orient.status_code == 200
+    git_payload = orient.json()["git"]
+    assert git_payload["primary_checkout"] == {
+        "role": "primary",
+        "head_sha": "0" * 40,
+        "dirty_count": 0,
+    }
+    assert git_payload["cwd_role"] in {"primary", "worktree", "other"}
+    encoded = json.dumps(git_payload)
+    assert "main_root" not in encoded
+    assert "checked_cwd" not in encoded
+    assert "data_checkout" not in encoded
+    assert isolated_fixture.root.name == PATH_CANARY
 
 
 def test_registry_reports_a_removed_operation() -> None:

--- a/tests/api/test_release_snapshot.py
+++ b/tests/api/test_release_snapshot.py
@@ -484,7 +484,17 @@ def test_real_release_serves_live_data_routers_with_logical_paths(tmp_path: Path
         key_paths = agent_payload["key_paths"]
         assert curriculum_payload["a1"]["module_count"] >= 0
         assert preparation_payload["track"] == "a1"
-        assert preparation_payload["authority"]["data_checkout"]["root"] == str(PROJECT_ROOT.resolve())
+        assert "data_checkout" not in preparation_payload["authority"]
+        expected_role = (
+            "dispatch_worktree"
+            if ".worktrees/dispatch" in PROJECT_ROOT.as_posix()
+            else "linked_worktree"
+            if (PROJECT_ROOT / ".git").is_file()
+            else "live_primary"
+        )
+        assert preparation_payload["authority"]["primary_checkout"]["role"] == expected_role
+        assert len(preparation_payload["authority"]["primary_checkout"]["head_sha"]) == 40
+        assert preparation_payload["authority"]["cwd_role"] == "other"
         assert preparation_payload["authority"]["service_code"]["mode"] == "release"
         assert key_paths["orchestration_dir"].startswith("curriculum/l2-uk-en/")
         assert not key_paths["orchestration_dir"].startswith(str(release_dir))

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -204,12 +204,20 @@ def test_orient_git_exposes_primary_checkout_dirty_signal(monkeypatch, tmp_path)
     assert response.status_code == 200
     git_info = response.json()["git"]
     assert git_info["primary_checkout_dirty"] is True
-    assert git_info["primary_checkout"]["checked_cwd"] == str(repo)
-    assert git_info["primary_checkout"]["tracked_dirty_count"] == 1
-    assert git_info["primary_checkout"]["entries"] == [{"xy": " M", "path": "tracked.txt", "kind": "tracked"}]
+    assert git_info["primary_checkout"] == {
+        "role": "primary",
+        "head_sha": _git(repo, "rev-parse", "HEAD").stdout.strip(),
+        "dirty_count": 1,
+    }
+    assert git_info["cwd_role"] == "primary"
     assert git_info["authority"]["repository"] == "learn-ukrainian/learn-ukrainian.github.io"
-    assert git_info["authority"]["data_checkout"]["root"] == str(repo)
-    assert git_info["authority"]["data_checkout"]["head_sha"] == _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert "data_checkout" not in git_info["authority"]
+    assert git_info["authority"]["primary_checkout"] == {
+        "role": "live_primary",
+        "head_sha": _git(repo, "rev-parse", "HEAD").stdout.strip(),
+        "dirty_count": 1,
+    }
+    assert git_info["authority"]["cwd_role"] == "primary"
     assert git_info["authority"]["service_code"]["mode"] == "development"
 
 
@@ -240,8 +248,14 @@ def test_orient_git_survives_primary_checkout_probe_failure(monkeypatch, tmp_pat
     assert git_info["branch"]
     assert git_info["head"]
     assert git_info["primary_checkout_dirty"] is False
-    assert git_info["primary_checkout"]["error"] == "git status failed"
-    assert git_info["primary_checkout"]["checked_cwd"] == str(repo)
+    assert git_info["primary_checkout"] == {
+        "role": "primary",
+        "head_sha": _git(repo, "rev-parse", "HEAD").stdout.strip(),
+        "dirty_count": 0,
+    }
+    assert git_info["cwd_role"] == "primary"
+    assert "error" not in git_info["primary_checkout"]
+    assert "data_checkout" not in git_info["authority"]
 
 
 def test_health_includes_core_bare_canary(monkeypatch):

--- a/tests/test_preparation_api.py
+++ b/tests/test_preparation_api.py
@@ -14,7 +14,7 @@ from jsonschema import Draft202012Validator
 
 from scripts.api import preparation_state, state_router
 from scripts.api.main import app
-from scripts.api.repository_authority import build_repository_authority, preparation_data_root
+from scripts.api.repository_authority import build_repository_authority, cwd_role, preparation_data_root
 from scripts.orchestration import curriculum_readiness
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -67,6 +67,19 @@ def _repo(path: Path, *, remote: str) -> Path:
     (path / "tracked.txt").write_text(path.name, encoding="utf-8")
     _git(path, "add", "tracked.txt")
     _git(path, "commit", "-q", "-m", "init")
+    return path
+
+
+def _clone_repo(source: Path, path: Path) -> Path:
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(source), str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+        timeout=120,
+    )
+    _git(path, "remote", "set-url", "origin", "https://github.com/learn-ukrainian/learn-ukrainian.github.io.git")
     return path
 
 
@@ -474,10 +487,41 @@ def test_repository_authority_reads_immutable_release_manifest(tmp_path: Path) -
     }
 
 
+def test_repository_authority_classifies_checkout_roles_by_structure(tmp_path: Path) -> None:
+    primary = _repo(
+        tmp_path / "repo",
+        remote="https://github.com/learn-ukrainian/learn-ukrainian.github.io.git",
+    )
+    dispatch = primary / ".worktrees" / "dispatch" / "codex" / "task"
+    linked = tmp_path / "linked"
+    other = primary / ".worktrees" / "legacy"
+    _git(primary, "worktree", "add", "-q", "-b", "codex/task", str(dispatch))
+    _git(primary, "worktree", "add", "-q", "-b", "linked", str(linked))
+    _git(primary, "worktree", "add", "-q", "-b", "legacy", str(other))
+
+    cases = (
+        (primary, "live_primary", "primary"),
+        (dispatch, "dispatch_worktree", "worktree"),
+        (linked, "linked_worktree", "worktree"),
+        # The guardrail calls every registered non-dispatch worktree
+        # ``other_worktree``; the public authority vocabulary stays
+        # ``linked_worktree`` for compatibility.
+        (other, "linked_worktree", "worktree"),
+    )
+    for checkout, expected_role, expected_cwd_role in cases:
+        authority = build_repository_authority(project_root=checkout, live_repo_root=checkout)
+        assert authority["primary_checkout"]["role"] == expected_role
+        assert authority["cwd_role"] == expected_cwd_role
+    assert cwd_role(tmp_path / "other") == "other"
+
+
 def test_release_route_reads_from_the_reported_primary_checkout(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    primary = _clone_repo(ROOT, tmp_path / "repo")
+    dispatch = primary / ".worktrees" / "dispatch" / "codex" / "release-test"
+    _git(primary, "worktree", "add", "-q", "-b", "codex/release-test", str(dispatch))
     release_sha = "e" * 40
     release = tmp_path / ".runtime/api/releases" / release_sha
     release.mkdir(parents=True)
@@ -486,7 +530,7 @@ def test_release_route_reads_from_the_reported_primary_checkout(
         encoding="utf-8",
     )
     monkeypatch.setattr(state_router, "PROJECT_ROOT", release)
-    monkeypatch.setattr(state_router, "LIVE_REPO_ROOT", ROOT)
+    monkeypatch.setattr(state_router, "LIVE_REPO_ROOT", dispatch)
 
     response = CLIENT.get("/api/state/preparation?track=a1")
 
@@ -495,7 +539,7 @@ def test_release_route_reads_from_the_reported_primary_checkout(
     VALIDATOR.validate(data)
     assert "data_checkout" not in data["authority"]
     assert data["authority"]["primary_checkout"]["role"] == "dispatch_worktree"
-    assert data["authority"]["primary_checkout"]["head_sha"] == _git(ROOT, "rev-parse", "HEAD")
+    assert data["authority"]["primary_checkout"]["head_sha"] == _git(dispatch, "rev-parse", "HEAD")
     assert data["authority"]["cwd_role"] == "other"
     assert data["authority"]["service_code"] == {
         "mode": "release",
@@ -507,10 +551,10 @@ def test_release_route_reads_from_the_reported_primary_checkout(
 
 def test_development_dispatch_worktree_is_reported_as_the_primary_checkout(tmp_path: Path) -> None:
     primary = _repo(
-        tmp_path / "primary",
+        tmp_path / "repo",
         remote="https://github.com/learn-ukrainian/learn-ukrainian.github.io.git",
     )
-    dispatch = tmp_path / ".worktrees/dispatch/codex/example"
+    dispatch = primary / ".worktrees/dispatch/codex/example"
     dispatch.parent.mkdir(parents=True)
     _git(primary, "worktree", "add", "-q", "-b", "codex/example", str(dispatch))
 

--- a/tests/test_preparation_api.py
+++ b/tests/test_preparation_api.py
@@ -23,12 +23,12 @@ VALIDATOR = Draft202012Validator(SCHEMA)
 CLIENT = TestClient(app, raise_server_exceptions=False)
 AUTHORITY = {
     "repository": "learn-ukrainian/learn-ukrainian.github.io",
-    "data_checkout": {
+    "primary_checkout": {
         "role": "live_primary",
-        "root": "/fixed/repository",
-        "branch": "main",
         "head_sha": "a" * 40,
+        "dirty_count": 0,
     },
+    "cwd_role": "primary",
     "service_code": {
         "mode": "release",
         "commit_sha": "b" * 40,
@@ -427,7 +427,7 @@ def test_ready_to_build_is_additively_deprecated_and_session_start_migrated() ->
     assert "/api/state/preparation" in script
 
 
-def test_repository_authority_distinguishes_data_checkout_from_development_code(tmp_path: Path) -> None:
+def test_repository_authority_distinguishes_primary_checkout_from_development_code(tmp_path: Path) -> None:
     data = _repo(
         tmp_path / "data",
         remote="https://secret-token@github.com/learn-ukrainian/learn-ukrainian.github.io.git",
@@ -441,12 +441,13 @@ def test_repository_authority_distinguishes_data_checkout_from_development_code(
 
     assert authority["repository"] == "learn-ukrainian/learn-ukrainian.github.io"
     assert "secret-token" not in json.dumps(authority)
-    assert authority["data_checkout"] == {
+    assert authority["primary_checkout"] == {
         "role": "live_primary",
-        "root": str(data),
-        "branch": "main",
         "head_sha": _git(data, "rev-parse", "HEAD"),
+        "dirty_count": 0,
     }
+    assert authority["cwd_role"] == "primary"
+    assert "data_checkout" not in authority
     assert authority["service_code"]["mode"] == "development"
     assert authority["service_code"]["commit_sha"] == _git(code, "rev-parse", "HEAD")
 
@@ -473,7 +474,7 @@ def test_repository_authority_reads_immutable_release_manifest(tmp_path: Path) -
     }
 
 
-def test_release_route_reads_from_the_reported_live_data_checkout(
+def test_release_route_reads_from_the_reported_primary_checkout(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -492,7 +493,10 @@ def test_release_route_reads_from_the_reported_live_data_checkout(
     assert response.status_code == 200
     data = response.json()
     VALIDATOR.validate(data)
-    assert data["authority"]["data_checkout"]["root"] == str(ROOT)
+    assert "data_checkout" not in data["authority"]
+    assert data["authority"]["primary_checkout"]["role"] == "dispatch_worktree"
+    assert data["authority"]["primary_checkout"]["head_sha"] == _git(ROOT, "rev-parse", "HEAD")
+    assert data["authority"]["cwd_role"] == "other"
     assert data["authority"]["service_code"] == {
         "mode": "release",
         "commit_sha": release_sha,
@@ -501,7 +505,7 @@ def test_release_route_reads_from_the_reported_live_data_checkout(
     assert data["tracks"][0]["module_state_counts"]["built"] == 55
 
 
-def test_development_dispatch_worktree_is_reported_as_the_data_checkout(tmp_path: Path) -> None:
+def test_development_dispatch_worktree_is_reported_as_the_primary_checkout(tmp_path: Path) -> None:
     primary = _repo(
         tmp_path / "primary",
         remote="https://github.com/learn-ukrainian/learn-ukrainian.github.io.git",
@@ -514,5 +518,10 @@ def test_development_dispatch_worktree_is_reported_as_the_data_checkout(tmp_path
     authority = build_repository_authority(project_root=dispatch, live_repo_root=data_root)
 
     assert data_root == dispatch
-    assert authority["data_checkout"]["role"] == "dispatch_worktree"
-    assert authority["data_checkout"]["root"] == str(dispatch)
+    assert authority["primary_checkout"] == {
+        "role": "dispatch_worktree",
+        "head_sha": _git(dispatch, "rev-parse", "HEAD"),
+        "dirty_count": 0,
+    }
+    assert authority["cwd_role"] == "worktree"
+    assert "data_checkout" not in authority

--- a/tests/test_session_streams_api.py
+++ b/tests/test_session_streams_api.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
 from scripts.api.session_streams_router import router
 
 
@@ -23,13 +24,22 @@ def test_session_streams_health_and_dual_write() -> None:
     assert h.status_code == 200
     body = h.json()
     assert body["ok"] is True
-    assert "db_exists" in body
+    assert "repo_root" not in body
+    assert "db_path" not in body
+    assert set(body["repo"]) == {"role", "sha"}
+    assert body["repo"]["role"] in {"live", "release"}
+    assert set(body["store"]) == {"reachable", "schema_versions"}
 
     d = client.get("/api/session-streams/v1/dual-write-status")
     assert d.status_code == 200
     dual = d.json()
+    assert "repo_root" not in dual
+    assert "db_path" not in dual
+    assert set(dual["repo"]) == {"role", "sha"}
+    assert set(dual["store"]) == {"reachable", "schema_versions"}
     assert "candidates" in dual
     assert dual["total"] >= 0
+    assert all("path" not in candidate for candidate in dual["candidates"])
 
     c = client.get("/api/session-streams/v1/plane-continuity")
     assert c.status_code == 200
@@ -68,7 +78,8 @@ def test_session_streams_repo_root_uses_live_primary_under_release(
     db_dir = live / ".agent" / "session-streams" / "v1"
     db_dir.mkdir(parents=True)
     db = db_dir / "session-streams.sqlite3"
-    db.write_bytes(b"")
+    connection = SessionStreamDatabase(db).connect()
+    connection.close()
 
     # Synthetic release path shape: .runtime/api/releases/<40-hex>
     release = tmp_path / ".runtime" / "api" / "releases" / ("a" * 40)
@@ -80,5 +91,8 @@ def test_session_streams_repo_root_uses_live_primary_under_release(
     assert ssr._repo_root() == live
     assert ssr._db_path() == db
     health = ssr.session_streams_health()
-    assert health["db_exists"] is True
-    assert health["repo_root"] == str(live)
+    assert "repo_root" not in health
+    assert "db_path" not in health
+    assert health["repo"] == {"role": "live", "sha": None}
+    assert health["store"]["reachable"] is True
+    assert health["store"]["schema_versions"]


### PR DESCRIPTION
Parent: #7177. Refs #7182 (PR-B family 1).

Removes path-bearing session-streams and repository-authority fields (`repo_root`, `db_path`, orient `main_root`/`checked_cwd`), adds fixture happy paths for `dual-write-status` and orient's git block (the two coverage gaps noted on #7182), updates consumers/contracts/schema/docs, and removes the family-1 known-leak rows.

Evidence (author, codex lane):
- OPSEC sweep: 10 passed; findings=21; known_leaks=16
- Focused validation: 49 passed · required guards: 29 passed · ruff: passed

Table diff: removed `session-health-repo-root` and `session-health-db-path` from `known_leaks.toml` and `FROZEN_IDS`.

Cross-family review of record: Gemini seat (author = codex). Main verification posted as a comment. No auto-merge until APPROVE + green.
