### PR TITLE
fix(delegate): ignore gitignored paths in read-only mutation detector (#7253)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2779,7 +2779,7 @@ def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str 
         ),
         (
             "ignored",
-            ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "-z"],
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored"],
         ),
     )
     outputs: dict[str, str] = {}
@@ -2827,8 +2827,15 @@ def _read_only_checkout_snapshot(cwd: Path) -> tuple[dict[str, str] | None, str 
             entries[path] = state
         if rename_source is not None and not _is_read_only_snapshot_excluded_path(rename_source):
             entries[rename_source] = f"{state}:source"
-    for path in outputs["ignored"].split("\0"):
-        if path and not _is_read_only_snapshot_excluded_path(path):
+    # ``git status`` without ``--ignored`` omits ignored paths entirely. The
+    # second status invocation makes those paths observable as ``!!`` while
+    # retaining porcelain's tracked/untracked classification for the first
+    # invocation. Do not let the second invocation overwrite real statuses.
+    for record in outputs["ignored"].split("\0"):
+        if len(record) < 4 or record[:2] != "!!" or record[2] != " ":
+            continue
+        path = record[3:]
+        if not _is_read_only_snapshot_excluded_path(path):
             entries[path] = "!!"
     return entries, None
 
@@ -2924,7 +2931,8 @@ def _is_read_only_runtime_state_path(path: str) -> bool:
 
     Covers Entire telemetry (#6803) plus the gitignored runtime dirs and sqlite
     sidecars that false-failed successful read-only tasks (#6860). Task-authored
-    ignored leaks such as ``.cache/`` stay visible to the guard (#4840).
+    ignored paths such as ``.cache/`` are classified separately as diagnostic
+    notes (#4840, #7253).
     """
     if _is_read_only_delegate_snapshot_sidecar_path(path):
         return True
@@ -2991,13 +2999,48 @@ def _is_read_only_runtime_state_exemption(path: str, *, before_state: str | None
     )
 
 
+def _is_read_only_ignored_status(state: str | None) -> bool:
+    """Return whether a snapshot status is Git's ignored ``!!`` marker."""
+    return state is not None and state[:2] == "!!"
+
+
+def _is_read_only_ignored_mutation(*, before_state: str | None, after_state: str | None) -> bool:
+    """Return whether a changed path is ignored in its observable final state.
+
+    A deleted ignored file disappears from both porcelain snapshots, so its
+    pre-snapshot ``!!`` marker is also sufficient to classify that delta as an
+    ignored mutation. A path that becomes ordinary untracked ``??`` remains a
+    real mutation and is intentionally not classified as ignored.
+    """
+    if after_state is not None:
+        return _is_read_only_ignored_status(after_state)
+    return _is_read_only_ignored_status(before_state)
+
+
+def _read_only_ignored_mutation_paths(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Return changed paths Git reports as ignored, for diagnostic notes only."""
+    before_roots = _read_only_dispatch_sandbox_roots(before)
+    return sorted(
+        path
+        for path in set(before) | set(after)
+        if before.get(path) != after.get(path)
+        and _is_read_only_ignored_mutation(
+            before_state=before.get(path),
+            after_state=after.get(path),
+        )
+        and not _is_read_only_new_sibling_dispatch_sandbox_path(path, before_roots=before_roots)
+    )
+
+
 def _read_only_mutation_paths(before: dict[str, str], after: dict[str, str]) -> list[str]:
     """Return exact paths whose observable Git state changed during a review.
 
-    Gitignored harness/tooling runtime state is excluded when it is ignored or
-    untracked: the runtime owns those writes, so they are not evidence that a
-    read-only worker mutated the tree (#6803, #6860). Tracked paths under the
-    same prefixes (including force-added files) still trip the guard.
+    Gitignored paths are excluded because ``git status`` marks them ``!!`` (or
+    omits them without ``--ignored``); they are recorded by
+    :func:`_read_only_ignored_mutation_paths` instead. Runtime-state exemptions
+    remain for older snapshots and for paths whose status is not ignored.
+    Tracked paths under runtime prefixes (including force-added files) still
+    trip the guard.
 
     Newly appeared sibling dispatch sandboxes under
     ``.worktrees/dispatch/<agent>/<task>/`` are also excluded (#6938): concurrent
@@ -3011,6 +3054,10 @@ def _read_only_mutation_paths(before: dict[str, str], after: dict[str, str]) -> 
         path
         for path in set(before) | set(after)
         if before.get(path) != after.get(path)
+        and not _is_read_only_ignored_mutation(
+            before_state=before.get(path),
+            after_state=after.get(path),
+        )
         and not _is_read_only_runtime_state_exemption(
             path,
             before_state=before.get(path),
@@ -4476,6 +4523,7 @@ def _run_worker(
     read_only_checkout_post: dict[str, str] | None = None
     read_only_snapshot_error: str | None = None
     read_only_mutation_paths: list[str] = []
+    read_only_ignored_mutation_paths: list[str] = []
     if mode == "read-only":
         read_only_checkout_pre, read_only_snapshot_error = _read_only_checkout_snapshot(cwd)
         _write_read_only_snapshot_sidecar(task_id, "pre", read_only_checkout_pre)
@@ -4674,10 +4722,15 @@ def _run_worker(
                 read_only_snapshot_error = post_snapshot_error
             final_state["read_only_checkout_snapshot_error"] = read_only_snapshot_error
             if read_only_checkout_pre is not None and read_only_checkout_post is not None:
+                read_only_ignored_mutation_paths = _read_only_ignored_mutation_paths(
+                    read_only_checkout_pre,
+                    read_only_checkout_post,
+                )
                 read_only_mutation_paths = _read_only_mutation_paths(
                     read_only_checkout_pre,
                     read_only_checkout_post,
                 )
+            final_state["read_only_ignored_mutation_paths"] = read_only_ignored_mutation_paths
             final_state["read_only_mutation_paths"] = read_only_mutation_paths
             if read_only_mutation_paths:
                 final_status = "failed"

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2421,17 +2421,18 @@ def test_read_only_seminar_review_fails_and_records_exact_leaked_artifacts(
         timeout=30,
     )
 
+    ignored_paths = [".cache/lemma-frequency-c1-999.json"]
     leaked_paths = [
-        ".cache/lemma-frequency-c1-999.json",
         "curriculum/l2-uk-en/bio/andrii-malyshko/audit/module-audit.md",
         "curriculum/l2-uk-en/bio/andrii-malyshko/status/module.json",
     ]
+    all_written_paths = [*ignored_paths, *leaked_paths]
     state_path = delegate._state_path("read-only-seminar-leak")
     delegate._write_state_atomic(state_path, {"task_id": "read-only-seminar-leak"})
     result = _finalize_mock_result()
 
     def legacy_audit_side_effect(*_args, **_kwargs):
-        for relative_path in leaked_paths:
+        for relative_path in all_written_paths:
             target = worktree / relative_path
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text("legacy audit leak\n", encoding="utf-8")
@@ -2454,6 +2455,7 @@ def test_read_only_seminar_review_fails_and_records_exact_leaked_artifacts(
     assert state["status"] == "failed"
     assert state["read_only_checkout_pre"] == {}
     assert state["read_only_mutation_paths"] == leaked_paths
+    assert state["read_only_ignored_mutation_paths"] == ignored_paths
     assert state["read_only_checkout_post"] == {
         ".cache/lemma-frequency-c1-999.json": "!!",
         "curriculum/l2-uk-en/bio/andrii-malyshko/audit/module-audit.md": "??",
@@ -2482,6 +2484,7 @@ def _seed_read_only_checkout_fixture(repo: Path, monkeypatch) -> None:
     )
     (repo / ".gitignore").write_text(
         ".agent/\n"
+        ".cache/\n"
         "batch_state/\n"
         ".pytest_cache/\n"
         ".pytest_breadcrumbs/\n"
@@ -2769,7 +2772,18 @@ def test_read_only_mutation_paths_ignore_runtime_state_only():
     assert delegate._read_only_mutation_paths(before, after_mixed) == ["tracked.txt"]
 
     after_cache_leak = {**after_runtime, ".cache/lemma-frequency-c1-999.json": "!!"}
-    assert delegate._read_only_mutation_paths(before, after_cache_leak) == [".cache/lemma-frequency-c1-999.json"]
+    assert delegate._read_only_mutation_paths(before, after_cache_leak) == []
+    assert delegate._read_only_ignored_mutation_paths(before, after_cache_leak) == sorted(
+        [*after_runtime, ".cache/lemma-frequency-c1-999.json"]
+    )
+    assert delegate._read_only_mutation_paths(
+        {".cache/lemma-frequency-c1-999.json": "!!"},
+        {},
+    ) == []
+    assert delegate._read_only_ignored_mutation_paths(
+        {".cache/lemma-frequency-c1-999.json": "!!"},
+        {},
+    ) == [".cache/lemma-frequency-c1-999.json"]
 
     # Force-added tracked file under an exempted prefix must still trip (#6803 r2 / #6860).
     tracked_session = ".agent/sessions/force-added.json"
@@ -2833,6 +2847,52 @@ def test_read_only_dispatch_allows_harness_runtime_state(
     for relative_path in _READ_ONLY_RUNTIME_STATE_PATHS:
         assert state["read_only_checkout_post"][relative_path] == "!!"
         assert (checkout / relative_path).exists()
+
+
+def test_read_only_dispatch_allows_gitignored_cache_write(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """#7253: a new gitignored cache file is diagnostic-only, not a failure."""
+    checkout = (tmp_path / "gitignored-cache").resolve()
+    checkout.mkdir(parents=True, exist_ok=True)
+    _seed_read_only_checkout_fixture(checkout, monkeypatch)
+
+    task_id = "read-only-gitignored-cache"
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {"task_id": task_id, "cwd": str(checkout)},
+    )
+    cache_path = ".cache/lemma-frequency-c1-999.json"
+
+    def cache_only_side_effect(*_args, **_kwargs):
+        target = checkout / cache_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("cache\n", encoding="utf-8")
+        return _finalize_mock_result()
+
+    with patch("agent_runtime.runner.invoke", side_effect=cache_only_side_effect):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="codex",
+            prompt="Review without editing the tree.",
+            mode="read-only",
+            cwd_str=str(checkout),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(state_path)
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["read_only_mutation_paths"] == []
+    assert state["read_only_ignored_mutation_paths"] == [cache_path]
+    assert state["last_error"] is None
+    assert state["read_only_checkout_post"][cache_path] == "!!"
+    assert (checkout / cache_path).exists()
 
 
 @pytest.mark.parametrize(
@@ -2993,8 +3053,8 @@ def test_read_only_mutation_paths_ignore_new_sibling_dispatch_sandbox_only():
     existing = f"{_SIBLING_DISPATCH_SANDBOX}/README.md"
     planted = f"{_SIBLING_DISPATCH_SANDBOX}/evil.txt"
     assert delegate._read_only_mutation_paths(
-        {existing: "!!"},
-        {existing: "!!", planted: "!!"},
+        {existing: "??"},
+        {existing: "??", planted: "??"},
     ) == [planted]
 
 


### PR DESCRIPTION
## Outcome

Read-only dispatch no longer fails when gitignored caches/runtime files change (`data/lexicon/slovnyk_cache`, `wiki/.state/progress.db`). Those paths are recorded as `read_only_ignored_mutation_paths` notes. Tracked and untracked-not-ignored leaks still fail.

This dispatch itself settled `needs_finalize` (clean local commit, unpushed) — the #7311/#7315 detector working as designed. Driver pushed.

Fixes #7253.

## Evidence

```
pytest tests/test_delegate.py -q -k "read_only or mutation"
33 passed, 287 deselected
ruff check scripts/delegate.py tests/test_delegate.py
All checks passed
```

X-Agent: codex/fix-7253-readonly-gitignore