### PR TITLE
feat(monitor): epics & areas relationship map dashboard (#7295)

### DIFF
--- a/dashboards/epics-map.html
+++ b/dashboards/epics-map.html
@@ -1,0 +1,704 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Epics Map - ukraine-ops</title>
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
+<style>
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+button { font: inherit; }
+.topbar { display: flex; align-items: center; gap: 16px; padding: 15px 24px; position: sticky; top: 0; z-index: 10; }
+.brand { min-width: 200px; }
+.brand h1 { margin: 0; font-family: Charter, Georgia, serif; font-size: 25px; letter-spacing: -.02em; }
+.brand p { margin: 3px 0 0; color: var(--text3); font-size: 12px; }
+.spacer { flex: 1; }
+.meta-status { color: var(--text3); font-size: 12px; margin-right: 4px; }
+.refresh { appearance: none; background: var(--text); border: 1px solid var(--text); border-radius: 4px; color: var(--bg); cursor: pointer; font-weight: 700; padding: 8px 11px; }
+.refresh:hover, .refresh:focus-visible { background: var(--accent); border-color: var(--accent); }
+.refresh:focus-visible, a:focus-visible, button:focus-visible {
+  outline: 3px solid var(--accent); outline-offset: 2px;
+}
+.wrap { max-width: 1600px; margin: 0 auto; padding: 24px 24px 64px; }
+.hero { border-bottom: 1px solid var(--text); display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, .42fr); gap: 24px; padding: 4px 0 18px; }
+.eyebrow { color: var(--accent); font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.hero h2 { font-family: Charter, Georgia, serif; font-size: clamp(28px, 4vw, 42px); font-weight: 700; letter-spacing: -.04em; line-height: 1.05; margin: 8px 0 10px; }
+.hero p { color: var(--text2); line-height: 1.5; margin: 0; max-width: 760px; font-size: 14px; }
+.signal-card { align-self: end; background: var(--bg2); border: 1px solid var(--border); border-left: 4px solid var(--accent); padding: 14px 16px; }
+.signal-card strong { display: block; font-family: Charter, Georgia, serif; font-size: 18px; margin-bottom: 4px; }
+.signal-card p { color: var(--text3); font-size: 12px; margin: 0; line-height: 1.4; }
+
+.summary-strip { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; margin: 18px 0; }
+.metric { background: var(--bg2); border: 1px solid var(--border); padding: 12px 14px; position: relative; }
+.metric::before { background: var(--accent); content: ''; height: 3px; left: 0; position: absolute; right: 0; top: 0; }
+.metric:nth-child(2)::before { background: var(--accent); }
+.metric:nth-child(3)::before { background: var(--green); }
+.metric:nth-child(4)::before { background: var(--red); }
+.metric:nth-child(5)::before { background: var(--gray); }
+.metric:nth-child(3) .number { color: var(--green); }
+.metric:nth-child(4) .number { color: var(--red); }
+.metric:nth-child(5) .number { color: var(--gray); }
+.metric .number { font-family: Charter, Georgia, serif; font-size: 28px; font-weight: 700; line-height: 1; margin-top: 6px; }
+.metric .label { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; margin-top: 5px; text-transform: uppercase; }
+
+.error { background: var(--bg2); border-left: 3px solid var(--red); color: var(--red); font-size: 13px; line-height: 1.5; margin: 0 0 14px; padding: 12px 14px; }
+.hidden { display: none !important; }
+.map-layout { align-items: start; display: grid; gap: 16px; grid-template-columns: minmax(0, 1.55fr) minmax(340px, .65fr); }
+.panel { background: var(--bg2); border: 1px solid var(--border); min-width: 0; }
+.panel-head { align-items: baseline; border-bottom: 1px solid var(--border); display: flex; gap: 12px; justify-content: space-between; padding: 12px 14px; }
+.panel-head h3 { font-family: Charter, Georgia, serif; font-size: 18px; margin: 0; }
+.panel-head p { color: var(--text3); font-size: 11px; margin: 0; text-align: right; }
+.map-toolbar { align-items: center; border-bottom: 1px solid var(--border); display: flex; flex-wrap: wrap; gap: 10px 18px; justify-content: space-between; padding: 9px 14px; }
+.map-toolbar p { color: var(--text3); font-size: 11px; margin: 0; }
+.legend { display: flex; flex-wrap: wrap; gap: 8px 14px; }
+.status-key { align-items: center; color: var(--text3); display: inline-flex; font-size: 10px; font-weight: 800; gap: 5px; text-transform: uppercase; }
+.status-key::before { background: currentColor; content: ''; display: inline-block; height: 8px; width: 8px; }
+.status-key.status-active { color: var(--green); }
+.status-key.status-expired { color: var(--red); }
+.status-key.status-unregistered, .status-key.status-released { color: var(--gray); }
+.status-key.status-none { color: var(--text3); }
+.status-key.status-unregistered::before { background: transparent; border: 1px dashed currentColor; }
+.status-key.status-released::before { background: transparent; border: 1px dotted currentColor; }
+
+.area-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(270px, 1fr)); padding: 14px; }
+.area-cluster { background: var(--bg); border: 1px solid var(--border); border-top: 3px solid var(--accent); min-width: 0; }
+.area-cluster-head { border-bottom: 1px solid var(--border); padding: 10px 11px 9px; }
+.area-cluster-title { font-family: Charter, Georgia, serif; font-size: 16px; line-height: 1.15; margin: 0; overflow-wrap: anywhere; }
+.area-cluster-meta { color: var(--text3); font-size: 10px; margin: 4px 0 0; overflow-wrap: anywhere; }
+.epic-list { display: grid; gap: 8px; padding: 10px; }
+.epic-node { appearance: none; background: var(--bg2); border: 1px solid var(--border); border-left: 4px solid var(--border); color: var(--text); cursor: pointer; display: block; min-width: 0; padding: 10px 11px; text-align: left; width: 100%; }
+.epic-node:hover { border-color: var(--accent); }
+.epic-node[aria-pressed="true"] { background: var(--bg3); border-color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); }
+.epic-node.status-active { border-left-color: var(--green); }
+.epic-node.status-active[aria-pressed="true"] { border-color: var(--green); box-shadow: inset 3px 0 0 var(--green); }
+.epic-node.status-expired { border-left-color: var(--red); }
+.epic-node.status-expired[aria-pressed="true"] { border-color: var(--red); box-shadow: inset 3px 0 0 var(--red); }
+.epic-node.status-unregistered { border-left-color: var(--gray); border-left-style: dashed; }
+.epic-node.status-released { border-left-color: var(--gray); border-left-style: dotted; }
+.epic-node-top { align-items: center; display: flex; gap: 7px; justify-content: space-between; }
+.epic-number { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 12px; font-weight: 800; }
+.status-chip { border: 1px solid var(--border); color: var(--text3); display: inline-block; font-size: 10px; font-weight: 800; letter-spacing: .02em; padding: 2px 6px; white-space: nowrap; }
+.status-chip.status-active { border-color: var(--green); color: var(--green); }
+.status-chip.status-expired { border-color: var(--red); color: var(--red); }
+.status-chip.status-unregistered, .status-chip.status-released { border-color: var(--gray); color: var(--gray); }
+.status-chip.status-unregistered { border-style: dashed; }
+.status-chip.status-released { border-style: dotted; }
+.epic-title { font-size: 13px; font-weight: 700; line-height: 1.3; margin-top: 7px; overflow-wrap: anywhere; }
+.epic-meta { color: var(--text3); display: flex; flex-wrap: wrap; font-size: 10px; gap: 4px 10px; margin-top: 8px; }
+.epic-driver { border-top: 1px solid var(--border); color: var(--text2); font-size: 10px; margin-top: 8px; padding-top: 7px; overflow-wrap: anywhere; }
+.epic-state { color: var(--text3); font-size: 10px; line-height: 1.35; margin: 6px 0 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.area-empty { color: var(--text3); font-size: 12px; padding: 11px; }
+
+.detail-pane { max-height: min(78vh, 900px); overflow: auto; padding: 14px 16px 20px; }
+.detail-pane h4 { font-family: Charter, Georgia, serif; font-size: 22px; margin: 0 0 4px; overflow-wrap: anywhere; }
+.detail-lede { color: var(--text2); font-size: 13px; line-height: 1.4; margin: 0 0 12px; overflow-wrap: anywhere; }
+.detail-section { border-top: 1px solid var(--border); margin-top: 14px; padding-top: 12px; }
+.detail-section:first-child { border-top: 0; margin-top: 0; padding-top: 0; }
+.detail-section h5 { font-family: Charter, Georgia, serif; font-size: 15px; margin: 0 0 8px; }
+.detail-grid { display: grid; gap: 8px 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 8px; }
+.detail-field { min-width: 0; }
+.detail-field dt { color: var(--text3); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.detail-field dd { font-size: 12px; line-height: 1.4; margin: 2px 0 0; overflow-wrap: anywhere; word-break: break-word; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 11px; }
+.muted { color: var(--text3); }
+.empty { color: var(--text3); font-size: 13px; line-height: 1.5; padding: 18px 14px; }
+.empty.compact { padding: 10px 0; }
+.cache-note { background: var(--bg); border-left: 3px solid var(--accent); color: var(--text2); font-size: 12px; line-height: 1.45; margin: 0 0 10px; padding: 9px 10px; }
+.issue-list { display: grid; gap: 7px; list-style: none; margin: 0; padding: 0; }
+.issue-item { background: var(--bg); border: 1px solid var(--border); padding: 8px 9px; }
+.issue-row { align-items: baseline; display: flex; gap: 7px; min-width: 0; }
+.issue-number { color: var(--accent); flex: 0 0 auto; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 11px; font-weight: 800; }
+.issue-title { color: var(--text); font-size: 12px; line-height: 1.35; overflow-wrap: anywhere; }
+.issue-state { color: var(--text3); font-size: 10px; margin-left: auto; text-transform: uppercase; white-space: nowrap; }
+.issue-link { text-decoration: none; }
+.issue-link:hover .issue-title { color: var(--accent); }
+.footnote { color: var(--text3); font-size: 11px; line-height: 1.5; margin-top: 18px; }
+
+@media (max-width: 1100px) {
+  .map-layout, .hero { grid-template-columns: 1fr; }
+}
+@media (max-width: 760px) {
+  .summary-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .area-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 480px) {
+  .wrap { padding: 16px 12px 48px; }
+  .topbar { flex-wrap: wrap; padding: 12px; }
+  .brand { min-width: 0; }
+  .summary-strip { grid-template-columns: 1fr 1fr; }
+  .detail-grid { grid-template-columns: 1fr; }
+  .panel-head { align-items: flex-start; flex-direction: column; }
+}
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto !important; transition: none !important; animation: none !important; }
+}
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <h1>Epics map</h1>
+    <p>Areas, epic ownership, and issue membership · read-only</p>
+  </div>
+  <div class="spacer"></div>
+  <span id="last-updated-text" class="meta-status">Loading…</span>
+  <button class="refresh" type="button" id="btn-refresh">Refresh</button>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/fleet.html">Fleet</a>
+    <a href="/epics.html">Epics</a>
+    <a class="active" href="/epics-map.html">Map</a>
+    <a href="/work.html">Work</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+    <a href="/docs">API</a>
+  </nav>
+</header>
+
+<main class="wrap" data-read-only="true">
+  <section class="hero" aria-labelledby="epics-map-title">
+    <div>
+      <div class="eyebrow">Relationship map · cached membership</div>
+      <h2 id="epics-map-title">Epics grouped by their operating area.</h2>
+      <p>Read the small relationship graph at a glance: each area is a cluster, each epic is a selectable node, and the detail panel exposes its cached open-issue membership. Sourced from the live <code>/api/epics/graph/v1</code> feed.</p>
+    </div>
+    <aside class="signal-card" aria-label="Map posture">
+      <strong>Read-only map</strong>
+      <p id="posture-copy">Lease and issue data are observations only. The browser has no claim, release, or other mutation controls.</p>
+    </aside>
+  </section>
+
+  <div id="error-banner" class="error hidden" role="status"></div>
+
+  <section class="summary-strip" aria-label="Graph metrics">
+    <article class="metric"><div class="number" id="metric-areas">—</div><div class="label">Areas</div></article>
+    <article class="metric"><div class="number" id="metric-epics">—</div><div class="label">Epics</div></article>
+    <article class="metric"><div class="number" id="metric-active">—</div><div class="label">Active leases</div></article>
+    <article class="metric"><div class="number" id="metric-expired">—</div><div class="label">Expired</div></article>
+    <article class="metric"><div class="number" id="metric-unregistered">—</div><div class="label">Unregistered</div></article>
+  </section>
+
+  <section class="map-layout">
+    <article class="panel" aria-labelledby="map-heading">
+      <div class="panel-head">
+        <h3 id="map-heading">Areas and Epics</h3>
+        <p id="map-count-meta">Loading…</p>
+      </div>
+      <div class="map-toolbar">
+        <p>Click an epic node to inspect its cached issue membership.</p>
+        <div class="legend" aria-label="Lease status legend">
+          <span class="status-key status-active">Active lease</span>
+          <span class="status-key status-expired">Expired</span>
+          <span class="status-key status-unregistered">Unregistered</span>
+          <span class="status-key status-released">Released</span>
+          <span class="status-key status-none">No active lease</span>
+        </div>
+      </div>
+      <div id="map-content" class="area-grid" aria-live="polite">
+        <div class="empty">Loading areas and epic nodes…</div>
+      </div>
+    </article>
+
+    <article class="panel" aria-labelledby="detail-heading">
+      <div class="panel-head">
+        <h3 id="detail-heading">Epic Issues</h3>
+        <p id="detail-meta">Select an epic to inspect</p>
+      </div>
+      <div id="detail-pane" class="detail-pane empty">Select an epic node to view its cached open-issue membership.</div>
+    </article>
+  </section>
+
+  <p class="footnote"><strong>Read-only operator dashboard:</strong> Areas, epic status, and cached issue membership are observations from <code>GET /api/epics/graph/v1</code>. Auto-refreshes every 15s. No claim, release, or other mutation controls are possible from the browser.</p>
+</main>
+
+<script>
+(function () {
+  const API_TIMEOUT_MS = 5000;
+  const AUTO_REFRESH_INTERVAL_MS = 15000;
+
+  const state = {
+    data: null,
+    areas: [],
+    epics: [],
+    selectedEpicId: null,
+    fetchError: null,
+    lastUpdated: null,
+  };
+
+  const els = {
+    errorBanner: document.getElementById('error-banner'),
+    lastUpdatedText: document.getElementById('last-updated-text'),
+    btnRefresh: document.getElementById('btn-refresh'),
+    mapContent: document.getElementById('map-content'),
+    mapCountMeta: document.getElementById('map-count-meta'),
+    detailPane: document.getElementById('detail-pane'),
+    detailMeta: document.getElementById('detail-meta'),
+    metricAreas: document.getElementById('metric-areas'),
+    metricEpics: document.getElementById('metric-epics'),
+    metricActive: document.getElementById('metric-active'),
+    metricExpired: document.getElementById('metric-expired'),
+    metricUnregistered: document.getElementById('metric-unregistered'),
+  };
+
+  function isObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function escapeHtml(value) {
+    if (value == null) return '';
+    const node = document.createElement('span');
+    node.textContent = String(value);
+    return node.innerHTML;
+  }
+
+  function short(value, fallback = '—') {
+    return value == null || value === '' ? fallback : String(value);
+  }
+
+  function positiveInteger(value) {
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
+      return value;
+    }
+    if (typeof value === 'string' && /^\d+$/.test(value)) {
+      const number = Number(value);
+      if (Number.isSafeInteger(number) && number > 0) return number;
+    }
+    return null;
+  }
+
+  function nonNegativeInteger(value, fallback = null) {
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) {
+      return value;
+    }
+    if (typeof value === 'string' && /^\d+$/.test(value)) {
+      const number = Number(value);
+      if (Number.isSafeInteger(number) && number >= 0) return number;
+    }
+    return fallback;
+  }
+
+  function epicNumber(epic) {
+    if (!isObject(epic)) return null;
+    const direct = positiveInteger(epic.number);
+    if (direct !== null) return direct;
+    const id = typeof epic.id === 'string' ? epic.id.match(/^epic:(\d+)$/) : null;
+    return id ? positiveInteger(id[1]) : null;
+  }
+
+  function epicId(epic, fallbackIndex = 0) {
+    if (isObject(epic) && typeof epic.id === 'string' && epic.id.trim()) {
+      return epic.id.trim();
+    }
+    const number = epicNumber(epic);
+    return number !== null ? 'epic:' + number : 'epic:unknown-' + String(fallbackIndex + 1);
+  }
+
+  function areaKey(value) {
+    if (typeof value !== 'string' || !value.trim()) return null;
+    const trimmed = value.trim();
+    return trimmed.indexOf('area:') === 0 ? trimmed.slice(6) : trimmed;
+  }
+
+  function getLeaseState(epic) {
+    const lease = isObject(epic) && isObject(epic.lease) ? epic.lease : null;
+    if (!lease) return 'none';
+    const rawState = typeof lease.state === 'string' ? lease.state.toLowerCase() : 'none';
+    if (rawState === 'active' && lease.expires_at) {
+      const expiresAtMs = new Date(lease.expires_at).getTime();
+      if (!Number.isNaN(expiresAtMs) && Date.now() >= expiresAtMs) return 'expired';
+    }
+    return ['active', 'expired', 'released'].includes(rawState) ? rawState : 'none';
+  }
+
+  function statusKey(epic) {
+    const leaseState = getLeaseState(epic);
+    if (leaseState === 'active') return 'active';
+    if (leaseState === 'expired') return 'expired';
+    if (leaseState === 'released') return 'released';
+    const registryStatus = isObject(epic) ? String(epic.registry_status || '').toLowerCase() : '';
+    return registryStatus === 'unregistered' ? 'unregistered' : 'none';
+  }
+
+  function statusLabel(status) {
+    if (status === 'active') return 'Active lease';
+    if (status === 'expired') return 'Expired lease';
+    if (status === 'released') return 'Released';
+    if (status === 'unregistered') return 'Unregistered';
+    return 'No active lease';
+  }
+
+  function formatTime(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+  }
+
+  function formatCount(value, fallback = '—') {
+    const count = nonNegativeInteger(value);
+    return count === null ? fallback : String(count);
+  }
+
+  function entryBody(entry) {
+    return isObject(entry) && typeof entry.body === 'string' && entry.body.trim()
+      ? entry.body.trim()
+      : '';
+  }
+
+  function formatHolder(holder) {
+    if (!isObject(holder)) return 'No active driver';
+    const parts = [holder.agent, holder.harness, holder.host_id]
+      .filter(value => value != null && String(value) !== '')
+      .map(value => String(value));
+    return parts.length ? parts.join(' · ') : 'No active driver';
+  }
+
+  function githubIssueUrl(number) {
+    const safeNumber = positiveInteger(number);
+    return safeNumber === null
+      ? null
+      : 'https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/' + String(safeNumber);
+  }
+
+  function githubSearchUrl(number) {
+    const safeNumber = positiveInteger(number);
+    return safeNumber === null
+      ? null
+      : 'https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues?q=is%3Aopen+' + encodeURIComponent(String(safeNumber));
+  }
+
+  function safeIssueUrl(issue) {
+    if (!isObject(issue)) return null;
+    const rawUrl = typeof issue.url === 'string' ? issue.url : '';
+    if (/^https:\/\/github\.com\/learn-ukrainian\/learn-ukrainian\.github\.io\/issues\/\d+$/.test(rawUrl)) {
+      return rawUrl;
+    }
+    return githubIssueUrl(issue.number);
+  }
+
+  async function fetchJson(path) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+    try {
+      const response = await fetch(path, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+      });
+      const text = await response.text();
+      let data = {};
+      try {
+        data = text ? JSON.parse(text) : {};
+      } catch {
+        data = { detail: text };
+      }
+      if (!response.ok) {
+        throw new Error(data.detail || data.error || 'HTTP ' + String(response.status));
+      }
+      return data;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  function showError(message) {
+    state.fetchError = message || null;
+    if (!message) {
+      els.errorBanner.classList.add('hidden');
+      els.errorBanner.textContent = '';
+      return;
+    }
+    els.errorBanner.classList.remove('hidden');
+    els.errorBanner.textContent = message;
+  }
+
+  function buildModel(data) {
+    const nodes = isObject(data.nodes) ? data.nodes : {};
+    const areaNodes = Array.isArray(nodes.areas) ? nodes.areas.filter(isObject) : [];
+    const epicNodes = Array.isArray(nodes.epics) ? nodes.epics.filter(isObject) : [];
+    const areas = areaNodes.map((area, index) => {
+      const id = typeof area.id === 'string' && area.id.trim()
+        ? area.id.trim()
+        : 'area:fallback-' + String(index + 1);
+      const streamId = typeof area.stream_id === 'string' && area.stream_id.trim()
+        ? area.stream_id.trim()
+        : areaKey(id);
+      return {
+        id: id,
+        streamId: streamId,
+        title: short(area.title, streamId || 'Area unavailable'),
+        epics: [],
+      };
+    });
+    const areaByKey = new Map();
+    areas.forEach(area => {
+      const key = areaKey(area.streamId || area.id);
+      if (key && !areaByKey.has(key)) areaByKey.set(key, area);
+    });
+
+    const edgeAreaByEpicId = new Map();
+    const edges = Array.isArray(data.edges) ? data.edges : [];
+    edges.forEach(edge => {
+      if (!isObject(edge) || edge.kind !== 'contains') return;
+      if (typeof edge.to !== 'string' || typeof edge.from !== 'string') return;
+      if (edge.to.indexOf('epic:') !== 0 || edge.from.indexOf('area:') !== 0) return;
+      edgeAreaByEpicId.set(edge.to, areaKey(edge.from));
+    });
+
+    let unassigned = null;
+    epicNodes.forEach((epic, index) => {
+      const id = epicId(epic, index);
+      const key = areaKey(epic.area_id) || edgeAreaByEpicId.get(id);
+      let area = key ? areaByKey.get(key) : null;
+      if (!area) {
+        if (!unassigned) {
+          unassigned = {
+            id: 'area:unassigned',
+            streamId: null,
+            title: 'Area unavailable',
+            epics: [],
+          };
+          areas.push(unassigned);
+        }
+        area = unassigned;
+      }
+      area.epics.push(Object.assign({}, epic, { id: id }));
+    });
+
+    return { areas: areas, epics: areas.flatMap(area => area.epics) };
+  }
+
+  function renderMetrics() {
+    if (!state.data) {
+      els.metricAreas.textContent = '—';
+      els.metricEpics.textContent = '—';
+      els.metricActive.textContent = '—';
+      els.metricExpired.textContent = '—';
+      els.metricUnregistered.textContent = '—';
+      return;
+    }
+    const counts = { active: 0, expired: 0, unregistered: 0 };
+    state.epics.forEach(epic => {
+      const status = statusKey(epic);
+      if (Object.prototype.hasOwnProperty.call(counts, status)) counts[status] += 1;
+    });
+    els.metricAreas.textContent = String(state.areas.length);
+    els.metricEpics.textContent = String(state.epics.length);
+    els.metricActive.textContent = String(counts.active);
+    els.metricExpired.textContent = String(counts.expired);
+    els.metricUnregistered.textContent = String(counts.unregistered);
+  }
+
+  function renderEpicNode(epic) {
+    const id = epicId(epic);
+    const number = epicNumber(epic);
+    const status = statusKey(epic);
+    const selected = state.selectedEpicId === id;
+    const numberLabel = number === null ? short(epic.id, 'Epic node') : '#' + String(number);
+    const title = short(epic.title, 'Title unavailable');
+    const stateText = entryBody(epic.last_state);
+    const holder = isObject(epic.lease) ? formatHolder(epic.lease.holder) : 'No active driver';
+    const ariaLabel = number === null
+      ? title + ', ' + statusLabel(status)
+      : 'Epic ' + String(number) + ': ' + title + ', ' + statusLabel(status);
+
+    return '<button class="epic-node status-' + escapeHtml(status) + '" type="button" data-epic-id="' + escapeHtml(id) + '" aria-pressed="' + (selected ? 'true' : 'false') + '" aria-label="' + escapeHtml(ariaLabel) + '">' +
+      '<span class="epic-node-top"><span class="epic-number">' + escapeHtml(numberLabel) + '</span><span class="status-chip status-' + escapeHtml(status) + '">' + escapeHtml(statusLabel(status)) + '</span></span>' +
+      '<span class="epic-title">' + escapeHtml(title) + '</span>' +
+      '<span class="epic-meta"><span>Open: ' + escapeHtml(formatCount(epic.open_issue_count, 'unknown')) + '</span><span>Closed: ' + escapeHtml(formatCount(epic.closed_issue_count, 'unknown')) + '</span></span>' +
+      '<span class="epic-driver">Driver: ' + escapeHtml(holder) + '</span>' +
+      (stateText ? '<span class="epic-state" title="' + escapeHtml(stateText) + '">Latest state: ' + escapeHtml(stateText) + '</span>' : '') +
+      '</button>';
+  }
+
+  function renderMap() {
+    if (!state.data) {
+      els.mapCountMeta.textContent = state.fetchError ? 'API unavailable' : 'Loading…';
+      els.mapContent.innerHTML = state.fetchError
+        ? '<div class="empty">The graph feed is unavailable, so area and epic state is unknown.</div>'
+        : '<div class="empty">Loading areas and epic nodes…</div>';
+      return;
+    }
+
+    const flags = [];
+    if (state.data.stale === true) flags.push('stale cache');
+    if (state.data.status === 'no-cache') flags.push('issue cache not ready');
+    if (state.data.refreshing === true) flags.push('refresh scheduled');
+    els.mapCountMeta.textContent = String(state.areas.length) + ' areas · ' + String(state.epics.length) + ' epics' + (flags.length ? ' · ' + flags.join(' · ') : '');
+
+    if (!state.areas.length) {
+      els.mapContent.innerHTML = '<div class="empty">The graph feed returned no area or epic nodes.</div>';
+      return;
+    }
+
+    els.mapContent.innerHTML = state.areas.map(area => {
+      const epicCount = area.epics.length;
+      const epicHtml = epicCount
+        ? area.epics.map(epic => renderEpicNode(epic)).join('')
+        : '<div class="area-empty">No epic nodes in this area.</div>';
+      return '<section class="area-cluster" aria-labelledby="' + escapeHtml(area.id) + '-title">' +
+        '<header class="area-cluster-head"><h4 class="area-cluster-title" id="' + escapeHtml(area.id) + '-title">' + escapeHtml(area.title) + '</h4>' +
+        '<p class="area-cluster-meta">' + escapeHtml(short(area.streamId, 'area id unavailable')) + ' · ' + String(epicCount) + ' epic' + (epicCount === 1 ? '' : 's') + '</p></header>' +
+        '<div class="epic-list">' + epicHtml + '</div>' +
+        '</section>';
+    }).join('');
+
+    els.mapContent.querySelectorAll('.epic-node').forEach(button => {
+      button.addEventListener('click', () => selectEpic(button.getAttribute('data-epic-id')));
+    });
+  }
+
+  function selectedEpic() {
+    return state.epics.find(epic => epicId(epic) === state.selectedEpicId) || null;
+  }
+
+  function areaForEpic(epic) {
+    if (!epic) return null;
+    return state.areas.find(area => area.epics.some(item => epicId(item) === epicId(epic))) || null;
+  }
+
+  function renderLeaseSection(epic, status) {
+    const lease = isObject(epic.lease) ? epic.lease : null;
+    if (!lease) {
+      const message = status === 'unregistered'
+        ? 'This epic is unregistered and has no lease projection.'
+        : 'This epic has no active lease projection.';
+      return '<section class="detail-section"><h5>Lease status</h5><p class="empty compact">' + escapeHtml(message) + '</p></section>';
+    }
+    const holder = isObject(lease.holder) ? lease.holder : {};
+    return '<section class="detail-section"><h5>Lease status</h5>' +
+      '<dl class="detail-grid">' +
+      '<div class="detail-field"><dt>State</dt><dd><span class="status-chip status-' + escapeHtml(status) + '">' + escapeHtml(statusLabel(status)) + '</span></dd></div>' +
+      '<div class="detail-field"><dt>Session</dt><dd class="mono">' + escapeHtml(short(epic.session_state || lease.session_state)) + '</dd></div>' +
+      '<div class="detail-field"><dt>Holder</dt><dd class="mono">' + escapeHtml(formatHolder(holder)) + '</dd></div>' +
+      '<div class="detail-field"><dt>Expires</dt><dd>' + escapeHtml(formatTime(lease.expires_at)) + '</dd></div>' +
+      '</dl></section>';
+  }
+
+  function renderIssueSection(epic) {
+    const number = epicNumber(epic);
+    const issuesByEpic = state.data && isObject(state.data.issues_by_epic) ? state.data.issues_by_epic : null;
+    const bucket = issuesByEpic && number !== null && isObject(issuesByEpic[String(number)])
+      ? issuesByEpic[String(number)]
+      : null;
+    const feedHasNoCache = state.data && state.data.status === 'no-cache';
+
+    if (!bucket || feedHasNoCache) {
+      const message = feedHasNoCache
+        ? 'Issue membership is not yet cached because the background audit has no completed cache.'
+        : 'Issue membership for this epic is not yet cached. The background audit may still be warming the feed.';
+      return '<section class="detail-section"><h5>Cached issue membership</h5><div class="empty"><strong>Not yet cached.</strong><br>' + escapeHtml(message) + '</div></section>';
+    }
+
+    const items = Array.isArray(bucket.items) ? bucket.items.filter(isObject) : [];
+    const totalOpen = nonNegativeInteger(bucket.total_open, items.length);
+    const truncated = bucket.truncated === true;
+    const cacheLabel = state.data.stale === true ? 'in the stale cache.' : 'in the cache.';
+    const summary = truncated
+      ? 'Showing ' + String(items.length) + ' of ' + String(totalOpen) + ' open issues.'
+      : String(totalOpen) + ' open issue' + (totalOpen === 1 ? '' : 's') + ' ' + cacheLabel;
+    const issueHtml = items.length
+      ? '<ul class="issue-list">' + items.map(issue => {
+        const issueNumber = positiveInteger(issue.number);
+        const label = issueNumber === null ? short(issue.title, 'Issue') : '#' + String(issueNumber);
+        const title = short(issue.title, issueNumber === null ? 'Title unavailable' : 'Issue #' + String(issueNumber));
+        const issueState = short(issue.state, 'unknown');
+        const url = safeIssueUrl(issue);
+        const labelHtml = url
+          ? '<a class="issue-link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer"><span class="issue-row"><span class="issue-number">' + escapeHtml(label) + '</span><span class="issue-title">' + escapeHtml(title) + '</span><span class="issue-state">' + escapeHtml(issueState) + '</span></span></a>'
+          : '<span class="issue-row"><span class="issue-number">' + escapeHtml(label) + '</span><span class="issue-title">' + escapeHtml(title) + '</span><span class="issue-state">' + escapeHtml(issueState) + '</span></span>';
+        return '<li class="issue-item">' + labelHtml + '</li>';
+      }).join('') + '</ul>'
+      : '<div class="empty compact">No issue rows are available in the cached membership.</div>';
+    const fallbackUrl = githubSearchUrl(number);
+    const truncationHtml = truncated && fallbackUrl
+      ? '<p class="cache-note"><a href="' + escapeHtml(fallbackUrl) + '" target="_blank" rel="noopener noreferrer">View all ' + escapeHtml(String(totalOpen)) + ' on GitHub</a>. The feed caps this panel at 50 issue rows.</p>'
+      : '';
+
+    return '<section class="detail-section"><h5>Cached issue membership</h5><p class="detail-lede">' + escapeHtml(summary) + '</p>' + truncationHtml + issueHtml + '</section>';
+  }
+
+  function renderDetail() {
+    const epic = selectedEpic();
+    if (!epic) {
+      els.detailMeta.textContent = state.fetchError ? 'Feed unavailable' : 'Select an epic to inspect';
+      els.detailPane.classList.add('empty');
+      els.detailPane.innerHTML = state.fetchError
+        ? '<div class="empty">Select an epic after the graph feed becomes available.</div>'
+        : '<div class="empty">Select an epic node to view its cached open-issue membership.</div>';
+      return;
+    }
+
+    const number = epicNumber(epic);
+    const status = statusKey(epic);
+    const area = areaForEpic(epic);
+    const title = short(epic.title, 'Title unavailable');
+    const epicLink = githubIssueUrl(number);
+    const linkHtml = epicLink
+      ? '<a href="' + escapeHtml(epicLink) + '" target="_blank" rel="noopener noreferrer">Epic #' + escapeHtml(String(number)) + ' on GitHub</a>'
+      : '<span class="muted">GitHub issue number unavailable</span>';
+    const stateText = entryBody(epic.last_state);
+    const registryStatus = short(epic.registry_status, 'unknown');
+
+    els.detailMeta.textContent = number === null ? 'Epic node' : 'Epic #' + String(number);
+    els.detailPane.classList.remove('empty');
+    els.detailPane.innerHTML =
+      '<section class="detail-section"><h4>' + escapeHtml(number === null ? 'Epic node' : 'Epic #' + String(number)) + '</h4>' +
+      '<p class="detail-lede">' + escapeHtml(title) + '</p><p class="detail-lede">' + linkHtml + '</p>' +
+      '<dl class="detail-grid">' +
+      '<div class="detail-field"><dt>Area</dt><dd>' + escapeHtml(area ? area.title : short(epic.area_id, 'Area unavailable')) + '</dd></div>' +
+      '<div class="detail-field"><dt>Registry</dt><dd class="mono">' + escapeHtml(registryStatus) + '</dd></div>' +
+      '<div class="detail-field"><dt>Open issues</dt><dd>' + escapeHtml(formatCount(epic.open_issue_count, 'unknown')) + '</dd></div>' +
+      '<div class="detail-field"><dt>Closed issues</dt><dd>' + escapeHtml(formatCount(epic.closed_issue_count, 'unknown')) + '</dd></div>' +
+      '</dl></section>' +
+      renderLeaseSection(epic, status) +
+      '<section class="detail-section"><h5>Latest state</h5><p class="detail-lede">' + escapeHtml(stateText || 'No latest state entry.') + '</p></section>' +
+      renderIssueSection(epic);
+  }
+
+  function selectEpic(id) {
+    if (!id) return;
+    state.selectedEpicId = id;
+    renderMap();
+    renderDetail();
+  }
+
+  function renderAll() {
+    renderMetrics();
+    renderMap();
+    renderDetail();
+  }
+
+  async function loadGraph() {
+    try {
+      const data = await fetchJson('/api/epics/graph/v1');
+      if (!isObject(data) || data.schema !== 'epics-graph.v1' || !isObject(data.nodes)) {
+        throw new Error('response did not contain the epics-graph.v1 schema');
+      }
+      const model = buildModel(data);
+      state.data = data;
+      state.areas = model.areas;
+      state.epics = model.epics;
+      if (state.selectedEpicId && !state.epics.some(epic => epicId(epic) === state.selectedEpicId)) {
+        state.selectedEpicId = null;
+      }
+      state.lastUpdated = new Date();
+      showError('');
+      els.lastUpdatedText.textContent = 'Updated ' + state.lastUpdated.toLocaleTimeString();
+      renderAll();
+    } catch (error) {
+      showError('Failed to fetch /api/epics/graph/v1: ' + error.message);
+      els.lastUpdatedText.textContent = 'Update failed';
+      renderAll();
+    }
+  }
+
+  els.btnRefresh.addEventListener('click', () => { loadGraph(); });
+  loadGraph();
+  setInterval(loadGraph, AUTO_REFRESH_INTERVAL_MS);
+})();
+</script>
+</body>
+</html>

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -1167,6 +1167,17 @@ PAGE_CONTRACTS: tuple[PageContract, ...] = (
         "keep as the canonical remote epic lifecycle observer",
     ),
     PageContract(
+        "epics-map.html",
+        "/epics-map.html",
+        "Read-only relationship map of issue-stream areas, epic lease/status nodes, and cached issue membership.",
+        "GET /api/epics/graph/v1 over issue_streams.yaml area membership, API-host SessionStreamStore projections, and the bounded issue-stream audit cache.",
+        "Client fetches the live graph with a 5s timeout and auto-refreshes every 15s; stale/no-cache markers are rendered explicitly and there are no client mutation controls.",
+        ("humans", "operators", "orchestrators"),
+        "Complements epics.html's flat lifecycle table with area grouping and issue-membership detail.",
+        "medium if stale or no-cache data is mistaken for confirmed zero issue membership",
+        "keep as the read-only epic relationship-map observer",
+    ),
+    PageContract(
         "channels.html",
         "/channels.html",
         "Compatibility redirect to the consolidated read-only Fleet Observer.",


### PR DESCRIPTION
Parent: #7295 (design merged as #7308, backing endpoint merged as #7312). Last PR in the #7295
sequence per docs/design/monitor-epics-graph-map.md §7.

**Note (driver):** independently verified before finalizing this PR — this dispatch's branch was
already pushed to origin (unlike 5 earlier dispatches this session that needed a manual push), but
no PR had been opened yet.

- `tests/api/opsec_sweep/` + `tests/test_epics_dashboard_contract.py` +
  `tests/api/test_api_index_route.py` — 30 passed.
- `ruff check` on the touched Python file — clean.
- Field-access audit: the dashboard's JS reads `epic.id`, `epic.registry_status`, `area.id`,
  `area.stream_id`, `epic.area_id`, `epic.last_state`, `issues_by_epic[...].total_open`,
  `issues_by_epic[...].truncated` — all confirmed against the real live
  `GET /api/epics/graph/v1` response I curled directly against this host, not just the design
  doc's illustrative JSON.
- Self-contained: only `/monitor.css` imported, no external CDN, matches `dashboards/epics.html`'s
  established conventions.

**What it does:**
- New `dashboards/epics-map.html` — areas as clusters, epics as selectable nodes, a detail panel
  for cached issue membership with truncation handling.
- Registers the new page in `scripts/api/route_contracts.py`'s `PAGE_CONTRACTS` (proactively
  found and fixed — the existing `epics.html` entry is the pattern; a contract test enforces
  every dashboard page is registered).

X-Agent: claude-monitor