### PR TITLE
fix(wiki): bound subprocess calls (#7213 slice 13)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -57,9 +57,3 @@ scripts/sync/promote_module.py::_run_make_atlas::subprocess.run
 scripts/sync/prune_module_forensics.py::_run_git::subprocess.run
 scripts/validate/verify_track.py::run_audit::subprocess.run
 scripts/vocab/rebuild_vocab_from_yaml.py::populate_database::subprocess.run
-scripts/wiki/backfill_generated_by_model.py::load_head_text::subprocess.run
-scripts/wiki/backfill_generated_by_model.py::load_historical_meta::subprocess.run
-scripts/wiki/backfill_generated_by_model.py::run_git::subprocess.run
-scripts/wiki/diagnostics/corpus_gaps/audit.py::run_codex_concept_extraction::subprocess.run
-scripts/wiki/mlx_bridge.py::get_physical_ram::subprocess.check_output
-scripts/wiki/rebuild.py::_run_compile::subprocess.run

--- a/scripts/wiki/backfill_generated_by_model.py
+++ b/scripts/wiki/backfill_generated_by_model.py
@@ -22,6 +22,7 @@ REPORT_PATH = PROJECT_ROOT / "audit" / "phase-2a-wiki-metadata" / "report.md"
 CHAT_DIR = Path.home() / ".gemini" / "tmp" / "learn-ukrainian" / "chats"
 FIXED_MODEL = "gemini-2.5-pro"
 UNKNOWN_MODEL = "unknown"
+GIT_TIMEOUT_S = 30
 FALLBACK_CUTOVER = datetime.fromisoformat("2026-04-21T13:12:10+02:00")
 WIKI_META_RE = re.compile(r"<!--\s*wiki-meta\b(?P<body>.*?)-->", re.DOTALL)
 PROMPT_META_RE = re.compile(r"<!--\s*wiki-meta\s*\n(?P<body>.*?)-->", re.DOTALL)
@@ -133,13 +134,21 @@ def render_wiki_meta(meta: dict) -> str:
 
 def run_git(*args: str, check: bool = True) -> str:
     """Run a git command from the project root and return stdout."""
-    result = subprocess.run(
-        ["git", *args],
-        cwd=PROJECT_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=PROJECT_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if check:
+            raise RuntimeError(
+                f"git command timed out after {GIT_TIMEOUT_S}s: git {' '.join(args)}"
+            ) from exc
+        return ""
     if check and result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "git command failed")
     return result.stdout
@@ -228,13 +237,17 @@ def file_last_commit_time(path: Path) -> datetime | None:
 def load_head_text(path: Path) -> str:
     """Read the tracked ``HEAD`` version of a file for stable report diffs."""
     relpath = str(path.relative_to(PROJECT_ROOT))
-    result = subprocess.run(
-        ["git", "show", f"HEAD:{relpath}"],
-        cwd=PROJECT_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{relpath}"],
+            cwd=PROJECT_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return path.read_text(encoding="utf-8")
     if result.returncode != 0:
         return path.read_text(encoding="utf-8")
     return result.stdout
@@ -245,13 +258,17 @@ def load_historical_meta(path: Path) -> tuple[dict, str | None]:
     relpath = str(path.relative_to(PROJECT_ROOT))
     commit_ids = [line.strip() for line in run_git("log", "--follow", "--format=%H", "--", relpath).splitlines() if line.strip()]
     for commit_id in commit_ids:
-        result = subprocess.run(
-            ["git", "show", f"{commit_id}:{relpath}"],
-            cwd=PROJECT_ROOT,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "show", f"{commit_id}:{relpath}"],
+                cwd=PROJECT_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=GIT_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            continue
         if result.returncode != 0:
             continue
         meta, _ = parse_wiki_meta(result.stdout)

--- a/scripts/wiki/diagnostics/corpus_gaps/audit.py
+++ b/scripts/wiki/diagnostics/corpus_gaps/audit.py
@@ -35,6 +35,7 @@ A1_REPORT_PATH = PROJECT_ROOT / "docs" / "architecture" / "corpus-coverage-map-a
 
 DEFAULT_TRACKS = ("a1", "a2", "b1")
 DEFAULT_MODEL = "gpt-5.5"
+CODEX_TIMEOUT_S = 300
 DEFAULT_CHUNKS_PER_PAGE = 1.4
 MAX_CONCEPTS_PER_ARTICLE = 15
 MIN_CONCEPTS_PER_ARTICLE = 8
@@ -680,13 +681,19 @@ def run_codex_concept_extraction(prompt: str, model: str = DEFAULT_MODEL) -> dic
             str(PROJECT_ROOT),
             "-",
         ]
-        completed = subprocess.run(
-            command,
-            input=prompt,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        try:
+            completed = subprocess.run(
+                command,
+                input=prompt,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=CODEX_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Codex concept extraction failed: timed out after {CODEX_TIMEOUT_S}s"
+            ) from exc
         if completed.returncode != 0:
             raise RuntimeError(
                 "Codex concept extraction failed: "

--- a/scripts/wiki/mlx_bridge.py
+++ b/scripts/wiki/mlx_bridge.py
@@ -36,7 +36,7 @@ def get_physical_ram() -> int | None:
     """Read physical RAM size in bytes. Returns None if it cannot be determined."""
     if sys.platform == "darwin":
         try:
-            out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], text=True)
+            out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], text=True, timeout=10)
             return int(out.strip())
         except Exception:
             return None

