### PR TITLE
fix(session-supervisor): default worker-env no longer dumps secrets (#7259)

### DIFF
--- a/agents_extensions/shared/hooks/guard-secret-print.py
+++ b/agents_extensions/shared/hooks/guard-secret-print.py
@@ -13,11 +13,14 @@ This guard is deliberately narrow. It catches high-confidence dump shapes only:
   - `grep` / `rg` / `ugrep` reading dotenv-style secret files without a
     key-only/count transform
   - `echo` / `printf` expanding known secret environment variables
+  - `scripts.session_supervisor worker-env` environment views, including the
+    explicit `--all` form
 
 Quote-aware tokenization keeps dangerous-looking strings inside a quoted commit
 message from becoming false positives. If parsing is uncertain, the hook allows
 the command; this is a guardrail, not a shell interpreter.
 """
+
 from __future__ import annotations
 
 import json
@@ -38,6 +41,8 @@ KNOWN_SECRET_VARS = {
     "GITHUB_TOKEN",
     "OPENAI_API_KEY",
 }
+WORKER_ENV_MODULE = "scripts.session_supervisor"
+WORKER_ENV_COMMAND = "worker-env"
 
 _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*\Z")
 _VAR_REF_RE = re.compile(
@@ -361,6 +366,28 @@ def _env_dump_reason(pipeline: list[list[str]]) -> str | None:
     return f"`{cmd}` would print the full shell environment"
 
 
+def _is_python_command(command: str) -> bool:
+    return bool(re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", command.rsplit("/", 1)[-1]))
+
+
+def _worker_env_reason(seg: list[str]) -> str | None:
+    command = _command_at(seg)
+    if command is None:
+        return None
+    cmd, args, _idx = command
+    if cmd == WORKER_ENV_MODULE and WORKER_ENV_COMMAND in args:
+        return "`worker-env` can print environment values"
+    if _is_python_command(cmd):
+        for index, arg in enumerate(args[:-1]):
+            if (
+                _strip_quotes(arg) == "-m"
+                and _strip_quotes(args[index + 1]) == WORKER_ENV_MODULE
+                and any(_strip_quotes(candidate) == WORKER_ENV_COMMAND for candidate in args[index + 2 :])
+            ):
+                return "`python -m scripts.session_supervisor worker-env` can print environment values"
+    return None
+
+
 def _display_file_reason(pipeline: list[list[str]], seg_index: int) -> str | None:
     command = _command_at(pipeline[seg_index])
     if command is None:
@@ -511,6 +538,9 @@ def _danger_reason(pipeline: list[list[str]]) -> str | None:
         return reason
 
     for i, segment in enumerate(pipeline):
+        reason = _worker_env_reason(segment)
+        if reason:
+            return reason
         reason = _display_file_reason(pipeline, i)
         if reason:
             return reason

--- a/scripts/session_supervisor/__init__.py
+++ b/scripts/session_supervisor/__init__.py
@@ -38,7 +38,6 @@ from agents_extensions.shared.session_streams.store import (
     SessionStreamError,
     SessionStreamStore,
 )
-from scripts.secret_redactor import REDACTION, redact_value
 
 from .remote import RemoteEpicClient, RemoteSupervisorError
 
@@ -122,6 +121,8 @@ def worker_environment(environment: Mapping[str, str], *, include_all: bool = Fa
     metadata. ``include_all`` is reserved for the explicit ``--all`` or
     ``LEARN_UK_SECRETS_OK=1`` path and still uses the shared egress redactor.
     """
+    from scripts.secret_redactor import REDACTION, redact_value
+
     selected = {
         key: value
         for key, value in environment.items()

--- a/scripts/session_supervisor/__init__.py
+++ b/scripts/session_supervisor/__init__.py
@@ -38,11 +38,13 @@ from agents_extensions.shared.session_streams.store import (
     SessionStreamError,
     SessionStreamStore,
 )
+from scripts.secret_redactor import REDACTION, redact_value
 
 from .remote import RemoteEpicClient, RemoteSupervisorError
 
 CAPSULE_SCHEMA = "session-supervisor-bootstrap.v1"
 LEASE_ENV_PREFIX = "SESSION_STREAM_"
+_WORKER_ENV_SECRET_SUFFIXES = ("_TOKEN", "_KEY", "_SECRET", "_PAT", "_AUTH")
 
 
 class SupervisorError(ValueError):
@@ -106,6 +108,27 @@ class BootstrapCapsule:
 def strip_lease_credentials(environment: Mapping[str, str]) -> dict[str, str]:
     """Return a worker-safe environment with every lease field removed."""
     return {key: value for key, value in environment.items() if not key.startswith(LEASE_ENV_PREFIX)}
+
+
+def _is_worker_env_secret_key(key: str) -> bool:
+    upper = key.upper()
+    return upper.endswith(_WORKER_ENV_SECRET_SUFFIXES)
+
+
+def worker_environment(environment: Mapping[str, str], *, include_all: bool = False) -> dict[str, str]:
+    """Return the CLI environment view, redacting every included value.
+
+    The default view is deliberately limited to non-credential session-stream
+    metadata. ``include_all`` is reserved for the explicit ``--all`` or
+    ``LEARN_UK_SECRETS_OK=1`` path and still uses the shared egress redactor.
+    """
+    selected = {
+        key: value
+        for key, value in environment.items()
+        if include_all or (key.startswith(LEASE_ENV_PREFIX) and not _is_worker_env_secret_key(key))
+    }
+    redacted = redact_value(selected)
+    return {key: REDACTION if _is_worker_env_secret_key(key) else str(value) for key, value in redacted.items()}
 
 
 class SessionSupervisor:
@@ -466,7 +489,15 @@ def build_parser() -> argparse.ArgumentParser:
     capsule.add_argument("--stream", required=True)
     capsule.add_argument("--digest-limit", type=int, default=20)
 
-    commands.add_parser("worker-env", help="Print the current environment with all lease fields stripped.")
+    worker_env = commands.add_parser(
+        "worker-env",
+        help="Print SESSION_STREAM_* metadata; --all prints a redacted full environment.",
+        description=(
+            "Print non-credential SESSION_STREAM_* metadata. Use --all or "
+            "LEARN_UK_SECRETS_OK=1 for a redacted full environment."
+        ),
+    )
+    worker_env.add_argument("--all", action="store_true", help="Include all environment keys after redaction.")
     return parser
 
 
@@ -485,7 +516,8 @@ def main(argv: list[str] | None = None) -> int:
     """Run one lifecycle action and render only JSON to stdout."""
     args = build_parser().parse_args(argv)
     if args.command == "worker-env":
-        print(json.dumps(strip_lease_credentials(os.environ), ensure_ascii=False, sort_keys=True))
+        include_all = args.all or os.environ.get("LEARN_UK_SECRETS_OK") == "1"
+        print(json.dumps(worker_environment(os.environ, include_all=include_all), ensure_ascii=False, sort_keys=True))
         return 0
 
     if args.local:

--- a/tests/test_guard_secret_print.py
+++ b/tests/test_guard_secret_print.py
@@ -83,6 +83,7 @@ def test_secret_dump_shapes_blocked(monkeypatch, capsys, cmd):
         "jq keys",
         'git commit -m "notes: gh pr merge --admin and echo $GH_TOKEN"',
         'git commit -m "ref guard-secret-print.py"',
+        'git commit -m "document scripts.session_supervisor worker-env"',
         "git commit -F - <<EOF\nref guard-secret-print\nEOF",
         "tail -3 <<EOF\n.env\nEOF",
         "LEARN_UK_SECRETS_OK=1 env",
@@ -98,3 +99,17 @@ def test_environment_override_allowed(monkeypatch):
 
 def test_single_quoted_secret_var_literal_allowed(monkeypatch):
     assert _run(monkeypatch, "echo '$GH_TOKEN'") == 0
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "scripts.session_supervisor worker-env",
+        "python -m scripts.session_supervisor worker-env",
+        ".venv/bin/python -m scripts.session_supervisor worker-env --all",
+        "python3 -m scripts.session_supervisor --all worker-env",
+    ],
+)
+def test_worker_env_commands_are_blocked(monkeypatch, capsys, cmd):
+    assert _run(monkeypatch, cmd) == 2
+    assert "worker-env" in capsys.readouterr().err

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
+import subprocess
+import sys
 from dataclasses import replace
 from pathlib import Path
 
