### PR TITLE
fix(hooks): bound git plumbing subprocesses (#7213 slice 17)

### DIFF
--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -22,8 +22,6 @@ scripts/generate_mdx/core.py::main::subprocess.run
 scripts/generate_mdx/generate_plan_markdown.py::main::subprocess.run
 scripts/hooks/hook_timing.py::run_wrapped::subprocess.run
 scripts/hooks/measure_hook_stack.py::_time_one::subprocess.run
-scripts/hygiene/lane_disk_retention.py::_git::subprocess.run
-scripts/hygiene/root_entry_guard.py::_run_git::subprocess.run
 scripts/lexicon/fill_from_content.py::_run_enrichment::subprocess.run
 scripts/lexicon/runner/atlas_job.py::_run_backup_doctor::subprocess.call
 scripts/lexicon/runner/atlas_job.py::run_restic_sink::subprocess.run
@@ -31,16 +29,12 @@ scripts/lexicon/runner/atlas_job.py::run_restic_sink::subprocess.run
 scripts/lexicon/runner/durable_mirror.py::sync_source_to_mirror::subprocess.run
 scripts/lib/session_record.py::canonical_state_root::subprocess.run
 scripts/migrate/rename_track.py::git_mv::subprocess.run
-scripts/pre_commit/check_plan_immutability.py::_git_blob_exists::subprocess.run
-scripts/pre_commit/check_plan_immutability.py::_run_git::subprocess.run
 scripts/projects/open_model_data/phase3_heldout_label_transport.py::run_cycle002::subprocess.run
 scripts/projects/open_model_data/phase3_rule_author_runner.py::run::subprocess.run
 scripts/projects/open_model_data/phase3_source_production_transport.py::_subprocess_invoke::subprocess.run
 scripts/projects/ua_eval_harness/build_heldout_manifest.py::_git_head::subprocess.run
 scripts/projects/ua_eval_harness/run_codex_baseline.py::_cli_version::subprocess.run
 scripts/review/snapshot.py::_run_git::subprocess.run
-scripts/session_canary/grok_lane.py::cmd_mint::subprocess.run
-scripts/session_canary/grok_lane.py::cmd_score::subprocess.run
 scripts/sync/promote_module.py::_run_make_atlas::subprocess.run
 scripts/validate/verify_track.py::run_audit::subprocess.run
 scripts/vocab/rebuild_vocab_from_yaml.py::populate_database::subprocess.run

--- a/scripts/hygiene/lane_disk_retention.py
+++ b/scripts/hygiene/lane_disk_retention.py
@@ -24,6 +24,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WORKTREE_STALE_HOURS = 72
 DEFAULT_SESSION_STALE_DAYS = 14
+_GIT_TIMEOUT_SECONDS = 30
 
 
 @dataclass(frozen=True)
@@ -37,13 +38,17 @@ class WorktreeReport:
 
 
 def _git(args: list[str], *, cwd: Path) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ""
     return (result.stdout or "").strip()
 
 

--- a/scripts/hygiene/root_entry_guard.py
+++ b/scripts/hygiene/root_entry_guard.py
@@ -37,6 +37,9 @@ except ImportError:  # scripts/ on sys.path (stripped flavor)
 
 __all__ = ["UnexpectedEntry", "main", "scan_unexpected_root_entries"]
 
+_GIT_TIMEOUT_SECONDS = 30
+_TIMEOUT_RETURN_CODE = 124
+
 
 class UnexpectedEntry:
     """One top-level repo-root entry that git does not expect."""
@@ -56,13 +59,23 @@ class UnexpectedEntry:
 
 
 def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", "-C", str(root), *args],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=sanitized_git_env(),
-    )
+    command = ["git", "-C", str(root), *args]
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=sanitized_git_env(),
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s",
+        )
 
 
 def _tracked_top_level_names(root: Path) -> set[str]:

--- a/scripts/pre_commit/check_plan_immutability.py
+++ b/scripts/pre_commit/check_plan_immutability.py
@@ -23,17 +23,29 @@ METADATA_ONLY_FIELDS = {
     "prerequisites",
 }
 YAML_BACKUP_SUFFIXES = (".yaml.bak", ".yml.bak", ".yaml.orig", ".yml.orig")
+_GIT_TIMEOUT_SECONDS = 30
+_TIMEOUT_RETURN_CODE = 124
 
 
 def _run_git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     """Run a git command from the target repository."""
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    command = ["git", *args]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        result = subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or f"git {' '.join(args)} timed out after {exc.timeout}s",
+        )
     if check and result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
     return result
@@ -62,14 +74,22 @@ def _is_yaml_backup_path(path: str) -> bool:
 
 
 def _git_blob_exists(repo_root: Path, spec: str) -> bool:
