### PR TITLE
fix(open-dataset): bound GitHub release subprocesses (#7213 slice 15)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -31,10 +31,6 @@ scripts/lexicon/runner/atlas_job.py::run_restic_sink::subprocess.run
 scripts/lexicon/runner/durable_mirror.py::sync_source_to_mirror::subprocess.run
 scripts/lib/session_record.py::canonical_state_root::subprocess.run
 scripts/migrate/rename_track.py::git_mv::subprocess.run
-scripts/open_dataset/hydrate.py::_download_with_gh::subprocess.run
-scripts/open_dataset/publish.py::ensure_release::subprocess.run
-scripts/open_dataset/publish.py::ensure_release::subprocess.run
-scripts/open_dataset/publish.py::upload_release_asset::subprocess.run
 scripts/pre_commit/check_plan_immutability.py::_git_blob_exists::subprocess.run
 scripts/pre_commit/check_plan_immutability.py::_run_git::subprocess.run
 scripts/projects/open_model_data/phase3_heldout_label_transport.py::run_cycle002::subprocess.run

--- a/scripts/open_dataset/hydrate.py
+++ b/scripts/open_dataset/hydrate.py
@@ -17,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DATASET_ROOT = ROOT / "data" / "lexicon-dataset"
 DEFAULT_POINTER = ROOT / "data" / "lexicon-dataset.pointer.json"
 ASSET_NAME = "lexicon-open-dataset.json.gz"
+GH_RELEASE_DOWNLOAD_TIMEOUT_SECONDS = 180.0
 REQUIRED_POINTER_KEYS = (
     "asset_url",
     "release_tag",
@@ -74,8 +75,9 @@ def _download_with_gh(pointer: dict[str, Any], repo: str) -> bytes | None:
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
+            timeout=GH_RELEASE_DOWNLOAD_TIMEOUT_SECONDS,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None

--- a/scripts/open_dataset/publish.py
+++ b/scripts/open_dataset/publish.py
@@ -19,6 +19,9 @@ DEFAULT_GZIP = ROOT / "data" / "lexicon-open-dataset.json.gz"
 DEFAULT_RELEASE_TAG = "atlas-open-dataset"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-open-dataset.json.gz"
+GH_RELEASE_VIEW_TIMEOUT_SECONDS = 30.0
+GH_RELEASE_CREATE_TIMEOUT_SECONDS = 60.0
+GH_RELEASE_ASSET_TIMEOUT_SECONDS = 180.0
 REQUIRED_DATASET_FILES = (
     "README.md",
     "ATTRIBUTION.md",
@@ -29,6 +32,15 @@ REQUIRED_DATASET_FILES = (
 
 class OpenDatasetPublishError(RuntimeError):
     """Raised when the open dataset package cannot be published."""
+
+
+def _called_process_error_from_timeout(exc: subprocess.TimeoutExpired) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(
+        returncode=124,
+        cmd=exc.cmd,
+        output=exc.output,
+        stderr=exc.stderr,
+    )
 
 
 def _sha256(data: bytes) -> str:
@@ -129,46 +141,55 @@ def write_pointer(pointer_path: Path, payload: dict[str, Any]) -> None:
 
 
 def ensure_release(release_tag: str, repo: str) -> None:
-    existing = subprocess.run(
-        ["gh", "release", "view", release_tag, "--repo", repo],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        existing = subprocess.run(
+            ["gh", "release", "view", release_tag, "--repo", repo],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OpenDatasetPublishError(f"Timed out checking whether GitHub release {release_tag!r} exists") from exc
     if existing.returncode == 0:
         return
-    subprocess.run(
-        [
-            "gh",
-            "release",
-            "create",
-            release_tag,
-            "--repo",
-            repo,
-            "--title",
-            "Word Atlas open dataset",
-            "--notes",
-            "Release asset storage for the open Word Atlas lexicon dataset.",
-        ],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "release",
+                "create",
+                release_tag,
+                "--repo",
+                repo,
+                "--title",
+                "Word Atlas open dataset",
+                "--notes",
+                "Release asset storage for the open Word Atlas lexicon dataset.",
+            ],
+            check=True,
+            timeout=GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _called_process_error_from_timeout(exc) from exc
 
 
 def upload_release_asset(gzip_path: Path, *, release_tag: str, repo: str) -> None:
     ensure_release(release_tag, repo)
-    subprocess.run(
-        [
-            "gh",
-            "release",
-            "upload",
-            release_tag,
-            str(gzip_path),
-            "--repo",
-            repo,
-            "--clobber",
-        ],
-        check=True,
-    )
+    command = [
+        "gh",
+        "release",
+        "upload",
+        release_tag,
+        str(gzip_path),
+        "--repo",
+        repo,
+        "--clobber",
+    ]
+    try:
+        subprocess.run(command, check=True, timeout=GH_RELEASE_ASSET_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        raise _called_process_error_from_timeout(exc) from exc
 
 
 def publish_open_dataset(

--- a/tests/test_open_dataset_timeouts.py
+++ b/tests/test_open_dataset_timeouts.py
@@ -1,0 +1,175 @@
+"""Timeout and failure-shape tests for open-dataset GitHub Release calls (#7213 slice 15)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from urllib.request import Request
+
+import pytest
+
+from scripts.open_dataset import hydrate as hydrate_module
+from scripts.open_dataset import publish as publish_module
+
+
+def test_release_subprocesses_use_operation_timeouts_and_preserve_clobber(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "lexicon-open-dataset.json.gz"
+    upload_path.write_bytes(b"gzip bytes")
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        if cmd[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    publish_module.ensure_release("tag", "owner/repo")
+    monkeypatch.setattr(publish_module, "ensure_release", lambda *_args, **_kwargs: None)
+    publish_module.upload_release_asset(upload_path, release_tag="tag", repo="owner/repo")
+
+    assert [call["timeout"] for call in calls] == [
+        publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS,
+    ]
+    upload_call = next(call for call in calls if call["cmd"][:3] == ["gh", "release", "upload"])
+    assert "--clobber" in upload_call["cmd"]
+
+
+def test_ensure_release_view_timeout_is_publish_error_and_never_creates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(publish_module.OpenDatasetPublishError, match="Timed out"):
+        publish_module.ensure_release("tag", "owner/repo")
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS
+    assert calls[0]["cmd"][:3] == ["gh", "release", "view"]
+
+
+def test_ensure_release_create_timeout_maps_to_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        if cmd[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout=None, stderr=None)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module.ensure_release("tag", "owner/repo")
+
+    assert exc_info.value.returncode == 124
+    assert [call["timeout"] for call in calls] == [
+        publish_module.GH_RELEASE_VIEW_TIMEOUT_SECONDS,
+        publish_module.GH_RELEASE_CREATE_TIMEOUT_SECONDS,
+    ]
+    assert calls[1]["cmd"][:3] == ["gh", "release", "create"]
+
+
+def test_upload_release_asset_timeout_maps_to_called_process_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "lexicon-open-dataset.json.gz"
+    upload_path.write_bytes(b"gzip bytes")
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(publish_module, "ensure_release", lambda *_args, **_kwargs: None)
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(publish_module.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        publish_module.upload_release_asset(upload_path, release_tag="tag", repo="owner/repo")
+
+    assert exc_info.value.returncode == 124
+    assert calls[0]["timeout"] == publish_module.GH_RELEASE_ASSET_TIMEOUT_SECONDS
+    assert "--clobber" in calls[0]["cmd"]
+
+
+def test_download_with_gh_timeout_maps_to_none_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+    pointer = {"release_tag": "atlas-open-dataset"}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(hydrate_module.subprocess, "run", fake_run)
+
+    assert hydrate_module._download_with_gh(pointer, repo="owner/repo") is None
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == hydrate_module.GH_RELEASE_DOWNLOAD_TIMEOUT_SECONDS
+    assert calls[0]["cmd"][:3] == ["gh", "release", "download"]
+
+
+def test_download_with_gh_timeout_falls_back_to_asset_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeResponse:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return self._payload
+
+    gh_calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        gh_calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(hydrate_module.subprocess, "run", fake_run)
+    url_calls: list[Request] = []
+
+    def fake_urlopen(request: Request, timeout: float) -> _FakeResponse:
+        url_calls.append(request)
+        assert timeout > 0
+        return _FakeResponse(b"url bytes")
+
+    monkeypatch.setattr(hydrate_module, "urlopen", fake_urlopen)
+
+    pointer = {"release_tag": "atlas-open-dataset", "asset_url": "https://example.com/asset.gz"}
+    assert hydrate_module.download_asset(pointer, repo="owner/repo") == b"url bytes"
+
+    assert len(gh_calls) == 1
+    assert len(url_calls) == 1
+
+
+def test_download_with_gh_success_returns_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        calls.append({"cmd": cmd, **kwargs})
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"gzip bytes", stderr=b"")
+
+    monkeypatch.setattr(hydrate_module.subprocess, "run", fake_run)
+
+    pointer = {"release_tag": "atlas-open-dataset"}
+    assert hydrate_module._download_with_gh(pointer, repo="owner/repo") == b"gzip bytes"
+    assert calls[0]["timeout"] == hydrate_module.GH_RELEASE_DOWNLOAD_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary
Slice 15 of #7213: bound all 4 timeout-less `subprocess.run` sites under `scripts/open_dataset/` and remove those allowlist keys.

Allowlist **40 → 36**. Remaining `scripts/open_dataset/` keys: **0**.

Mirrors practice_deck (#7287): view 30s, create 60s, upload/download 180s. Timed-out `gh release view` raises `OpenDatasetPublishError` and does not create. `_download_with_gh` maps TimeoutExpired to the existing `None` fallback. `--clobber` preserved.

New `tests/test_open_dataset_timeouts.py`.

## Driver verification
```
15 passed (guard + open_dataset timeouts)
ruff: All checks passed!
```

Implement: ox-alpha (OpenCode stealth; canary PONG $0 this hour). CF: kimi.

Closes nothing (slice of #7213). Refs #7213, #7176.