### PR TITLE
fix(sync): bound subprocess calls (#7213 slice 16)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -41,10 +41,6 @@ scripts/projects/ua_eval_harness/run_codex_baseline.py::_cli_version::subprocess
 scripts/review/snapshot.py::_run_git::subprocess.run
 scripts/session_canary/grok_lane.py::cmd_mint::subprocess.run
 scripts/session_canary/grok_lane.py::cmd_score::subprocess.run
-scripts/sync/promote_module.py::_branch_for_worktree::subprocess.run
-scripts/sync/promote_module.py::_run_generate_readings::subprocess.run
-scripts/sync/promote_module.py::_run_git::subprocess.run
 scripts/sync/promote_module.py::_run_make_atlas::subprocess.run
-scripts/sync/prune_module_forensics.py::_run_git::subprocess.run
 scripts/validate/verify_track.py::run_audit::subprocess.run
 scripts/vocab/rebuild_vocab_from_yaml.py::populate_database::subprocess.run

--- a/scripts/sync/promote_module.py
+++ b/scripts/sync/promote_module.py
@@ -52,6 +52,9 @@ ATLAS_OUTPUT_FILES = (
 )
 READINGS_GENERATOR = "scripts.readings.generate_readings"
 PROMOTE_QUALITY_FILE = "promote_quality.json"
+_GIT_TIMEOUT_SECONDS = 30
+_READINGS_TIMEOUT_SECONDS = 300
+_TIMEOUT_RETURN_CODE = 124
 
 LESSON_SOURCE_FILES = frozenset(
     {
@@ -102,12 +105,29 @@ def _sanitized_git_env() -> dict[str, str]:
 
 
 def _run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
-    return subprocess.run(
-        ["git", "-C", str(repo_root), *args],
-        check=check,
-        capture_output=True,
-        env=_sanitized_git_env(),
-    )
+    command = ["git", "-C", str(repo_root), *args]
+    try:
+        return subprocess.run(
+            command,
+            check=check,
+            capture_output=True,
+            env=_sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if check:
+            raise subprocess.CalledProcessError(
+                _TIMEOUT_RETURN_CODE,
+                command,
+                output=exc.output,
+                stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s".encode(),
+            ) from exc
+        return subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout=exc.output or b"",
+            stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s".encode(),
+        )
 
 
 def _decode(data: bytes) -> str:
@@ -204,12 +224,17 @@ def _resolve_latest_branch(repo_root: Path, level: str, slug: str) -> str:
 
 
 def _branch_for_worktree(worktree: Path) -> str | None:
-    proc = subprocess.run(
-        ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
-        check=False,
-        capture_output=True,
-        env=_sanitized_git_env(),
-    )
+    command = ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"]
+    try:
+        proc = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            env=_sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     if proc.returncode != 0:
         return None
     branch = _decode(proc.stdout).strip()
@@ -389,19 +414,33 @@ def _run_generate_readings(repo_root: Path, source: SourceSpec) -> tuple[int, li
     if source.level != "folk":
         return 0, []
     module_dir = CURRICULUM_ROOT / source.level / source.slug
-    proc = subprocess.run(
-        [
-            str(_python(repo_root)),
-            "-m",
-            READINGS_GENERATOR,
-            module_dir.as_posix(),
-            "--json",
-        ],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        env=_sanitized_git_env(),
-    )
+    command = [
+        str(_python(repo_root)),
+        "-m",
+        READINGS_GENERATOR,
+        module_dir.as_posix(),
+        "--json",
+    ]
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            env=_sanitized_git_env(),
+            timeout=_READINGS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stderr = exc.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        print(
+            f"ERROR readings generator timed out after {_READINGS_TIMEOUT_SECONDS}s",
+            file=sys.stderr,
+        )
+        if stderr:
+            print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
+        return _TIMEOUT_RETURN_CODE, []
     if proc.stderr:
         print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
     if proc.returncode != 0:

--- a/scripts/sync/prune_module_forensics.py
+++ b/scripts/sync/prune_module_forensics.py
@@ -16,6 +16,9 @@ if str(ROOT) not in sys.path:
 
 from scripts.sync.promote_module import CURRICULUM_ROOT, FORENSICS_FILES, _sanitized_git_env
 
+_GIT_TIMEOUT_SECONDS = 30
+_TIMEOUT_RETURN_CODE = 124
+
 
 @dataclass(frozen=True)
 class ModuleTarget:
@@ -32,12 +35,29 @@ class ModuleTarget:
 
 
 def _run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
-    return subprocess.run(
-        ["git", "-C", str(repo_root), *args],
-        check=check,
-        capture_output=True,
-        env=_sanitized_git_env(),
-    )
+    command = ["git", "-C", str(repo_root), *args]
+    try:
+        return subprocess.run(
+            command,
+            check=check,
+            capture_output=True,
+            env=_sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if check:
+            raise subprocess.CalledProcessError(
+                _TIMEOUT_RETURN_CODE,
+                command,
+                output=exc.output,
+                stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s".encode(),
+            ) from exc
+        return subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout=exc.output or b"",
+            stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s".encode(),
+        )
 
 
 def _decode(data: bytes) -> str:

--- a/tests/test_sync_timeouts.py
+++ b/tests/test_sync_timeouts.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.sync import promote_module, prune_module_forensics
+
+
+def _raise_timeout(calls: list[dict[str, Any]]) -> Any:
+    def fake_run(*args: object, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    return fake_run
+
+
+def test_promote_run_git_timeout_returns_124_when_check_false(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(promote_module.subprocess, "run", _raise_timeout(calls))
+
+    result = promote_module._run_git(tmp_path, ["status"], check=False)
+
+    assert calls[0]["timeout"] == 30
+    assert result.returncode == 124
+    assert result.args == ["git", "-C", str(tmp_path), "status"]
+    assert result.stderr == b"TimeoutExpired after 30s"
+
+
+def test_promote_run_git_timeout_raises_called_process_error_when_check_true(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(promote_module.subprocess, "run", _raise_timeout(calls))
+
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        promote_module._run_git(tmp_path, ["status"])
+
+    assert calls[0]["timeout"] == 30
+    assert raised.value.returncode == 124
+
+
+def test_prune_run_git_timeout_returns_124_when_check_false(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(prune_module_forensics.subprocess, "run", _raise_timeout(calls))
+
+    result = prune_module_forensics._run_git(tmp_path, ["status"], check=False)
+
+    assert calls[0]["timeout"] == 30
+    assert result.returncode == 124
+
+
+def test_branch_for_worktree_timeout_returns_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(promote_module.subprocess, "run", _raise_timeout(calls))
+
+    assert promote_module._branch_for_worktree(tmp_path) is None
+    assert calls[0]["timeout"] == 30
+
+
+def test_generate_readings_timeout_returns_nonzero_and_prints_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(promote_module.subprocess, "run", _raise_timeout(calls))
+    source = promote_module.SourceSpec(build_ref="", level="folk", slug="test-module")
+
+    status, written = promote_module._run_generate_readings(tmp_path, source)
+
+    assert status == 124
+    assert written == []
+    assert calls[0]["timeout"] == 300
+    assert "readings generator timed out after 300s" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
Slice 16 of #7213: bound 4 timeout-less `subprocess.run` sites under `scripts/sync/` and remove those allowlist keys. Kept `make atlas` unbounded (SKIP-class data-plane) with its allowlist row.

Allowlist **36 → 32**. Remaining `scripts/sync/` keys: **1** (`_run_make_atlas` only).

Timeouts: git 30s; folk readings generator 300s. `_branch_for_worktree` timeout → None. `_run_git(check=True)` timeout → CalledProcessError rc=124. `_run_generate_readings` timeout → return 124, [].

New `tests/test_sync_timeouts.py`.

## Driver verification
```
13 passed (guard + sync timeouts)
ruff: All checks passed!
```

Implement: Codex (NOTE substitution — ox-alpha stealth 429 this hour). CF: kimi.

Closes nothing (slice of #7213). Refs #7213, #7176.