### PR TITLE
ci(fastlane): select release-snapshot test on API script changes (#7277)

### DIFF
--- a/scripts/ci/changed_tests.py
+++ b/scripts/ci/changed_tests.py
@@ -92,12 +92,15 @@ def load_repo_invariant_tests() -> list[str]:
 def select_test_modules(paths: Iterable[str], *, include_repo_invariants: bool = False) -> list[str]:
     """Return direct tests, optionally unioned with triggered repo invariants."""
     changed_paths = list(paths)
-    selected = sorted({path for path in changed_paths if is_test_module(path)})
+    selected = {path for path in changed_paths if is_test_module(path)}
 
-    if include_repo_invariants and any(is_repo_invariant_trigger(path) for path in changed_paths):
-        selected = sorted(set(selected).union(load_repo_invariant_tests()))
+    if include_repo_invariants:
+        if any(is_repo_invariant_trigger(path) for path in changed_paths):
+            selected.update(load_repo_invariant_tests())
+        if any(path.startswith("scripts/api/") for path in changed_paths):
+            selected.add("tests/api/test_release_snapshot.py")
 
-    return selected
+    return sorted(selected)
 
 
 def write_plan(path: str, selected: Sequence[str]) -> None:

--- a/tests/test_ci_changed_tests.py
+++ b/tests/test_ci_changed_tests.py
@@ -77,12 +77,33 @@ def test_shell_changes_trigger_repo_invariant_manifest_but_docs_do_not() -> None
 
 def test_monitor_opsec_surface_changes_trigger_repo_invariant_manifest() -> None:
     for path in (
-        "scripts/api/opsec_scan.py",
-        "scripts/api/session_streams_router.py",
         "dashboards/index.html",
         "tests/api/opsec_sweep/registry.py",
     ):
         assert changed_tests.select_test_modules([path], include_repo_invariants=True) == sorted(_manifest())
+
+
+def test_api_script_changes_trigger_repo_invariant_manifest_and_select_release_snapshot() -> None:
+    manifest = _manifest()
+    assert "tests/api/test_release_snapshot.py" not in manifest, (
+        "release snapshot test is exempted from fastlane_always_tests.txt to preserve PR-tier budget"
+    )
+    for path in (
+        "scripts/api/docs_router.py",
+        "scripts/api/release_snapshot.py",
+        "scripts/api/opsec_scan.py",
+        "scripts/api/session_streams_router.py",
+    ):
+        selected = changed_tests.select_test_modules([path], include_repo_invariants=True)
+        assert selected == sorted(set(manifest).union({"tests/api/test_release_snapshot.py"}))
+        assert "tests/api/test_release_snapshot.py" in selected
+
+    deduped = changed_tests.select_test_modules(
+        ["tests/api/test_release_snapshot.py", "scripts/api/docs_router.py"],
+        include_repo_invariants=True,
+    )
+    assert deduped == sorted(set(manifest).union({"tests/api/test_release_snapshot.py"}))
+    assert len(deduped) == len(set(deduped))
 
 
 def test_config_and_fixture_changes_trigger_repo_invariant_manifest() -> None:


### PR DESCRIPTION
## Summary
- Targeted PR-tier mapping: any `scripts/api/` change selects `tests/api/test_release_snapshot.py` in addition to the repo-invariant always-list.
- Keeps that test **off** `fastlane_always_tests.txt` so the existing budget exemption in `tests/test_repo_invariant_fastlane.py` stays intact.
- Unit test `test_api_script_changes_trigger_repo_invariant_manifest_and_select_release_snapshot` covers docs_router, release_snapshot, opsec_scan, session_streams_router, and dedup.

Fixes the class that let a `scripts/api/docs_router.py` change look PR-tier green and fail only in merge group (#7273 / run 32777274329).

Closes #7277. Refs #5703, #7274, #7276.

## Driver verification (primary venv, worktree)
```
api has snapshot True n 20
docs []
other has snapshot False
17 passed in 16.19s  (test_ci_changed_tests + test_repo_invariant_fastlane)
ruff: All checks passed
```

Author lane: agy (Cursor first-pick failed AppArmor nested sandbox — #7307). Driver: grok-devops. CF: outside Gemini family.

## Residual
Mutation check 3 (revert `a64557ad10` docs_router hunk and show `test_real_release_serves_live_data_routers_with_logical_paths` red) was not re-run on this sparse worktree (`curriculum/` absent). Selector + unit tests are the gate for this PR.

CLOBBER SELF-AUDIT: `select_test_modules` still returns a sorted unique list; always-list membership unchanged.

X-Agent: grok-devops (push/PR finalize of agy/ci-7277-agy)