### PR TITLE
fix(delegate): mark unpushed write-capable dispatches as needs_finalize (#7311)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2591,6 +2591,50 @@ def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
     return None
 
 
+def _unpushed_commit_refs(worktree: Path, branch: str) -> tuple[str, ...]:
+    """Return ordered remote-tracking ref candidates for unpushed-commit checks."""
+    clean_branch = branch.removeprefix("refs/heads/").removeprefix("refs/remotes/")
+    if clean_branch.startswith("origin/"):
+        clean_branch = clean_branch.removeprefix("origin/")
+    if not clean_branch:
+        return ()
+
+    candidates: list[str] = [f"{clean_branch}@{{upstream}}", "@{upstream}"]
+    tracking_remote = _tracking_remote_for_current_branch(worktree)
+    if tracking_remote:
+        candidates.append(f"{tracking_remote}/{clean_branch}")
+    candidates.append(f"origin/{clean_branch}")
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def _count_unpushed_commits(worktree: Path, branch: str) -> int | None:
+    """Return commits on HEAD not reachable from the branch's remote, or None.
+
+    ``None`` means cannot count or no remote tracking ref exists. Fail closed
+    on unknown or unpushed commits (#7311).
+    """
+    for candidate in _unpushed_commit_refs(worktree, branch):
+        try:
+            proc = subprocess.run(
+                ["git", "rev-list", "--count", f"{candidate}..HEAD"],
+                cwd=worktree,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=_sanitized_git_env(),
+                timeout=DEFAULT_GIT_TIMEOUT_S,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if proc.returncode != 0:
+            continue
+        try:
+            return int((proc.stdout or "").strip())
+        except ValueError:
+            return None
+    return None
+
+
 def _commit_count_base_ref(worktree: Path, base_branch: str) -> str:
     """Keep an explicit available non-origin remote base for finalization."""
     explicit_ref = base_branch.removeprefix("refs/remotes/")
@@ -4701,6 +4745,26 @@ def _run_worker(
                 # the task for finalization rather than letting it settle as ``done``.
                 if dirty_on_exit in (True, None) and commits_ahead in (0, None):
                     needs_finalize = True
+
+                # Catch committed-but-unpushed write dispatches (#7311):
+                # A clean tree with local commits on the dispatch branch has commits_ahead >= 1
+                # relative to base_ref (e.g. origin/main), but if those commits were never
+                # pushed to the branch's remote tracking ref, the work has not left the machine.
+                worktree_branch = final_state.get("worktree_branch")
+                if isinstance(worktree_branch, str) and worktree_branch.strip():
+                    normalized_branch = worktree_branch.strip()
+                    if normalized_branch.startswith("refs/heads/"):
+                        normalized_branch = normalized_branch.removeprefix("refs/heads/")
+                    if normalized_branch.startswith("origin/"):
+                        normalized_branch = normalized_branch.removeprefix("origin/")
+                    containment = _load_worktree_containment()
+                    if normalized_branch not in containment.PROTECTED_BRANCHES:
+                        unpushed_commits = _count_unpushed_commits(
+                            Path(worktree_path),
+                            normalized_branch,
+                        )
+                        if unpushed_commits is None or unpushed_commits > 0:
+                            needs_finalize = True
 
                 if needs_finalize and returncode == 0 and mode == "danger":
                     auto_finalize = _auto_finalize_dirty_worktree(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -3392,6 +3392,197 @@ def test_run_worker_marks_needs_finalize_when_dirty_state_is_unknown(
     assert rc == 1
 
 
+@pytest.mark.parametrize("mode", ["workspace-write", "danger"])
+@pytest.mark.parametrize("unpushed_count", [1, None])
+def test_run_worker_marks_needs_finalize_for_unpushed_commits(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    mode,
+    unpushed_count,
+):
+    """Clean tree with unpushed commits or no remote tracking ref must need finalize (#7311)."""
+    task_id = f"needs-finalize-unpushed-{mode}-{unpushed_count}"
+    worktree = tmp_path / f"wt-{task_id}"
+    worktree.mkdir()
+    state_path = delegate._state_path(task_id)
+    _init_git_repo_for_test(worktree, monkeypatch)
+    delegate._write_state_atomic(
+        state_path,
+        {
+            "task_id": task_id,
+            "worktree_path": str(worktree),
+            "worktree_base": "main",
+            "worktree_branch": "feat/fix-7311",
+        },
+    )
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()),
+        patch.object(delegate, "_count_commits_ahead", return_value=1),
+        patch.object(delegate, "_count_unpushed_commits", return_value=unpushed_count),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="codex",
+            prompt="do the work",
+            mode=mode,
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "needs_finalize", (
+        f"unpushed commits reported {state['status']!r}; a clean dispatch with unpushed "
+        "commits must not settle as done"
+    )
+    assert state["needs_finalize"] is True
+    assert state["commits_ahead"] == 1
+    assert state["worktree_dirty_on_exit"] is False
+    assert rc == 1
+
+
+@pytest.mark.parametrize("mode", ["workspace-write", "danger"])
+def test_run_worker_marks_done_when_branch_commits_pushed(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    mode,
+):
+    """Pushed branch commits prove delivery and settle as done (#7311)."""
+    task_id = f"shipped-pushed-{mode}"
+    worktree = tmp_path / f"wt-{task_id}"
+    worktree.mkdir()
+    state_path = delegate._state_path(task_id)
+    _init_git_repo_for_test(worktree, monkeypatch)
+    delegate._write_state_atomic(
+        state_path,
+        {
+            "task_id": task_id,
+            "worktree_path": str(worktree),
+            "worktree_base": "main",
+            "worktree_branch": "feat/fix-7311",
+        },
+    )
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()),
+        patch.object(delegate, "_count_commits_ahead", return_value=1),
+        patch.object(delegate, "_count_unpushed_commits", return_value=0),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="codex",
+            prompt="do the work",
+            mode=mode,
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert state["commits_ahead"] == 1
+    assert rc == 0
+
+
+@pytest.mark.parametrize("branch", [None, "", "main", "master"])
+def test_run_worker_unpushed_check_skips_omitted_or_protected_branch(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    branch,
+):
+    """Omitted or protected worktree_branch keeps existing commits_ahead delivery behavior (#7311)."""
+    task_id = f"skip-unpushed-check-{branch}"
+    worktree = tmp_path / f"wt-{task_id}"
+    worktree.mkdir()
+    state_path = delegate._state_path(task_id)
+    _init_git_repo_for_test(worktree, monkeypatch)
+    state_payload = {
+        "task_id": task_id,
+        "worktree_path": str(worktree),
+        "worktree_base": "main",
+    }
+    if branch is not None:
+        state_payload["worktree_branch"] = branch
+    delegate._write_state_atomic(state_path, state_payload)
+
+    unpushed_called = False
+
+    def _mock_unpushed(*_args, **_kwargs):
+        nonlocal unpushed_called
+        unpushed_called = True
+        return None
+
+    monkeypatch.setattr(delegate, "_count_unpushed_commits", _mock_unpushed)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()),
+        patch.object(delegate, "_count_commits_ahead", return_value=1),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="codex",
+            prompt="do the work",
+            mode="workspace-write",
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert unpushed_called is False
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert rc == 0
+
+
+def test_count_unpushed_commits_resolves_remote_ref_or_none(tmp_path, monkeypatch):
+    """_count_unpushed_commits returns correct count against origin ref or None (#7311)."""
+    _sanitize_git_env_for_test(monkeypatch)
+    origin = tmp_path / "origin.git"
+    worktree = tmp_path / "worktree"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True, timeout=30)
+    subprocess.run(["git", "init", "--initial-branch=main", str(worktree)], check=True, capture_output=True, timeout=30)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=worktree, check=True, capture_output=True, timeout=30)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=worktree, check=True, capture_output=True, timeout=30)
+    (worktree / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=worktree, check=True, capture_output=True, timeout=30)
+
+    # 1. New local branch not yet pushed to origin: returns None (cannot count / no remote ref)
+    subprocess.run(["git", "checkout", "-b", "feat/my-branch"], cwd=worktree, check=True, capture_output=True, timeout=30)
+    (worktree / "file.txt").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file.txt"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "feat: add file"], cwd=worktree, check=True, timeout=30)
+
+    assert delegate._count_unpushed_commits(worktree, "feat/my-branch") is None
+
+    # 2. Push branch to origin: now 0 unpushed commits
+    subprocess.run(["git", "push", "-u", "origin", "feat/my-branch"], cwd=worktree, check=True, capture_output=True, timeout=30)
+    assert delegate._count_unpushed_commits(worktree, "feat/my-branch") == 0
+
+    # 3. Add 1 local commit without pushing: now 1 unpushed commit
+    (worktree / "file2.txt").write_text("hello 2\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file2.txt"], cwd=worktree, check=True, timeout=30)
+    subprocess.run(["git", "commit", "-m", "feat: add file 2"], cwd=worktree, check=True, timeout=30)
+    assert delegate._count_unpushed_commits(worktree, "feat/my-branch") == 1
+
+    # 4. Non-existent worktree path: returns None
+    assert delegate._count_unpushed_commits(tmp_path / "nonexistent", "feat/my-branch") is None
+
+
 def test_run_worker_auto_finalizes_dirty_agy_worktree(
     tmp_tasks_dir,
     tmp_path,


### PR DESCRIPTION
## Outcome

Write-capable `delegate.py` dispatches that commit locally but never push no longer settle as `done`. They surface as `needs_finalize` when `worktree_branch` is set and HEAD is ahead of `origin/<branch>` / `@{upstream}`, or when that remote ref cannot be counted.

Fixes #7311 (the silent-exit class reproduced 3/3 this session, including the implementer of this PR).

## What changed

- New `_count_unpushed_commits` helper, independent of `_count_commits_ahead` (still vs `main`).
- Orthogonal to the dirty-tree check. Omitted/protected `worktree_branch` keeps existing tests green.
- After a successful danger auto-finalize (commit+push), unpushed count is 0 so `done` remains valid.

## Evidence

```
.venv/bin/python -m pytest tests/test_delegate.py -q -k "unpushed or shipped-pushed or skip-unpushed or needs_finalize or committed_change or count_commits"
19 passed, 300 deselected
ruff check scripts/delegate.py tests/test_delegate.py  # All checks passed
```

X-Agent: agy/fix-7311-needs-finalize