-    """Return whether a git object spec resolves successfully."""
-    result = subprocess.run(
-        ["git", "cat-file", "-e", spec],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    """Return whether a git object spec resolves successfully.
+
+    A timed-out probe counts as missing (falsy) so the pre-commit hook
+    degrades to skipping the comparison instead of hanging or raising.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-e", spec],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return result.returncode == 0
 
 

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -84,6 +84,8 @@ EPIC_STREAM_DEFAULTS: dict[str, str] = _epic_stream_defaults()
 DEFAULT_PASS_RATIO = 0.8
 DEFAULT_SIM_THRESHOLD = 0.75
 N_ANCHORS = 10
+_CANARY_TIMEOUT_SECONDS = 30
+_TIMEOUT_RETURN_CODE = 124
 
 
 def _utc_now() -> str:
@@ -363,21 +365,31 @@ def cmd_mint(args: argparse.Namespace) -> int:
     facts_path.write_text(json.dumps(facts, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     # Delegate freeze to context_canary (legacy path) so scoring stays shared.
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(repo / "scripts" / "context_canary.py"),
-            "mint",
-            "--facts",
-            str(facts_path),
-            "--out",
-            str(probe_path),
-        ],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    command = [
+        sys.executable,
+        str(repo / "scripts" / "context_canary.py"),
+        "mint",
+        "--facts",
+        str(facts_path),
+        "--out",
+        str(probe_path),
+    ]
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CANARY_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        proc = subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout="",
+            stderr=exc.stderr or f"context_canary mint timed out after {exc.timeout}s",
+        )
     if proc.returncode != 0:
         print(proc.stdout, end="")
         print(proc.stderr, end="", file=sys.stderr)
@@ -450,31 +462,41 @@ def cmd_score(args: argparse.Namespace) -> int:
     pass_ratio = float(args.pass_ratio)
     threshold = float(args.threshold)
 
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(repo / "scripts" / "context_canary.py"),
-            "score",
-            "--probe",
-            str(probe_path),
-            "--answers",
-            str(answers_path),
-            "--pass-ratio",
-            str(pass_ratio),
-            "--threshold",
-            str(threshold),
-            "--context-tokens",
-            str(int(args.context_tokens)),
-            "--model",
-            args.model,
-            "--log",
-            str(log_path),
-        ],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    command = [
+        sys.executable,
+        str(repo / "scripts" / "context_canary.py"),
+        "score",
+        "--probe",
+        str(probe_path),
+        "--answers",
+        str(answers_path),
+        "--pass-ratio",
+        str(pass_ratio),
+        "--threshold",
+        str(threshold),
+        "--context-tokens",
+        str(int(args.context_tokens)),
+        "--model",
+        args.model,
+        "--log",
+        str(log_path),
+    ]
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CANARY_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        proc = subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout="",
+            stderr=exc.stderr or f"context_canary score timed out after {exc.timeout}s",
+        )
     print(proc.stdout, end="")
     if proc.stderr:
         print(proc.stderr, end="", file=sys.stderr)

--- a/tests/test_git_probe_timeouts.py
+++ b/tests/test_git_probe_timeouts.py
@@ -1,0 +1,189 @@
+"""Timeout contracts for the six git-probe subprocess sites (#7213 slice 17).
+
+Every site below previously ran ``subprocess.run`` unbounded and now must:
+1. pass ``timeout=30`` to every call, and
+2. map ``subprocess.TimeoutExpired`` onto its existing fail-closed /
+   non-zero / falsy shape (these run in hooks and CLI lanes, so a raw
+   TimeoutExpired traceback must never escape).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.hygiene import lane_disk_retention, root_entry_guard
+from scripts.pre_commit import check_plan_immutability
+from scripts.session_canary import grok_lane
+
+
+def _raise_timeout(calls: list[dict[str, Any]]) -> Any:
+    def fake_run(*args: object, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    return fake_run
+
+
+def _completed_ok(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+
+# --- scripts/pre_commit/check_plan_immutability.py ---------------------------
+
+
+def test_check_plan_run_git_timeout_raises_runtime_error_when_check_true(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(check_plan_immutability.subprocess, "run", _raise_timeout(calls))
+
+    with pytest.raises(RuntimeError, match="timed out after 30s"):
+        check_plan_immutability._run_git(tmp_path, "rev-parse", "--show-toplevel")
+
+    assert calls[0]["timeout"] == 30
+
+
+def test_check_plan_run_git_timeout_returns_rc124_when_check_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(check_plan_immutability.subprocess, "run", _raise_timeout(calls))
+
+    result = check_plan_immutability._run_git(tmp_path, "status", check=False)
+
+    assert calls[0]["timeout"] == 30
+    assert result.returncode == 124
+
+
+def test_check_plan_git_blob_exists_timeout_returns_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(check_plan_immutability.subprocess, "run", _raise_timeout(calls))
+
+    assert check_plan_immutability._git_blob_exists(tmp_path, "HEAD:curriculum/a1/plans/x.yaml") is False
+    assert calls[0]["timeout"] == 30
+
+
+def test_check_plan_git_blob_exists_still_reports_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(check_plan_immutability.subprocess, "run", _completed_ok)
+
+    assert check_plan_immutability._git_blob_exists(tmp_path, "HEAD:x") is True
+
+
+# --- scripts/session_canary/grok_lane.py -------------------------------------
+
+
+def _mint_args(repo: Path, out_dir: Path, handoff: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo=repo,
+        epic="probe-epic",
+        stream="epic:999",
+        handoff=str(handoff),
+        out_dir=str(out_dir),
+        stream_limit=5,
+        preferred=None,
+    )
+
+
+def test_grok_lane_cmd_mint_timeout_returns_124(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(grok_lane.subprocess, "run", _raise_timeout(calls))
+    monkeypatch.setattr(grok_lane, "_load_stream_entries", lambda *a, **k: [])
+    facts = [{"id": f"fact-{i}", "q": f"q{i}?", "a": f"a{i}"} for i in range(grok_lane.N_ANCHORS)]
+    monkeypatch.setattr(grok_lane, "_build_facts", lambda **k: facts)
+    handoff = tmp_path / "handoff.md"
+    handoff.write_text("# Next Drive\n- x\n", encoding="utf-8")
+    out_dir = tmp_path / "canary"
+
+    rc = grok_lane.cmd_mint(_mint_args(tmp_path, out_dir, handoff))
+
+    assert rc == 124
+    assert calls[0]["timeout"] == grok_lane._CANARY_TIMEOUT_SECONDS == 30
+    assert "context_canary mint timed out after 30s" in capsys.readouterr().err
+
+
+def _score_args(tmp_path: Path, out_dir: Path, answers: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo=tmp_path,
+        epic="probe-epic",
+        out_dir=str(out_dir),
+        answers=str(answers),
+        context_tokens=1234,
+        model="test-model",
+        pass_ratio=grok_lane.DEFAULT_PASS_RATIO,
+        threshold=grok_lane.DEFAULT_SIM_THRESHOLD,
+        handoff=None,
+        next_drive="",
+        pins="",
+        open_prs="",
+        hands_off="",
+        pending_user="",
+        worktrees="",
+        no_hydrate=True,
+        preferred=None,
+    )
+
+
+def test_grok_lane_cmd_score_timeout_maps_to_fail_handoff_and_124(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(grok_lane.subprocess, "run", _raise_timeout(calls))
+    out_dir = tmp_path / "canary"
+    out_dir.mkdir()
+    (out_dir / "probe.json").write_text(json.dumps({"anchors": []}), encoding="utf-8")
+    answers = tmp_path / "answers.json"
+    answers.write_text("{}", encoding="utf-8")
+
+    rc = grok_lane.cmd_score(_score_args(tmp_path, out_dir, answers))
+
+    assert rc == 124
+    assert calls[0]["timeout"] == grok_lane._CANARY_TIMEOUT_SECONDS == 30
+    verdict = json.loads((out_dir / "last_verdict.json").read_text(encoding="utf-8"))
+    assert verdict["verdict"] == "FAIL-HANDOFF"
+    assert verdict["rc"] == 124
+
+
+# --- scripts/hygiene/lane_disk_retention.py ----------------------------------
+
+
+def test_lane_disk_retention_git_timeout_returns_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(lane_disk_retention.subprocess, "run", _raise_timeout(calls))
+
+    assert lane_disk_retention._git(["status", "--porcelain"], cwd=tmp_path) == ""
+    assert calls[0]["timeout"] == 30
+
+
+# --- scripts/hygiene/root_entry_guard.py -------------------------------------
+
+
+def test_root_entry_guard_run_git_timeout_maps_to_rc124(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(root_entry_guard.subprocess, "run", _raise_timeout(calls))
+
+    proc = root_entry_guard._run_git(tmp_path, "ls-files", "-z")
+
+    assert calls[0]["timeout"] == 30
+    assert proc.returncode == root_entry_guard._TIMEOUT_RETURN_CODE == 124
+    assert "TimeoutExpired after 30s" in proc.stderr
+
+
+def test_root_entry_guard_tracked_names_fail_closed_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(root_entry_guard.subprocess, "run", _raise_timeout(calls))
+
+    with pytest.raises(RuntimeError, match="TimeoutExpired"):
+        root_entry_guard._tracked_top_level_names(tmp_path)
+    assert calls[0]["timeout"] == 30


### PR DESCRIPTION
## Summary
Slice 17 of #7213: bound 6 timeout-less git `subprocess.run` sites in `scripts/pre_commit/check_plan_immutability.py`, `scripts/session_canary/grok_lane.py`, `scripts/hygiene/lane_disk_retention.py`, and `scripts/hygiene/root_entry_guard.py`.

Allowlist **32 → 26**. Remaining keys in those four files: **0**.

Timeouts: git 30s. TimeoutExpired mapped onto existing fail-closed shapes (rc-124 CompletedProcess / False / empty string / FAIL-HANDOFF).

New `tests/test_git_probe_timeouts.py`.

## Driver verification
```
17 passed (guard + git probe timeouts)
ruff: All checks passed!
primary checkout remains clean on main
```

Implement: ox-alpha (OpenCode stealth). CF: kimi.

Closes nothing (slice of #7213). Refs #7213, #7176.