### PR TITLE
fix(atlas): wikipedia title-case + dab skip; --target poc-thin

### DIFF
--- a/scripts/audit/audit_atlas_poc_richness.py
+++ b/scripts/audit/audit_atlas_poc_richness.py
@@ -282,6 +282,29 @@ def _row(entry: dict[str, Any], sections: set[str], *, entry_class: str) -> dict
     }
 
 
+def poc_thin_entries(
+    manifest: dict[str, Any],
+    *,
+    min_rich_sections: int = 5,
+) -> list[dict[str, Any]]:
+    """Return old-gate-enriched static search entries failing the POC richness gate."""
+    entries = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
+    search_entries = [entry for entry in entries if _is_static_search_entry(entry)]
+    old_enriched = [entry for entry in search_entries if old_gate_enriched(entry)]
+    targets: list[dict[str, Any]] = []
+    for entry in old_enriched:
+        entry_class = classify_entry(entry)
+        sections = rendered_sections(entry)
+        if _entry_is_poc_thin(
+            entry,
+            sections,
+            entry_class=entry_class,
+            min_rich_sections=min_rich_sections,
+        ):
+            targets.append(entry)
+    return targets
+
+
 def audit_manifest(
     manifest: dict[str, Any],
     *,

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -28,6 +28,7 @@ DEFAULT_CANARY_LEMMAS = ["вода", "аби", "хліб", "свіжий"]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts.audit.audit_atlas_poc_richness import poc_thin_entries
 from scripts.audit.audit_atlas_thin_enriched import (
     has_learner_english_anchor,
     thin_old_gate_entries,
@@ -556,6 +557,9 @@ def reenrich_thin_entries(
         targets = missing_translation_entries(manifest)
     elif target == "missing-anchor":
         targets = thin_old_gate_entries(manifest)
+    elif target == "poc-thin":
+        targets = poc_thin_entries(manifest)
+        full_entry = True
     elif target == "full-catalog":
         targets = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
         full_entry = True
@@ -697,11 +701,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--target",
-        choices=("missing-anchor", "missing-translation", "full-catalog"),
+        choices=("missing-anchor", "missing-translation", "poc-thin", "full-catalog"),
         default="missing-anchor",
         help=(
             "Select entries to re-enrich. Default keeps the old gate repair behavior; "
-            "missing-translation fills sourced translation cards; full-catalog re-enriches all catalog entries."
+            "missing-translation fills sourced translation cards; "
+            "poc-thin selects richness-gate thin pages; "
+            "full-catalog re-enriches all catalog entries."
         ),
     )
     parser.add_argument(

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -74,29 +74,66 @@ def _get(url: str, timeout: int = REQUEST_TIMEOUT, **kwargs) -> requests.Respons
 
 WIKI_REST = "https://uk.wikipedia.org/api/rest_v1"
 WIKI_API = "https://uk.wikipedia.org/w/api.php"
+WIKI_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational; uk.wikipedia REST summary per lemma)"
+WIKI_REST_HEADERS = {
+    "User-Agent": WIKI_USER_AGENT,
+    "Accept": "application/json",
+}
+
+
+def _wiki_title_candidates(title: str) -> list[str]:
+    raw = (title or "").strip()
+    if not raw:
+        return []
+    candidates = [raw]
+    sentence_cased = raw[0].upper() + raw[1:]
+    if sentence_cased not in candidates:
+        candidates.append(sentence_cased)
+    return candidates
+
+
+def _is_disambiguation_summary(data: dict[str, Any]) -> bool:
+    if data.get("type") == "disambiguation":
+        return True
+    title = str(data.get("title") or "")
+    if "(значення)" in title.casefold():
+        return True
+    desc = str(data.get("description") or "").casefold()
+    return "сторінка значень" in desc
 
 
 def wikipedia_summary(title: str) -> dict[str, Any] | None:
     """Fetch a Wikipedia article summary via REST API.
 
-    Returns dict with keys: title, description, extract, url
-    or None if article not found.
+    Returns dict with keys: title, description, extract, url, type
+    or None if article not found or is a disambiguation page.
     """
-    url = f"{WIKI_REST}/page/summary/{quote(title)}"
-    try:
-        r = _get(url)
-        if r.status_code == 404:
-            return None
-        r.raise_for_status()
-        data = r.json()
-        return {
-            "title": data.get("title", ""),
-            "description": data.get("description", ""),
-            "extract": data.get("extract", ""),
-            "url": data.get("content_urls", {}).get("desktop", {}).get("page", ""),
-        }
-    except requests.RequestException:
+    candidates = _wiki_title_candidates(title)
+    if not candidates:
         return None
+
+    for cand in candidates:
+        url = f"{WIKI_REST}/page/summary/{quote(cand)}"
+        try:
+            r = requests.get(url, headers=WIKI_REST_HEADERS, timeout=REQUEST_TIMEOUT)
+            if r.status_code in (403, 404):
+                continue
+            r.raise_for_status()
+            data = r.json()
+            if not isinstance(data, dict):
+                continue
+            if _is_disambiguation_summary(data):
+                return None
+            return {
+                "title": data.get("title", ""),
+                "description": data.get("description", ""),
+                "extract": data.get("extract", ""),
+                "url": data.get("content_urls", {}).get("desktop", {}).get("page", ""),
+                "type": data.get("type", "standard"),
+            }
+        except (requests.RequestException, ValueError):
+            continue
+    return None
 
 
 def wikipedia_search(query: str, limit: int = 5) -> list[dict[str, str]]:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -227,7 +227,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "d3254c40b672d083e05b8cb5563f2b2d12986fa7b8871b1f442190d32c56a27f"
+        "sha256": "b3349d0b17311070440705d388df7c99a5617f2e2602a178604a2a5b0681cee3"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -980,3 +980,103 @@ def test_diminutive_fallback_fails_closed_when_vesum_rejects(monkeypatch) -> Non
     dim_entry = manifest["entries"][1]
     assert summary["filled_translation"] == 0
     assert "translation" not in dim_entry.get("enrichment", {})
+
+
+def test_poc_thin_target_selection_and_full_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = {
+        "entries": [
+            # Entry 1: 4 sections (meaning, morphology, literary, translation) -> POC-thin (< 5)
+            {
+                "lemma": "ампір",
+                "pos": "noun",
+                "url_slug": "ампір",
+                "gloss": "Empire style",
+                "enrichment": {
+                    "meaning": {"definitions": ["стиль пізнього класицизму"]},
+                    "morphology": {"forms": ["ампір", "ампіру"]},
+                    "literary_attestation": {"text": "приклад у літературі"},
+                    "translation": {"en": ["Empire style"], "source": "fixture"},
+                },
+            },
+            # Entry 2: 5 sections (meaning, morphology, literary, translation, wikipedia) -> NOT thin (>= 5)
+            {
+                "lemma": "вода",
+                "pos": "noun",
+                "url_slug": "вода",
+                "gloss": "water",
+                "enrichment": {
+                    "meaning": {"definitions": ["прозора рідина"]},
+                    "morphology": {"forms": ["вода", "води"]},
+                    "literary_attestation": {"text": "тече вода"},
+                    "translation": {"en": ["water"], "source": "fixture"},
+                },
+                "wiki_reference": {
+                    "wikipedia": {"title": "Вода", "summary": "Вода...", "url": "https://uk.wikipedia.org/wiki/Вода"}
+                },
+            },
+            # Entry 3: grammar term -> not static search entry -> NOT thin
+            {
+                "lemma": "іменник",
+                "pos": "grammar term",
+                "url_slug": "іменник",
+                "enrichment": {
+                    "meaning": {"definitions": ["частина мови"]},
+                },
+            },
+        ]
+    }
+
+    seen: list[str] = []
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags=False):
+        seen.append(entry["lemma"])
+        entry["wiki_reference"] = {
+            "wikipedia": {"title": "Ампір", "summary": "Ампір...", "url": "https://uk.wikipedia.org/wiki/Ампір"}
+        }
+
+    monkeypatch.setattr(enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich.reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="poc-thin",
+            refresh_wiki=True,
+        )
+
+    assert seen == ["ампір"]
+    assert summary["targets"] == 1
+    assert manifest["entries"][0]["wiki_reference"]["wikipedia"]["title"] == "Ампір"
+    assert "wiki_reference" not in manifest["entries"][2]
+
+
+def test_poc_thin_target_cli_skips_canary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"entries": []}), encoding="utf-8")
+
+    canary_called = False
+
+    def fake_canary(*args, **kwargs):
+        nonlocal canary_called
+        canary_called = True
+        return {"success": True, "details": {}}
+
+    monkeypatch.setattr(reenrich, "run_canary_check", fake_canary)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reenrich_thin_manifest_entries.py",
+            "--local",
+            "--manifest",
+            str(manifest_path),
+            "--target",
+            "poc-thin",
+        ],
+    )
+
+    exit_code = reenrich.main()
+    assert exit_code == 0
+    assert not canary_called
+

