### PR TITLE
feat(monitor): app factory step 0 — MonitorContext + create_app core (#7269)

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
@@ -88,6 +88,7 @@ from .hermes_cron_router import router as hermes_cron_router
 from .images_router import router as images_router
 from .issues_router import router as issues_router
 from .knowledge_router import router as knowledge_router
+from .monitor_context import MonitorContext, production_context
 from .observer_presence import router as observer_presence_router
 from .occupancy import router as occupancy_router
 from .occupancy_local import resolve_launcher_host_id
@@ -114,6 +115,8 @@ from .wiki_router import router as wiki_router
 from .work_router import router as work_router
 from .work_router import warm_projection_cache
 from .worktrees_router import router as worktrees_router
+
+core_router = APIRouter()
 
 
 @asynccontextmanager
@@ -143,30 +146,6 @@ async def _lifespan(_app: FastAPI):
         yield
     finally:
         stop_periodic_refresh()
-
-
-app = FastAPI(
-    title="Playground API",
-    version="2.0.0",
-    description=(
-        "Monitor API for the Ukrainian curriculum pipeline. "
-        "Powers the ukraine-ops dashboards (root /), agent cold-start (orient, rules, session), "
-        "state queries, comms, delegate, build events, and operational tooling. "
-        "Interactive explorer: /docs (Swagger) and /redoc. "
-        "Machine-readable route contracts: /api/contracts/routes. "
-        "See docs/MONITOR-API.md for the full reference."
-    ),
-    lifespan=_lifespan,
-)
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-app.middleware("http")(resilience_middleware)
 
 
 def _error_envelope(error: str, detail: Any, *, status_code: int, headers: dict[str, str] | None = None) -> JSONResponse:
@@ -223,7 +202,6 @@ def _sanitize_public_detail(detail: Any) -> Any:
     return detail
 
 
-@app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     """Normalize handled HTTP errors without changing their status codes."""
     del request
@@ -235,7 +213,6 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     )
 
 
-@app.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
     """Return validation shape without echoing submitted values."""
     del request
@@ -250,7 +227,6 @@ async def request_validation_exception_handler(request: Request, exc: RequestVal
     return _error_envelope("validation_error", sanitized_errors, status_code=422)
 
 
-@app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     """Consistent JSON error format for unhandled exceptions."""
     error_id = uuid.uuid4().hex
@@ -264,63 +240,6 @@ async def global_exception_handler(request: Request, exc: Exception):
             "detail": "internal server error",
         },
     )
-
-
-# Mount team routers — each team owns their own file
-app.include_router(admin_router, prefix="/api/admin")
-app.include_router(agent_router, prefix="/api/agent", tags=["agent"])
-app.include_router(agent_monitor_router, prefix="/api/agent-monitor")
-app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
-app.include_router(atlas_jobs_router, prefix="/api/atlas-jobs", tags=["atlas-jobs"])
-app.include_router(occupancy_router, prefix="/api/occupancy", tags=["occupancy"])
-app.include_router(observer_presence_router, prefix="/api/observer", tags=["observer"])
-app.include_router(epics_router, prefix="/api/epics", tags=["epics"])
-app.include_router(blue_router, prefix="/api/blue")
-app.include_router(comms_router, prefix="/api/comms")
-app.include_router(fleet_router, prefix="/api/fleet", tags=["fleet"])
-app.include_router(project_state_router, prefix="/api/fleet", tags=["fleet"])
-app.include_router(fleet_workers_router, prefix="/api/fleet", tags=["fleet"])
-app.include_router(session_streams_router, prefix="/api/session-streams", tags=["session-streams"])
-app.include_router(coordination_router, prefix="/api/coordination")
-app.include_router(consultation_router, prefix="/api/consultation")
-app.include_router(cost_router, prefix="/api/cost")
-app.include_router(cost_router, prefix="/api/analytics/cost")
-app.include_router(contracts_router, prefix="/api/contracts", tags=["contracts"])
-app.include_router(dashboard_router, prefix="/api/dashboard")
-app.include_router(decisions_router, prefix="/api/decisions", tags=["decisions"])
-app.include_router(delegate_router, prefix="/api/delegate")
-app.include_router(docs_router, prefix="/artifacts")
-app.include_router(docs_router, prefix="/files")
-app.include_router(discussions_router, prefix="/api/discussions", tags=["discussions"])
-app.include_router(git_hygiene_router, prefix="/api/git", tags=["git"])
-app.include_router(ops_router, prefix="/api/ops", tags=["ops"])
-app.include_router(gold_router, prefix="/api/gold")
-app.include_router(governance_router, prefix="/api/state/governance", tags=["governance"])
-app.include_router(hermes_cron_router, prefix="/api/hermes-cron", tags=["hermes-cron"])
-app.include_router(build_events_router, prefix="/api/build/events")
-app.include_router(images_router, prefix="/api/images")
-app.include_router(issues_router, prefix="/api/issues", tags=["issues"])
-app.include_router(knowledge_router, prefix="/api/knowledge", tags=["knowledge"])
-app.include_router(sources_router, prefix="/api/sources", tags=["sources"])
-app.include_router(sources_router, prefix="/api/rag", tags=["rag"], deprecated=True)
-# GH #1529 P3 — reviewer-ghost telemetry nested under /api/state so clients
-# can discover it alongside the other state-query endpoints.
-app.include_router(
-    reviewer_ghosts_router,
-    prefix="/api/state/reviewer-ghosts",
-    tags=["reviewer-ghosts"],
-)
-app.include_router(rollover_router, prefix="/api/rollovers", tags=["rollovers"])
-app.include_router(rules_router, prefix="/api/rules", tags=["rules"])
-app.include_router(runtime_router, prefix="/api/runtime")
-app.include_router(session_router, prefix="/api/session", tags=["session"])
-app.include_router(site_router, prefix="/api/site", tags=["site"])
-app.include_router(state_router, prefix="/api/state")
-app.include_router(telemetry_router)
-app.include_router(wiki_router, prefix="/api/wiki", tags=["wiki"])
-app.include_router(worktrees_router, prefix="/api/worktrees", tags=["worktrees"])
-app.include_router(work_router, prefix="/api/work", tags=["work"])
-
 
 # Server start time for uptime calculation
 _SERVER_START = datetime.now(UTC)