--- a/scripts/wiki/rebuild.py
+++ b/scripts/wiki/rebuild.py
@@ -125,6 +125,11 @@ PHASES: list[dict[str, Any]] = [
 #: File where orchestrator state lives. Lives alongside wiki build log.
 _STATE_FILE = WIKI_STATE_DIR / "rebuild-progress.json"
 
+#: Hard ceiling for one ``compile.py --track … --review`` invocation. Track
+#: compiles can be slow, but a hung subprocess must never wedge the rebuild
+#: loop forever; expiry is reported as returncode 124 (see ``_run_compile``).
+COMPILE_TIMEOUT_S = 1800
+
 #: Status values a task can hold.
 _STATUS_PENDING = "pending"
 _STATUS_RUNNING = "running"
@@ -285,6 +290,11 @@ def _run_compile(task: TaskState, *, dry_run: bool = False) -> int:
     re-invoking on the same track is idempotent — already-compiled
     articles are skipped. ``--review`` runs the per-dim + MIN orchestrator
     (post-#1455 — the legacy single-call weighted-average path is gone).
+
+    The invocation is hard-bounded at ``COMPILE_TIMEOUT_S`` (1800s
+    documented ceiling — track compile+review can be slow, but must stay
+    bounded); expiry kills the subprocess and returns 124 instead of
+    crashing with an uncaught traceback.
     """
     cmd = [
         ".venv/bin/python", "scripts/wiki/compile.py",
@@ -307,12 +317,19 @@ def _run_compile(task: TaskState, *, dry_run: bool = False) -> int:
     # (no start_new_session), so Ctrl-C hits both. compile.py's
     # KeyboardInterrupt handler finishes current article and exits.
     try:
-        proc = subprocess.run(cmd, cwd=_REPO_ROOT, check=False)
+        proc = subprocess.run(cmd, cwd=_REPO_ROOT, check=False, timeout=COMPILE_TIMEOUT_S)
         return proc.returncode
     except KeyboardInterrupt:
         # Shouldn't reach here — subprocess.run propagates but we
         # catch it defensively.
         return 130
+    except subprocess.TimeoutExpired:
+        print(
+            f"⏱️  {task.display()} exceeded the {COMPILE_TIMEOUT_S}s ceiling; "
+            "killing compile subprocess.",
+            file=sys.stderr,
+        )
+        return 124
 
 
 # ── Runner ────────────────────────────────────────────────────────

--- a/tests/test_wiki_timeouts.py
+++ b/tests/test_wiki_timeouts.py
@@ -1,0 +1,326 @@
+"""Unit tests for subprocess timeout bounds in scripts/wiki (#7213 slice 13).
+
+Every bounded call site must pass an explicit ``timeout=`` — 30s for git
+plumbing, 10s for the Darwin ``sysctl`` RAM probe, 300s for Codex concept
+extraction, and the documented 1800s ceiling for a wiki track compile+review —
+and must map ``subprocess.TimeoutExpired`` onto its documented degradation
+instead of an uncaught traceback:
+
+* ``backfill_generated_by_model.run_git``              → RuntimeError (check=True) / empty stdout (check=False)
+* ``backfill_generated_by_model.load_head_text``       → fall back to the on-disk working-tree text
+* ``backfill_generated_by_model.load_historical_meta`` → skip that commit (continue), like a non-zero rc
+* ``corpus_gaps.audit.run_codex_concept_extraction``   → RuntimeError("Codex concept extraction failed: …")
+* ``mlx_bridge.get_physical_ram``                      → return None (existing ``except Exception`` shape)
+* ``rebuild._run_compile``                             → non-zero exit code 124, no traceback
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from wiki.backfill_generated_by_model import (
+    GIT_TIMEOUT_S,
+    load_head_text,
+    load_historical_meta,
+    run_git,
+)
+from wiki.diagnostics.corpus_gaps.audit import CODEX_TIMEOUT_S, run_codex_concept_extraction
+
+from tests.project_python import project_python
+from wiki import backfill_generated_by_model as backfill
+from wiki import mlx_bridge, rebuild
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SYSCTL_TIMEOUT_S = 10
+
+
+def _completed(
+    cmd: list[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _timed_out(cmd: list[str], **_kwargs: object) -> subprocess.TimeoutExpired:
+    raise subprocess.TimeoutExpired(cmd, 30)
+
+
+# ---------------------------------------------------------------------------
+# backfill_generated_by_model.run_git
+# ---------------------------------------------------------------------------
+
+
+def test_run_git_passes_explicit_timeout() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"cmd": cmd, **kwargs})
+        return _completed(cmd, stdout="abc123\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        assert run_git("log", "-1", "--format=%H") == "abc123\n"
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == GIT_TIMEOUT_S == 30
+
+
+def test_run_git_maps_timeout_to_runtime_error_when_check() -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        with pytest.raises(RuntimeError, match="timed out after"):
+            run_git("log", "--follow")
+
+
+def test_run_git_timeout_returns_empty_stdout_when_check_false() -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        assert run_git("log", "-1", check=False) == ""
+
+
+# ---------------------------------------------------------------------------
+# backfill_generated_by_model.load_head_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def article_root(tmp_path: Path) -> tuple[Path, Path]:
+    """A fake project root holding one wiki article (created BEFORE patching)."""
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    article = wiki_dir / "article.md"
+    article.write_text("working-tree text\n", encoding="utf-8")
+    return tmp_path, article
+
+
+def test_load_head_text_passes_explicit_timeout(article_root, monkeypatch) -> None:
+    root, article = article_root
+    monkeypatch.setattr(backfill, "PROJECT_ROOT", root)
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        return _completed(cmd, stdout="head text\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        assert load_head_text(article) == "head text\n"
+
+    assert captured["timeout"] == GIT_TIMEOUT_S
+    assert captured["cwd"] == root
+    assert "HEAD:wiki/article.md" in captured["cmd"]
+
+
+def test_load_head_text_maps_timeout_to_disk_fallback(article_root, monkeypatch) -> None:
+    root, article = article_root
+    monkeypatch.setattr(backfill, "PROJECT_ROOT", root)
+
+    with patch("subprocess.run", side_effect=_timed_out):
+        assert load_head_text(article) == "working-tree text\n"
+
+
+# ---------------------------------------------------------------------------
+# backfill_generated_by_model.load_historical_meta
+# ---------------------------------------------------------------------------
+
+
+def test_load_historical_meta_passes_explicit_timeout_on_every_call(
+    article_root,
+    monkeypatch,
+) -> None:
+    root, article = article_root
+    monkeypatch.setattr(backfill, "PROJECT_ROOT", root)
+
+    timeouts: list[Any] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        timeouts.append(kwargs.get("timeout"))
+        if cmd[1] == "log":
+            return _completed(cmd, stdout="c1\nc2\n")
+        return _completed(cmd, stdout="<!-- wiki-meta\ngenerated_by_model: m\n-->")
+
+    with patch("subprocess.run", side_effect=fake_run):  # type: ignore[arg-type]
+        meta, origin = load_historical_meta(article)
+
+    assert set(timeouts) == {GIT_TIMEOUT_S}
+    assert len(timeouts) >= 2
+    assert meta.get("generated_by_model") == "m"
+    assert origin == "c1"
+
+
+def test_load_historical_meta_maps_timeout_to_commit_skip(article_root, monkeypatch) -> None:
+    root, article = article_root
+    monkeypatch.setattr(backfill, "PROJECT_ROOT", root)
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[1] == "log":
+            return _completed(cmd, stdout="c1\nc2\n")
+        raise subprocess.TimeoutExpired(cmd, GIT_TIMEOUT_S)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        meta, origin = load_historical_meta(article)
+
+    assert meta == {}
+    assert origin is None
+
+
+# ---------------------------------------------------------------------------
+# corpus_gaps.audit.run_codex_concept_extraction
+# ---------------------------------------------------------------------------
+
+
+def test_codex_extraction_passes_explicit_timeout() -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["timeout"] = kwargs.get("timeout")
+        output_idx = cmd.index("--output-last-message")
+        Path(cmd[output_idx + 1]).write_text(json.dumps({"concepts": []}), encoding="utf-8")
+        return _completed(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        payload = run_codex_concept_extraction("prompt")
+
+    assert payload == {"concepts": []}
+    assert captured["timeout"] == CODEX_TIMEOUT_S == 300
+
+
+def test_codex_extraction_maps_timeout_to_runtime_error() -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        with pytest.raises(RuntimeError, match="Codex concept extraction failed"):
+            run_codex_concept_extraction("prompt")
+
+
+# ---------------------------------------------------------------------------
+# mlx_bridge.get_physical_ram
+# ---------------------------------------------------------------------------
+
+
+def test_get_physical_ram_probe_passes_explicit_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    captured: dict[str, Any] = {}
+
+    def fake_check_output(cmd: list[str], **kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "17179869184\n"
+
+    with patch("subprocess.check_output", side_effect=fake_check_output):
+        assert mlx_bridge.get_physical_ram() == 17179869184
+
+    assert captured["timeout"] == SYSCTL_TIMEOUT_S == 10
+
+
+def test_get_physical_ram_maps_timeout_to_none(monkeypatch) -> None:
+    """TimeoutExpired is an Exception — the existing degrade-to-None shape holds."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    def timed_out_check_output(cmd: list[str], **_kwargs: Any) -> str:
+        raise subprocess.TimeoutExpired(cmd, SYSCTL_TIMEOUT_S)
+
+    with patch("subprocess.check_output", side_effect=timed_out_check_output):
+        assert mlx_bridge.get_physical_ram() is None
+
+
+# ---------------------------------------------------------------------------
+# rebuild._run_compile
+# ---------------------------------------------------------------------------
+
+
+def _task(slug: str | None = None) -> rebuild.TaskState:
+    return rebuild.TaskState(phase=2, track="b1", slug=slug)
+
+
+def test_run_compile_passes_documented_ceiling() -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        return _completed(cmd, returncode=0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        rc = rebuild._run_compile(_task())
+
+    assert rc == 0
+    assert captured["timeout"] == rebuild.COMPILE_TIMEOUT_S == 1800
+    assert "--review" in captured["cmd"]
+
+
+def test_run_compile_slug_task_extends_command() -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return _completed(cmd, returncode=3)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        rc = rebuild._run_compile(_task(slug="some-slug"))
+
+    assert rc == 3
+    assert commands[0][-2:] == ["--slug", "some-slug"]
+
+
+def test_run_compile_maps_timeout_to_nonzero_rc_not_traceback(capsys) -> None:
+    with patch("subprocess.run", side_effect=_timed_out):
+        rc = rebuild._run_compile(_task())
+
+    assert rc == 124
+    err = capsys.readouterr().err
+    assert "1800s" in err
+    assert "ceiling" in err
+
+
+def test_run_compile_keyboard_interrupt_still_returns_130() -> None:
+    def interrupted(cmd: list[str], **_kwargs: object) -> None:
+        raise KeyboardInterrupt
+
+    with patch("subprocess.run", side_effect=interrupted):
+        assert rebuild._run_compile(_task()) == 130
+
+
+# ---------------------------------------------------------------------------
+# Entry-point smoke (--help where a CLI exists; mlx_bridge has none)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("script", "needle"),
+    [
+        ("scripts/wiki/backfill_generated_by_model.py", "--write"),
+        ("scripts/wiki/diagnostics/corpus_gaps/audit.py", "--tracks"),
+        ("scripts/wiki/rebuild.py", "run"),
+    ],
+)
+def test_entry_point_help_smoke(script: str, needle: str) -> None:
+    """``--help`` parses and exits 0 for every wiki CLI touched by this slice.
+
+    ``PYTHONPATH`` mirrors the interpreter layout pytest itself provides via
+    pyproject ``pythonpath``: bare ``python scripts/wiki/<x>.py --help`` cannot
+    resolve the ``scripts`` namespace on main either (pre-existing F007-class
+    gap in scripts/storage/__init__.py, outside this slice's owned paths).
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PYTEST_") and key != "COV_CORE_SOURCE"
+    }
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    proc = subprocess.run(
+        [str(project_python()), str(REPO_ROOT / script), "--help"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, f"{script} --help failed:\n{proc.stdout}\n{proc.stderr}"
+    assert needle in proc.stdout


### PR DESCRIPTION
## Summary
Slice 13 of #7213: bound all 6 timeout-less subprocess sites under `scripts/wiki/` and remove those allowlist keys.

Allowlist **51 → 45**. Remaining `scripts/wiki/` keys: **0**.

Timeouts:
- git (`run_git`, `git show`): 30s
- Darwin `sysctl` RAM probe: 10s (existing `except Exception: return None`)
- Codex concept extraction: 300s → existing `RuntimeError("Codex concept extraction failed: …")`
- wiki compile+review: documented `COMPILE_TIMEOUT_S=1800` → return 124

New `tests/test_wiki_timeouts.py`.

## Driver verification
```
26 passed (guard + wiki timeouts)
ruff: All checks passed!
```

Implement: ox-alpha (OpenCode stealth). CF: kimi (ox-alpha is not CF of record).

Closes nothing (slice of #7213). Refs #7213, #7176.