### PR TITLE
fix(open-model-data): allow provider-free Cycle007 bootstrap

### DIFF
--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -54,9 +54,9 @@ operator explicitly starts a provider stage.
 
 The existing reviewed controller remains the authority for provider preflight,
 packet verification, stage ordering, and stage seals. A pristine installation
-may run provider-free `prepare`, `status`, and `plan` without provider bindings;
-that bootstrap path fails closed if it finds any stage state, provider receipt,
-non-empty output root, controller, or worker. Before `resume`, and whenever
+may run provider-free `prepare`, `status`, and `plan` without provider bindings.
+The bootstrap `status` and `plan` paths fail closed if they find any stage state,
+provider receipt, non-empty output root, controller, or worker. Before `resume`, and whenever
 provider state exists, the guardian requires explicit absolute AGY and Grok
 executable bindings and all three preflight receipts. The controller verifies
 each resolved regular file against its provider-attested canary hash before any

--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -52,11 +52,15 @@ operator explicitly starts a provider stage.
 
 ## Minimal architecture
 
-The existing reviewed controller remains the authority for preflight, packet
-verification, stage ordering, and stage seals. The guardian requires explicit
-absolute AGY and Grok executable bindings, and the controller verifies each
-resolved regular file against its provider-attested canary hash before status,
-planning, or execution. No provider executable is discovered from a workstation
+The existing reviewed controller remains the authority for provider preflight,
+packet verification, stage ordering, and stage seals. A pristine installation
+may run provider-free `prepare`, `status`, and `plan` without provider bindings;
+that bootstrap path fails closed if it finds any stage state, provider receipt,
+non-empty output root, controller, or worker. Before `resume`, and whenever
+provider state exists, the guardian requires explicit absolute AGY and Grok
+executable bindings and all three preflight receipts. The controller verifies
+each resolved regular file against its provider-attested canary hash before any
+provider execution. No provider executable is discovered from a workstation
 path or from `PATH`. A small Linux-only guardian adds only the missing
 operational layer:
 
@@ -150,12 +154,14 @@ of being claimed as automatically resumable.
 ## Run sequence
 
 1. `prepare`: mount and verify storage only; provider calls remain off.
-2. `plan`: report the next missing stage and safe counts only.
-3. `resume --through gemini`: finish and seal Gemini.
-4. `resume --through grok`: finish and seal Grok.
-5. `resume --through adjudicate`: compare, audit, and adjudicate after both
+2. `status`: verify the pristine provider-off state and safe counts only.
+3. `plan`: report Gemini as the next missing stage and safe counts only.
+4. `resume --through gemini`: require the complete provider preflight, then
+   finish and seal Gemini.
+5. `resume --through grok`: finish and seal Grok.
+6. `resume --through adjudicate`: compare, audit, and adjudicate after both
    provider seals exist.
-6. `resume --through certify`: run authorized resolution when required and the
+7. `resume --through certify`: run authorized resolution when required and the
    existing certifier; success requires zero unresolved rows.
 
 The staged `--through` boundary prevents an operator intending to start one

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -62,11 +62,11 @@ class Config:
     controller_lock: Path
     execution_lock: Path
     controller: Path
-    preflight_receipt: Path
-    gemini_canary_receipt: Path
-    grok_canary_receipt: Path
-    agy_executable: Path
-    grok_executable: Path
+    preflight_receipt: Path | None
+    gemini_canary_receipt: Path | None
+    grok_canary_receipt: Path | None
+    agy_executable: Path | None
+    grok_executable: Path | None
     code_paths: dict[str, Path]
     owner_uid: int
     owner_gid: int
@@ -239,6 +239,8 @@ def _validate_roots(config: Config, *, create: bool) -> None:
         config.agy_executable,
         config.grok_executable,
     ):
+        if path is None:
+            continue
         _assert_absolute(path)
     _assert_no_symlink_components(config.package)
     _assert_no_symlink_components(config.backing_root)
