### PR TITLE
fix(guardrails): bound subprocess calls (#7213 slice 12)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -20,12 +20,6 @@ scripts/etymology/bulk_ocr_gemini.py::decode_pages::subprocess.run
 scripts/fleet_comms/github_pr_metrics.py::collect_github_pr_metrics::subprocess.run
 scripts/generate_mdx/core.py::main::subprocess.run
 scripts/generate_mdx/generate_plan_markdown.py::main::subprocess.run
-scripts/guardrails/assert_primary_on_main.py::_git::subprocess.run
-scripts/guardrails/primary_write_guard.py::apply_guard::subprocess.run
-scripts/guardrails/primary_write_guard.py::get_writable_tracked_files::subprocess.run
-scripts/guardrails/primary_write_guard.py::install_hooks::subprocess.run
-scripts/guardrails/primary_write_guard.py::release_guard::subprocess.run
-scripts/guardrails/worktree_containment.py::_run_git::subprocess.run
 scripts/hooks/hook_timing.py::run_wrapped::subprocess.run
 scripts/hooks/measure_hook_stack.py::_time_one::subprocess.run
 scripts/hygiene/lane_disk_retention.py::_git::subprocess.run

--- a/scripts/guardrails/assert_primary_on_main.py
+++ b/scripts/guardrails/assert_primary_on_main.py
@@ -28,6 +28,10 @@ from scripts.guardrails.worktree_containment import (
     resolve_main_root,
 )
 
+# Git probes feed primary_head_state / heal decisions; bound them so a wedged
+# git surfaces as a failed probe instead of hanging a launcher (#7213).
+_GIT_TIMEOUT_S = 30
+
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
@@ -40,14 +44,26 @@ def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
         "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     ):
         env.pop(name, None)
-    return subprocess.run(
-        ["git", *args],
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    argv = ["git", *args]
+    try:
+        return subprocess.run(
+            argv,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Map to a failed CompletedProcess so the existing detached /
+        # wrong-branch / heal-failure paths fire; never raise from a hook.
+        return subprocess.CompletedProcess(
+            argv,
+            returncode=124,
+            stdout="",
+            stderr=f"TimeoutExpired after {exc.timeout}s",
+        )
 
 
 def primary_head_state(cwd: Path | None = None) -> dict[str, object]:

--- a/scripts/guardrails/primary_write_guard.py
+++ b/scripts/guardrails/primary_write_guard.py
@@ -43,6 +43,12 @@ except ImportError:
             return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
 
 
+# These guards run inside git hooks; a wedged git or hook installer must exit
+# loudly instead of hanging the session (#7213).
+_GIT_TIMEOUT_S = 30
+_HOOK_INSTALL_TIMEOUT_S = 60
+
+
 def check_primary_checkout_root(hook_mode: bool = False) -> Path:
     """Verify that we are executing from the root of the primary checkout."""
     try:
@@ -86,8 +92,9 @@ def get_writable_tracked_files(main_root: Path) -> list[Path]:
             text=True,
             check=True,
             env=sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_S,
         )
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         print(f"Error listing tracked files: {e}", file=sys.stderr)
         sys.exit(1)
 
@@ -130,8 +137,9 @@ def apply_guard(hook_mode: bool = False) -> None:
             text=True,
             check=True,
             env=sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_S,
         )
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         print(f"Error listing tracked files: {e}", file=sys.stderr)
         sys.exit(1)
 
@@ -171,8 +179,9 @@ def release_guard() -> None:
             text=True,
             check=True,
             env=sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_S,
         )
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         print(f"Error listing tracked files: {e}", file=sys.stderr)
         sys.exit(1)
 
@@ -246,8 +255,9 @@ def install_hooks() -> None:
             cwd=main_root,
             check=True,
             env=sanitized_git_env(),
+            timeout=_HOOK_INSTALL_TIMEOUT_S,
         )