--- a/tests/test_source_query_wikipedia.py
+++ b/tests/test_source_query_wikipedia.py
@@ -1,0 +1,183 @@
+"""Offline unit tests for Wikipedia REST query in scripts/rag/source_query.py."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import pytest
+import requests
+
+from scripts.lexicon import enrich_manifest
+from scripts.rag.source_query import (
+    WIKI_REST,
+    WIKI_USER_AGENT,
+    _is_disambiguation_summary,
+    _wiki_title_candidates,
+    wikipedia_summary,
+)
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, data: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self._data = data
+        self.text = text
+
+    def json(self):
+        if self._data is not None:
+            return self._data
+        raise ValueError("Invalid JSON")
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            http_err = requests.HTTPError(f"HTTP {self.status_code}")
+            http_err.response = self
+            raise http_err
+
+
+def test_wiki_title_candidates_sentence_case() -> None:
+    assert _wiki_title_candidates("ампір") == ["ампір", "Ампір"]
+    assert _wiki_title_candidates("школа") == ["школа", "Школа"]
+    assert _wiki_title_candidates("вода") == ["вода", "Вода"]
+    assert _wiki_title_candidates("абажур") == ["абажур", "Абажур"]
+    assert _wiki_title_candidates("ідея") == ["ідея", "Ідея"]
+    assert _wiki_title_candidates("їжак") == ["їжак", "Їжак"]
+    assert _wiki_title_candidates("єнот") == ["єнот", "Єнот"]
+    assert _wiki_title_candidates("ґанок") == ["ґанок", "Ґанок"]
+    assert _wiki_title_candidates("Київ") == ["Київ"]
+    assert _wiki_title_candidates("київська область") == ["київська область", "Київська область"]
+    assert _wiki_title_candidates("") == []
+    assert _wiki_title_candidates("   ") == []
+
+
+def test_is_disambiguation_summary() -> None:
+    assert _is_disambiguation_summary({"type": "disambiguation", "title": "Ампір"})
+    assert _is_disambiguation_summary({"type": "standard", "title": "Ампір (значення)"})
+    assert _is_disambiguation_summary({"type": "standard", "title": "ампір (значення)"})
+    assert _is_disambiguation_summary({
+        "type": "standard",
+        "title": "Ампір",
+        "description": "сторінка значень у проекті Вікімедіа",
+    })
+    assert _is_disambiguation_summary({
+        "type": "standard",
+        "title": "Ампір",
+        "description": "сторінка значень у проєкті Вікімедіа",
+    })
+    assert not _is_disambiguation_summary({
+        "type": "standard",
+        "title": "Ампір",
+        "description": "стиль пізнього класицизму",
+    })
+
+
+def test_wikipedia_summary_lowercase_403_falls_back_to_capitalized_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded_calls: list[tuple[str, dict]] = []
+
+    def mock_get(url: str, headers: dict | None = None, timeout: int = 15):
+        recorded_calls.append((url, headers or {}))
+        # Lowercase path returns 403 HTML
+        if quote("ампір") in url:
+            return DummyResponse(403, text="<html>Wikimedia Error 403 Forbidden</html>")
+        # Capitalized path returns 200 JSON
+        if quote("Ампір") in url:
+            return DummyResponse(
+                200,
+                data={
+                    "type": "standard",
+                    "title": "Ампір",
+                    "description": "стиль у мистецтві",
+                    "extract": "Ампі́р — стиль пізнього класицизму...",
+                    "content_urls": {
+                        "desktop": {
+                            "page": "https://uk.wikipedia.org/wiki/%D0%90%D0%BC%D0%BF%D1%96%D1%80"
+                        }
+                    },
+                },
+            )
+        return DummyResponse(404)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    result = wikipedia_summary("ампір")
+    assert result == {
+        "title": "Ампір",
+        "description": "стиль у мистецтві",
+        "extract": "Ампі́р — стиль пізнього класицизму...",
+        "url": "https://uk.wikipedia.org/wiki/%D0%90%D0%BC%D0%BF%D1%96%D1%80",
+        "type": "standard",
+    }
+    assert len(recorded_calls) == 2
+    assert recorded_calls[0][0] == f"{WIKI_REST}/page/summary/{quote('ампір')}"
+    assert recorded_calls[1][0] == f"{WIKI_REST}/page/summary/{quote('Ампір')}"
+    for _, hdrs in recorded_calls:
+        assert hdrs.get("User-Agent") == WIKI_USER_AGENT
+        assert hdrs.get("Accept") == "application/json"
+
+
+def test_wikipedia_summary_skips_disambiguation_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(url: str, headers: dict | None = None, timeout: int = 15):
+        return DummyResponse(
+            200,
+            data={
+                "type": "disambiguation",
+                "title": "Ампір (значення)",
+                "description": "сторінка значень у проєкті Вікімедіа",
+                "extract": "Ампі́р: Ампір — стиль...",
+                "content_urls": {
+                    "desktop": {
+                        "page": "https://uk.wikipedia.org/wiki/%D0%90%D0%BC%D0%BF%D1%96%D1%80_(%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%BD%D1%8F)"
+                    }
+                },
+            },
+        )
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    assert wikipedia_summary("Ампір (значення)") is None
+    assert wikipedia_summary("ампір (значення)") is None
+
+
+def test_wikipedia_summary_honest_miss_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(url: str, headers: dict | None = None, timeout: int = 15):
+        return DummyResponse(404, text="Not Found")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    assert wikipedia_summary("абзац") is None
+
+
+def test_enrich_manifest_query_wikipedia_and_wiki_reference(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    enrich_manifest.query_wikipedia.cache_clear()
+    monkeypatch.setattr(enrich_manifest, "_phase1_offline_mode", lambda: False)
+    monkeypatch.setattr(enrich_manifest, "WIKI_REFERENCE_CACHE", tmp_path / "wiki_reference.json")
+    monkeypatch.setattr(enrich_manifest, "_WIKI_REFERENCE_CACHE_DATA", None)
+    monkeypatch.setattr(enrich_manifest, "_WIKI_REFERENCE_CACHE_DIRTY", False)
+
+    def mock_get(url: str, headers: dict | None = None, timeout: int = 15):
+        if quote("Школа") in url:
+            return DummyResponse(
+                200,
+                data={
+                    "type": "standard",
+                    "title": "Школа",
+                    "description": "навчальний заклад",
+                    "extract": "Шко́ла — заклад освіти...",
+                    "content_urls": {
+                        "desktop": {
+                            "page": "https://uk.wikipedia.org/wiki/%D0%A8%D0%BA%D0%BE%D0%BB%D0%B0"
+                        }
+                    },
+                },
+            )
+        return DummyResponse(403, text="Forbidden")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    ref = enrich_manifest._wiki_reference("школа", literary_attestation={"text": "attestation"})
+    assert ref is not None
+    assert ref["wikipedia"]["title"] == "Школа"
+    assert ref["wikipedia"]["summary"] == "Шко́ла — заклад освіти..."
+    assert ref["wikipedia"]["url"] == "https://uk.wikipedia.org/wiki/%D0%A8%D0%BA%D0%BE%D0%BB%D0%B0"
+    assert ref["wiktionary_url"] == f"https://uk.wiktionary.org/wiki/{quote('школа')}"
+    assert ref["wikisource_url"] == f"https://uk.wikisource.org/wiki/{quote('школа')}"


### PR DESCRIPTION
## Summary

- **403 vs 200**: Lowercase `uk.wikipedia.org` REST summary queries returned 403 Forbidden with generic headers. Updated to send an identifying JSON `User-Agent` (`learn-ukrainian-word-atlas/1.0`) and try sentence-cased title candidates (fallback to 200 OK).
- **Held-out validation**: Tested with held-out lemmas `ампір`, `школа`, `вода`, and `абажур`.
- **Dab skip**: Disambiguation pages such as `Ампір (значення)` or descriptions matching `сторінка значень` are cleanly skipped.
- **`--target poc-thin`**: Added `--target poc-thin` selection mode in `scripts/lexicon/reenrich_thin_manifest_entries.py` using `poc_thin_entries()` from `scripts/audit/audit_atlas_poc_richness.py`, skipping the slovnyk canary.
- **No pointer flip**: Code & test changes only; no pointer flip or catalog publish.

Refs: #4387