@@ -1434,20 +1353,20 @@ def _health_instance_identity() -> dict[str, str | None]:
     }
 
 
-@app.get("/api", status_code=307)
+@core_router.get("/api", status_code=307)
 async def api_index():
     """API root — redirect humans to the interactive docs explorer (#7090)."""
     return RedirectResponse(url="/docs", status_code=307)
 
 
-@app.get("/api/health")
-async def health_check():
+@core_router.get("/api/health")
+async def health_check(request: Request):
     """Root health check — returns server status, version, uptime."""
     now = datetime.now(UTC)
     uptime = now - _SERVER_START
     return {
         "status": "ok",
-        "version": app.version,
+        "version": request.app.version,
         "uptime_seconds": int(uptime.total_seconds()),
         "started_at": _SERVER_START.isoformat(),
         "checked_at": now.isoformat(),
@@ -1597,7 +1516,7 @@ def _orient_section_specs() -> dict[str, tuple[Callable[..., Any], Any, bool]]:
     }
 
 
-@app.get("/api/orient")
+@core_router.get("/api/orient")
 async def orient(
     request: Request,
     fresh: bool = False,
@@ -1747,8 +1666,8 @@ def _attach_cold_start_research(response: dict[str, Any], role: str | None) -> N
         response.pop("research", None)
 
 
-@app.get("/api/config")
-async def get_config():
+@core_router.get("/api/config")
+async def get_config(request: Request):
     # Import pipeline phase config — single source of truth
     try:
         from scripts.build.phase_constants import PHASE_LABELS, PHASES  # noqa: PLC0415 — preserves endpoint fallback
@@ -1756,10 +1675,10 @@ async def get_config():
         pipeline_info = {"phases": PHASES, "phase_labels": PHASE_LABELS}
     except ImportError:
         pipeline_info = {}
-    return {"levels": LEVELS, "api_version": app.version, "pipeline": pipeline_info}
+    return {"levels": LEVELS, "api_version": request.app.version, "pipeline": pipeline_info}
 
 
-@app.get("/api/batch/dispatcher")
+@core_router.get("/api/batch/dispatcher")
 async def get_dispatcher_state():
     state_file = BATCH_STATE_DIR / "dispatcher_state.json"
     if not state_file.exists():
@@ -1768,7 +1687,7 @@ async def get_dispatcher_state():
         return json.load(f)
 
 
-@app.get("/api/batch/active")
+@core_router.get("/api/batch/active")
 async def get_active_orchestration():
     active = []
     for track_dir in CURRICULUM_ROOT.iterdir():
@@ -1795,7 +1714,7 @@ async def get_active_orchestration():
     return active
 
 
-@app.get("/api/batch/failures")
+@core_router.get("/api/batch/failures")
 async def get_failure_queue():
     f_file = BATCH_STATE_DIR / "failure_queue.json"
     if not f_file.exists():
@@ -1804,7 +1723,7 @@ async def get_failure_queue():
         return json.load(f)
 
 
-@app.get("/api/batch/usage")
+@core_router.get("/api/batch/usage")
 async def get_batch_usage():
     usage_dir = BATCH_STATE_DIR / "api_usage"
     if not usage_dir.exists():
@@ -1820,7 +1739,7 @@ async def get_batch_usage():
     return summaries
 
 
-@app.get("/api/batch/checkpoints")
+@core_router.get("/api/batch/checkpoints")
 async def get_all_checkpoints():
     results = {}
     for f in BATCH_STATE_DIR.glob("checkpoint_*.json"):
@@ -1833,12 +1752,12 @@ async def get_all_checkpoints():
     return results
 
 
-@app.get("/api/batch/dispatcher/running")
+@core_router.get("/api/batch/dispatcher/running")
 async def dispatcher_running():
     return {"running": False}
 
 
-@app.post("/api/batch/dispatcher/scan")
+@core_router.post("/api/batch/dispatcher/scan")
 async def run_dispatcher_scan():
     cmd = [
         str(LIVE_REPO_ROOT / ".venv" / "bin" / "python"),
@@ -1852,7 +1771,7 @@ async def run_dispatcher_scan():
     return {"status": "ok"}
 
 
-@app.get("/api/batch/dispatcher/logs")
+@core_router.get("/api/batch/dispatcher/logs")
 async def get_dispatcher_logs(lines: int = 50):
     log_file = PROJECT_ROOT / "logs" / "dispatcher.log"
     if not log_file.exists():
@@ -1863,7 +1782,7 @@ async def get_dispatcher_logs(lines: int = 50):
 # ==================== WEBSOCKET ====================
 
 
-@app.websocket("/ws/batch")
+@core_router.websocket("/ws/batch")
 async def batch_websocket(websocket: WebSocket):
     await websocket.accept()
     try:
@@ -1888,7 +1807,7 @@ def _safe_join(base: Path, *parts: str | Path) -> Path | None:
         return None
 
 
-@app.get("/images/{path:path}")
+@core_router.get("/images/{path:path}")
 async def serve_image(path: str):
     """Serve textbook images with caching. Path relative to data/textbook_images/."""
     file_path = _safe_join(_IMAGE_DIR, path)
@@ -1913,7 +1832,7 @@ async def serve_image(path: str):
 # ==================== STATIC FILES (MUST BE LAST) ====================
 
 
-@app.get("/{path:path}")
+@core_router.get("/{path:path}")
 async def serve_static(path: str):
     if not path or path == "/":
         return FileResponse(DASHBOARDS_DIR / "index.html")
@@ -1937,3 +1856,94 @@ async def serve_static(path: str):
         ):
             return FileResponse(html_candidate)
     raise HTTPException(status_code=404)
+
+
+def create_app(context: MonitorContext, *, lifespan: Any = None) -> FastAPI:
+    """Build a fresh Monitor API app bound to one context."""
+    factory_lifespan = _lifespan if lifespan is None else lifespan
+    factory_app = FastAPI(
+        title="Playground API",
+        version="2.0.0",
+        description=(
+            "Monitor API for the Ukrainian curriculum pipeline. "
+            "Powers the ukraine-ops dashboards (root /), agent cold-start (orient, rules, session), "
+            "state queries, comms, delegate, build events, and operational tooling. "
+            "Interactive explorer: /docs (Swagger) and /redoc. "
+            "Machine-readable route contracts: /api/contracts/routes. "
+            "See docs/MONITOR-API.md for the full reference."
+        ),
+        lifespan=factory_lifespan,
+    )
+    factory_app.state.ctx = context
+    factory_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    factory_app.middleware("http")(resilience_middleware)
+    factory_app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    factory_app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    factory_app.add_exception_handler(Exception, global_exception_handler)
+
+    # Mount team routers in the established order. The core router must remain
+    # last so its catch-all route keeps today's matching precedence.
+    factory_app.include_router(admin_router, prefix="/api/admin")
+    factory_app.include_router(agent_router, prefix="/api/agent", tags=["agent"])
+    factory_app.include_router(agent_monitor_router, prefix="/api/agent-monitor")
+    factory_app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
+    factory_app.include_router(atlas_jobs_router, prefix="/api/atlas-jobs", tags=["atlas-jobs"])
+    factory_app.include_router(occupancy_router, prefix="/api/occupancy", tags=["occupancy"])
+    factory_app.include_router(observer_presence_router, prefix="/api/observer", tags=["observer"])
+    factory_app.include_router(epics_router, prefix="/api/epics", tags=["epics"])
+    factory_app.include_router(blue_router, prefix="/api/blue")
+    factory_app.include_router(comms_router, prefix="/api/comms")
+    factory_app.include_router(fleet_router, prefix="/api/fleet", tags=["fleet"])
+    factory_app.include_router(project_state_router, prefix="/api/fleet", tags=["fleet"])
+    factory_app.include_router(fleet_workers_router, prefix="/api/fleet", tags=["fleet"])
+    factory_app.include_router(session_streams_router, prefix="/api/session-streams", tags=["session-streams"])
+    factory_app.include_router(coordination_router, prefix="/api/coordination")
+    factory_app.include_router(consultation_router, prefix="/api/consultation")
+    factory_app.include_router(cost_router, prefix="/api/cost")
+    factory_app.include_router(cost_router, prefix="/api/analytics/cost")
+    factory_app.include_router(contracts_router, prefix="/api/contracts", tags=["contracts"])
+    factory_app.include_router(dashboard_router, prefix="/api/dashboard")
+    factory_app.include_router(decisions_router, prefix="/api/decisions", tags=["decisions"])
+    factory_app.include_router(delegate_router, prefix="/api/delegate")
+    factory_app.include_router(docs_router, prefix="/artifacts")
+    factory_app.include_router(docs_router, prefix="/files")
+    factory_app.include_router(discussions_router, prefix="/api/discussions", tags=["discussions"])
+    factory_app.include_router(git_hygiene_router, prefix="/api/git", tags=["git"])
+    factory_app.include_router(ops_router, prefix="/api/ops", tags=["ops"])
+    factory_app.include_router(gold_router, prefix="/api/gold")
+    factory_app.include_router(governance_router, prefix="/api/state/governance", tags=["governance"])
+    factory_app.include_router(hermes_cron_router, prefix="/api/hermes-cron", tags=["hermes-cron"])
+    factory_app.include_router(build_events_router, prefix="/api/build/events")
+    factory_app.include_router(images_router, prefix="/api/images")
+    factory_app.include_router(issues_router, prefix="/api/issues", tags=["issues"])
+    factory_app.include_router(knowledge_router, prefix="/api/knowledge", tags=["knowledge"])
+    factory_app.include_router(sources_router, prefix="/api/sources", tags=["sources"])
+    factory_app.include_router(sources_router, prefix="/api/rag", tags=["rag"], deprecated=True)
+    # GH #1529 P3 — reviewer-ghost telemetry nested under /api/state so clients
+    # can discover it alongside the other state-query endpoints.
+    factory_app.include_router(
+        reviewer_ghosts_router,
+        prefix="/api/state/reviewer-ghosts",
+        tags=["reviewer-ghosts"],
+    )
+    factory_app.include_router(rollover_router, prefix="/api/rollovers", tags=["rollovers"])
+    factory_app.include_router(rules_router, prefix="/api/rules", tags=["rules"])
+    factory_app.include_router(runtime_router, prefix="/api/runtime")
+    factory_app.include_router(session_router, prefix="/api/session", tags=["session"])
+    factory_app.include_router(site_router, prefix="/api/site", tags=["site"])
+    factory_app.include_router(state_router, prefix="/api/state")
+    factory_app.include_router(telemetry_router)
+    factory_app.include_router(wiki_router, prefix="/api/wiki", tags=["wiki"])
+    factory_app.include_router(worktrees_router, prefix="/api/worktrees", tags=["worktrees"])
+    factory_app.include_router(work_router, prefix="/api/work", tags=["work"])
+    factory_app.include_router(core_router)
+    return factory_app
+
+
+app = create_app(production_context())

--- a/scripts/api/monitor_context.py
+++ b/scripts/api/monitor_context.py
@@ -1,0 +1,274 @@
+"""Application-scoped roots and store handles for the Monitor API."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from fastapi import Request
+
+from agents_extensions.shared.session_streams.db import (
+    SessionStreamDatabase,
+    default_database_path,
+)
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+from . import config
+from .docs_router import EFFECTIVE_ROOTS
+from .observer_presence import _STORE as _PRESENCE_STORE
+from .project_state_store import _STORE as _REPORT_STORE
+from .resilience import connect_sqlite
+
+
+def _as_path(value: os.PathLike[str] | str) -> Path:
+    return Path(value).expanduser()
+
+
+def _frozen_mapping(values: Mapping[str, Path]) -> Mapping[str, Path]:
+    return MappingProxyType({key: Path(value) for key, value in values.items()})
+
+
+@dataclass(frozen=True)
+class MonitorRoots:
+    """Filesystem roots used by Monitor routes and their store handles."""
+
+    project_root: Path
+    live_repo_root: Path
+    dashboards_dir: Path
+    batch_state_dir: Path
+    curriculum_root: Path
+    plans_root: Path
+    backup_dir: Path
+    logs_dir: Path
+    queue_dir: Path
+    pid_dir: Path
+    effective_roots: Mapping[str, Path] = field(default_factory=dict)
+    images_dir: Path | None = None
+    textbooks_dir: Path | None = None
+    sources_db_path: Path | None = None
+    message_db_path: Path | None = None
+    session_streams_db_path: Path | None = None
+    epics_db_path: Path | None = None
+
+    def __getitem__(self, name: str) -> Path | Mapping[str, Path] | None:
+        return getattr(self, name)
+
+
+@dataclass(frozen=True)
+class DatabaseHandle:
+    """A validated database target whose connection is opened on demand."""
+
+    path: Path
+    _opener: Callable[..., Any] = field(repr=False, compare=False)
+
+    def connect(self, *, read_only: bool = False) -> Any:
+        """Open the database through its owning context."""
+        return self._opener(self.path, read_only=read_only)
+
+    open = connect
+
+
+@dataclass(frozen=True)
+class MonitorStores:
+    """Store handles owned by one Monitor application context."""
+
+    sources_db: DatabaseHandle | None = None
+    message_db: DatabaseHandle | None = None
+    presence_store: dict[Any, Any] | None = None
+    report_store: dict[Any, Any] | None = None
+    session_streams_database: SessionStreamDatabase | None = None
+    session_streams_store: SessionStreamStore | None = None
+    epics_database: SessionStreamDatabase | None = None
+    epics_store: SessionStreamStore | None = None
+
+    def __getitem__(self, name: str) -> Any:
+        return getattr(self, name)
+
+    def items(self) -> Iterator[tuple[str, Any]]:
+        for name in self.__dataclass_fields__:
+            yield name, getattr(self, name)
+
+
+@dataclass(frozen=True)
+class MonitorContext:
+    """Immutable roots plus the store handles for one Monitor app instance."""
+
+    roots: MonitorRoots
+    stores: MonitorStores
+    root: Path | None = field(default=None, repr=False, compare=False)
+
+    def _resolve_db_path(self, database: os.PathLike[str] | str) -> Path:
+        """Resolve a database target and enforce a fixture root, if present."""
+        resolved = _as_path(database).resolve()
+        if self.root is not None:
+            fixture_root = self.root.resolve()
+            if not resolved.is_relative_to(fixture_root):
+                raise ValueError("database path escapes the fixture context root")
+        return resolved
+
+    def _open_db(
+        self,
+        database: os.PathLike[str] | str,
+        *,
+        read_only: bool = False,
+        session_streams: bool = False,
+    ) -> Any:
+        """Open one database through the context's single guarded choke point."""
+        path = self._resolve_db_path(database)
+        if session_streams:
+            return SessionStreamDatabase(path)
+        if read_only:
+            return connect_sqlite(f"file:{path}?mode=ro", uri=True)
+        return connect_sqlite(str(path))
+
+
+def get_ctx(request: Request) -> MonitorContext:
+    """Return the context attached to the app serving the current request."""
+    return request.app.state.ctx
+
+
+def _effective_roots(project_root: Path) -> Mapping[str, Path]:
+    project_root_resolved = project_root.resolve()
+    remapped: dict[str, Path] = {}
+    for name, path in EFFECTIVE_ROOTS.items():
+        candidate = Path(path)
+        try:
+            relative = candidate.resolve().relative_to(project_root_resolved)
+        except ValueError:
+            relative = Path(name)
+        remapped[name] = project_root / relative
+    return _frozen_mapping(remapped)
+
+
+def _roots(
+    *,
+    project_root: Path,
+    live_repo_root: Path,
+    dashboards_dir: Path,
+    batch_state_dir: Path,
+    curriculum_root: Path,
+    message_db_path: Path,
+    session_streams_db_path: Path,
+    backup_dir: Path,
+) -> MonitorRoots:
+    image_dir = project_root / "data" / "textbook_images"
+    return MonitorRoots(
+        project_root=project_root,
+        live_repo_root=live_repo_root,
+        dashboards_dir=dashboards_dir,
+        batch_state_dir=batch_state_dir,
+        curriculum_root=curriculum_root,
+        plans_root=project_root / "plans",
+        backup_dir=backup_dir,
+        logs_dir=project_root / "logs",
+        queue_dir=project_root / "agents_extensions" / "shared" / "consultation-queue",
+        pid_dir=project_root / ".mcp" / "servers" / "message-broker" / "pids",
+        effective_roots=_effective_roots(project_root),
+        images_dir=image_dir,
+        textbooks_dir=project_root / "data" / "textbooks",
+        sources_db_path=project_root / "data" / "sources.db",
+        message_db_path=message_db_path,
+        session_streams_db_path=session_streams_db_path,
+        epics_db_path=session_streams_db_path,
+    )
+
+
+def _stores(context: MonitorContext, *, fixture: bool) -> MonitorStores:
+    roots = context.roots
+    session_database = context._open_db(roots.session_streams_db_path, session_streams=True)
+    epics_database = context._open_db(roots.epics_db_path, session_streams=True)
+
+    if fixture:
+        presence_store: dict[Any, Any] = {}
+        report_store: dict[Any, Any] = {}
+    else:
+        presence_store = _PRESENCE_STORE
+        report_store = _REPORT_STORE
+
+    return MonitorStores(
+        sources_db=DatabaseHandle(roots.sources_db_path, context._open_db),
+        message_db=DatabaseHandle(roots.message_db_path, context._open_db),
+        presence_store=presence_store,
+        report_store=report_store,
+        session_streams_database=session_database,
+        session_streams_store=SessionStreamStore(session_database),
+        epics_database=epics_database,
+        epics_store=SessionStreamStore(epics_database),
+    )
+
+
+def _build_context(
+    *,
+    project_root: Path,
+    live_repo_root: Path,
+    dashboards_dir: Path,
+    batch_state_dir: Path,
+    curriculum_root: Path,
+    message_db_path: Path,
+    session_streams_db_path: Path,
+    backup_dir: Path,
+    fixture: bool,
+) -> MonitorContext:
+    root = project_root.resolve() if fixture else None
+    roots = _roots(
+        project_root=project_root,
+        live_repo_root=live_repo_root,
+        dashboards_dir=dashboards_dir,
+        batch_state_dir=batch_state_dir,
+        curriculum_root=curriculum_root,
+        message_db_path=message_db_path,
+        session_streams_db_path=session_streams_db_path,
+        backup_dir=backup_dir,
+    )
+    context = MonitorContext(roots=roots, stores=MonitorStores(), root=root)
+    return replace(context, stores=_stores(context, fixture=fixture))
+
+
+def production_context() -> MonitorContext:
+    """Build a context from the current production configuration resolution."""
+    project_root = Path(config.PROJECT_ROOT)
+    live_repo_root = Path(config.LIVE_REPO_ROOT)
+    return _build_context(
+        project_root=project_root,
+        live_repo_root=live_repo_root,
+        dashboards_dir=Path(config.DASHBOARDS_DIR),
+        batch_state_dir=Path(config.BATCH_STATE_DIR),
+        curriculum_root=Path(config.CURRICULUM_ROOT),
+        message_db_path=Path(config.MESSAGE_DB),
+        session_streams_db_path=default_database_path(live_repo_root),
+        backup_dir=Path(
+            os.environ.get("BACKUP_DIR", str(project_root / "data" / "backups"))
+        ),
+        fixture=False,
+    )
+
+
+def fixture_context(root: os.PathLike[str] | str) -> MonitorContext:
+    """Build a context whose roots and stores are entirely under ``root``."""
+    fixture_root = _as_path(root).resolve()
+    return _build_context(
+        project_root=fixture_root,
+        live_repo_root=fixture_root,
+        dashboards_dir=fixture_root / "dashboards",
+        batch_state_dir=fixture_root / "batch_state",
+        curriculum_root=fixture_root / "curriculum" / "l2-uk-en",
+        message_db_path=fixture_root / ".mcp" / "servers" / "message-broker" / "messages.db",
+        session_streams_db_path=fixture_root / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3",
+        backup_dir=fixture_root / "data" / "backups",
+        fixture=True,
+    )
+
+
+__all__ = [
+    "DatabaseHandle",
+    "MonitorContext",
+    "MonitorRoots",
+    "MonitorStores",
+    "fixture_context",
+    "get_ctx",
+    "production_context",
+]

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -1,6 +1,7 @@
 tests/ai_agent_bridge/test_module_identity.py
 tests/api/opsec_sweep/test_opsec_route_sweep.py
 tests/api/opsec_sweep/test_opsec_scan.py
+tests/api/test_app_factory.py
 tests/api/test_import_pinning.py
 tests/test_ask_opencode.py
 tests/test_bio_preparation_ci_routing.py

--- a/tests/api/opsec_sweep/registry.py
+++ b/tests/api/opsec_sweep/registry.py
@@ -158,7 +158,14 @@ def _walk_routes(node: Any, prefix: str = "") -> Iterable[tuple[str, Operation]]
     if callable(effective_contexts):
         for context in effective_contexts():
             original_route = getattr(context, "original_route", context)
-            path = normalize_path_template(getattr(context, "path", getattr(original_route, "path", "/")))
+            context_path = getattr(context, "path", None)
+            if not context_path:
+                # FastAPI's included-router context currently leaves the
+                # synthetic path blank for WebSocket routes while retaining
+                # the correctly prefixed Starlette route.
+                starlette_route = getattr(context, "starlette_route", None)
+                context_path = getattr(starlette_route, "path", None)
+            path = normalize_path_template(context_path or getattr(original_route, "path", "/"))
             if isinstance(original_route, WebSocketRoute):
                 yield "websocket", Operation("WEBSOCKET", path)
             elif isinstance(original_route, APIRoute) and getattr(context, "include_in_schema", True):

--- a/tests/api/test_app_factory.py
+++ b/tests/api/test_app_factory.py
@@ -1,0 +1,183 @@
+"""Step-0 structural and context tests for the Monitor API app factory."""
+
+from __future__ import annotations
+
+import re
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from fastapi.exception_handlers import websocket_request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from scripts.api import main as api_main
+from scripts.api.monitor_context import fixture_context, production_context
+from scripts.api.resilience import resilience_middleware
+from tests.api.opsec_sweep import registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DB_ACCESS_PATTERNS = (
+    re.compile(r"\bsqlite3\.connect\("),
+    re.compile(r"\bconnect_sqlite\("),
+    re.compile(r"\bSessionStreamDatabase\("),
+)
+
+# The exact pre-migration inventory from design §4.1: 22 access sites in 21
+# unique files. Infrastructure files are listed too so the denominator cannot
+# silently shrink when the exemptions below are changed.
+DB_ACCESS_ALLOWLIST = frozenset(
+    {
+        "scripts/api/admin_router.py",
+        "scripts/api/agent_monitor_router.py",
+        "scripts/api/comms_router.py",
+        "scripts/api/dashboard_comms.py",
+        "scripts/api/delegate_router.py",
+        "scripts/api/discussions_router.py",
+        "scripts/api/epics_router.py",
+        "scripts/api/fleet_router.py",
+        "scripts/api/fleet_workers_collect.py",
+        "scripts/api/hramatka_cache.py",
+        "scripts/api/hramatka_router.py",
+        "scripts/api/occupancy_local.py",
+        "scripts/api/resilience.py",
+        "scripts/api/runtime_router.py",
+        "scripts/api/session_streams_router.py",
+        "scripts/api/state_helpers.py",
+        "scripts/api/telemetry/legacy_comms.py",
+        "scripts/api/telemetry_router.py",
+        "scripts/api/wiki_router.py",
+        "scripts/api/gold_router.py",
+        "agents_extensions/shared/session_streams/db.py",
+    }
+)
+DB_ACCESS_INFRASTRUCTURE = frozenset(
+    {
+        "scripts/api/monitor_context.py",
+        "scripts/api/resilience.py",
+        "agents_extensions/shared/session_streams/db.py",
+    }
+)
+
+
+def test_factory_route_table_keeps_frozen_denominator() -> None:
+    factory_app = api_main.create_app(production_context())
+
+    registry.assert_frozen_denominator(factory_app)
+    assert factory_app.routes[-1].original_router is api_main.core_router
+    core_contexts = list(factory_app.routes[-1].effective_route_contexts())
+    assert core_contexts[-1].path == "/{path:path}"
+    assert core_contexts[-2].path == "/images/{path:path}"
+
+
+def test_factory_snapshot_preserves_middleware_and_exception_handlers() -> None:
+    app = api_main.create_app(production_context())
+
+    assert [(entry.cls, entry.args) for entry in app.user_middleware] == [
+        (BaseHTTPMiddleware, ()),
+        (CORSMiddleware, ()),
+    ]
+    assert app.user_middleware[0].kwargs["dispatch"] is resilience_middleware
+    assert app.user_middleware[1].kwargs == {
+        "allow_origins": ["*"],
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
+
+    assert set(app.exception_handlers) == {
+        api_main.StarletteHTTPException,
+        RequestValidationError,
+        WebSocketRequestValidationError,
+        Exception,
+    }
+    assert app.exception_handlers[api_main.StarletteHTTPException] is api_main.http_exception_handler
+    assert app.exception_handlers[RequestValidationError] is api_main.request_validation_exception_handler
+    assert app.exception_handlers[WebSocketRequestValidationError] is websocket_request_validation_exception_handler
+    assert app.exception_handlers[Exception] is api_main.global_exception_handler
+
+
+def test_factory_lifespan_is_wired_and_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    start_periodic_refresh = Mock()
+    stop_periodic_refresh = Mock()
+    monkeypatch.setattr(api_main, "preload_all", Mock())
+    monkeypatch.setattr(api_main, "install_signal_logging", Mock())
+    monkeypatch.setattr(api_main, "ensure_broker_db_ready", Mock())
+    monkeypatch.setattr(api_main, "seed_manifest_inventory", Mock())
+    monkeypatch.setattr(api_main.isa, "schedule_refresh", Mock())
+    monkeypatch.setattr(api_main, "warm_projection_cache", Mock())
+    monkeypatch.setattr(api_main, "start_periodic_refresh", start_periodic_refresh)
+    monkeypatch.setattr(api_main, "stop_periodic_refresh", stop_periodic_refresh)
+
+    factory_app = api_main.create_app(fixture_context(tmp_path))
+    with TestClient(factory_app):
+        pass
+
+    start_periodic_refresh.assert_called_once_with()
+    stop_periodic_refresh.assert_called_once_with()
+
+
+def test_fixture_context_resolves_roots_and_rejects_symlink_escape(tmp_path: Path) -> None:
+    context = fixture_context(tmp_path)
+
+    for field_name, value in context.roots.__dict__.items():
+        if field_name == "effective_roots":
+            values = value.values()
+        elif value is None:
+            continue
+        else:
+            values = (value,)
+        for path in values:
+            assert Path(path).resolve().is_relative_to(tmp_path.resolve())
+
+    assert context.stores.sources_db.path.resolve().is_relative_to(tmp_path.resolve())
+    assert context.stores.message_db.path.resolve().is_relative_to(tmp_path.resolve())
+    assert context.stores.session_streams_database.path.resolve().is_relative_to(tmp_path.resolve())
+    assert context.stores.epics_database.path.resolve().is_relative_to(tmp_path.resolve())
+
+    outside = tmp_path.parent / "monitor-context-outside"
+    outside.mkdir()
+    escaped = tmp_path / "escaped"
+    escaped.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="escapes"):
+        context._open_db(escaped / "messages.sqlite3")
+
+
+def test_core_routes_read_the_serving_app_version(tmp_path: Path) -> None:
+    @asynccontextmanager
+    async def no_lifespan(_app):
+        yield
+
+    first = api_main.create_app(fixture_context(tmp_path / "first"), lifespan=no_lifespan)
+    second = api_main.create_app(fixture_context(tmp_path / "second"), lifespan=no_lifespan)
+    first.version = "first-version"
+    second.version = "second-version"
+
+    with TestClient(first) as first_client, TestClient(second) as second_client:
+        assert first_client.get("/api/health").json()["version"] == "first-version"
+        assert second_client.get("/api/health").json()["version"] == "second-version"
+        assert first_client.get("/api/config").json()["api_version"] == "first-version"
+        assert second_client.get("/api/config").json()["api_version"] == "second-version"
+
+
+def test_db_access_patterns_have_the_step_zero_allowlist() -> None:
+    assert len(DB_ACCESS_ALLOWLIST) == 21
+    files = sorted((REPO_ROOT / "scripts/api").rglob("*.py"))
+    files.append(REPO_ROOT / "agents_extensions/shared/session_streams/db.py")
+    findings: list[str] = []
+    for path in files:
+        relative = path.relative_to(REPO_ROOT).as_posix()
+        if relative in DB_ACCESS_INFRASTRUCTURE:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if any(pattern.search(source) for pattern in DB_ACCESS_PATTERNS):
+            findings.append(relative)
+
+    expected_non_infrastructure = DB_ACCESS_ALLOWLIST - DB_ACCESS_INFRASTRUCTURE
+    assert set(findings) == expected_non_infrastructure, {
+        "missing": sorted(expected_non_infrastructure - set(findings)),
+        "unexpected": sorted(set(findings) - expected_non_infrastructure),
+    }

--- a/tests/api/test_app_factory.py
+++ b/tests/api/test_app_factory.py
@@ -19,6 +19,8 @@ from scripts.api.monitor_context import fixture_context, production_context
 from scripts.api.resilience import resilience_middleware
 from tests.api.opsec_sweep import registry
 
+pytestmark = pytest.mark.repo_invariant
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DB_ACCESS_PATTERNS = (
     re.compile(r"\bsqlite3\.connect\("),


### PR DESCRIPTION
## What
Implements step 0 of the approved Monitor API app-factory design
(`docs/design/monitor-api-app-factory.md` §4, §5.1 — 9 rounds of cross-family review,
approved 2026-08-25):

- `scripts/api/monitor_context.py` — `MonitorContext`/`MonitorRoots`/`MonitorStores`,
  `production_context()`/`fixture_context()`, and the `_open_db` guarded choke point
  (canonical `Path.resolve()` + `is_relative_to` check for fixture roots; wraps the existing
  `connect_sqlite()` and `SessionStreamDatabase` rather than inventing a new DB-access mechanism).
- `scripts/api/main.py` — `create_app(context, *, lifespan=None)` factory; the 15 routes and 3
  exception handlers that were inline on the module-level `app` object are converted to a
  `core_router = APIRouter()` (included **last**, preserving the catch-all's route-matching order)
  and explicit `app.add_exception_handler(...)` calls; `health_check`/`get_config` switch from the
  module-global `app.version` to `request.app.version` (proven by a test asserting two independent
  `create_app()` instances report their own version); `main.py`'s bottom becomes
  `app = create_app(production_context())`.
- `tests/api/test_app_factory.py` — route-table digest reuse (OPSEC sweep's frozen denominator),
  middleware/exception-handler structural snapshot (4 handler keys incl. FastAPI's own
  `WebSocketRequestValidationError` default), a **mandatory** lifespan-wiring spy assertion (not an
  optional "no exception" check), fixture-context root/symlink-escape rejection, the
  `request.app.version` isolation proof, and the DB-access-pattern allowlist (21 files, matching the
  design doc's inventory).
- `tests/api/opsec_sweep/registry.py` — minor registry accommodation for the refactor.

## Why
First implementation step of #7269 (parent epic #7177, M5 hardening). No behavior change to any
route response; `main.py`'s inline routes/handlers move to a router object for the reasons the
design doc's §10 review record explains in detail (a genuine architectural gap the original sketch
didn't anticipate — decorators need `app` to exist before they run).

## Verified independently (monitor-epic driver, not just the worker's self-report)
- `tests/api/test_app_factory.py` — 6/6 passed.
- `tests/api/opsec_sweep/` — 19/19 passed, frozen 280 HTTP-op / 1 WebSocket denominator unchanged.
- `tests/api -n 4` — 363 passed, 1 skipped, 1 failed. The failure
  (`test_real_release_serves_live_data_routers_with_logical_paths`) is **pre-existing and unrelated**
  — reproduced the same failure against unmodified `main` (spins a real uvicorn subprocess; times out
  in this sandbox regardless of this diff).
- `ruff check` on all changed files: clean.
- `git diff --check`: clean.

## Review
Independent cross-family review already completed (agy, PASS) — full evidence-based verdict in
`batch_state/tasks/monitor-7269-step0-review.result`, covering fixture-root escape defense, route
ordering, the middleware/handler snapshot, the lifespan wiring, and the `app.version` isolation fix.

Refs #7177, #7269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)