### PR TITLE
feat(monitor): GET /api/epics/graph/v1 backing endpoint (#7295)

### DIFF
--- a/scripts/api/epics_router.py
+++ b/scripts/api/epics_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import logging
@@ -12,7 +13,8 @@ from pathlib import Path
 from threading import Lock
 from typing import Any
 
-from fastapi import APIRouter, Request
+import yaml
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase, default_database_path
@@ -43,12 +45,14 @@ from agents_extensions.shared.session_streams.store import (
 from scripts.api.config import LIVE_REPO_ROOT
 from scripts.api.observer_presence import _direct_loopback_peer
 from scripts.api.occupancy_sanitize import opaque_host_id, safe_field
+from scripts.orchestration import issue_stream_audit as audit
 from scripts.orchestration.thread_handoff import _bundle_extract, _bundle_secret_hits
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 SCHEMA = "remote-epic-lifecycle.v1"
+GRAPH_SCHEMA = "epics-graph.v1"
 DEFAULT_TTL_SECONDS = 15 * 60
 MAX_DIGEST_LIMIT = 100
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -564,6 +568,198 @@ def remote_epic_list() -> JSONResponse:
         content={"schema": SCHEMA, "registry_status": registry_status, "streams": rows},
         headers={"Cache-Control": "no-store"},
     )
+
+
+def _load_issue_streams() -> dict[str, Any]:
+    try:
+        path = resolve_streams_yaml(LIVE_REPO_ROOT)
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and isinstance(data.get("streams"), dict):
+            return data["streams"]
+    except Exception:
+        logger.warning("Failed to load issue-stream registry", exc_info=True)
+    return {}
+
+
+@router.get("/graph/v1")
+async def remote_epics_graph(
+    fresh: bool = Query(False, description="Schedule a refresh instead of only serving the cache."),
+) -> JSONResponse:
+    """Epics & Areas Relationship Map backing endpoint (#7295, M5 of #7177)."""
+
+    def _load() -> dict[str, Any]:
+        store = _store()
+        report = audit.read_cache(max_age_s=3600)
+        stale = None if report is not None else audit.read_cache(max_age_s=7 * 24 * 3600)
+
+        state = (
+            audit.schedule_refresh(force=fresh)
+            if fresh or report is None
+            else audit.read_refresh_state()
+        )
+
+        streams_data = _load_issue_streams()
+        audit_data = report if report is not None else (stale or {})
+        effective_membership = audit_data.get("effective_membership") or {}
+        open_issue_numbers = {int(n) for n in (audit_data.get("open_issue_numbers") or [])}
+        open_issue_titles = {
+            str(k): v for k, v in (audit_data.get("open_issue_titles") or {}).items()
+        }
+
+        registry_status = registry_health_snapshot()["status"]
+        projections = {str(row["stream_id"]): row for row in store.list_remote_projections()}
+        now = utc_now()
+
+        all_epic_numbers: set[int] = set()
+        areas: list[dict[str, Any]] = []
+        edges: list[dict[str, Any]] = []
+
+        for stream_id, spec in streams_data.items():
+            if not isinstance(spec, dict):
+                continue
+            epics = [int(n) for n in (spec.get("epics") or [])]
+            for e in epics:
+                all_epic_numbers.add(e)
+            area_title = _response_registry_text(spec.get("title")) or str(stream_id)
+            areas.append(
+                {
+                    "id": f"area:{stream_id}",
+                    "stream_id": stream_id,
+                    "title": area_title,
+                    "epic_count": len(epics),
+                }
+            )
+            for epic_num in epics:
+                edges.append(
+                    {
+                        "kind": "contains",
+                        "from": f"area:{stream_id}",
+                        "to": f"epic:{epic_num}",
+                    }
+                )
+
+        open_by_epic: dict[int, list[int]] = {e: [] for e in all_epic_numbers}
+        closed_by_epic: dict[int, list[int]] = {e: [] for e in all_epic_numbers}
+
+        for issue_str, entry in effective_membership.items():
+            if not isinstance(entry, dict):
+                continue
+            try:
+                issue_num = int(issue_str)
+            except (TypeError, ValueError):
+                continue
+            for e in entry.get("epics", []):
+                try:
+                    e_int = int(e)
+                except (TypeError, ValueError):
+                    continue
+                if e_int not in open_by_epic:
+                    continue
+                if issue_num in open_issue_numbers:
+                    open_by_epic[e_int].append(issue_num)
+                else:
+                    closed_by_epic[e_int].append(issue_num)
+
+        epics_nodes: list[dict[str, Any]] = []
+        issues_by_epic: dict[str, Any] = {}
+
+        for stream_id, spec in streams_data.items():
+            if not isinstance(spec, dict):
+                continue
+            epics = [int(n) for n in (spec.get("epics") or [])]
+            for epic_num in epics:
+                stream_key = f"epic:{epic_num}"
+                row = projections.get(stream_key)
+                lease_payload = None
+                session_state = None
+                if row is not None and row.get("lease_id") is not None:
+                    lease = store._lease_from_row(row)
+                    session_state = (
+                        SessionState.EXPIRED.value if row.get("session_expired_at") else str(row["session_state"])
+                    )
+                    lease_payload = _lease_payload(
+                        lease,
+                        projection_state=str(row["state"]),
+                        session_state=session_state,
+                        now=now,
+                    )
+                digest = _digest_payload(store, stream_key, 3) if row is not None else {"pinned": [], "recent": []}
+                latest = {entry["type"]: entry for entry in (*digest["pinned"], *digest["recent"])}
+                reg_fields = (
+                    _registry_fields(store, stream_key)
+                    if row is not None
+                    else {"registered": False, "stream_name": None, "title": None}
+                )
+
+                epic_title = reg_fields.get("title") or _response_registry_text(open_issue_titles.get(str(epic_num)))
+                epic_reg_status = registry_status if reg_fields.get("registered") else "unregistered"
+
+                open_issues = sorted(open_by_epic.get(epic_num, []))
+                closed_issues = closed_by_epic.get(epic_num, [])
+                open_count = len(open_issues)
+                closed_count = len(closed_issues)
+
+                epics_nodes.append(
+                    {
+                        "id": f"epic:{epic_num}",
+                        "number": epic_num,
+                        "area_id": stream_id,
+                        "title": epic_title,
+                        "registry_status": epic_reg_status,
+                        "lease": lease_payload,
+                        "session_state": session_state,
+                        "last_state": latest.get(EntryType.STATE.value),
+                        "last_decision": latest.get(EntryType.DECISION.value),
+                        "last_next_action": latest.get(EntryType.NEXT_ACTION.value),
+                        "open_issue_count": open_count,
+                        "closed_issue_count": closed_count,
+                    }
+                )
+
+                capped_items = open_issues[:50]
+                issues_by_epic[str(epic_num)] = {
+                    "items": [
+                        {
+                            "number": n,
+                            "title": " ".join(str(open_issue_titles.get(str(n)) or f"Issue #{n}").split()),
+                            "state": "open",
+                            "url": f"https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/{n}",
+                        }
+                        for n in capped_items
+                    ],
+                    "total_open": open_count,
+                    "truncated": open_count > 50,
+                }
+
+        payload: dict[str, Any] = {
+            "schema": GRAPH_SCHEMA,
+            "generated_at": isoformat_z(now),
+            "nodes": {
+                "areas": areas,
+                "epics": epics_nodes,
+            },
+            "edges": edges,
+            "issues_by_epic": issues_by_epic,
+        }
+
+        if report is None:
+            if stale is not None:
+                payload["stale"] = True
+            else:
+                payload["status"] = "no-cache"
+                payload["ok"] = None
+
+        refresh = audit.public_refresh_view(state)
+        payload["refreshing"] = refresh["phase"] in {"scheduled", "running"}
+        payload["refresh"] = refresh
+
+        return payload
+
+    try:
+        payload = await asyncio.to_thread(_load)
+        return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})
+    except Exception:
+        return _server_error()
 
 
 @router.get("/v1/{stream_id}")

