### PR TITLE
fix(session-streams): stop rollover bundle FK from blocking infra claims (#7297)

### DIFF
--- a/agents_extensions/shared/session_streams/migrations/0007_rollover_bundle_lease_audit.sql
+++ b/agents_extensions/shared/session_streams/migrations/0007_rollover_bundle_lease_audit.sql
@@ -1,0 +1,51 @@
+-- Keep the historical lease token as audit data, not a reference to the
+-- mutable unique key currently held by stream_leases.
+DROP INDEX IF EXISTS rollover_bundles_lineage_order;
+DROP INDEX IF EXISTS rollover_bundles_stream_order;
+DROP INDEX IF EXISTS rollover_bundles_bundle_sha256_unique;
+DROP INDEX IF EXISTS rollover_bundles_identity_unique;
+
+ALTER TABLE rollover_bundles RENAME TO rollover_bundles_v6;
+
+CREATE TABLE rollover_bundles (
+    bundle_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    agent TEXT NOT NULL,
+    lineage_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    rollover_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    prepared_at TEXT NOT NULL,
+    bundle_sha256 TEXT NOT NULL CHECK (length(bundle_sha256) = 64),
+    manifest_json TEXT NOT NULL CHECK (json_valid(manifest_json)),
+    blob BLOB NOT NULL CHECK (length(blob) > 0),
+    uploaded_at TEXT NOT NULL,
+    uploaded_by_lease_id TEXT NOT NULL
+) STRICT;
+
+INSERT INTO rollover_bundles(
+    bundle_id, stream_id, agent, lineage_id, generation, rollover_id,
+    status, prepared_at, bundle_sha256, manifest_json, blob, uploaded_at,
+    uploaded_by_lease_id
+)
+SELECT
+    bundle_id, stream_id, agent, lineage_id, generation, rollover_id,
+    status, prepared_at, bundle_sha256, manifest_json, blob, uploaded_at,
+    uploaded_by_lease_id
+FROM rollover_bundles_v6;
+
+DROP TABLE rollover_bundles_v6;
+
+CREATE UNIQUE INDEX rollover_bundles_bundle_sha256_unique
+    ON rollover_bundles(bundle_sha256);
+
+CREATE UNIQUE INDEX rollover_bundles_identity_unique
+    ON rollover_bundles(
+        stream_id, agent, lineage_id, rollover_id, status, prepared_at
+    );
+
+CREATE INDEX rollover_bundles_lineage_order
+    ON rollover_bundles(stream_id, agent, lineage_id, bundle_id DESC);
+
+CREATE INDEX rollover_bundles_stream_order
+    ON rollover_bundles(stream_id, bundle_id DESC);

--- a/scripts/api/epics_router.py
+++ b/scripts/api/epics_router.py
@@ -6,6 +6,7 @@ import base64
 import binascii
 import logging
 import re
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
@@ -34,6 +35,7 @@ from agents_extensions.shared.session_streams.store import (
     MAX_ROLLOVER_BUNDLE_BYTES,
     ContentRejectedError,
     LeaseConflictError,
+    LifecycleError,
     NotFoundError,
     SessionStreamStore,
     validate_entry_body,
@@ -616,6 +618,9 @@ def remote_claim(stream_id: str, request: Request, body: dict[str, Any]) -> JSON
         )
     except (ValueError, ContentRejectedError):
         return _error(400, "invalid epic claim request")
+    except (sqlite3.IntegrityError, LifecycleError):
+        logger.exception("Remote epic claim rejected by a session-stream invariant")
+        return _error(409, "epic claim rejected by a session-stream invariant")
     except Exception:
         return _server_error()
 

--- a/tests/api/test_epics_router.py
+++ b/tests/api/test_epics_router.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
+import logging
+import sqlite3
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
-from agents_extensions.shared.session_streams.store import SessionStreamStore
+from agents_extensions.shared.session_streams.store import LifecycleError, SessionStreamStore
 from scripts.api import epics_router
 
 
@@ -129,6 +132,41 @@ def test_router_responses_have_no_paths_or_host_network_tokens(tmp_path: Path, m
     assert status.status_code == 200
     assert "/Users/" not in status.text
     assert "/home/" not in status.text
+
+
+@pytest.mark.parametrize("failure", [sqlite3.IntegrityError("foreign key"), LifecycleError("unsafe lifecycle")])
+def test_router_claim_invariant_failures_are_logged_and_not_store_unavailable(
+    tmp_path: Path, monkeypatch, caplog, failure: Exception
+) -> None:
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "api.sqlite3"))
+
+    def fail_claim(**_kwargs):
+        raise failure
+
+    monkeypatch.setattr(store, "claim_remote_session", fail_claim)
+    monkeypatch.setattr(epics_router, "_store", lambda: store)
+    app = FastAPI()
+    app.include_router(epics_router.router, prefix="/api/epics")
+
+    with caplog.at_level(logging.ERROR, logger=epics_router.__name__):
+        response = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 8765)).post(
+            "/api/epics/v1/epic:7178/claim",
+            json={
+                "session_id": "failed-session",
+                "lease_id": "failed-lease",
+                "lineage_id": "failed-lineage",
+                "agent": "codex",
+                "harness": "codex-cli",
+                "instance_id": "failed-instance",
+                "process_id": 1234,
+                "host_id": "failed-host",
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "epic claim rejected by a session-stream invariant"
+    assert "store unavailable" not in response.text
+    assert any(record.exc_info for record in caplog.records)
 
 
 def test_router_force_release_requires_and_records_actor(tmp_path: Path, monkeypatch) -> None:

--- a/tests/api/test_rollover_bundle_router.py
+++ b/tests/api/test_rollover_bundle_router.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import sqlite3
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -232,6 +233,11 @@ def test_rollover_schema_has_both_unique_indexes_and_raw_digest_constraint(
         }
         assert "rollover_bundles_bundle_sha256_unique" in unique_indexes
         assert "rollover_bundles_identity_unique" in unique_indexes
+        foreign_keys = {
+            (str(row[2]), str(row[3]), str(row[4]))
+            for row in connection.execute("PRAGMA foreign_key_list('rollover_bundles')").fetchall()
+        }
+        assert foreign_keys == {("streams", "stream_id", "stream_id")}
 
         manifest_json = json.dumps(
             {
@@ -266,6 +272,66 @@ def test_rollover_schema_has_both_unique_indexes_and_raw_digest_constraint(
             )
     finally:
         connection.close()
+
+
+def test_claim_replaces_released_lease_with_historical_bundle_token(tmp_path: Path) -> None:
+    database = SessionStreamDatabase(tmp_path / "reclaim.sqlite3")
+    store = SessionStreamStore(database)
+    base_time = datetime(2026, 8, 25, 10, 0, tzinfo=UTC)
+    old_lease, _ = store.claim_remote_session(
+        stream_id="epic:7178",
+        holder=LeaseHolder(agent="claude", harness="claude-cli", instance_id="old", process_id=1234),
+        lineage_id="historical-lineage",
+        ttl_seconds=900,
+        session_id="historical-session",
+        lease_id="historical-lease",
+        now=base_time,
+    )
+    store.release_remote_session(old_lease, now=base_time + timedelta(seconds=1))
+
+    connection = database.connect()
+    try:
+        connection.execute(
+            "INSERT INTO rollover_bundles("
+            "stream_id, agent, lineage_id, generation, rollover_id, status, prepared_at, "
+            "bundle_sha256, manifest_json, blob, uploaded_at, uploaded_by_lease_id"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "epic:7178",
+                "claude-infra",
+                "historical-lineage",
+                1,
+                "historical-rollover",
+                "pending_start",
+                "2026-08-25T10:00:00Z",
+                "a" * 64,
+                json.dumps({"status": "pending_start", "prepared_at": "2026-08-25T10:00:00Z"}),
+                b"historical bundle",
+                "2026-08-25T10:00:00Z",
+                old_lease.lease_id,
+            ),
+        )
+    finally:
+        connection.close()
+
+    successor, outcome = store.claim_remote_session(
+        stream_id="epic:7178",
+        holder=LeaseHolder(agent="grok", harness="grok-cli", instance_id="new", process_id=5678),
+        lineage_id="successor-lineage",
+        ttl_seconds=900,
+        session_id="successor-session",
+        lease_id="successor-lease",
+        now=base_time + timedelta(seconds=2),
+    )
+
+    assert successor.lease_id == "successor-lease"
+    assert outcome in {"claimed", "recovered"}
+    with database.connect(read_only=True) as connection:
+        bundle = connection.execute(
+            "SELECT uploaded_by_lease_id FROM rollover_bundles WHERE rollover_id = ?",
+            ("historical-rollover",),
+        ).fetchone()
+    assert bundle["uploaded_by_lease_id"] == old_lease.lease_id
 
 
 def test_bundle_upload_enforces_four_mib_cap(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_session_streams_inventory_receipts.py
+++ b/tests/test_session_streams_inventory_receipts.py
@@ -84,7 +84,7 @@ def test_inventory_does_not_use_hard_coded_exclusive_list(tmp_path: Path) -> Non
 
 def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
     migrations = load_migrations()
-    assert [m.version for m in migrations] == [1, 2, 3, 4, 5, 6]
+    assert [m.version for m in migrations] == [1, 2, 3, 4, 5, 6, 7]
     assert "inventory_receipts" in migrations[1].name
     assert "app_thread_holders" in migrations[2].name
     assert "remote_epic_lifecycle" in migrations[3].name
@@ -93,7 +93,7 @@ def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
     conn = db.connect()
     try:
         versions = [int(r[0]) for r in conn.execute("SELECT version FROM schema_migrations ORDER BY 1")]
-        assert versions == [1, 2, 3, 4, 5, 6]
+        assert versions == [1, 2, 3, 4, 5, 6, 7]
         for table in (
             "stream_migration_state",
             "stream_inventory_receipts",
@@ -183,7 +183,7 @@ def test_rollover_bundle_v5_receipt_upgrades_to_status_binding_schema(tmp_path: 
             "rollover_bundles_identity_unique",
         }
         versions = [int(item[0]) for item in connection.execute("SELECT version FROM schema_migrations ORDER BY 1")]
-        assert versions == [1, 2, 3, 4, 5, 6]
+        assert versions == [1, 2, 3, 4, 5, 6, 7]
     finally:
         connection.close()
 


### PR DESCRIPTION
## Summary

`./start-grok-driver.sh infra` was 503ing with `Monitor session-stream store unavailable` even though `/api/epics/v1/health` was `ok`. The store is healthy. `claim_remote_session` UPDATEs the unique `stream_leases.lease_id`; a pending `claude-infra` rollover bundle on `epic:6943` still FKs `uploaded_by_lease_id` to that live key, so SQLite raises `IntegrityError`. The router swallowed it as a fake 503.

## Changes

- Migration `0007` rebuilds `rollover_bundles` without the FK to `stream_leases(lease_id)`. The column stays NOT NULL audit text.
- `remote_claim` maps `sqlite3.IntegrityError` and `LifecycleError` to 409 with `logger.exception`, not 503 store-unavailable.
- Regression: released lease + historical bundle token, then reclaim; bundle token unchanged.

Fixes #7297

## Evidence

```
.venv/bin/python -m pytest tests/api/test_rollover_bundle_router.py::test_claim_replaces_released_lease_with_historical_bundle_token tests/api/test_epics_router.py::test_router_claim_invariant_failures_are_logged_and_not_store_unavailable tests/test_session_streams_inventory_receipts.py::test_schema_applies_inventory_receipts_migration -q
# 4 passed
```

Worker also reported ruff all checks passed and 28/9 related tests passed before push failed on job-host `gh` auth (`#7166` class: worker could not push). This PR is the finalize push from the driver seat.

## After merge

Restart the job-host Monitor so it applies migration 0007 to the live session-stream DB. Then `./start-grok-driver.sh infra` should get past lease claim.

Do not delete the pending `claude-infra` rollover bundle.