### PR TITLE
fix(agent-runtime): register claude-monitor identity row (#7177)

### DIFF
--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -115,6 +115,20 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": False,
         "resume_policy": "never",
     },
+    "claude-monitor": {
+        "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
+        "default_model": "claude-sonnet-5",
+        "cost_tier": "high",
+        "capabilities": frozenset(
+            {
+                "architecture",
+                "review",
+                "planning",
+            }
+        ),
+        "cli_available": False,
+        "resume_policy": "never",
+    },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",
         "default_model": "gemini-3.1-pro-high",

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -191,6 +191,7 @@ def test_registry_has_known_agents():
         "claude",
         "claude-desktop",
         "claude-infra",
+        "claude-monitor",
         "gemini",
         "grok",
         "grok-build",
@@ -437,6 +438,17 @@ def test_claude_desktop_entry_is_human_invoked():
     assert entry["adapter"] == "scripts.agent_runtime.adapters.claude:ClaudeAdapter"
     assert entry["cli_available"] is False
     assert entry["resume_policy"] == "never"
+
+
+def test_claude_monitor_entry_is_non_dispatchable_identity():
+    entry = get_agent_entry("claude-monitor")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.claude:ClaudeAdapter"
+    assert entry["default_model"] == "claude-sonnet-5"
+    assert entry["cost_tier"] == "high"
+    assert entry["cli_available"] is False
+    assert entry["resume_policy"] == "never"
+    assert entry["capabilities"] == frozenset({"architecture", "review", "planning"})
+    assert "claude-monitor" not in available_agents()
 
 
 def test_claude_entry_has_bridge_only_resume_policy():


### PR DESCRIPTION
## What
Registers a `claude-monitor` row in `scripts/agent_runtime/registry.py::AGENTS`, mirroring the
existing `claude-infra` per-epic identity row exactly (`cli_available: False`, `resume_policy:
"never"` — a non-dispatchable identity, not a real spawnable CLI lane).

## Why
The `monitor` epic (#7177, created 2026-08-23) had no registry row, so every monitor-epic
SessionStart's dispatch-lane self-test (`scripts/agent_runtime/lane_probe.py`) logged:
`DISPATCH LANE SELF-TEST FAILED for claude-monitor: agent is not registered`.

## Verified independently (monitor-epic driver, not just the worker's report)
- `lane_probe.py --agent claude-monitor` now reports `status: skipped, reason: "lane is disabled
  in the runtime registry"` (was: not registered).
- `ruff check` clean.
- `pytest tests/test_agent_runtime.py tests/agent_runtime/test_lane_probe.py` — 225 passed.

Refs #7177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)