### PR TITLE
fix(timeouts): bound remaining CLI tails (#7213 slice 20)

### DIFF
--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -63,6 +63,7 @@ _PREFLIGHT_MULTI_STEP_RE = re.compile(
     re.IGNORECASE,
 )
 _ALLOWED_DEADLINE_SECONDS = (300, 600, 900, 1200, 1800, 2400, 3000)
+_EDITOR_TIMEOUT_SECONDS = 30
 _GEMINI_AUTH_CHOICES = ["auto", "subscription", "api-key", "api"]
 _DISCUSSION_READONLY_TOOL_CONFIG = {"discussion_readonly": True}
 _CURSOR_SESSION_ID_RE = re.compile(r'"(?:sessionId|session_id)"\s*:\s*"([^"]+)"')
@@ -1034,7 +1035,10 @@ def _handle_channel_context(args) -> int:
         # respecting POSIX quoting so "nvim -R" and similar work.
         editor_argv = shlex.split(editor) if editor else ["vi"]
         try:
-            result = subprocess.run([*editor_argv, str(path)])
+            result = subprocess.run(
+                [*editor_argv, str(path)],
+                timeout=_EDITOR_TIMEOUT_SECONDS,
+            )
         except FileNotFoundError:
             print(
                 f"❌ editor '{editor_argv[0]}' not found on PATH "
@@ -1046,6 +1050,12 @@ def _handle_channel_context(args) -> int:
             print(
                 f"❌ editor '{editor_argv[0]}' is not executable "
                 f"(check file permissions)",
+                file=sys.stderr,
+            )
+            return 1
+        except subprocess.TimeoutExpired as exc:
+            print(
+                f"❌ editor '{editor_argv[0]}' timed out after {exc.timeout}s",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/bench/writer_matrix.py
+++ b/scripts/bench/writer_matrix.py
@@ -90,6 +90,9 @@ DEFAULT_EFFORT_OVERRIDES: dict[str, str] = {
     "codex-tools": "xhigh",
 }
 
+_CELL_TIMEOUT_SECONDS = 1800
+_TIMEOUT_RETURN_CODE = 124
+
 # Phase progression — used to compute ``phase_reached`` per cell.
 PHASE_ORDER: tuple[str, ...] = (
     "knowledge_packet",
@@ -230,13 +233,25 @@ def _run_one_cell(
 
     t0 = time.monotonic()
     worktree_path: str | None = None
-    with cell_log.open("w", encoding="utf-8") as logf:
-        proc = subprocess.run(
+    try:
+        with cell_log.open("w", encoding="utf-8") as logf:
+            proc = subprocess.run(
+                argv,
+                cwd=PROJECT_ROOT,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+                check=False,
+                timeout=_CELL_TIMEOUT_SECONDS,
+            )
+    except subprocess.TimeoutExpired as exc:
+        timeout_message = f"writer cell timed out after {exc.timeout}s"
+        with cell_log.open("a", encoding="utf-8") as logf:
+            logf.write(f"\n{timeout_message}\n")
+        proc = subprocess.CompletedProcess(
             argv,
-            cwd=PROJECT_ROOT,
-            stdout=logf,
-            stderr=subprocess.STDOUT,
-            check=False,
+            _TIMEOUT_RETURN_CODE,
+            stdout="",
+            stderr=timeout_message,
         )
     duration = time.monotonic() - t0
 

--- a/scripts/ci/subprocess_timeout_allowlist.txt
+++ b/scripts/ci/subprocess_timeout_allowlist.txt
@@ -12,10 +12,6 @@
 #    covered by an existing entry in this file will fail CI.
 # 4. KEY FORMAT: `path::qualname::callee` (sorted alphabetically). Duplicate lines
 #    represent multiple timeout-less calls within the same enclosing function/scope.
-scripts/ai_agent_bridge/_channels_cli.py::_handle_channel_context::subprocess.run
-scripts/bench/writer_matrix.py::_run_one_cell::subprocess.run
-scripts/etymology/bulk_ocr_gemini.py::decode_pages::subprocess.run
-scripts/fleet_comms/github_pr_metrics.py::collect_github_pr_metrics::subprocess.run
 scripts/lexicon/runner/atlas_job.py::_run_backup_doctor::subprocess.call
 scripts/lexicon/runner/atlas_job.py::run_restic_sink::subprocess.run
 scripts/lexicon/runner/atlas_job.py::run_restic_sink::subprocess.run
@@ -26,5 +22,3 @@ scripts/projects/open_model_data/phase3_source_production_transport.py::_subproc
 scripts/projects/ua_eval_harness/build_heldout_manifest.py::_git_head::subprocess.run
 scripts/projects/ua_eval_harness/run_codex_baseline.py::_cli_version::subprocess.run
 scripts/sync/promote_module.py::_run_make_atlas::subprocess.run
-scripts/validate/verify_track.py::run_audit::subprocess.run
-scripts/vocab/rebuild_vocab_from_yaml.py::populate_database::subprocess.run

--- a/scripts/etymology/bulk_ocr_gemini.py
+++ b/scripts/etymology/bulk_ocr_gemini.py
@@ -35,6 +35,8 @@ DEFAULT_CONCURRENCY = 10
 DEFAULT_RPM = 15
 ROLLING_WINDOW = 100
 ROLLING_ERROR_LIMIT = 20
+_DECODE_TIMEOUT_SECONDS = 120
+_TIMEOUT_RETURN_CODE = 124
 
 ZIP_RE = re.compile(r"etslukrmov(\d+)_jp2\.zip$")
 PAGE_RE = re.compile(r"_(\d+)\.jp2$", re.IGNORECASE)
@@ -311,13 +313,23 @@ def decode_pages(pages: list[Page]) -> None:
 
         page.png_path.parent.mkdir(parents=True, exist_ok=True)
         started = time.monotonic()
-        proc = subprocess.run(
-            ["opj_decompress", "-i", str(page.jp2_path), "-o", str(page.png_path)],
-            cwd=ROOT,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        command = ["opj_decompress", "-i", str(page.jp2_path), "-o", str(page.png_path)]
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_DECODE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            proc = subprocess.CompletedProcess(
+                command,
+                _TIMEOUT_RETURN_CODE,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s",
+            )
         duration = time.monotonic() - started
         if proc.returncode != 0 or not _has_content(page.png_path):
             raise RuntimeError(

--- a/scripts/fleet_comms/github_pr_metrics.py
+++ b/scripts/fleet_comms/github_pr_metrics.py
@@ -11,6 +11,8 @@ import subprocess
 from datetime import datetime
 from typing import Any
 
+_GH_TIMEOUT_SECONDS = 30
+
 
 def _parse_ts(value: str | None) -> datetime | None:
     if not value:
@@ -45,7 +47,22 @@ def collect_github_pr_metrics(
         "--json",
         "number,title,createdAt,mergedAt,additions,deletions,changedFiles",
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "content_included": False,
+            "ok": False,
+            "error": f"gh timed out after {_GH_TIMEOUT_SECONDS}s",
+            "repo": repo,
+            "search": search,
+        }
     if proc.returncode != 0:
         return {
             "content_included": False,

--- a/scripts/validate/verify_track.py
+++ b/scripts/validate/verify_track.py
@@ -20,6 +20,8 @@ YELLOW = "\033[93m"
 DIM = "\033[2m"
 BOLD = "\033[1m"
 RESET = "\033[0m"
+_AUDIT_TIMEOUT_SECONDS = 300
+_TIMEOUT_RETURN_CODE = 124
 
 
 def load_curriculum():
@@ -64,9 +66,16 @@ def run_audit(content_path, skip_activities, project_root):
         cmd.append("--skip-activities")
     cmd.append(str(content_path))
 
-    result = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=str(project_root),
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=_AUDIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return _TIMEOUT_RETURN_CODE, f"Audit timed out after {_AUDIT_TIMEOUT_SECONDS}s"
     return result.returncode, result.stdout
 
 

--- a/scripts/vocab/rebuild_vocab_from_yaml.py
+++ b/scripts/vocab/rebuild_vocab_from_yaml.py
@@ -22,6 +22,9 @@ from pathlib import Path
 
 import yaml
 
+_VOCAB_INIT_TIMEOUT_SECONDS = 300
+_TIMEOUT_RETURN_CODE = 124
+
 # Configuration
 CURRICULUM_DIR = Path("curriculum/l2-uk-en")
 DB_PATH = CURRICULUM_DIR / "vocabulary.db"
@@ -144,9 +147,21 @@ def populate_database(levels: list[str], force: bool = False):
     # Initialize fresh database
     print(f"🆕 Initializing database: {DB_PATH}")
     import subprocess
-    result = subprocess.run([
-        '.venv/bin/python', 'scripts/vocab_init.py', 'l2-uk-en', '--force'
-    ], capture_output=True, text=True)
+    command = ['.venv/bin/python', 'scripts/vocab_init.py', 'l2-uk-en', '--force']
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=_VOCAB_INIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        result = subprocess.CompletedProcess(
+            command,
+            _TIMEOUT_RETURN_CODE,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or f"TimeoutExpired after {exc.timeout}s",
+        )
 
     if result.returncode != 0:
         print("❌ Failed to initialize database")

--- a/tests/test_cli_tail_timeouts.py
+++ b/tests/test_cli_tail_timeouts.py
@@ -1,0 +1,113 @@
+"""Timeout contracts for the six remaining CLI subprocess sites (#7213 slice 20)."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ai_agent_bridge import _channels_cli
+from scripts.bench import writer_matrix
+from scripts.etymology import bulk_ocr_gemini
+from scripts.fleet_comms import github_pr_metrics
+from scripts.validate import verify_track
+from scripts.vocab import rebuild_vocab_from_yaml
+
+
+def _raise_timeout(calls: list[dict[str, object]]):
+    def fake_run(*args: object, **kwargs: object) -> object:
+        calls.append({"args": args, **kwargs})
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    return fake_run
+
+
+def test_channel_context_timeout_returns_editor_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, object]] = []
+    context_path = tmp_path / "context.md"
+    monkeypatch.setattr(_channels_cli._channels, "channel_context_path", lambda _name: context_path)
+    monkeypatch.setenv("EDITOR", "test-editor")
+    monkeypatch.setattr(_channels_cli.subprocess, "run", _raise_timeout(calls))
+
+    result = _channels_cli._handle_channel_context(SimpleNamespace(name="test", edit=True))
+
+    assert result == 1
+    assert calls[0]["timeout"] == _channels_cli._EDITOR_TIMEOUT_SECONDS == 30
+    assert "editor 'test-editor' timed out after 30s" in capsys.readouterr().err
+
+
+def test_writer_matrix_timeout_returns_failed_bench_cell(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    calls: list[dict[str, object]] = []
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    monkeypatch.setattr(writer_matrix, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(writer_matrix.subprocess, "run", _raise_timeout(calls))
+
+    cell = writer_matrix._run_one_cell("writer", "a1", "module", None, tmp_path / "out")
+
+    assert cell.exit_code == 124
+    assert cell.failure_class == "infra"
+    assert calls[0]["timeout"] == writer_matrix._CELL_TIMEOUT_SECONDS == 1800
+    assert "writer cell timed out after 1800s" in (tmp_path / "out/cell-logs/writer__a1__module.log").read_text()
+
+
+def test_ocr_decode_timeout_maps_to_existing_runtime_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(bulk_ocr_gemini.subprocess, "run", _raise_timeout(calls))
+    page = bulk_ocr_gemini.Page(
+        1,
+        1,
+        tmp_path / "page.jp2",
+        tmp_path / "page.png",
+        tmp_path / "page.md",
+    )
+
+    with pytest.raises(RuntimeError, match=r"opj_decompress failed for vol1/p0001 rc=124") as raised:
+        bulk_ocr_gemini.decode_pages([page])
+
+    assert "TimeoutExpired after 120s" in str(raised.value)
+    assert calls[0]["timeout"] == bulk_ocr_gemini._DECODE_TIMEOUT_SECONDS == 120
+
+
+def test_github_metrics_timeout_returns_failed_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(github_pr_metrics.subprocess, "run", _raise_timeout(calls))
+
+    result = github_pr_metrics.collect_github_pr_metrics(limit=5)
+
+    assert result["ok"] is False
+    assert result["content_included"] is False
+    assert result["error"] == "gh timed out after 30s"
+    assert calls[0]["timeout"] == github_pr_metrics._GH_TIMEOUT_SECONDS == 30
+
+
+def test_verify_track_audit_timeout_returns_nonzero_tuple(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(verify_track.subprocess, "run", _raise_timeout(calls))
+
+    result = verify_track.run_audit(tmp_path / "module.md", False, tmp_path)
+
+    assert result == (124, "Audit timed out after 300s")
+    assert calls[0]["timeout"] == verify_track._AUDIT_TIMEOUT_SECONDS == 300
+
+
+def test_vocab_rebuild_timeout_reuses_initialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(rebuild_vocab_from_yaml, "DB_PATH", tmp_path / "vocabulary.db")
+    monkeypatch.setattr(subprocess, "run", _raise_timeout(calls))
+
+    assert rebuild_vocab_from_yaml.populate_database([], force=True) is None
+
+    output = capsys.readouterr().out
+    assert "Failed to initialize database" in output
+    assert "TimeoutExpired after 300s" in output
+    assert calls[0]["timeout"] == rebuild_vocab_from_yaml._VOCAB_INIT_TIMEOUT_SECONDS == 300


### PR DESCRIPTION
## Summary
#7213 slice 20: add explicit `timeout=` on the last 6 FIX-class CLI tails and shrink the allowlist 16→10.

Sites:
- `scripts/ai_agent_bridge/_channels_cli.py` editor 30s → existing rc=1
- `scripts/bench/writer_matrix.py` cell 1800s → exit 124 / failure_class infra
- `scripts/etymology/bulk_ocr_gemini.py` decode 120s → RuntimeError rc=124
- `scripts/fleet_comms/github_pr_metrics.py` gh 30s → ok=False
- `scripts/validate/verify_track.py` audit 300s → (124, timed-out)
- `scripts/vocab/rebuild_vocab_from_yaml.py` init 300s → existing init-failure path

New tests: `tests/test_cli_tail_timeouts.py`.

Left as SKIP (not this PR): restic/backup_doctor/durable_mirror, `make atlas`, freeze-pinned ua_eval, phase3 transports.

## NOTE
Ox-alpha canary 429 stealth rate-limit this session; Codex substituted.

## Driver acceptance (quoted)
```
14 passed in 11.25s  (test_subprocess_timeout_guard.py + test_cli_tail_timeouts.py)
ruff: All checks passed!
allowlist keys remaining in this branch: 10
```

X-Agent: codex/timeout-burndown-7213-s20
Closes nothing (parent #7213 stays open until allowlist empty / operator-accepted residual).