### PR TITLE
fix(cycle007): validate AGY response fallback

### DIFF
--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -18,6 +18,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -591,22 +592,68 @@ def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
     config, result = init.get("init"), result_event.get("result")
     if not isinstance(config, dict) or config.get("model") != MODEL:
         raise Error("structured_output_envelope_drift", structural=True)
-    if not isinstance(result, dict) or result.get("status") != "SUCCESS" or "structured_output" not in result:
+    if (
+        not isinstance(result, dict)
+        or result.get("status") != "SUCCESS"
+        or ("structured_output" not in result and "response" not in result)
+    ):
         raise Error("structured_output_envelope_drift", structural=True)
     return init, result
 
 
+def _strict_result_payload(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Decode exactly one label object from AGY's schema or response field."""
+    if "structured_output" in result:
+        output = result["structured_output"]
+        if isinstance(output, str):
+            try:
+                output = json.loads(output, object_pairs_hook=_pairs)
+            except (json.JSONDecodeError, Error) as exc:
+                raise Error("label_json_invalid", structural=True) from exc
+        if not isinstance(output, dict):
+            raise Error("structured_output_envelope_drift", structural=True)
+        return output
+
+    candidates: list[dict[str, Any]] = []
+
+    def inspect(value: Any, *, depth: int = 0) -> None:
+        if depth > 4:
+            return
+        if isinstance(value, str):
+            text = value.strip()
+            fence = "`" * 3
+            if text.startswith(fence) and text.endswith(fence):
+                text = text[len(fence) : -len(fence)].strip()
+                if text.startswith("json"):
+                    text = text[4:].lstrip()
+            try:
+                decoded = json.loads(text, object_pairs_hook=_pairs)
+            except (json.JSONDecodeError, Error):
+                return
+            if isinstance(decoded, dict) and "labels_by_position" in decoded:
+                candidates.append(decoded)
+            return
+        if isinstance(value, list):
+            for item in value:
+                inspect(item, depth=depth + 1)
+            return
+        if isinstance(value, dict):
+            if "labels_by_position" in value:
+                candidates.append(value)
+                return
+            for key in ("content", "message", "parts", "response", "text"):
+                if key in value:
+                    inspect(value[key], depth=depth + 1)
+
+    inspect(result.get("response"))
+    if len(candidates) != 1:
+        raise Error("structured_output_envelope_drift", structural=True)
+    return candidates[0]
+
+
 def _extract(raw: bytes) -> dict[str, Any]:
     _, result = _agy_stream(raw)
-    output = result["structured_output"]
-    if isinstance(output, str):
-        try:
-            output = json.loads(output, object_pairs_hook=_pairs)
-        except (json.JSONDecodeError, Error) as exc:
-            raise Error("label_json_invalid", structural=True) from exc
-    if not isinstance(output, dict):
-        raise Error("structured_output_envelope_drift", structural=True)
-    return output
+    return _strict_result_payload(result)
 
 
 def _semantic_failure(exc: Exception) -> Error:

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -543,21 +543,71 @@ def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
         raise CanaryStructuralError("result_envelope_drift")
     if result.get("status") != "SUCCESS":
         raise CanaryStructuralError(_agy_static_failure_code(result))
-    if "structured_output" not in result:
+    if "structured_output" not in result and "response" not in result:
         raise CanaryStructuralError("structured_output_missing")
     return init, result
 
 
+def _strict_result_payload(result: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
+    """Decode one exact label object from AGY's schema or response field.
+
+    AGY 1.1.20 can return a successful, schema-guided turn in ``response``
+    without copying the validated JSON into ``structured_output``.  Accept
+    only one standalone JSON object (or one standalone fenced JSON object),
+    then leave all identity and semantic enforcement to the existing closed
+    validators below.
+    """
+    if "structured_output" in result:
+        output = result["structured_output"]
+        if isinstance(output, str):
+            try:
+                output = json.loads(output, object_pairs_hook=_pairs)
+            except (json.JSONDecodeError, CanaryError) as exc:
+                raise CanaryStructuralError("label_json_invalid") from exc
+        if not isinstance(output, dict):
+            raise CanaryStructuralError("structured_output_type_drift")
+        return output, "structured_output"
+
+    candidates: list[dict[str, Any]] = []
+
+    def inspect(value: Any, *, depth: int = 0) -> None:
+        if depth > 4:
+            return
+        if isinstance(value, str):
+            text = value.strip()
+            fence = "`" * 3
+            if text.startswith(fence) and text.endswith(fence):
+                text = text[len(fence) : -len(fence)].strip()
+                if text.startswith("json"):
+                    text = text[4:].lstrip()
+            try:
+                decoded = json.loads(text, object_pairs_hook=_pairs)
+            except (json.JSONDecodeError, CanaryError):
+                return
+            if isinstance(decoded, dict) and "labels_by_position" in decoded:
+                candidates.append(decoded)
+            return
+        if isinstance(value, list):
+            for item in value:
+                inspect(item, depth=depth + 1)
+            return
+        if isinstance(value, dict):
+            if "labels_by_position" in value:
+                candidates.append(value)
+                return
+            for key in ("content", "message", "parts", "response", "text"):
+                if key in value:
+                    inspect(value[key], depth=depth + 1)
+
+    inspect(result.get("response"))
+    if len(candidates) != 1:
+        raise CanaryStructuralError("structured_output_missing")
+    return candidates[0], "response_json"
+
+
 def _extract_gemini(raw: bytes, challenge: str) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     init, result = _agy_stream(raw)
-    output = result["structured_output"]
-    if isinstance(output, str):
-        try:
-            output = json.loads(output, object_pairs_hook=_pairs)
-        except (json.JSONDecodeError, CanaryError) as exc:
-            raise CanaryStructuralError("label_json_invalid") from exc
-    if not isinstance(output, dict):
-        raise CanaryStructuralError("structured_output_type_drift")
+    output, _transport = _strict_result_payload(result)
     if set(output) != {"labels_by_position", "liveness_challenge"}:
         raise CanaryStructuralError("structured_output_keys_drift")
     if output.get("liveness_challenge") != challenge:
@@ -1049,6 +1099,9 @@ def invoke_canary(
                     provenance = {
                         "init_model": init_ev["init"]["model"],
                         "result_status": res_ev.get("status", "SUCCESS"),
+                        "result_transport": (
+                            "structured_output" if "structured_output" in res_ev else "response_json"
+                        ),
                         "init_conversation_id": init_ev.get("conversation_id"),
                         "result_conversation_id": res_ev.get("conversation_id"),
                         "challenge_sha256": digest(challenge.encode("utf-8")),

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -82,3 +82,26 @@ def test_real_invoke_rejects_relative_and_symlink_provider(tmp_path: Path) -> No
     link.symlink_to(target)
     with pytest.raises(runner.CanaryError, match="invalid_executable"):
         runner.invoke_canary("gemini", link, execution_mode="real")
+
+
+def test_canary_accepts_one_strict_response_json_and_rejects_ambiguity() -> None:
+    runner = _load_runner()
+    payload = {"labels_by_position": {"p01": {}, "p02": {}}, "liveness_challenge": "challenge"}
+
+    decoded, transport = runner._strict_result_payload({"response": json.dumps(payload)})
+    assert decoded == payload
+    assert transport == "response_json"
+
+    with pytest.raises(runner.CanaryStructuralError, match="structured_output_missing"):
+        runner._strict_result_payload({"response": [json.dumps(payload), json.dumps(payload)]})
+
+
+def test_batch_runner_accepts_one_fenced_response_json() -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_test", path)
+    assert spec is not None and spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+    payload = {"labels_by_position": {"p01": {}, "p02": {}}}
+
+    assert runner._strict_result_payload({"response": f"```json\n{json.dumps(payload)}\n```"}) == payload


### PR DESCRIPTION
## Outcome

Recover Cycle007 Gemini canary and packet execution when AGY 1.1.20 returns a successful schema-guided JSON result in `response` without populating `structured_output`.

## Safety

- accepts exactly one standalone JSON object, optionally in one standalone JSON fence
- rejects prose, ambiguity, duplicate JSON candidates, excessive nesting, and missing labels
- preserves exact model/status checks
- preserves existing identity, ordering, evidence, semantic, liveness, and receipt validation
- records the selected transport in the canary provenance
- no schema, model, prompt, endpoint, or evidence changes

## Verification

- Ruff passed
- 79 focused tests passed

Production remains fail-closed with zero label outputs and zero stage seals. Continues #6375.