### PR TITLE
fix(cycle007): bind canary provider explicitly

### DIFF
--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -916,21 +916,21 @@ def invoke_canary(
     if execution_mode == "real" and mcp_endpoint != compiler.DEFAULT_MCP_ENDPOINT:
         raise CanaryError("real_mode_sources_endpoint_drift")
 
-    # Verify real executable identity if real mode is requested
+    # Verify the explicitly bound real executable identity.  Production runs
+    # may execute on a writer whose home differs from the review workstation;
+    # the receipt binds the selected regular file by hash and the controller
+    # independently revalidates that hash before any labeling call.
     if execution_mode == "real":
+        if not provider_bin.is_absolute():
+            raise CanaryError("provider_executable_not_absolute")
         try:
+            if provider_bin.is_symlink():
+                raise CanaryError("invalid_executable")
             resolved_exe = provider_bin.resolve(strict=True)
         except OSError as exc:
             raise CanaryError("provider_executable_unavailable") from exc
         if not resolved_exe.is_file() or resolved_exe.is_symlink():
             raise CanaryError("invalid_executable")
-        expected_live_bin = AGY if provider_name == "gemini" else GROK
-        try:
-            resolved_live = expected_live_bin.resolve(strict=True)
-        except OSError:
-            resolved_live = None
-        if resolved_live is None or resolved_exe != resolved_live:
-            raise CanaryError("provider_executable_mismatch")
         exe_sha256 = contract.sha256_file(resolved_exe)
     else:
         try:
@@ -1122,6 +1122,11 @@ def invoke_canary(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--provider", choices=("gemini", "grok"), required=True, help="target provider harness")
+    parser.add_argument(
+        "--provider-bin",
+        type=Path,
+        help="explicit absolute real-provider executable; required for real mode",
+    )
     parser.add_argument("--static", action="store_true", help="static schema/evidence proof without provider execution")
     parser.add_argument("--test-provider-bin", type=Path, help="synthetic provider executable fixture")
     parser.add_argument("--synthetic-mcp", action="store_true", help="use in-memory synthetic Sources MCP double")
@@ -1131,7 +1136,7 @@ def main() -> int:
 
     try:
         if args.static:
-            if args.test_provider_bin or args.synthetic_mcp:
+            if args.provider_bin or args.test_provider_bin or args.synthetic_mcp:
                 raise CanaryError("static_mode_prohibits_provider_args")
             result = static_verify(args.provider)
             if args.receipt:
@@ -1151,10 +1156,11 @@ def main() -> int:
         else:
             if args.receipt is None:
                 raise CanaryError("receipt_path_required_for_real_mode")
-            provider_bin = AGY if args.provider == "gemini" else GROK
+            if args.provider_bin is None:
+                raise CanaryError("provider_bin_required_for_real_mode")
             result = invoke_canary(
                 args.provider,
-                provider_bin,
+                args.provider_bin,
                 execution_mode="real",
                 receipt_path=args.receipt,
                 mcp_endpoint=args.mcp_endpoint,

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "batch_state" / "phase3-run-cycle007-public-canaries-v1.py"
+
+
+def _load_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("cycle007_public_canaries_test", RUNNER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_real_cli_requires_explicit_provider_bin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runner = _load_runner()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(RUNNER), "--provider", "gemini", "--receipt", str(tmp_path / "receipt.json")],
+    )
+
+    assert runner.main() == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "failure_code": "provider_bin_required_for_real_mode",
+        "ok": False,
+        "text_free": True,
+    }
+
+
+def test_real_cli_passes_explicit_provider_bin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = _load_runner()
+    provider = (tmp_path / "agy").resolve()
+    receipt = tmp_path / "receipt.json"
+    observed: dict[str, object] = {}
+
+    def fake_invoke(provider_name: str, provider_bin: Path, **kwargs: object) -> dict[str, object]:
+        observed.update(provider_name=provider_name, provider_bin=provider_bin, **kwargs)
+        return {"ok": True, "text_free": True}
+
+    monkeypatch.setattr(runner, "invoke_canary", fake_invoke)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(RUNNER),
+            "--provider",
+            "gemini",
+            "--provider-bin",
+            str(provider),
+            "--receipt",
+            str(receipt),
+        ],
+    )
+
+    assert runner.main() == 0
+    assert observed["provider_name"] == "gemini"
+    assert observed["provider_bin"] == provider
+    assert observed["execution_mode"] == "real"
+    assert observed["receipt_path"] == receipt
+
+
+def test_real_invoke_rejects_relative_and_symlink_provider(tmp_path: Path) -> None:
+    runner = _load_runner()
+    with pytest.raises(runner.CanaryError, match="provider_executable_not_absolute"):
+        runner.invoke_canary("gemini", Path("agy"), execution_mode="real")
+
+    target = tmp_path / "agy-real"
+    target.write_bytes(b"#!/bin/sh\n")
+    target.chmod(0o700)
+    link = tmp_path / "agy"
+    link.symlink_to(target)
+    with pytest.raises(runner.CanaryError, match="invalid_executable"):
+        runner.invoke_canary("gemini", link, execution_mode="real")


### PR DESCRIPTION
## Outcome

Allow the reviewed Cycle007 public canary to run on the production writer using an explicit absolute provider executable, while retaining hash binding and controller revalidation.

## Safety

- real mode requires `--provider-bin`
- relative and symlink executable paths fail closed
- receipt schema and provider identity validation are unchanged
- zero provider calls were made by the failed production attempt

## Verification

- Ruff: passed
- 77 focused tests: passed

Fixes the production-start defect encountered while continuing #6375.