### PR TITLE
fix(practice-deck): bound GitHub release subprocesses (#7213 slice 14)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -35,11 +35,6 @@ scripts/open_dataset/hydrate.py::_download_with_gh::subprocess.run
 scripts/open_dataset/publish.py::ensure_release::subprocess.run
 scripts/open_dataset/publish.py::ensure_release::subprocess.run
 scripts/open_dataset/publish.py::upload_release_asset::subprocess.run
-scripts/practice_deck/publish.py::_download_release_asset::subprocess.run
-scripts/practice_deck/publish.py::_release_asset_names::subprocess.run
-scripts/practice_deck/publish.py::ensure_release::subprocess.run
-scripts/practice_deck/publish.py::ensure_release::subprocess.run
-scripts/practice_deck/publish.py::upload_release_asset::subprocess.run
 scripts/pre_commit/check_plan_immutability.py::_git_blob_exists::subprocess.run
 scripts/pre_commit/check_plan_immutability.py::_run_git::subprocess.run
 scripts/projects/open_model_data/phase3_heldout_label_transport.py::run_cycle002::subprocess.run

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -38,6 +38,9 @@ DEFAULT_RELEASE_TAG = "atlas-practice-deck"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-practice-deck.json.gz"
 LEVELS = ("A1", "A2", "B1", "B2", "C1")
+GH_RELEASE_VIEW_TIMEOUT_SECONDS = 30.0
+GH_RELEASE_CREATE_TIMEOUT_SECONDS = 60.0
+GH_RELEASE_ASSET_TIMEOUT_SECONDS = 180.0
 KINDS = {
     "index": ("practice-index.{level}.json", "atlas-practice-index"),
     "lexemes": ("practice-lexemes.{level}.json", "atlas-practice-lexemes"),
@@ -55,6 +58,15 @@ KINDS = {
 
 class PracticeDeckPublishError(RuntimeError):
     """Raised when the practice deck release asset cannot be built."""
+
+
+def _called_process_error_from_timeout(exc: subprocess.TimeoutExpired) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(
+        returncode=124,
+        cmd=exc.cmd,
+        output=exc.output,
+        stderr=exc.stderr,
+    )
 
 
 def _sha256(data: bytes) -> str:
@@ -238,29 +250,39 @@ def write_pointer(pointer_path: Path, payload: dict[str, Any]) -> None:
 
 
 def ensure_release(release_tag: str, repo: str) -> None:
-    existing = subprocess.run(
-        ["gh", "release", "view", release_tag, "--repo", repo],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        existing = subprocess.run(
+            ["gh", "release", "view", release_tag, "--repo", repo],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise PracticeDeckPublishError(
+            f"Timed out checking whether GitHub release {release_tag!r} exists"
+        ) from exc
     if existing.returncode == 0:
         return
-    subprocess.run(
-        [
-            "gh",
-            "release",
-            "create",
-            release_tag,
-            "--repo",
-            repo,
-            "--title",
-            "Atlas practice deck",
-            "--notes",
-            "Release asset storage for generated Atlas practice deck shards.",
-        ],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "release",
+                "create",
+                release_tag,
+                "--repo",
+                repo,
+                "--title",
+                "Atlas practice deck",
+                "--notes",
+                "Release asset storage for generated Atlas practice deck shards.",
+            ],
+            check=True,
+            timeout=GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _called_process_error_from_timeout(exc) from exc
 
 
 def upload_release_asset(
@@ -289,16 +311,23 @@ def upload_release_asset(
         ]
         if clobber:
             command.append("--clobber")
-        subprocess.run(command, check=True)
+        try:
+            subprocess.run(command, check=True, timeout=GH_RELEASE_ASSET_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            raise _called_process_error_from_timeout(exc) from exc
 
 
 def _release_asset_names(*, release_tag: str = DEFAULT_RELEASE_TAG, repo: str = DEFAULT_REPO) -> set[str]:
-    result = subprocess.run(
-        ["gh", "release", "view", release_tag, "--repo", repo, "--json", "assets"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "release", "view", release_tag, "--repo", repo, "--json", "assets"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _called_process_error_from_timeout(exc) from exc
     payload = json.loads(result.stdout)
     assets = payload.get("assets", [])
     if not isinstance(assets, list):
@@ -312,11 +341,15 @@ def _download_release_asset(
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
 ) -> bytes:
-    result = subprocess.run(
-        ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
-        check=True,
-        capture_output=True,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
+            check=True,
+            capture_output=True,
+            timeout=GH_RELEASE_ASSET_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _called_process_error_from_timeout(exc) from exc
     return result.stdout
 
 
@@ -418,21 +451,36 @@ def publish_practice_deck(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Publish the Atlas practice deck release asset.")
-    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
-    parser.add_argument("--gzip", type=Path, default=DEFAULT_GZIP)
-    parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
-    parser.add_argument("--atlas-db", type=Path, default=DEFAULT_ATLAS_DB)
-    parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
-    parser.add_argument("--sentence-inventory", type=Path, default=DEFAULT_SENTENCE_INVENTORY)
-    parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
-    parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
-    parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS)
-    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS)
-    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
-    parser.add_argument("--curated-membership", type=Path)
-    parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
-    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build and publish the hash-pinned Atlas practice deck release asset.\n"
+            "Use after rebuilding the practice shards; use --dry-run to validate without publishing."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  /home/ops/learn-ukrainian/.venv/bin/python scripts/practice_deck/publish.py --dry-run\n"
+            "  /home/ops/learn-ukrainian/.venv/bin/python scripts/practice_deck/publish.py "
+            "--release-tag atlas-practice-deck --repo learn-ukrainian/learn-ukrainian.github.io\n\n"
+            "Outputs: writes the gzip asset and pointer locally; without --dry-run, uploads GitHub Release assets.\n"
+            "Exit codes: 0 on success; non-zero when validation, GitHub, or filesystem work fails.\n"
+            "Related: practice-deck generation and timeout guard for issue #7213."
+        ),
+    )
+    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR, help="Shard directory (default: %(default)s).")
+    parser.add_argument("--gzip", type=Path, default=DEFAULT_GZIP, help="Output gzip package path (default: %(default)s).")
+    parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER, help="Output pointer JSON path (default: %(default)s).")
+    parser.add_argument("--atlas-db", type=Path, default=DEFAULT_ATLAS_DB, help="Public Atlas DB input (default: %(default)s).")
+    parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES, help="Cloze-source JSON input (default: %(default)s).")
+    parser.add_argument("--sentence-inventory", type=Path, default=DEFAULT_SENTENCE_INVENTORY, help="Sentence-inventory JSON input (default: %(default)s).")
+    parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS, help="Heritage-pair YAML input (default: %(default)s).")
+    parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS, help="Paronym-pair YAML input (default: %(default)s).")
+    parser.add_argument("--antonym-pairs", type=Path, default=DEFAULT_ANTONYM_PAIRS, help="Antonym-pair YAML input (default: %(default)s).")
+    parser.add_argument("--homonym-pairs", type=Path, default=DEFAULT_HOMONYM_PAIRS, help="Homonym-pair YAML input (default: %(default)s).")
+    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS, help="Synonym-verdict YAML input (default: %(default)s).")
+    parser.add_argument("--curated-membership", type=Path, help="Optional curated-membership JSON input (default: none).")
+    parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG, help="GitHub Release tag (default: %(default)s).")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository in OWNER/REPO form (default: %(default)s).")
     parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading/writing pointer")
     args = parser.parse_args()
     pointer = publish_practice_deck(

--- a/tests/test_practice_deck_timeouts.py
+++ b/tests/test_practice_deck_timeouts.py
@@ -1,0 +1,154 @@
+"""Timeout and failure-shape tests for practice-deck GitHub Release calls."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.practice_deck import publish as publish_module
+
+
+def test_release_subprocesses_use_operation_timeouts_and_preserve_clobber(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / publish_module.ASSET_NAME
+    upload_path.write_bytes(b"gzip bytes")
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        if cmd[:3] == ["gh", "release", "view"]:
+            if "--json" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout='{"assets":[]}', stderr="")
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+        if cmd[:3] == ["gh", "release", "download"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"gzip bytes", stderr=b"")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    publish_module.ensure_release("tag", "owner/repo")
+    assert publish_module._release_asset_names(release_tag="tag", repo="owner/repo") == set()
+    monkeypatch.setattr(publish_module, "ensure_release", lambda *_args, **_kwargs: None)
+    publish_module.upload_release_asset(
+        upload_path,
+        release_tag="tag",
+        repo="owner/repo",
+        clobber=True,
+    )
+    assert publish_module._download_release_asset("asset.gz", release_tag="tag", repo="owner/repo") == b"gzip bytes"
+
+    assert [call["timeout"] for call in calls] == [
+        publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS,
+    ]
+    upload_call = next(call for call in calls if call["cmd"][:3] == ["gh", "release", "upload"])
+    assert "--clobber" in upload_call["cmd"]
+
+
+def test_ensure_release_view_timeout_is_publish_error_and_never_creates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(publish_module.PracticeDeckPublishError, match="Timed out"):
+        publish_module.ensure_release("tag", "owner/repo")
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS
+    assert calls[0]["cmd"][:3] == ["gh", "release", "view"]
+
+
+def test_ensure_release_create_timeout_maps_to_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        if cmd[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout=None, stderr=None)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module.ensure_release("tag", "owner/repo")
+
+    assert exc_info.value.returncode == 124
+    assert [call["timeout"] for call in calls] == [
+        publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+    ]
+    assert calls[1]["cmd"][:3] == ["gh", "release", "create"]
+
+
+def test_upload_release_asset_timeout_maps_to_called_process_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / publish_module.ASSET_NAME
+    upload_path.write_bytes(b"gzip bytes")
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(publish_module, "ensure_release", lambda *_args, **_kwargs: None)
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module.upload_release_asset(upload_path, clobber=True)
+
+    assert exc_info.value.returncode == 124
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS
+    assert "--clobber" in calls[0]["cmd"]
+
+
+def test_release_asset_names_timeout_maps_to_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module._release_asset_names()
+
+    assert exc_info.value.returncode == 124
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS
+
+
+def test_download_release_asset_timeout_maps_to_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module._download_release_asset("asset.gz")
+
+    assert exc_info.value.returncode == 124
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary
Slice 14 of #7213: bound all 5 timeout-less `subprocess.run` sites in `scripts/practice_deck/publish.py` and remove those allowlist keys.

Allowlist **45 → 40**. Remaining `scripts/practice_deck/` keys: **0**.

Timeouts: `gh release view` 30s; `create` 60s; `upload`/`download` 180s.

Critical mapping: a timed-out `gh release view` raises `PracticeDeckPublishError` and **does not** fall through into `gh release create`. Other `check=True` timeouts map to `CalledProcessError(returncode=124)`.

New `tests/test_practice_deck_timeouts.py`.

## Driver verification
```
14 passed (guard + practice_deck timeouts)
ruff: All checks passed!
```

Implement: Codex (NOTE substitution — ox-alpha OpenCode hit `stealth/ox-alpha is temporarily rate-limited upstream`, same class as slice 9). CF: kimi.

Nit for reviewer: `main()` argparse help/epilog was expanded in the same commit (not required by the timeout brief). Functional timeout work is independent.

Closes nothing (slice of #7213). Refs #7213, #7176.