@@ -381,6 +383,12 @@ def _parse_controller_output(completed: subprocess.CompletedProcess[bytes]) -> d
 
 
 def _controller_command(config: Config, action: str, stage: str | None = None) -> list[str]:
+    _provider_bindings_complete(config, required=True)
+    assert config.preflight_receipt is not None
+    assert config.gemini_canary_receipt is not None
+    assert config.grok_canary_receipt is not None
+    assert config.agy_executable is not None
+    assert config.grok_executable is not None
     command = [
         sys.executable,
         str(config.controller),
@@ -478,6 +486,82 @@ def _completed_stages(status: dict[str, Any]) -> list[str]:
     if completed != list(STAGES[: len(completed)]):
         raise GuardianError("invalid_stage_seal")
     return completed
+
+
+def _provider_bindings_complete(config: Config, *, required: bool) -> bool:
+    values = (
+        config.preflight_receipt,
+        config.gemini_canary_receipt,
+        config.grok_canary_receipt,
+        config.agy_executable,
+        config.grok_executable,
+    )
+    present = sum(value is not None for value in values)
+    if present == 0:
+        if required:
+            raise GuardianError("provider_preflight_required")
+        return False
+    if present != len(values):
+        raise GuardianError("provider_binding_incomplete")
+    return True
+
+
+def _require_lock_idle(path: Path, failure_code: str) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise GuardianError("lock_path_drift")
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    acquired = False
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+        except BlockingIOError:
+            raise GuardianError(failure_code) from None
+        finally:
+            if acquired:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def _fresh_provider_free_status(config: Config, *, mounts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Report the pristine pre-provider state without weakening the resume gate."""
+    _require_lock_idle(config.controller_lock, "controller_already_running")
+    _require_lock_idle(config.execution_lock, "active_worker")
+    control = config.package / "control"
+    state_paths = [
+        *(control / f"stage-{stage}.complete.json" for stage in STAGES),
+        *(control / f"guardian-{stage}.active.json" for stage in MARKED_STAGES),
+        control / "preflight-receipt.json",
+        control / "gemini-canary-receipt.json",
+        control / "grok-canary-receipt.json",
+    ]
+    if any(path.exists() or path.is_symlink() for path in state_paths):
+        raise GuardianError("provider_preflight_required")
+    for root_name in OUTPUT_ROOTS:
+        try:
+            if any((config.backing_root / root_name).iterdir()):
+                raise GuardianError("bootstrap_output_not_empty")
+        except OSError:
+            raise GuardianError("mount_target_unreadable") from None
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "ok": True,
+        "action": config.action,
+        "completed_stages": [],
+        "next_stage": STAGES[0],
+        "through": config.through,
+        "mount_count": len(mounts),
+        "mounts": mounts,
+        "available_bytes": _available_bytes(config.backing_root),
+        "min_free_bytes": config.min_free_bytes,
+        "recovered_temporary_count": 0,
+        "ready": False,
+        "text_free": True,
+    }
 
 
 def _safe_status(config: Config, *, mounts: list[dict[str, Any]], recovered: int = 0) -> dict[str, Any]:
@@ -598,11 +682,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--controller-lock", type=Path, required=True, help="distinct stable controller lock")
     parser.add_argument("--execution-lock", type=Path, required=True, help="distinct inherited runner lock")
     parser.add_argument("--controller", type=Path, required=True, help="reviewed controller path")
-    parser.add_argument("--preflight-receipt", type=Path, required=True, help="text-free reviewed preflight receipt")
-    parser.add_argument("--gemini-canary-receipt", type=Path, required=True, help="text-free Gemini canary receipt")
-    parser.add_argument("--grok-canary-receipt", type=Path, required=True, help="text-free Grok canary receipt")
-    parser.add_argument("--agy-executable", type=Path, required=True, help="explicit reviewed AGY executable")
-    parser.add_argument("--grok-executable", type=Path, required=True, help="explicit reviewed Grok executable")
+    parser.add_argument("--preflight-receipt", type=Path, help="text-free reviewed preflight receipt")
+    parser.add_argument("--gemini-canary-receipt", type=Path, help="text-free Gemini canary receipt")
+    parser.add_argument("--grok-canary-receipt", type=Path, help="text-free Grok canary receipt")
+    parser.add_argument("--agy-executable", type=Path, help="explicit reviewed AGY executable")
+    parser.add_argument("--grok-executable", type=Path, help="explicit reviewed Grok executable")
     parser.add_argument("--code-path", action="append", default=[], help="LABEL=/absolute/public/code/path; repeat")
     parser.add_argument("--owner-uid", type=int, required=True, help="required output owner UID")
     parser.add_argument("--owner-gid", type=int, required=True, help="required output owner GID")
@@ -629,6 +713,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         config = _config(args)
         if config.owner_uid < 0 or config.owner_gid < 0 or config.min_free_bytes <= 0:
             raise GuardianError("invalid_runtime_parameter")
+        provider_bindings = _provider_bindings_complete(config, required=config.action == "resume")
         guardian = _lock(config.guardian_lock, "guardian_already_running")
         mounts = _ensure_mounts(config, mutate=config.action in {"prepare", "resume"})
         _require_free_space(config)
@@ -645,7 +730,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             }
         elif config.action in {"status", "plan"}:
             _reconcile_markers(config, mutate=False)
-            result = _safe_status(config, mounts=mounts)
+            result = (
+                _safe_status(config, mounts=mounts)
+                if provider_bindings
+                else _fresh_provider_free_status(config, mounts=mounts)
+            )
         else:
             result = _resume(config, mounts)
     except GuardianError as exc:

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -405,6 +405,188 @@ def test_prepare_path_never_invokes_controller(guardian: ModuleType, tmp_path: P
     assert guardian.main(arguments) == 0
 
 
+def test_provider_free_prepare_accepts_no_provider_bindings(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action="prepare",
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        agy_executable=None,
+        grok_executable=None,
+    )
+    monkeypatch.setattr(guardian, "_config", lambda _args: config)
+    monkeypatch.setattr(guardian, "_lock", lambda *_args: _temporary_file())
+    monkeypatch.setattr(
+        guardian,
+        "_ensure_mounts",
+        lambda *_args, **_kwargs: [{"name": name} for name in guardian.OUTPUT_ROOTS],
+    )
+    monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
+    monkeypatch.setattr(guardian, "_available_bytes", lambda *_args: 100)
+    monkeypatch.setattr(
+        guardian,
+        "_invoke_controller",
+        lambda *_args, **_kwargs: pytest.fail("prepare invoked controller"),
+    )
+    assert guardian.main(
+        [
+            "prepare",
+            "--package", "/package",
+            "--backing-root", "/backing",
+            "--guardian-lock", "/locks/guardian",
+            "--controller-lock", "/locks/controller",
+            "--execution-lock", "/locks/execution",
+            "--controller", "/controller",
+            "--owner-uid", "1",
+            "--owner-gid", "1",
+            "--min-free-bytes", "1",
+        ]
+    ) == 0
+
+
+@pytest.mark.parametrize("action", ["status", "plan"])
+def test_provider_free_fresh_status_reports_gemini_without_controller(
+    guardian: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action=action,
+        through=None,
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        agy_executable=None,
+        grok_executable=None,
+    )
+    (config.package / "control").mkdir(mode=0o700)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+    monkeypatch.setattr(guardian, "_config", lambda _args: config)
+    monkeypatch.setattr(guardian, "_lock", lambda *_args: _temporary_file())
+    monkeypatch.setattr(
+        guardian,
+        "_ensure_mounts",
+        lambda *_args, **_kwargs: [{"name": name} for name in guardian.OUTPUT_ROOTS],
+    )
+    monkeypatch.setattr(guardian, "_require_free_space", lambda *_args: 100)
+    monkeypatch.setattr(guardian, "_available_bytes", lambda *_args: 100)
+    monkeypatch.setattr(
+        guardian,
+        "_invoke_controller",
+        lambda *_args, **_kwargs: pytest.fail("fresh provider-free status invoked controller"),
+    )
+    receipts: list[dict[str, Any]] = []
+    monkeypatch.setattr(guardian, "print", lambda value: receipts.append(json.loads(value)), raising=False)
+    assert guardian.main(
+        [
+            action,
+            "--package", "/package",
+            "--backing-root", "/backing",
+            "--guardian-lock", "/locks/guardian",
+            "--controller-lock", "/locks/controller",
+            "--execution-lock", "/locks/execution",
+            "--controller", "/controller",
+            "--owner-uid", "1",
+            "--owner-gid", "1",
+            "--min-free-bytes", "1",
+        ]
+    ) == 0
+    assert receipts == [
+        {
+            "action": action,
+            "available_bytes": 100,
+            "completed_stages": [],
+            "min_free_bytes": 1,
+            "mount_count": 6,
+            "mounts": [{"name": name} for name in guardian.OUTPUT_ROOTS],
+            "next_stage": "gemini",
+            "ok": True,
+            "ready": False,
+            "recovered_temporary_count": 0,
+            "schema_version": guardian.RECEIPT_SCHEMA,
+            "text_free": True,
+            "through": None,
+        }
+    ]
+
+
+def test_provider_free_bootstrap_rejects_partial_bindings(guardian: ModuleType, tmp_path: Path) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        grok_executable=None,
+    )
+    with pytest.raises(guardian.GuardianError, match="provider_binding_incomplete"):
+        guardian._provider_bindings_complete(config, required=False)
+
+
+def test_resume_still_requires_complete_provider_preflight(guardian: ModuleType, tmp_path: Path) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        agy_executable=None,
+        grok_executable=None,
+    )
+    with pytest.raises(guardian.GuardianError, match="provider_preflight_required"):
+        guardian._provider_bindings_complete(config, required=True)
+
+
+def test_provider_free_status_rejects_non_pristine_state(guardian: ModuleType, tmp_path: Path) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action="status",
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        agy_executable=None,
+        grok_executable=None,
+    )
+    control = config.package / "control"
+    control.mkdir(mode=0o700)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+    (control / "stage-gemini.complete.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(guardian.GuardianError, match="provider_preflight_required"):
+        guardian._fresh_provider_free_status(config, mounts=[])
+
+
+def test_provider_free_status_rejects_active_worker(guardian: ModuleType, tmp_path: Path) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action="status",
+        preflight_receipt=None,
+        gemini_canary_receipt=None,
+        grok_canary_receipt=None,
+        agy_executable=None,
+        grok_executable=None,
+    )
+    (config.package / "control").mkdir(mode=0o700)
+    for name in guardian.OUTPUT_ROOTS:
+        (config.backing_root / name).mkdir(mode=0o700)
+    worker = guardian._lock(config.execution_lock, "active_worker")
+    try:
+        with pytest.raises(guardian.GuardianError, match="active_worker"):
+            guardian._fresh_provider_free_status(config, mounts=[])
+    finally:
+        worker.close()
+
+
 def test_plan_uses_status_only_and_reports_next_stage(
     guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Outcome

Allow pristine Cycle007 production storage to run guardian `prepare`, `status`, and `plan` without provider executables or real-provider receipts. `resume` still requires the complete preflight, both canary receipts, and both explicit executable bindings before any provider execution.

## Safety

- Fresh provider-free status fails closed on any stage seal, active marker, installed provider receipt, non-empty output root, controller lock, or execution lock.
- Partial provider bindings fail closed.
- No schema, prompt, model, endpoint, evidence, custody, denominator, or provider execution change.
- Zero provider calls in implementation and tests.

## Verification

- Ruff: passed
- Guardian and held-out black-box tests: 41 passed
- Focused guardian/controller/adjudication/Grok suite: 104 passed
- `git diff --check`: passed

Issue: #6375