@@ -12,7 +16,14 @@ import yaml
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
 from agents_extensions.shared.session_streams.model import LeaseHolder
 from agents_extensions.shared.session_streams.store import LeaseConflictError, SessionStreamStore
-from scripts.session_supervisor import LaunchRole, SessionSupervisor, SupervisorError, main, strip_lease_credentials
+from scripts.secret_redactor import REDACTION
+from scripts.session_supervisor import (
+    LaunchRole,
+    SessionSupervisor,
+    SupervisorError,
+    main,
+    strip_lease_credentials,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _ISSUE_STREAMS = _REPO_ROOT / "scripts" / "config" / "issue_streams.yaml"
@@ -102,6 +113,69 @@ def test_worker_environment_strips_every_lease_credential() -> None:
         "KEEP_ME": "safe",
     }
     assert strip_lease_credentials(environment) == {"KEEP_ME": "safe"}
+
+
+def test_worker_env_default_is_sorted_safe_session_metadata_without_secret_env(tmp_path: Path) -> None:
+    fake_secret_values = {
+        "CLAUDE_CODE_MESSAGING_TOKEN": "fake-claude-token-value",
+        "OPENAI_API_KEY": "fake-openai-key-value",
+    }
+    child_env = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "SESSION_STREAM_ID": "epic:test",
+        "SESSION_STREAM_LEASE_ID": "lease-test",
+        "SESSION_STREAM_FENCING_TOKEN": "fencing-test",
+        "UNRELATED_RUNTIME_FLAG": "visible-only-in-full-mode",
+        **fake_secret_values,
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.session_supervisor", "worker-env"],
+        cwd=_REPO_ROOT,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert list(payload) == sorted(payload)
+    assert set(payload) <= {"SESSION_STREAM_ID", "SESSION_STREAM_LEASE_ID"}
+    assert not any(re.search(r"(?:_TOKEN|_KEY|_SECRET|_PAT|_AUTH)$", key) for key in payload)
+    assert not any(name in result.stdout for name in fake_secret_values)
+    assert not any(value in result.stdout for value in fake_secret_values.values())
+
+
+def test_worker_env_all_redacts_secret_values_without_override(tmp_path: Path) -> None:
+    fake_secrets = {
+        "CLAUDE_CODE_MESSAGING_TOKEN": "fake-claude-token-value",
+        "OPENAI_API_KEY": "fake-openai-key-value",
+        "EXAMPLE_KEY": "fake-example-key-value",
+        "EXAMPLE_SECRET": "fake-example-secret-value",
+        "EXAMPLE_PAT": "fake-example-pat-value",
+        "EXAMPLE_AUTH": "fake-example-auth-value",
+    }
+    child_env = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "UNRELATED_RUNTIME_FLAG": "visible-in-full-mode",
+        **fake_secrets,
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.session_supervisor", "worker-env", "--all"],
+        cwd=_REPO_ROOT,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["UNRELATED_RUNTIME_FLAG"] == "visible-in-full-mode"
+    assert all(payload[name] == REDACTION for name in fake_secrets)
+    assert not any(value in result.stdout for value in fake_secrets.values())
 
 
 def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -136,6 +136,7 @@ def test_worker_env_default_is_sorted_safe_session_metadata_without_secret_env(t
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
     assert result.returncode == 0
@@ -169,6 +170,7 @@ def test_worker_env_all_redacts_secret_values_without_override(tmp_path: Path) -
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
     assert result.returncode == 0

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import re
@@ -178,6 +179,43 @@ def test_worker_env_all_redacts_secret_values_without_override(tmp_path: Path) -
     assert payload["UNRELATED_RUNTIME_FLAG"] == "visible-in-full-mode"
     assert all(payload[name] == REDACTION for name in fake_secrets)
     assert not any(value in result.stdout for value in fake_secrets.values())
+
+
+def test_session_supervisor_import_without_secret_redactor(monkeypatch: pytest.MonkeyPatch) -> None:
+    subprocess_code = (
+        "import sys; "
+        "sys.modules['scripts.secret_redactor'] = None; "
+        "import scripts.session_supervisor; "
+        "assert hasattr(scripts.session_supervisor, 'SessionSupervisor')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", subprocess_code],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    monkeypatch.setitem(sys.modules, "scripts.secret_redactor", None)
+    monkeypatch.delitem(sys.modules, "scripts.session_supervisor", raising=False)
+    supervisor_mod = importlib.import_module("scripts.session_supervisor")
+    assert hasattr(supervisor_mod, "SessionSupervisor")
+
+    with pytest.raises(ModuleNotFoundError):
+        supervisor_mod.worker_environment({"CLAUDE_CODE_MESSAGING_TOKEN": "secret"}, include_all=True)
+
+    monkeypatch.undo()
+    monkeypatch.delitem(sys.modules, "scripts.session_supervisor", raising=False)
+    restored_mod = importlib.import_module("scripts.session_supervisor")
+    env = {
+        "CLAUDE_CODE_MESSAGING_TOKEN": "real-secret-token",
+        "UNRELATED_RUNTIME_FLAG": "visible",
+    }
+    redacted = restored_mod.worker_environment(env, include_all=True)
+    assert redacted["CLAUDE_CODE_MESSAGING_TOKEN"] == REDACTION
+    assert redacted["UNRELATED_RUNTIME_FLAG"] == "visible"
 
 
 def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

`python -m scripts.session_supervisor worker-env` prints only non-secret `SESSION_STREAM_*` keys by default. `--all` or `LEARN_UK_SECRETS_OK=1` prints a redacted full environment. The secret-print hook blocks `worker-env` argv shapes.

Fixes #7259.

## Evidence

```
pytest tests/test_session_supervisor.py tests/test_guard_secret_print.py -q
39 passed
ruff check scripts/session_supervisor tests/test_session_supervisor.py agents_extensions/shared/hooks/guard-secret-print.py tests/test_guard_secret_print.py
All checks passed
```

X-Agent: codex/fix-7259-worker-env