--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -53,10 +53,14 @@ DEFAULT_MAX_CONFIRMED_AGE_DAYS = 14
 MAX_MILESTONE_ISSUE_RANGE = 100
 
 # ADR-011 P4 — private keys added to the cache report for the strict adoption
-# gate/observability. They carry an exact effective issue→epic membership index
-# and the bounded open-issue set; both are stripped from the public
-# ``/api/issues/streams`` response (see ``issues_router.strip_private_index``).
-PRIVATE_CACHE_KEYS = ("effective_membership", "open_issue_numbers")
+# gate/observability. They carry an exact effective issue→epic membership index,
+# the bounded open-issue set, and the open-issue titles map; all are stripped
+# from the public ``/api/issues/streams`` response (see ``issues_router._strip_private_index``).
+PRIVATE_CACHE_KEYS = (
+    "effective_membership",
+    "open_issue_numbers",
+    "open_issue_titles",
+)
 
 # A resolver proving issue N is a live child of stream epic E, offline, from a
 # fresh cache. Signature mirrors P1's ``check_research_registry.MembershipResolver``.

--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -969,6 +969,7 @@ def classify(
             epic_numbers, stream_of_epic, membership
         ),
         "open_issue_numbers": sorted(open_numbers),
+        "open_issue_titles": {str(k): v for k, v in titles.items()},
     }
 
 