-    except (OSError, subprocess.CalledProcessError) as exc:
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         print(f"Failed to install tracked Git hooks: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -112,6 +112,11 @@ class WriteDecision:
 # git helpers
 # ---------------------------------------------------------------------------
 
+# Read-only plumbing probes run on hook hot paths; a wedged git must degrade
+# to a failed probe, never hang the session (#7213).
+_GIT_TIMEOUT_S = 30
+
+
 def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run a read-only git command scoped to ``cwd`` with sanitized env."""
     argv = ["git", "-C", str(cwd), *args]
@@ -122,6 +127,17 @@ def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
             text=True,
             check=False,
             env=sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Same contract as the FileNotFoundError branch below: represent the
+        # failure as a failed probe (124 = conventional shell timeout exit)
+        # so callers fall back instead of unwinding through a hook.
+        return subprocess.CompletedProcess(
+            argv,
+            returncode=124,
+            stdout="",
+            stderr=f"TimeoutExpired after {exc.timeout}s",
         )
     except FileNotFoundError as exc:
         # Root resolution promises an on-disk .git fallback when Git cannot

--- a/tests/test_guardrails_timeouts.py
+++ b/tests/test_guardrails_timeouts.py
@@ -1,0 +1,298 @@
+"""Unit tests for subprocess timeout bounds in scripts/guardrails/ (#7213 slice 12).
+
+Every bounded call site must (a) pass an explicit ``timeout=`` — 30s for git
+plumbing, 60s for the hook installer — and (b) map ``subprocess.TimeoutExpired``
+to its documented degradation instead of an uncaught traceback, because these
+helpers run inside git hooks / launchers:
+
+* ``worktree_containment._run_git``       → failed probe (returncode 124), callers fall back
+* ``assert_primary_on_main._git``         → failed CompletedProcess, detached/error paths fire
+* ``primary_write_guard`` ls-files sites  → print + ``sys.exit(1)``
+* ``primary_write_guard.install_hooks``   → print + ``sys.exit(1)`` via the OSError handler
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.guardrails import assert_primary_on_main as apom
+from scripts.guardrails import primary_write_guard as pwg
+from scripts.guardrails import worktree_containment as wc
+
+GIT_TIMEOUT_S = 30
+HOOK_INSTALL_TIMEOUT_S = 60
+
+
+def _completed(
+    args: list[str] | None = None,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=args or [],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _timed_out(cmd: list[str], **_kwargs: object) -> subprocess.TimeoutExpired:
+    raise subprocess.TimeoutExpired(cmd, GIT_TIMEOUT_S)
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _real_git(repo: Path, *args: str) -> None:
+    """Fixture-side git setup with a REAL subprocess (before any patching)."""
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def primary_repo(tmp_path: Path) -> Path:
+    """Real primary checkout on main, built BEFORE any subprocess patching."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+        timeout=30,
+    )
+    _real_git(root, "config", "user.email", "test@example.com")
+    _real_git(root, "config", "user.name", "Test")
+    _real_git(root, "commit", "--allow-empty", "-m", "init")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# worktree_containment._run_git
+# ---------------------------------------------------------------------------
+
+
+def test_run_git_passes_explicit_timeout(tmp_path: Path) -> None:
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": cmd, **kwargs})
+        return _completed(cmd, stdout="main\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        proc = wc._run_git(tmp_path, "symbolic-ref", "--quiet", "--short", "HEAD")
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == GIT_TIMEOUT_S
+    assert proc.returncode == 0
+    assert proc.stdout == "main\n"
+
+
+def test_run_git_maps_timeout_to_failed_probe_not_raise(tmp_path: Path) -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        proc = wc._run_git(tmp_path, "status", "--porcelain")
+
+    assert isinstance(proc, subprocess.CompletedProcess)
+    assert proc.returncode == 124
+    assert proc.stdout == ""
+    assert "TimeoutExpired" in proc.stderr
+
+
+def test_resolve_main_root_falls_back_to_fs_walk_when_git_times_out(tmp_path: Path) -> None:
+    """The FileNotFoundError fallback contract must also cover timeouts."""
+    fake_repo = tmp_path / "main"
+    (fake_repo / ".git").mkdir(parents=True)
+
+    with patch("subprocess.run", side_effect=_timed_out):
+        assert wc.resolve_main_root(fake_repo) == fake_repo.resolve()
+
+
+# ---------------------------------------------------------------------------
+# assert_primary_on_main._git
+# ---------------------------------------------------------------------------
+
+
+def test_assert_primary_git_passes_explicit_timeout(tmp_path: Path) -> None:
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": cmd, **kwargs})
+        return _completed(cmd, stdout="main\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        proc = apom._git(tmp_path, "symbolic-ref", "--quiet", "--short", "HEAD")
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == GIT_TIMEOUT_S
+    assert proc.stdout.strip() == "main"
+
+
+def test_assert_primary_git_maps_timeout_to_failed_process(tmp_path: Path) -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        proc = apom._git(tmp_path, "rev-parse", "--short", "HEAD")
+
+    assert isinstance(proc, subprocess.CompletedProcess)
+    assert proc.returncode == 124
+    assert proc.stdout == ""
+    assert "TimeoutExpired" in proc.stderr
+
+
+def test_primary_head_state_survives_total_git_timeout(primary_repo: Path) -> None:
+    """A wedged git must land in the detached/error path, never raise (#7213).
+
+    Every git probe inside primary_head_state times out; root resolution falls
+    back to the on-disk ``.git`` walk and symbolic-ref reads as failed, so the
+    pre-existing detached-head diagnostics fire.
+    """
+    with patch("subprocess.run", side_effect=_timed_out):
+        state = apom.primary_head_state(primary_repo)
+
+    assert state["ok"] is False
+    assert state["reason"] == "detached_head"
+    assert state["path"] == str(primary_repo.resolve())
+    assert "unknown" in str(state["message"])
+
+
+# ---------------------------------------------------------------------------
+# primary_write_guard — ls-files sites (get_writable_tracked_files /
+# apply_guard / release_guard)
+# ---------------------------------------------------------------------------
+
+
+def test_get_writable_tracked_files_passes_explicit_timeout(tmp_path: Path) -> None:
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": cmd, **kwargs})
+        return _completed(cmd, stdout="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        assert pwg.get_writable_tracked_files(tmp_path) == []
+
+    assert len(calls) == 1
+    assert calls[0]["cmd"] == ["git", "ls-files", "-z"]
+    assert calls[0]["timeout"] == GIT_TIMEOUT_S
+
+
+@pytest.mark.parametrize(
+    "guard_call",
+    [
+        lambda: pwg.get_writable_tracked_files(Path("/unused")),
+        lambda: pwg.apply_guard(hook_mode=False),
+        lambda: pwg.release_guard(),
+    ],
+    ids=["get_writable_tracked_files", "apply_guard", "release_guard"],
+)
+def test_ls_files_timeout_exits_1_not_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    guard_call,
+) -> None:
+    """TimeoutExpired must be caught exactly like CalledProcessError: print + exit 1."""
+    monkeypatch.setattr(pwg, "check_primary_checkout_root", lambda hook_mode=False: tmp_path)
+
+    with patch("subprocess.run", side_effect=_timed_out):
+        with pytest.raises(SystemExit) as excinfo:
+            guard_call()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Error listing tracked files:" in captured.err
+    # str(TimeoutExpired) reads "Command [...] timed out after N seconds".
+    assert "timed out after" in captured.err
+
+
+@pytest.mark.parametrize(
+    "guard_call, expect_owner_write",
+    [
+        (lambda: pwg.apply_guard(hook_mode=False), False),
+        (lambda: pwg.release_guard(), True),
+    ],
+    ids=["apply_guard", "release_guard"],
+)
+def test_ls_files_success_still_applies_after_timeout_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    guard_call,
+    expect_owner_write: bool,
+) -> None:
+    """Happy path keeps working with the new kwarg present (signature smoke)."""
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("x\n", encoding="utf-8")
+    tracked.chmod(0o444)
+    monkeypatch.setattr(pwg, "check_primary_checkout_root", lambda hook_mode=False: tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        assert kwargs["timeout"] == GIT_TIMEOUT_S
+        return _completed(cmd, stdout="tracked.txt\0")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        guard_call()
+
+    owner_write = bool(os.stat(tracked).st_mode & 0o200)
+    assert owner_write is expect_owner_write
+
+
+# ---------------------------------------------------------------------------
+# primary_write_guard.install_hooks (hook installer, 60s)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def installer_root(tmp_path: Path) -> Path:
+    installer = tmp_path / "scripts" / "install_git_hooks.sh"
+    installer.parent.mkdir(parents=True)
+    installer.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_install_hooks_passes_60s_timeout(installer_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pwg, "check_primary_checkout_root", lambda hook_mode=False: installer_root)
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": cmd, **kwargs})
+        return _completed(cmd, returncode=0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        pwg.install_hooks()
+
+    assert len(calls) == 1
+    assert calls[0]["cmd"] == ["bash", str(installer_root / "scripts" / "install_git_hooks.sh")]
+    assert calls[0]["timeout"] == HOOK_INSTALL_TIMEOUT_S
+
+
+def test_install_hooks_timeout_exits_1_via_existing_handler(
+    installer_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """TimeoutExpired joins the existing (OSError, CalledProcessError) handler."""
+    monkeypatch.setattr(pwg, "check_primary_checkout_root", lambda hook_mode=False: installer_root)
+
+    def timed_out(cmd, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd, HOOK_INSTALL_TIMEOUT_S)
+
+    with patch("subprocess.run", side_effect=timed_out):
+        with pytest.raises(SystemExit) as excinfo:
+            pwg.install_hooks()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Failed to install tracked Git hooks:" in captured.err
+    assert "timed out after" in captured.err


### PR DESCRIPTION
## Summary
Slice 12 of #7213: bound all 6 timeout-less `subprocess.run` sites under `scripts/guardrails/` and remove those allowlist keys.

Allowlist **57 → 51**. Remaining `scripts/guardrails/` keys: **0**.

Timeouts:
- git plumbing (`ls-files`, `git -C`, `symbolic-ref`/`rev-parse`): 30s
- hook installer: 60s

TimeoutExpired mapping (hook-safe, no traceback):
- `worktree_containment._run_git` → failed probe `returncode=124` (same contract as FileNotFoundError)
- `assert_primary_on_main._git` → failed `CompletedProcess` so existing detached/wrong-branch paths fire
- `primary_write_guard` ls-files / `install_hooks` → print + `sys.exit(1)`

New `tests/test_guardrails_timeouts.py`.

## Driver verification (re-run in worktree with primary venv)
```
140 passed (guard + new timeouts + worktree_containment + assert_primary_on_main + primary write guard)
ruff: All checks passed!
```

Implement: ox-alpha (OpenCode stealth). CF: kimi (ox-alpha is not CF of record).

Closes nothing (slice of #7213). Refs #7213, #7176.