### PR TITLE
fix(eval): bound ua_open_weight_eval subprocess calls (#7213 slice 11)

### DIFF
--- a/data/projects/ua_open_weight_eval/v0.1.0/release_receipt.json
+++ b/data/projects/ua_open_weight_eval/v0.1.0/release_receipt.json
@@ -6,7 +6,7 @@
     "foundry_firewall": "a1c2f3693a8672f7ab1d8e745fafd75c5c45eab2ba2bcd5e17d9ac4739635aee",
     "local_run_config_example": "0e3fc35c1e8631b6aba1258141ac7d3d33726493481ca783deec15f474a5fa55",
     "saved_response_schema": "652e2ce89d170d5011a4fcfdf4fdd02fe7e1728d19c6b8a7479e38fc58b4cdb2",
-    "suite_cli": "476cd3ab1872acf0ab9c96ed995f8b54b78fbef54a60f0498a3244b9a1f5095c"
+    "suite_cli": "3d530290c063166237d044b8b59bbf8c665d239c38755bb8433557cbc3870db9"
   },
   "counts": {
     "by_category": {

--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -53,12 +53,6 @@ scripts/projects/open_model_data/phase3_rule_author_runner.py::run::subprocess.r
 scripts/projects/open_model_data/phase3_source_production_transport.py::_subprocess_invoke::subprocess.run
 scripts/projects/ua_eval_harness/build_heldout_manifest.py::_git_head::subprocess.run
 scripts/projects/ua_eval_harness/run_codex_baseline.py::_cli_version::subprocess.run
-scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py::job_command::subprocess.run
-scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py::launch_once::subprocess.run
-scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py::source_commit::subprocess.run
-scripts/projects/ua_open_weight_eval/hf_jobs_transport.py::run_worker::subprocess.run
-scripts/projects/ua_open_weight_eval/hf_jobs_transport.py::run_worker::subprocess.run
-scripts/projects/ua_open_weight_eval/suite_cli.py::run_local::subprocess.run
 scripts/review/snapshot.py::_run_git::subprocess.run
 scripts/session_canary/grok_lane.py::cmd_mint::subprocess.run
 scripts/session_canary/grok_lane.py::cmd_score::subprocess.run

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_baseline.py
@@ -79,13 +79,17 @@ def sha256_file(path: Path) -> str:
 
 
 def source_commit() -> str:
-    completed = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise BaselineError("git rev-parse timed out before producing a source commit") from exc
     commit = completed.stdout.strip()
     _require(completed.returncode == 0 and re.fullmatch(r"[a-f0-9]{40}", commit) is not None, "source commit drift")
     return commit
@@ -691,7 +695,16 @@ def job_command(
         transport_prefix=transport_prefix,
         manifest=manifest,
     )
-    observed_cli = subprocess.run([str(hf_cli), "--version"], check=False, capture_output=True, text=True)
+    try:
+        observed_cli = subprocess.run(
+            [str(hf_cli), "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise BaselineError("HF CLI version probe timed out") from exc
     _require(observed_cli.returncode == 0, "HF CLI version probe failed")
     _require(
         observed_cli.stdout.strip() == config["runtime"]["huggingface_hub_cli_version"],
@@ -882,7 +895,12 @@ def launch_once(*, command: Sequence[str], mode: str, state_path: Path, execute:
     )
     runs[mode] = intent
     write_atomic(state_path, state)
-    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True, timeout=120)
+    except subprocess.TimeoutExpired as exc:
+        intent["status"] = "launch_response_failed_reconcile_required"
+        write_atomic(state_path, state)
+        raise BaselineError("HF Jobs launch timed out; reconcile provider state before retry") from exc
     intent["launch_returncode"] = completed.returncode
     if completed.returncode != 0:
         intent["status"] = "launch_response_failed_reconcile_required"

--- a/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
+++ b/scripts/projects/ua_open_weight_eval/hf_jobs_transport.py
@@ -20,6 +20,10 @@ SHA256_PATTERN = re.compile(r"[a-f0-9]{64}")
 REPO_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/[A-Za-z0-9][A-Za-z0-9_.-]{0,95}")
 SAFE_PATH_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.\-/]{0,255}")
 TRANSPORT_RECEIPT_SCHEMA = "ua_open_weight_eval_hf_jobs_transport_receipt.v1"
+PLUGIN_INSTALL_TIMEOUT_SECONDS = 300
+# The direct transport passes no HF job timeout to the in-container worker, so its
+# subprocess is bounded by this documented ceiling instead of a job label.
+WORKER_TIMEOUT_SECONDS = 3600
 
 
 class TransportError(ValueError):
@@ -190,10 +194,14 @@ def run_preflight(args: argparse.Namespace, files: list[dict[str, Any]]) -> dict
 def run_worker(args: argparse.Namespace, root: Path) -> int:
     config = json.loads((root / "run_config.json").read_text(encoding="utf-8"))
     plugin = config["runtime"]["vllm_gguf_plugin"]["filename"]
-    install = subprocess.run(
-        ["uv", "pip", "install", "--system", str(root / plugin)],
-        check=False,
-    )
+    try:
+        install = subprocess.run(
+            ["uv", "pip", "install", "--system", str(root / plugin)],
+            check=False,
+            timeout=PLUGIN_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise TransportError("verified plugin installation timed out") from exc
     _require(install.returncode == 0, "verified plugin installation failed")
     output = root / "output"
     command = [
@@ -216,7 +224,14 @@ def run_worker(args: argparse.Namespace, root: Path) -> int:
     ]
     if args.mode == "canary":
         command.extend(["--selection", str(root / "canary_selection.json")])
-    return subprocess.run(command, check=False).returncode
+    try:
+        return subprocess.run(command, check=False, timeout=WORKER_TIMEOUT_SECONDS).returncode
+    except subprocess.TimeoutExpired:
+        print(
+            f"worker exceeded its {WORKER_TIMEOUT_SECONDS}s subprocess bound",
+            file=sys.stderr,
+        )
+        return 124
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/projects/ua_open_weight_eval/suite_cli.py
+++ b/scripts/projects/ua_open_weight_eval/suite_cli.py
@@ -136,6 +136,9 @@ RUN_CONFIG_FIELDS = frozenset(
     }
 )
 FORBIDDEN_COMMAND_EXECUTABLES = frozenset({"anthropic", "claude", "curl", "openai", "ssh", "wget"})
+# Local run configs have no timeout field (RUN_CONFIG_FIELDS is closed), so the
+# offline runner subprocess is bounded by this documented ceiling.
+LOCAL_RUNNER_TIMEOUT_SECONDS = 1800
 
 
 class SuiteError(ValueError):
@@ -745,7 +748,16 @@ def run_local(config_path: Path, requests: Path, responses: Path, receipt_path: 
             "UA_EVAL_NETWORK_ALLOWED": "0",
         }
     )
-    completed = subprocess.run(command, cwd=ROOT, env=environment, check=False)
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            timeout=LOCAL_RUNNER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SuiteError(f"local runner timed out after {LOCAL_RUNNER_TIMEOUT_SECONDS}s") from exc
     _require(completed.returncode == 0, f"local runner exited {completed.returncode}")
     _require(responses.is_file(), "local runner did not create responses")
     receipt = {

--- a/tests/test_ua_open_weight_eval_hf_jobs.py
+++ b/tests/test_ua_open_weight_eval_hf_jobs.py
@@ -510,8 +510,9 @@ def test_transport_spawns_gpu_worker_with_available_python3(tmp_path: Path, monk
     (tmp_path / "run_config.json").write_text(json.dumps(config), encoding="utf-8")
     calls: list[list[str]] = []
 
-    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+    def fake_run(command: list[str], *, check: bool = False, **kwargs: object) -> subprocess.CompletedProcess:
         assert check is False
+        assert isinstance(kwargs.get("timeout"), int) and kwargs["timeout"] > 0
         calls.append(command)
         return subprocess.CompletedProcess(command, 0)
 

--- a/tests/test_ua_open_weight_eval_timeouts.py
+++ b/tests/test_ua_open_weight_eval_timeouts.py
@@ -1,0 +1,263 @@
+"""Every ua_open_weight_eval subprocess call passes an explicit timeout (#7213 slice 11)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.projects.ua_open_weight_eval import (
+    hf_jobs_baseline,
+    hf_jobs_transport,
+    suite_cli,
+)
+
+
+def _write_fake_hf_cli(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+
+
+def _canary_bundle_fixtures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    config = hf_jobs_baseline.load_config()
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    hf_cli = tmp_path / "hf"
+    _write_fake_hf_cli(hf_cli)
+    manifest = {
+        "bundle_sha256": "b" * 64,
+        "requests_sha256": "r" * 64,
+        "source_commit": "d" * 40,
+    }
+    monkeypatch.setattr(hf_jobs_baseline, "verify_bundle", lambda _: manifest)
+    monkeypatch.setattr(hf_jobs_baseline, "load_config", lambda *args, **kwargs: config)
+    return hf_cli
+
+
+def test_source_commit_bounds_git_and_maps_timeout_to_baseline_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout=f"{'a' * 40}\n", stderr="")
+
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", fake_run)
+    assert hf_jobs_baseline.source_commit() == "a" * 40
+    assert captured["timeout"] == 30
+
+    def hanging_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.TimeoutExpired(cmd=["git", "rev-parse", "HEAD"], timeout=30)
+
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", hanging_run)
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="timed out"):
+        hf_jobs_baseline.source_commit()
+
+
+def test_job_command_bounds_hf_version_probe_and_maps_timeout_to_baseline_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hf_cli = _canary_bundle_fixtures(monkeypatch, tmp_path)
+    config = hf_jobs_baseline.load_config()
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(
+            command, 0, stdout=config["runtime"]["huggingface_hub_cli_version"] + "\n", stderr=""
+        )
+
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", fake_run)
+    command = hf_jobs_baseline.job_command(
+        mode="preflight",
+        namespace="operator",
+        bundle=tmp_path / "bundle",
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        transport_revision="a" * 40,
+        transport_prefix=f"bundles/{'b' * 64}",
+        hf_cli=hf_cli,
+        timeout_seconds=300,
+    )
+    assert "--timeout 5m" in " ".join(command)
+    assert observed["timeout"] == 30
+
+    def hanging_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.TimeoutExpired(cmd=[str(hf_cli), "--version"], timeout=30)
+
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", hanging_run)
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="version probe timed out"):
+        hf_jobs_baseline.job_command(
+            mode="preflight",
+            namespace="operator",
+            bundle=tmp_path / "bundle",
+            transport_repo="operator/ua-open-weight-eval-staging-6273",
+            transport_revision="a" * 40,
+            transport_prefix=f"bundles/{'b' * 64}",
+            hf_cli=hf_cli,
+            timeout_seconds=300,
+        )
+
+
+def test_launch_once_bounds_detach_handshake_and_maps_timeout_to_reconcile_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_path = tmp_path / "state.json"
+    monkeypatch.setattr(
+        hf_jobs_baseline,
+        "load_disposition",
+        lambda *args, **kwargs: {"rerun_authorized": True},
+    )
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout=f"{'a' * 24}\n", stderr="")
+
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", fake_run)
+    launched = hf_jobs_baseline.launch_once(
+        command=["/absolute/hf", "jobs", "run", "--detach"],
+        mode="canary",
+        state_path=state_path,
+        execute=True,
+    )
+    assert launched["status"] == "launched"
+    assert observed["timeout"] == 120
+
+    def hanging_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.TimeoutExpired(cmd=["/absolute/hf", "jobs", "run", "--detach"], timeout=120)
+
+    state_path = tmp_path / "timeout-state.json"
+    monkeypatch.setattr(hf_jobs_baseline.subprocess, "run", hanging_run)
+    with pytest.raises(hf_jobs_baseline.BaselineError, match="launch timed out"):
+        hf_jobs_baseline.launch_once(
+            command=["/absolute/hf", "jobs", "run", "--detach"],
+            mode="canary",
+            state_path=state_path,
+            execute=True,
+        )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["runs"]["canary"]["status"] == "launch_response_failed_reconcile_required"
+
+
+def test_run_worker_bounds_install_and_worker_and_maps_timeout_to_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = hf_jobs_baseline.load_config()
+    plugin = config["runtime"]["vllm_gguf_plugin"]
+    (tmp_path / "run_config.json").write_text(json.dumps(config), encoding="utf-8")
+    (tmp_path / plugin["filename"]).write_bytes(b"wheel")
+    (tmp_path / "hf_jobs_worker.py").write_text("print('worker')\n", encoding="utf-8")
+    (tmp_path / "requests.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "canary_selection.json").write_text("{}\n", encoding="utf-8")
+    timeouts: list[object] = []
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool = False, **kwargs: object) -> subprocess.CompletedProcess:
+        assert check is False
+        timeouts.append(kwargs.get("timeout"))
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(hf_jobs_transport.subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        mode="canary",
+        requests_sha256="r" * 64,
+        transport_repo="operator/ua-open-weight-eval-staging-6273",
+        artifact_prefix="artifacts/bundle/canary",
+    )
+    assert hf_jobs_transport.run_worker(args, tmp_path) == 0
+    assert calls[0][:4] == ["uv", "pip", "install", "--system"]
+    assert timeouts == [hf_jobs_transport.PLUGIN_INSTALL_TIMEOUT_SECONDS, hf_jobs_transport.WORKER_TIMEOUT_SECONDS]
+    assert timeouts == [300, 3600]
+
+    def hanging_install(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.TimeoutExpired(cmd=["uv", "pip", "install", "--system"], timeout=300)
+
+    monkeypatch.setattr(hf_jobs_transport.subprocess, "run", hanging_install)
+    with pytest.raises(hf_jobs_transport.TransportError, match="installation timed out"):
+        hf_jobs_transport.run_worker(args, tmp_path)
+
+    worker_invocations: list[list[str]] = []
+
+    def hanging_worker(command: list[str], *, check: bool = False, **kwargs: object) -> subprocess.CompletedProcess:
+        worker_invocations.append(command)
+        if len(worker_invocations) == 1:
+            return subprocess.CompletedProcess(command, 0)
+        raise subprocess.TimeoutExpired(cmd=command, timeout=3600)
+
+    monkeypatch.setattr(hf_jobs_transport.subprocess, "run", hanging_worker)
+    assert hf_jobs_transport.run_worker(args, tmp_path) == 124
+
+
+def _valid_local_run_config(tmp_path: Path) -> tuple[Path, Path, Path]:
+    model = tmp_path / "model.gguf"
+    model.write_bytes(b"offline-model-bytes")
+    runner = tmp_path / "local_runner"
+    runner.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    runner.chmod(0o700)
+    requests = tmp_path / "requests.jsonl"
+    requests.write_text("{}\n", encoding="utf-8")
+    responses = tmp_path / "responses.jsonl"
+    config = {
+        "backend": "transformers",
+        "command": [str(runner), "--requests", "{requests}", "--responses", "{responses}"],
+        "model_path": str(model),
+        "model_revision": "main",
+        "model_sha256": hashlib.sha256(model.read_bytes()).hexdigest(),
+        "network_allowed": False,
+        "provider": None,
+    }
+    config_path = tmp_path / "local_run_config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    return config_path, requests, responses
+
+
+def test_run_local_bounds_offline_runner_and_maps_timeout_to_suite_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path, requests, responses = _valid_local_run_config(tmp_path)
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        observed.update(kwargs)
+        responses.write_text('{"item_id":"uaw-request-0001"}\n', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(suite_cli.subprocess, "run", fake_run)
+    receipt = suite_cli.run_local(config_path, requests, responses, tmp_path / "receipt.json")
+    assert receipt["closed_api_used"] is False
+    assert observed["timeout"] == suite_cli.LOCAL_RUNNER_TIMEOUT_SECONDS == 1800
+
+    def hanging_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.TimeoutExpired(cmd="local-runner", timeout=1800)
+
+    monkeypatch.setattr(suite_cli.subprocess, "run", hanging_run)
+    with pytest.raises(suite_cli.SuiteError, match=r"timed out after 1800s"):
+        suite_cli.run_local(config_path, requests, responses, tmp_path / "receipt-timeout.json")
+
+
+def test_timeout_bounded_modules_keep_their_entry_point_contracts(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    for module in (hf_jobs_baseline, hf_jobs_transport, suite_cli):
+        assert module.__doc__
+    for argv in (["--help"], ["verify", "--help"]):
+        with pytest.raises(SystemExit) as exc:
+            suite_cli.parse_args(argv)
+        assert exc.value.code == 0
+    with pytest.raises(SystemExit) as exc:
+        hf_jobs_baseline.parse_args(["--help"])
+    assert exc.value.code == 0
+    monkeypatch.setattr(sys, "argv", ["hf_jobs_transport.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        hf_jobs_transport.parse_args()
+    assert exc.value.code == 0
+    capsys.readouterr()


### PR DESCRIPTION
## Summary
Slice 11 of #7213: bound all 6 timeout-less `subprocess.run` sites under `scripts/projects/ua_open_weight_eval/` and remove those allowlist keys.

Allowlist **63 → 57**. Remaining `scripts/projects/ua_open_weight_eval/` keys: **0**.

Timeouts:
- `source_commit` git rev-parse: 30s → `BaselineError`
- `job_command` `hf --version`: 30s → `BaselineError`
- `launch_once` local `--detach` handshake: 120s → state `launch_response_failed_reconcile_required` + `BaselineError`
- `run_worker` uv plugin install: 300s → `TransportError`
- `run_worker` python worker: documented `WORKER_TIMEOUT_SECONDS=3600` (no job-timeout label reaches this in-container call) → return 124
- `run_local`: documented `LOCAL_RUNNER_TIMEOUT_SECONDS=1800` (`RUN_CONFIG_FIELDS` is closed) → `SuiteError`

Also updates `data/projects/ua_open_weight_eval/v0.1.0/release_receipt.json` `artifacts.suite_cli` to the new `suite_cli.py` SHA-256 so `verify_release()` stays fail-closed. Precedent: #6277.

New `tests/test_ua_open_weight_eval_timeouts.py`. Existing `test_transport_spawns_gpu_worker_with_available_python3` now accepts `**kwargs` and asserts `timeout > 0`.

## Driver verification (re-run in worktree with primary venv)
```
52 passed (guard + new timeouts + hf_jobs + suite)
ruff: All checks passed!
suite_cli sha256 matches receipt artifacts.suite_cli
```

Implement: ox-alpha (OpenCode stealth, `openrouter/stealth/ox-alpha`). CF: kimi (ox-alpha is not CF of record).

Closes nothing (slice of #7213). Refs #7213, #7176.