--- a/tests/api/opsec_sweep/registry.py
+++ b/tests/api/opsec_sweep/registry.py
@@ -29,9 +29,9 @@ FixtureKind = Literal["isolated", "skip"]
 
 # Filled from the current exact route tree after the implementation is
 # assembled.  The count and digest are intentionally independent checks.
-FROZEN_HTTP_OPERATION_COUNT = 280
+FROZEN_HTTP_OPERATION_COUNT = 281
 FROZEN_WEBSOCKET_ROUTE_COUNT = 1
-FROZEN_DENOMINATOR_SHA256 = "4876620305f8035f30103fc6f2d0f0d4f22e43dfb00247f1a7aa32604cbccd20"
+FROZEN_DENOMINATOR_SHA256 = "7d024f0daaa8149908b3c6343df51c7ae9d33f3a5279f06b64d74b223a6d4599"
 
 # The OpenAPI document records the successful response for most operations,
 # while the isolated fixture deliberately exercises empty stores, denied
@@ -60,6 +60,7 @@ EXERCISED_READ_5XX_REASONS: dict[str, str] = {
     "GET /api/dashboard/comms/conversation/{task_id}": "isolated fixture has no dashboard comms store",
     "GET /api/dashboard/comms/message/{message_id}": "isolated fixture has no dashboard comms store",
     "GET /api/dashboard/comms/messages": "isolated fixture has no dashboard comms store",
+    "GET /api/epics/graph/v1": "isolated fixture has no seeded epic registry snapshot",
     "GET /api/epics/v1": "isolated fixture has no seeded epic registry snapshot",
     "GET /api/rules": "isolated fixture has no deployed rule files",
     "GET /api/state/preparation": "sparse isolated fixture omits the curriculum tree",

--- a/tests/api/test_epics_router.py
+++ b/tests/api/test_epics_router.py
@@ -25,9 +25,15 @@ def _client(tmp_path: Path, monkeypatch) -> TestClient:
     return TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 8765))
 
 
-def _claim(client: TestClient, *, session_id: str = "api-session", lease_id: str = "api-lease") -> dict:
+def _claim(
+    client: TestClient,
+    stream_id: str = "epic:7178",
+    *,
+    session_id: str = "api-session",
+    lease_id: str = "api-lease",
+) -> dict:
     response = client.post(
-        "/api/epics/v1/epic:7178/claim",
+        f"/api/epics/v1/{stream_id}/claim",
         json={
             "session_id": session_id,
             "lease_id": lease_id,
@@ -369,16 +375,16 @@ def test_epics_graph_truncation_cap_at_50(tmp_path: Path, monkeypatch) -> None:
 
 def test_epics_graph_store_lease_and_decision_passthrough(tmp_path: Path, monkeypatch) -> None:
     client = _client(tmp_path, monkeypatch)
-    claimed = _claim(client)
+    claimed = _claim(client, "epic:7177")  # allow-hardcoded-epic: remote lifecycle route fixture
     lease = claimed["lease"]
 
     # Append a state entry and a decision entry
     client.post(
-        "/api/epics/v1/epic:7178/handoff",
+        "/api/epics/v1/epic:7177/handoff",  # allow-hardcoded-epic: remote lifecycle route fixture
         json={**lease, "type": "state", "body": "working on graph", "idempotency_key": "graph-state-1"},
     )
     client.post(
-        "/api/epics/v1/epic:7178/handoff",
+        "/api/epics/v1/epic:7177/handoff",  # allow-hardcoded-epic: remote lifecycle route fixture
         json={**lease, "type": "decision", "body": "design approved", "idempotency_key": "graph-dec-1"},
     )
 
@@ -390,10 +396,9 @@ def test_epics_graph_store_lease_and_decision_passthrough(tmp_path: Path, monkey
     data = response.json()
 
     epics_by_id = {e["id"]: e for e in data["nodes"]["epics"]}
-    # If epic:7178 was claimed in store, its lease/state/decision should be passed through
-    if "epic:7178" in epics_by_id:  # allow-hardcoded-epic: store passthrough check
-        epic_7178 = epics_by_id["epic:7178"]  # allow-hardcoded-epic: store passthrough check
-        assert epic_7178["lease"] is not None
-        assert epic_7178["last_state"]["body"] == "working on graph"
-        assert epic_7178["last_decision"]["body"] == "design approved"
+    assert "epic:7177" in epics_by_id  # allow-hardcoded-epic: store passthrough check
+    epic_7177 = epics_by_id["epic:7177"]  # allow-hardcoded-epic: store passthrough check
+    assert epic_7177["lease"] is not None
+    assert epic_7177["last_state"]["body"] == "working on graph"
+    assert epic_7177["last_decision"]["body"] == "design approved"
 

--- a/tests/api/test_epics_router.py
+++ b/tests/api/test_epics_router.py
@@ -18,6 +18,7 @@ from scripts.api import epics_router
 
 def _client(tmp_path: Path, monkeypatch) -> TestClient:
     store = SessionStreamStore(SessionStreamDatabase(tmp_path / "api.sqlite3"))
+    epics_router.seed_manifest_inventory(epics_router.LIVE_REPO_ROOT, store=store)
     monkeypatch.setattr(epics_router, "_store", lambda: store)
     app = FastAPI()
     app.include_router(epics_router.router, prefix="/api/epics")
@@ -210,3 +211,189 @@ def test_router_redacts_legacy_uri_references(tmp_path: Path, monkeypatch) -> No
     assert "/Users/" not in json.dumps(sanitized)
     assert sanitized["stream"] == "epic:7178"  # allow-hardcoded-epic: remote lifecycle response fixture
     assert sanitized["refs"] == []
+
+
+def test_epics_graph_endpoint_contract_and_structure(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+
+    mock_audit = {
+        "generated_at": 1700000000,
+        "effective_membership": {
+            "7269": {"epics": [7177], "streams": ["monitor"], "via": "native", "unique_stream": True},  # allow-hardcoded-epic: mock audit data
+            "7270": {"epics": [7177], "streams": ["monitor"], "via": "native", "unique_stream": True},  # allow-hardcoded-epic: mock audit data
+            "7271": {"epics": [7177], "streams": ["monitor"], "via": "native", "unique_stream": True},  # allow-hardcoded-epic: mock audit data
+            "7100": {"epics": [7177], "streams": ["monitor"], "via": "native", "unique_stream": True},  # allow-hardcoded-epic: mock audit data
+        },
+        "open_issue_numbers": [7269, 7270, 7271],
+        "open_issue_titles": {
+            "7269": "Epics graph endpoint",
+            "7270": "Dashboard map view",
+            "7271": "Verification gates",
+        },
+    }
+
+    monkeypatch.setattr(epics_router.audit, "read_cache", lambda max_age_s: mock_audit if max_age_s == 3600 else None)
+    monkeypatch.setattr(
+        epics_router.audit,
+        "read_refresh_state",
+        lambda: {"phase": "idle", "last_outcome": "succeeded", "last_outcome_at": 1700000000},
+    )
+
+    response = client.get("/api/epics/graph/v1")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["schema"] == "epics-graph.v1"
+    assert "generated_at" in data
+    assert data["refreshing"] is False
+    assert data["refresh"]["phase"] == "idle"
+
+    # Verify nodes.areas
+    areas = {a["id"]: a for a in data["nodes"]["areas"]}
+    assert "area:monitor" in areas
+    assert areas["area:monitor"]["stream_id"] == "monitor"
+    assert areas["area:monitor"]["epic_count"] == 1
+    assert "Monitor API + UI" in areas["area:monitor"]["title"]
+
+    # Verify nodes.epics
+    epics = {e["id"]: e for e in data["nodes"]["epics"]}
+    assert "epic:7177" in epics  # allow-hardcoded-epic: graph contract check
+    monitor_epic = epics["epic:7177"]  # allow-hardcoded-epic: graph contract check
+    assert monitor_epic["number"] == 7177  # allow-hardcoded-epic: graph contract check
+    assert monitor_epic["area_id"] == "monitor"
+    assert monitor_epic["open_issue_count"] == 3
+    assert monitor_epic["closed_issue_count"] == 1
+    assert "last_state" in monitor_epic
+    assert "last_decision" in monitor_epic
+    assert "last_next_action" in monitor_epic
+
+    # Verify edges
+    edge_pairs = {(e["from"], e["to"]) for e in data["edges"]}
+    assert ("area:monitor", "epic:7177") in edge_pairs  # allow-hardcoded-epic: graph edge check
+
+    # Verify issues_by_epic
+    assert "7177" in data["issues_by_epic"]  # allow-hardcoded-epic: issues_by_epic check
+    epic_issues = data["issues_by_epic"]["7177"]  # allow-hardcoded-epic: issues_by_epic check
+    assert epic_issues["total_open"] == 3
+    assert epic_issues["truncated"] is False
+    assert len(epic_issues["items"]) == 3
+
+    first_item = epic_issues["items"][0]
+    assert first_item["number"] == 7269
+    assert first_item["title"] == "Epics graph endpoint"
+    assert first_item["state"] == "open"
+    assert first_item["url"] == "https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/7269"
+
+
+def test_epics_graph_stale_and_no_cache_fallbacks(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+
+    stale_audit = {
+        "generated_at": 1600000000,
+        "effective_membership": {},
+        "open_issue_numbers": [],
+        "open_issue_titles": {},
+    }
+
+    # Case 1: Fresh cache miss, stale cache hit
+    monkeypatch.setattr(
+        epics_router.audit,
+        "read_cache",
+        lambda max_age_s: stale_audit if max_age_s > 3600 else None,
+    )
+    scheduled = []
+    monkeypatch.setattr(
+        epics_router.audit,
+        "schedule_refresh",
+        lambda force=False: scheduled.append(force) or {"phase": "scheduled", "requested_at": 1700000000},
+    )
+
+    resp_stale = client.get("/api/epics/graph/v1")
+    assert resp_stale.status_code == 200
+    stale_data = resp_stale.json()
+    assert stale_data["stale"] is True
+    assert stale_data["refreshing"] is True
+    assert scheduled == [False]
+
+    # Case 2: Complete cache miss (no fresh, no stale)
+    monkeypatch.setattr(epics_router.audit, "read_cache", lambda max_age_s: None)
+    scheduled.clear()
+    resp_no_cache = client.get("/api/epics/graph/v1")
+    assert resp_no_cache.status_code == 200
+    no_cache_data = resp_no_cache.json()
+    assert no_cache_data["status"] == "no-cache"
+    assert no_cache_data["ok"] is None
+    assert scheduled == [False]
+
+    # Case 3: Explicit fresh=true param
+    scheduled.clear()
+    resp_fresh = client.get("/api/epics/graph/v1?fresh=true")
+    assert resp_fresh.status_code == 200
+    assert scheduled == [True]
+
+
+def test_epics_graph_truncation_cap_at_50(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+
+    # 60 open issues for epic 7177
+    effective_membership = {
+        str(1000 + i): {"epics": [7177], "streams": ["monitor"], "via": "native", "unique_stream": True}  # allow-hardcoded-epic: mock audit data
+        for i in range(60)
+    }
+    open_issue_numbers = [1000 + i for i in range(60)]
+    open_issue_titles = {str(1000 + i): f"Open issue {1000 + i}" for i in range(60)}
+
+    mock_audit = {
+        "generated_at": 1700000000,
+        "effective_membership": effective_membership,
+        "open_issue_numbers": open_issue_numbers,
+        "open_issue_titles": open_issue_titles,
+    }
+
+    monkeypatch.setattr(epics_router.audit, "read_cache", lambda max_age_s: mock_audit)
+    monkeypatch.setattr(
+        epics_router.audit,
+        "read_refresh_state",
+        lambda: {"phase": "idle"},
+    )
+
+    response = client.get("/api/epics/graph/v1")
+    assert response.status_code == 200
+    data = response.json()
+
+    monitor_issues = data["issues_by_epic"]["7177"]  # allow-hardcoded-epic: truncation check
+    assert monitor_issues["total_open"] == 60
+    assert monitor_issues["truncated"] is True
+    assert len(monitor_issues["items"]) == 50
+
+
+def test_epics_graph_store_lease_and_decision_passthrough(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+    claimed = _claim(client)
+    lease = claimed["lease"]
+
+    # Append a state entry and a decision entry
+    client.post(
+        "/api/epics/v1/epic:7178/handoff",
+        json={**lease, "type": "state", "body": "working on graph", "idempotency_key": "graph-state-1"},
+    )
+    client.post(
+        "/api/epics/v1/epic:7178/handoff",
+        json={**lease, "type": "decision", "body": "design approved", "idempotency_key": "graph-dec-1"},
+    )
+
+    monkeypatch.setattr(epics_router.audit, "read_cache", lambda max_age_s: {"generated_at": 1700000000})
+    monkeypatch.setattr(epics_router.audit, "read_refresh_state", lambda: {"phase": "idle"})
+
+    response = client.get("/api/epics/graph/v1")
+    assert response.status_code == 200
+    data = response.json()
+
+    epics_by_id = {e["id"]: e for e in data["nodes"]["epics"]}
+    # If epic:7178 was claimed in store, its lease/state/decision should be passed through
+    if "epic:7178" in epics_by_id:  # allow-hardcoded-epic: store passthrough check
+        epic_7178 = epics_by_id["epic:7178"]  # allow-hardcoded-epic: store passthrough check
+        assert epic_7178["lease"] is not None
+        assert epic_7178["last_state"]["body"] == "working on graph"
+        assert epic_7178["last_decision"]["body"] == "design approved"
+

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -1041,3 +1041,13 @@ def test_refresh_state_atomic_replace_never_exposes_partial_json(tmp_path, monke
             failures.append(exc)
     thread.join()
     assert failures == []
+
+
+def test_private_cache_keys_includes_open_issue_titles():
+    assert "open_issue_titles" in issue_stream_audit.PRIVATE_CACHE_KEYS
+    assert issue_stream_audit.PRIVATE_CACHE_KEYS == (
+        "effective_membership",
+        "open_issue_numbers",
+        "open_issue_titles",
+    )
+

--- a/tests/test_research_registry_p4.py
+++ b/tests/test_research_registry_p4.py
@@ -1031,10 +1031,12 @@ def test_issues_streams_strips_private_index(tmp_path, monkeypatch):
         "orphans": [],
         "effective_membership": {"5": {"epics": [100], "streams": ["s"], "unique_stream": True}},
         "open_issue_numbers": [5, 100],
+        "open_issue_titles": {"5": "Issue 5 title", "100": "Issue 100 title"},
     }
     stripped = issues_router._strip_private_index(report)
     assert "effective_membership" not in stripped
     assert "open_issue_numbers" not in stripped
+    assert "open_issue_titles" not in stripped
     assert stripped["open_total"] == 3 and stripped["ok"] is True
 
 
@@ -1050,6 +1052,7 @@ _LEAKY_REPORT = {
     "orphans": [],
     "effective_membership": {"5": {"epics": [100], "streams": ["s"], "unique_stream": True}},
     "open_issue_numbers": [5, 100],
+    "open_issue_titles": {"5": "Issue 5 title", "100": "Issue 100 title"},
 }
 
 _IDLE_REFRESH = {
@@ -1075,6 +1078,7 @@ _SCHEDULED_REFRESH = {
 def _assert_no_private_keys(body: dict[str, Any]) -> None:
     assert "effective_membership" not in body
     assert "open_issue_numbers" not in body
+    assert "open_issue_titles" not in body
     assert body["open_total"] == 3 and body["ok"] is True
 
 

--- a/tests/test_work_api.py
+++ b/tests/test_work_api.py
@@ -72,6 +72,7 @@ def _sections_with_canary() -> dict[str, SectionResult]:
                 # Inject private keys that public streams API must strip — Work must not reintroduce them.
                 "effective_membership": {"5921": {"private": True}},
                 "open_issue_numbers": [5921],
+                "open_issue_titles": {"5921": "Private title should be stripped"},
             },
             count=1,
         ),
@@ -168,6 +169,7 @@ def test_projection_endpoint_with_injected_sources(monkeypatch):
     assert "SHOULD-NOT-APPEAR" not in blob
     assert "effective_membership" not in blob
     assert "open_issue_numbers" not in blob
+    assert "open_issue_titles" not in blob
     assert "sealed_verdict_blob" not in blob
 
 
@@ -671,6 +673,7 @@ def test_streams_loader_derives_public_membership_and_strips_private_index():
                 },
             },
             "open_issue_numbers": [6001],
+            "open_issue_titles": {"6001": "Title 6001"},
         }
 
     section = fetch_streams_projection(loader=loader)
@@ -679,6 +682,7 @@ def test_streams_loader_derives_public_membership_and_strips_private_index():
     # Closed issue 5000 never surfaces; the private index keys are stripped.
     assert "effective_membership" not in section.payload
     assert "open_issue_numbers" not in section.payload
+    assert "open_issue_titles" not in section.payload
     blob = json.dumps(section.payload)
     assert "5000" not in blob
     assert "unique_stream" not in blob
@@ -714,6 +718,7 @@ def test_streams_loader_allowlists_derived_and_preset_membership():
                 },
             },
             "open_issue_numbers": [6001, 6004],
+            "open_issue_titles": {"6001": "Title 6001", "6004": "Title 6004"},
             # Pre-set map with a typo — must be re-validated, not trusted.
             "open_stream_membership": {
                 "6009": ["infra-harness", "typo-stream"],


### PR DESCRIPTION
Parent: #7295 (design doc merged as #7308). Implements the backing endpoint per
`docs/design/monitor-epics-graph-map.md` §4.1/§4.3/§5 — dashboard view (`dashboards/epics-map.html`)
is a separate follow-up PR gated on this one, per the design's sequencing.

**Note (driver):** this dispatch (agy) finished `status=done` without pushing or opening a PR —
same silent-exit pattern as the two cursor dispatches earlier this session (#7311), so it isn't
cursor-specific. Independently verified the actual commit content before pushing it myself:

- `tests/api/opsec_sweep/` — 19/19 passed.
- `tests/api/test_epics_router.py` (new) — 13/13 passed.
- Full `tests/api -n 4` — 368 passed, 1 skipped (pre-existing, unrelated).
- `ruff check` on all changed files — clean.

**What it does:**
- `GET /api/epics/graph/v1` in `epics_router.py`, response shape per design §4.1.
- Mirrors `GET /api/issues/streams`'s caching pattern exactly (read-cache / stale-fallback /
  schedule-refresh / off-event-loop) rather than any live `gh` call on the request path.
- Adds `open_issue_titles` to `classify()`'s cached report (design §4.3's flagged gap).
- Area layer from `issue_streams.yaml` only, not the stale `fleet_taxonomy.yaml` (#7306).
- OPSEC sweep: `FROZEN_HTTP_OPERATION_COUNT` 280→281, re-derived digest, isolated fixture entry
  for the new route — sweep passing is the proof the digest is correct.

Requesting cross-family review before merge.

X-Agent: claude-monitor