### PR TITLE
feat(atlas): Wikidata unique UK-label English fallback

### DIFF
--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -115,7 +115,7 @@ Wikipedia is NEVER cited as the primary source for historical dates, names, or e
 - **ukrainianlessons.com** (Ukrainian Lessons Podcast, Anna Ohoiko) — **commercial, all rights reserved.** We may reference their free blog articles as external resources (link out only) but NEVER copy content from the paid ULP membership. The relationship is understood by the ULP author; see `docs/resources/external_resources.yaml` for the referenced URL set.
 - **Реальна Історія (Akím Galímov), imtgsh, Istoria-Movy, Speak Ukrainian, Red Purple Ukrainian** — YouTube channels with free-to-view content. Subtitle transcripts are used internally for wiki compilation as context, not republished. Links to the original videos appear in module Ресурси tabs for learners.
 - **Dobra Forma (opentext.ku.edu)** — Creative Commons licensed by the University of Kansas. We reference the URLs; derivative teaching material is separately attributed.
-- **Горох (goroh.pp.ua), e2u (e2u.org.ua), VESUM** — linguistic dictionaries, freely available for educational use. Never redistributed in bulk; used only as query services.
+- **Горох (goroh.pp.ua), e2u (e2u.org.ua), Wikidata (wikidata.org), VESUM** — linguistic dictionaries and structured knowledge bases, freely available for educational use. Never redistributed in bulk; used only as query services.
 
 ### Dictionaries
 
@@ -138,6 +138,7 @@ The following dictionaries are ingested as SQLite FTS5 indices for internal ling
 | **Ukrajinet WordNet** | 122K synsets; auto-translated from Open English WordNet per upstream README. ⚠️ Quality concern documented (#1657 Tier 3 audit). | Synonym lookup (with caveats) |
 | **English Wiktionary via Kaikki.org / wiktextract** | English Wiktionary extract, **CC BY-SA 3.0**. Preprocessed from the local Kaikki Ukrainian JSONL extract into a compact per-lemma lookup; Atlas pages that use it render the attribution line "Pronunciation / etymology from English Wiktionary, CC BY-SA 3.0." | IPA pronunciation and final-fallback etymology |
 | **e2u.org.ua** | Aggregator © r2u.org.ua (compilers Rysin, Starko et al.; constituent works: Гороть 2011/2016, Андрусишин–Крет 1955, scientific UK↔EN, …). Non-commercial educational use. | Per-query UK→EN lookup + short learner gloss + attribution. No bulk dump, no GitHub ingest. |
+| **Wikidata** | CC0 (Wikimedia Foundation) | Per-query UK→EN lookup for Word Atlas translation fallback. No bulk dump, no GitHub ingest. |
 
 ---
 
@@ -165,4 +166,4 @@ For modified derivative works:
 
 Licensing questions go to issues on GitHub or the maintainer directly. The above is a best-effort plain-language summary of the legal position — it is not legal advice. If you need formal permissions or have commercial redistribution questions beyond the standard CC BY-SA 4.0 terms, open an issue and we'll figure it out.
 
-Last updated: 2026-08-24 — added e2u.org.ua (Rysin, Starko et al.) for Word Atlas English translation lookup fallback (#4387). Predecessor: 2026-06-12 — added English Wiktionary via Kaikki.org / wiktextract (CC BY-SA 3.0) for Word Atlas IPA pronunciation and final-fallback etymology. Predecessor: 2026-05-05 — added good-faith / non-profit-posture section (user-requested defensive documentation), expanded dictionary inventory (ЕСУМ vol 1, slovnyk.me as СУМ-20 supersession, Гринчишин/Сербенська paronyms, Karavansky r2u, Holovashchuk pending, Ukrajinet caveat), noted СУМ-11 sovietization risk + Грінченко rename. Predecessor: 2026-04-11 (#1092).
+Last updated: 2026-08-25 — added Wikidata (CC0, Wikimedia Foundation) for Word Atlas English translation lookup fallback (#4387). Predecessor: 2026-08-24 — added e2u.org.ua (Rysin, Starko et al.) for Word Atlas English translation lookup fallback (#4387). Predecessor: 2026-06-12 — added English Wiktionary via Kaikki.org / wiktextract (CC BY-SA 3.0) for Word Atlas IPA pronunciation and final-fallback etymology. Predecessor: 2026-05-05 — added good-faith / non-profit-posture section (user-requested defensive documentation), expanded dictionary inventory (ЕСУМ vol 1, slovnyk.me as СУМ-20 supersession, Гринчишин/Сербенська paronyms, Karavansky r2u, Holovashchuk pending, Ukrajinet caveat), noted СУМ-11 sovietization risk + Грінченко rename. Predecessor: 2026-04-11 (#1092).

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -100,6 +100,7 @@ from scripts.lexicon.source_attribution import (
     SYNONYMS_LABEL,
     VTS_ACADEMIC_LABEL,
     VTS_SHORT_LABEL,
+    WIKIDATA_LABEL,
     attach_official_url,
     join_academic_source_labels,
     normalize_academic_label,
@@ -241,6 +242,9 @@ _GOROH_TRANSLATION_SOURCE = GOROH_LABEL
 _E2U_TRANSLATION_SOURCE = E2U_LABEL
 _E2U_DELAY_SECONDS = float(os.environ.get("LEXICON_E2U_DELAY", "0.34"))
 _E2U_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational per-lemma lookup)"
+_WIKIDATA_TRANSLATION_SOURCE = WIKIDATA_LABEL
+_WIKIDATA_DELAY_SECONDS = float(os.environ.get("LEXICON_WIKIDATA_DELAY", "0.34"))
+_WIKIDATA_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational; Wikidata wbsearch/entity per lemma)"
 _SLOVNYK_BASE = "https://slovnyk.me"
 # v3 (#6524 P1): bumped because every schema_version==2 cache file on disk was
 # written by the pre-fix `" ".join(...)` article-text join (#6465's root-cause
@@ -333,6 +337,7 @@ _SYNONYM_LABEL_RE = re.compile(
 
 _last_slovnyk_fetch = 0.0
 _last_e2u_fetch = 0.0
+_last_wikidata_fetch = 0.0
 _stressifier: Any | None = None
 
 # Same-sense A1 allowlist. A synonym is emitted only when it is both present in
@@ -1530,6 +1535,15 @@ def _polite_e2u_delay() -> None:
         if elapsed < _E2U_DELAY_SECONDS:
             time.sleep(_E2U_DELAY_SECONDS - elapsed)
     _last_e2u_fetch = time.monotonic()
+
+
+def _polite_wikidata_delay() -> None:
+    global _last_wikidata_fetch
+    if _last_wikidata_fetch:
+        elapsed = time.monotonic() - _last_wikidata_fetch
+        if elapsed < _WIKIDATA_DELAY_SECONDS:
+            time.sleep(_WIKIDATA_DELAY_SECONDS - elapsed)
+    _last_wikidata_fetch = time.monotonic()
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -6536,6 +6550,322 @@ def _e2u_translation(lemma: str, *, entry_pos: object = None) -> dict[str, objec
     return None
 
 
+def _wikidata_get_text(prop_dict: Any, lang: str) -> str:
+    if not isinstance(prop_dict, dict):
+        return ""
+    val = prop_dict.get(lang)
+    if isinstance(val, dict):
+        return str(val.get("value") or "").strip()
+    if isinstance(val, str):
+        return val.strip()
+    return ""
+
+
+def _wikidata_get_sitelink_title(sitelinks: Any, site: str) -> str:
+    if not isinstance(sitelinks, dict):
+        return ""
+    val = sitelinks.get(site)
+    if isinstance(val, dict):
+        return str(val.get("title") or "").strip()
+    if isinstance(val, str):
+        return val.strip()
+    return ""
+
+
+def _wikidata_get_p31_qids(claims: Any) -> list[str]:
+    if not isinstance(claims, dict):
+        return []
+    p31 = claims.get("P31")
+    if not p31:
+        return []
+    qids: list[str] = []
+    if isinstance(p31, list):
+        for item in p31:
+            if isinstance(item, str):
+                qids.append(item)
+            elif isinstance(item, dict):
+                if "id" in item:
+                    qids.append(str(item["id"]))
+                elif "mainsnak" in item and isinstance(item["mainsnak"], dict):
+                    snak = item["mainsnak"]
+                    datavalue = snak.get("datavalue")
+                    if isinstance(datavalue, dict):
+                        val = datavalue.get("value")
+                        if isinstance(val, dict) and "id" in val:
+                            qids.append(str(val["id"]))
+                        elif isinstance(val, str):
+                            qids.append(val)
+    return qids
+
+
+def _fold_wikidata_translit(text: str) -> str:
+    s = text.casefold()
+    s = re.sub(r"['ʼ`\-\s\(\)\[\]\"«».,;:!?]+", "", s)
+    s = s.replace("shch", "sh").replace("sch", "sh")
+    s = s.replace("kh", "h").replace("gh", "h")
+    s = s.replace("zh", "z").replace("ts", "c").replace("ch", "c")
+    s = s.replace("ya", "ia").replace("yu", "iu").replace("ye", "ie")
+    s = s.replace("g", "h").replace("y", "i").replace("j", "i")
+    return s
+
+
+def _is_wikidata_transliteration(uk_text: str, en_text: str) -> bool:
+    from scripts.etymology.transliterate import transliterate
+
+    uk_translit = transliterate(uk_text)
+    uk_folded = _fold_wikidata_translit(uk_translit)
+    en_folded = _fold_wikidata_translit(en_text)
+    if uk_folded and uk_folded == en_folded:
+        return True
+    if len(uk_folded) >= 4:
+        for word in re.findall(r"[A-Za-z0-9'ʼ`\-]+", en_text):
+            if _fold_wikidata_translit(word) == uk_folded:
+                return True
+    return False
+
+
+def _is_wikidata_scientific_binomial(en_label: str, entity: dict[str, Any]) -> bool:
+    s = en_label.strip()
+    p31_qids = _wikidata_get_p31_qids(entity.get("claims"))
+    if "Q16521" in p31_qids:
+        return True
+    uk_desc = _wikidata_get_text(entity.get("descriptions"), "uk").casefold()
+    en_desc = _wikidata_get_text(entity.get("descriptions"), "en").casefold()
+    taxon_desc_pattern = r"\b(?:species of|genus of|subspecies of|family of|taxon|вид |рід )\b"
+    if re.search(taxon_desc_pattern, uk_desc) or re.search(taxon_desc_pattern, en_desc):
+        return True
+    if re.match(r"^[A-Z][a-z]+\s+[A-Z][a-z]+$", s):
+        return True
+    if re.match(r"^[A-Z][a-z]+\s+[a-z]+$", s) and (
+        "reptile" in en_desc
+        or "plant" in en_desc
+        or "animal" in en_desc
+        or "bird" in en_desc
+        or "fish" in en_desc
+        or "insect" in en_desc
+        or "fungus" in en_desc
+        or "рослин" in uk_desc
+        or "тварин" in uk_desc
+        or "птахів" in uk_desc
+        or "риб" in uk_desc
+        or "комах" in uk_desc
+        or "плазунів" in uk_desc
+    ):
+        return True
+    return False
+
+
+_WIKIDATA_NOISE_P31 = frozenset({
+    "Q4167410",   # disambiguation page
+    "Q13406463",  # list article
+    "Q11266439",  # template
+    "Q11424",     # film
+    "Q202866",    # animated film
+    "Q24856",     # film series
+    "Q5398426",   # television series
+    "Q526877",    # television program
+    "Q21191270",  # TV episode
+    "Q7725634",   # literary work
+    "Q571",       # book
+    "Q8261",      # novel
+    "Q47461344",  # written work
+    "Q7366",      # song
+    "Q482994",    # album
+    "Q134556",    # single
+    "Q2188189",   # musical work
+    "Q523",       # star
+    "Q67206785",  # Bayer object
+    "Q3863",      # asteroid
+    "Q318",       # galaxy
+    "Q16521",     # taxon
+    "Q95074",     # fictional character
+    "Q15632617",  # fictional entity
+    "Q21070568",  # character in work
+})
+
+_WIKIDATA_TITLE_QUALIFIER_RE = re.compile(
+    r"\((?:фільм|кінофільм|телесеріал|серіал|пісня|альбом|сингл|зоря|зірка|сузір['ʼ’]?я|астероїд|значення|film|tv series|television series|song|album|single|star|constellation|asteroid|disambiguation)\b",
+    re.IGNORECASE,
+)
+
+_WIKIDATA_UK_NOISE_PATTERNS = (
+    re.compile(r"\bфільм\b", re.IGNORECASE),
+    re.compile(r"\bкінофільм\b", re.IGNORECASE),
+    re.compile(r"\bтелефільм\b", re.IGNORECASE),
+    re.compile(r"\bмультфільм\b", re.IGNORECASE),
+    re.compile(r"\bкороткометраж", re.IGNORECASE),
+    re.compile(r"\bтелесеріал\b", re.IGNORECASE),
+    re.compile(r"\bсеріал\b", re.IGNORECASE),
+    re.compile(r"\bмінісеріал\b", re.IGNORECASE),
+    re.compile(r"\bміні-серіал\b", re.IGNORECASE),
+    re.compile(r"\bвебсеріал\b", re.IGNORECASE),
+    re.compile(r"\bпісня\b", re.IGNORECASE),
+    re.compile(r"\bсингл\b", re.IGNORECASE),
+    re.compile(r"\bальбом\b", re.IGNORECASE),
+    re.compile(r"\bдиск\b", re.IGNORECASE),
+    re.compile(r"\bтрек\b", re.IGNORECASE),
+    re.compile(r"\bсаундтрек\b", re.IGNORECASE),
+    re.compile(r"\bзоря\b", re.IGNORECASE),
+    re.compile(r"\bзірка\b", re.IGNORECASE),
+    re.compile(r"\bастероїд\b", re.IGNORECASE),
+    re.compile(r"\bгалактика\b", re.IGNORECASE),
+    re.compile(r"сузір['ʼ’]?я", re.IGNORECASE),
+    re.compile(r"\bкомета\b", re.IGNORECASE),
+    re.compile(r"\bекзопланета\b", re.IGNORECASE),
+    re.compile(r"\bповість\b", re.IGNORECASE),
+    re.compile(r"\bроман\b", re.IGNORECASE),
+    re.compile(r"\bоповідання\b", re.IGNORECASE),
+    re.compile(r"\bп['ʼ’]?єса\b", re.IGNORECASE),
+    re.compile(r"\bпоема\b", re.IGNORECASE),
+    re.compile(r"сторінка значень", re.IGNORECASE),
+    re.compile(r"\bперсонаж\b", re.IGNORECASE),
+)
+
+_WIKIDATA_EN_NOISE_PATTERNS = (
+    re.compile(r"\bfilm\b", re.IGNORECASE),
+    re.compile(r"\bmovie\b", re.IGNORECASE),
+    re.compile(r"\btelevision series\b", re.IGNORECASE),
+    re.compile(r"\btv series\b", re.IGNORECASE),
+    re.compile(r"\bminiseries\b", re.IGNORECASE),
+    re.compile(r"\bweb series\b", re.IGNORECASE),
+    re.compile(r"\bepisode\b", re.IGNORECASE),
+    re.compile(r"\bsong\b", re.IGNORECASE),
+    re.compile(r"\bsingle\b", re.IGNORECASE),
+    re.compile(r"\balbum\b", re.IGNORECASE),
+    re.compile(r"\btrack\b", re.IGNORECASE),
+    re.compile(r"\bsoundtrack\b", re.IGNORECASE),
+    re.compile(r"\bstar\b", re.IGNORECASE),
+    re.compile(r"\basteroid\b", re.IGNORECASE),
+    re.compile(r"\bgalaxy\b", re.IGNORECASE),
+    re.compile(r"\bconstellation\b", re.IGNORECASE),
+    re.compile(r"\bcomet\b", re.IGNORECASE),
+    re.compile(r"\bexoplanet\b", re.IGNORECASE),
+    re.compile(r"\bnovella\b", re.IGNORECASE),
+    re.compile(r"\bnovel\b", re.IGNORECASE),
+    re.compile(r"\bshort story\b", re.IGNORECASE),
+    re.compile(r"\bplay by\b", re.IGNORECASE),
+    re.compile(r"\bpoem by\b", re.IGNORECASE),
+    re.compile(r"\bbook by\b", re.IGNORECASE),
+    re.compile(r"\bdisambiguation page\b", re.IGNORECASE),
+    re.compile(r"\bfictional character\b", re.IGNORECASE),
+    re.compile(r"\bcharacter in\b", re.IGNORECASE),
+)
+
+
+def _is_wikidata_noise_entity(entity: dict[str, Any]) -> bool:
+    p31_qids = set(_wikidata_get_p31_qids(entity.get("claims")))
+    if p31_qids & _WIKIDATA_NOISE_P31:
+        return True
+
+    uk_label = _wikidata_get_text(entity.get("labels"), "uk")
+    en_label = _wikidata_get_text(entity.get("labels"), "en")
+    uk_sitelink = _wikidata_get_sitelink_title(entity.get("sitelinks"), "ukwiki")
+    uk_desc = _wikidata_get_text(entity.get("descriptions"), "uk")
+    en_desc = _wikidata_get_text(entity.get("descriptions"), "en")
+
+    all_titles = f"{uk_label} {en_label} {uk_sitelink}"
+    if _WIKIDATA_TITLE_QUALIFIER_RE.search(all_titles):
+        return True
+
+    uk_text = f"{uk_label} {uk_desc}"
+    en_text = f"{en_label} {en_desc}"
+
+    if any(pat.search(uk_text) for pat in _WIKIDATA_UK_NOISE_PATTERNS):
+        return True
+    if any(pat.search(en_text) for pat in _WIKIDATA_EN_NOISE_PATTERNS):
+        return True
+
+    return False
+
+
+@functools.cache
+def query_wikidata_uk_en(lemma: str) -> list[dict[str, Any]]:
+    """Wrapper around rag.source_query Wikidata helpers to support caching and unit test mocking."""
+    if _phase1_offline_mode():
+        return []
+
+    try:
+        _polite_wikidata_delay()
+        from scripts.rag.source_query import wikidata_get_entities, wikidata_search_entities
+
+        headers = {"User-Agent": _WIKIDATA_USER_AGENT}
+        search_hits = wikidata_search_entities(lemma, language="uk", limit=5, headers=headers)
+        if not search_hits:
+            return []
+        qids = [str(hit.get("id")) for hit in search_hits if hit.get("id")]
+        if not qids:
+            return []
+        _polite_wikidata_delay()
+        entities = wikidata_get_entities(
+            qids,
+            languages=["uk", "en"],
+            props=["labels", "descriptions", "claims", "sitelinks"],
+            headers=headers,
+        )
+        return [entities[qid] for qid in qids if qid in entities and isinstance(entities[qid], dict)]
+    except Exception:
+        return []
+
+
+def _wikidata_translation(lemma: str) -> dict[str, object] | None:
+    """English translations for a Ukrainian lemma via Wikidata (#4387)."""
+    for variant in _split_lemma_variants(lemma):
+        norm_variant = _strip_stress(variant).strip().casefold()
+        if not norm_variant:
+            continue
+        entities = query_wikidata_uk_en(variant)
+        if not entities:
+            continue
+        distinct_en_labels: dict[str, tuple[str, str]] = {}
+        for ent in entities:
+            if not isinstance(ent, dict):
+                continue
+            qid = str(ent.get("id") or "").strip()
+            if not qid:
+                continue
+
+            # Step 2: Keep iff labels.uk or sitelinks.ukwiki.title exact-equals the variant
+            uk_label = _wikidata_get_text(ent.get("labels"), "uk")
+            uk_sitelink = _wikidata_get_sitelink_title(ent.get("sitelinks"), "ukwiki")
+            uk_label_norm = _strip_stress(uk_label).strip().casefold()
+            uk_sitelink_norm = _strip_stress(uk_sitelink).strip().casefold()
+            if uk_label_norm != norm_variant and uk_sitelink_norm != norm_variant:
+                continue
+
+            # Step 3: Drop conditions
+            en_label = _wikidata_get_text(ent.get("labels"), "en")
+            if not en_label or not _is_learner_english_text(en_label):
+                continue
+            if _is_wikidata_scientific_binomial(en_label, ent):
+                continue
+            if _is_wikidata_transliteration(norm_variant, en_label):
+                continue
+            if _is_wikidata_noise_entity(ent):
+                continue
+
+            clean_hw = _clean_ukreng_gloss(en_label) or en_label
+            if not clean_hw or not _is_learner_english_text(clean_hw):
+                continue
+            if len(clean_hw.split()) > 6:
+                continue
+
+            key = clean_hw.casefold()
+            if key not in distinct_en_labels:
+                distinct_en_labels[key] = (clean_hw, qid)
+
+        # Step 4: exactly 1 distinct English label -> return it
+        if len(distinct_en_labels) == 1:
+            label, qid = next(iter(distinct_en_labels.values()))
+            block = {
+                "en": [label],
+                "source": _WIKIDATA_TRANSLATION_SOURCE,
+                "source_url": f"https://www.wikidata.org/wiki/{qid}",
+            }
+            return block
+
+    return None
+
+
 def _translation(
     conn: sqlite3.Connection,
     lemma: str,
@@ -6555,7 +6885,7 @@ def _translation(
     existing learner-gloss hint from the source entry. When slovnyk.me has a cached or
     fetched ukreng entry, that is used next. When all previous sources miss, fall back
     to goroh.pp.ua translation (#6876). When goroh misses, fall back to e2u.org.ua
-    translation (#4387). Returns up to six glosses.
+    translation (#4387). When e2u misses, fall back to Wikidata (#4387). Returns up to six glosses.
     """
     for variant in _split_lemma_variants(lemma):
         rows = _dmklinger_lookup(conn, _dmklinger_key(variant))
@@ -6597,6 +6927,9 @@ def _translation(
     e2u_translation = _e2u_translation(lemma, entry_pos=entry_pos)
     if e2u_translation:
         return e2u_translation
+    wikidata_translation = _wikidata_translation(lemma)
+    if wikidata_translation:
+        return wikidata_translation
 
     for variant in _split_lemma_variants(lemma):
         curated = _CURATED_LEARNER_TRANSLATIONS.get(_lookup_key(variant).casefold())

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -6636,23 +6636,24 @@ def _is_wikidata_scientific_binomial(en_label: str, entity: dict[str, Any]) -> b
         return True
     if re.match(r"^[A-Z][a-z]+\s+[A-Z][a-z]+$", s):
         return True
-    if re.match(r"^[A-Z][a-z]+\s+[a-z]+$", s) and (
-        "reptile" in en_desc
-        or "plant" in en_desc
-        or "animal" in en_desc
-        or "bird" in en_desc
-        or "fish" in en_desc
-        or "insect" in en_desc
-        or "fungus" in en_desc
-        or "рослин" in uk_desc
-        or "тварин" in uk_desc
-        or "птахів" in uk_desc
-        or "риб" in uk_desc
-        or "комах" in uk_desc
-        or "плазунів" in uk_desc
-    ):
-        return True
-    return False
+    return bool(
+        re.match(r"^[A-Z][a-z]+\s+[a-z]+$", s)
+        and (
+            "reptile" in en_desc
+            or "plant" in en_desc
+            or "animal" in en_desc
+            or "bird" in en_desc
+            or "fish" in en_desc
+            or "insect" in en_desc
+            or "fungus" in en_desc
+            or "рослин" in uk_desc
+            or "тварин" in uk_desc
+            or "птахів" in uk_desc
+            or "риб" in uk_desc
+            or "комах" in uk_desc
+            or "плазунів" in uk_desc
+        )
+    )
 
 
 _WIKIDATA_NOISE_P31 = frozenset({
@@ -6772,10 +6773,7 @@ def _is_wikidata_noise_entity(entity: dict[str, Any]) -> bool:
 
     if any(pat.search(uk_text) for pat in _WIKIDATA_UK_NOISE_PATTERNS):
         return True
-    if any(pat.search(en_text) for pat in _WIKIDATA_EN_NOISE_PATTERNS):
-        return True
-
-    return False
+    return any(pat.search(en_text) for pat in _WIKIDATA_EN_NOISE_PATTERNS)
 
 
 @functools.cache

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -60,6 +60,7 @@ HOLOSKEVYCH_LABEL = "Правописний словник Голоскевич�
 ORTHOEPY_LABEL = "Орфоепічний словник української мови"
 GOROH_LABEL = "Горох (переклад)"
 E2U_LABEL = "e2u.org.ua (Rysin, Starko et al.)"
+WIKIDATA_LABEL = "Wikidata"
 
 
 RELATION_PAIRS_PREFIX = "relation_pairs/"
@@ -104,6 +105,9 @@ LEGACY_LABEL_ALIASES: dict[str, str] = {
     "e2u: Переклад": E2U_LABEL,
     "E2U": E2U_LABEL,
     E2U_LABEL: E2U_LABEL,
+    "wikidata": WIKIDATA_LABEL,
+    "Wikidata": WIKIDATA_LABEL,
+    WIKIDATA_LABEL: WIKIDATA_LABEL,
 }
 
 KNOWN_ACADEMIC_LABELS = frozenset(
@@ -134,6 +138,7 @@ KNOWN_ACADEMIC_LABELS = frozenset(
         ORTHOEPY_LABEL,
         GOROH_LABEL,
         E2U_LABEL,
+        WIKIDATA_LABEL,
     }
 )
 
@@ -255,6 +260,8 @@ def normalize_academic_label(label: str) -> str:
         return GOROH_LABEL
     if cleaned.casefold().startswith("e2u.org.ua") or cleaned.casefold() == "e2u":
         return E2U_LABEL
+    if cleaned.casefold() == "wikidata" or cleaned.casefold().startswith("wikidata.org"):
+        return WIKIDATA_LABEL
     if cleaned.casefold().startswith(RELATION_PAIRS_PREFIX):
         return _remap_relation_pairs_label(cleaned)
     if cleaned in LEGACY_LABEL_ALIASES:

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -1156,6 +1156,78 @@ def wiktionary_translate(ukrainian_word: str) -> str:
 
 
 # ══════════════════════════════════════════════════════════════════
+# Wikidata (wikidata.org) — Structured knowledge base
+# ══════════════════════════════════════════════════════════════════
+
+WIKIDATA_API = "https://www.wikidata.org/w/api.php"
+WIKIDATA_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational; Wikidata wbsearch/entity per lemma)"
+
+
+def wikidata_search_entities(
+    query: str,
+    language: str = "uk",
+    entity_type: str = "item",
+    limit: int = 5,
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Search Wikidata entities using wbsearchentities."""
+    req_headers = {"User-Agent": WIKIDATA_USER_AGENT, "Accept": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    params = {
+        "action": "wbsearchentities",
+        "search": query,
+        "language": language,
+        "type": entity_type,
+        "limit": limit,
+        "format": "json",
+        "utf8": 1,
+    }
+    try:
+        r = _get(WIKIDATA_API, params=params, headers=req_headers, timeout=REQUEST_TIMEOUT)
+        r.raise_for_status()
+        data = r.json()
+        if not isinstance(data, dict):
+            return []
+        return data.get("search", []) or []
+    except (requests.RequestException, ValueError):
+        return []
+
+
+def wikidata_get_entities(
+    entity_ids: list[str],
+    languages: list[str] | None = None,
+    props: list[str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Fetch Wikidata entity JSON for given IDs using wbgetentities."""
+    if not entity_ids:
+        return {}
+    req_headers = {"User-Agent": WIKIDATA_USER_AGENT, "Accept": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    params: dict[str, Any] = {
+        "action": "wbgetentities",
+        "ids": "|".join(entity_ids),
+        "format": "json",
+        "utf8": 1,
+    }
+    if languages:
+        params["languages"] = "|".join(languages)
+    if props:
+        params["props"] = "|".join(props)
+    try:
+        r = _get(WIKIDATA_API, params=params, headers=req_headers, timeout=REQUEST_TIMEOUT)
+        r.raise_for_status()
+        data = r.json()
+        if not isinstance(data, dict):
+            return {}
+        return data.get("entities", {}) or {}
+    except (requests.RequestException, ValueError):
+        return {}
+
+
+# ══════════════════════════════════════════════════════════════════
 # pravopys (2019.pravopys.net) — Ukrainian orthography rules
 # ══════════════════════════════════════════════════════════════════
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "9de5ecaec1bda9139e291e8f35a8d94372df58adc6cfbb18cd4a5158e4968a46"
+        "sha256": "cd23f67792bdfcc5aa590a487b30af075f8630eb3fd8f2e7a8fc9dd62673ec04"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "452c1b6cfa734f4cca9493ace9f6918f53d83694474c88f64fd759a24fdc6cb5"
+        "sha256": "9de5ecaec1bda9139e291e8f35a8d94372df58adc6cfbb18cd4a5158e4968a46"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -247,7 +247,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "cd3b50ea237554ffe1d3df1d2ab34a93abfa257fd4f4ca50005ac5a15e9e9bba"
+        "sha256": "fb63419f2ffb08f3f2b5d3f69d01f84951aa0414e21b1663edc87de5eb9ef96c"
       },
       {
         "path": "scripts/lexicon/sync_teacher_table_deck.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 import typing
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 import pytest
@@ -91,6 +92,7 @@ from scripts.lexicon.source_attribution import (
     ORTHOEPY_LABEL,
     ORTHOGRAPHY_LABEL,
     PROVERBS_LABEL,
+    WIKIDATA_LABEL,
     join_academic_source_labels,
 )
 
@@ -3030,7 +3032,7 @@ def test_translation_uses_goroh_after_source_misses(monkeypatch) -> None:
     assert translation["source"] == "Горох (переклад)"
 
 
-def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(monkeypatch) -> None:
+def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u_wikidata(monkeypatch) -> None:
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
@@ -3043,6 +3045,7 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
 
     goroh_calls: list[str] = []
     e2u_calls: list[str] = []
+    wikidata_calls: list[str] = []
 
     def mock_goroh(lemma: str) -> list[str]:
         goroh_calls.append(lemma)
@@ -3052,8 +3055,21 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
         e2u_calls.append(lemma)
         return [{"headword": "базиліка", "translation": "arch. basilica"}]
 
+    def mock_wikidata(lemma: str) -> list[dict[str, Any]]:
+        wikidata_calls.append(lemma)
+        return [
+            {
+                "id": "Q163687",
+                "labels": {"uk": {"value": "базиліка"}, "en": {"value": "basilica"}},
+                "descriptions": {"uk": {"value": "тип споруди"}, "en": {"value": "type of building"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Базиліка"}},
+            }
+        ]
+
     monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", mock_goroh)
     monkeypatch.setattr(enrich_manifest_module, "query_e2u_uk_en", mock_e2u)
+    monkeypatch.setattr(enrich_manifest_module, "query_wikidata_uk_en", mock_wikidata)
 
     # 1. dmklinger wins over everything
     conn.execute(
@@ -3066,6 +3082,7 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert res_dmklinger["source"] == enrich_manifest_module._TRANSLATION_SOURCE
     assert not goroh_calls
     assert not e2u_calls
+    assert not wikidata_calls
 
     # 2. Kaikki wins when dmklinger misses
     conn.execute("DELETE FROM dmklinger_uk_en")
@@ -3075,6 +3092,7 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert res_kaikki["source"] == KAIKKI_SOURCE
     assert not goroh_calls
     assert not e2u_calls
+    assert not wikidata_calls
 
     # 3. Balla reverse wins when dmklinger and Kaikki miss
     res_balla = _translation(conn, "базиліка", {}, entry_pos="noun", gloss_hints={"basilica"})
@@ -3082,6 +3100,7 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert res_balla["source"] == _BALLA_REVERSE_SOURCE
     assert not goroh_calls
     assert not e2u_calls
+    assert not wikidata_calls
 
     # 4. Slovnyk ukreng wins when Balla reverse misses
     slovnyk_cache = {
@@ -3098,8 +3117,9 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert res_slovnyk["source"] == _SLOVNYK_UKRENG_SOURCE
     assert not goroh_calls
     assert not e2u_calls
+    assert not wikidata_calls
 
-    # 5. Goroh wins when all previous miss (e2u is not called)
+    # 5. Goroh wins when all previous miss (e2u and wikidata not called)
     empty_cache = {"lookups": {"ukreng": None}}
     res_goroh = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
     assert res_goroh is not None
@@ -3107,8 +3127,9 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert res_goroh["en"] == ["basilica", "basilicas"]
     assert goroh_calls == ["базиліка"]
     assert not e2u_calls
+    assert not wikidata_calls
 
-    # 6. e2u wins when Goroh misses
+    # 6. e2u wins when Goroh misses (wikidata not called)
     monkeypatch.setattr(enrich_manifest_module, "query_goroh_translate", lambda lemma: [])
     res_e2u = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
     assert res_e2u is not None
@@ -3117,6 +3138,16 @@ def test_translation_precedence_order_dmklinger_kaikki_balla_slovnyk_goroh_e2u(m
     assert "source_url" in res_e2u
     assert "e2u.org.ua" in res_e2u["source_url"]
     assert e2u_calls == ["базиліка"]
+    assert not wikidata_calls
+
+    # 7. Wikidata wins when e2u misses
+    monkeypatch.setattr(enrich_manifest_module, "query_e2u_uk_en", lambda lemma: [])
+    res_wikidata = _translation(conn, "базиліка", {}, slovnyk_cache=empty_cache)
+    assert res_wikidata is not None
+    assert res_wikidata["source"] == WIKIDATA_LABEL
+    assert res_wikidata["en"] == ["basilica"]
+    assert res_wikidata["source_url"] == "https://www.wikidata.org/wiki/Q163687"
+    assert wikidata_calls == ["базиліка"]
 
 
 def test_goroh_translation_filters_non_english_and_caps_at_6(monkeypatch) -> None:
@@ -5452,4 +5483,349 @@ def test_morphology_filters_russian_infinitive_tsya_form(monkeypatch) -> None:
     marked_forms = morphology.get("marked_forms", [])
     marked_form_words = {row["form"] for row in marked_forms}
     assert "подаваться" not in marked_form_words
+
+
+def test_wikidata_translation_heldout_table(monkeypatch) -> None:
+    """Validate all held-out lemmas from the Wikidata translation spec (#4387)."""
+    mock_data: dict[str, list[dict[str, Any]]] = {
+        "школа": [
+            {
+                "id": "Q3914",
+                "labels": {"uk": {"value": "школа"}, "en": {"value": "school"}},
+                "descriptions": {
+                    "uk": {"value": "заклад освіти"},
+                    "en": {"value": "institution for the education of students by teachers"},
+                },
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q122754124"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Школа"}},
+            },
+            {
+                "id": "Q48041007",
+                "labels": {"uk": {"value": "Школа"}, "en": {"value": "School"}},
+                "descriptions": {
+                    "uk": {"value": "український телесеріал"},
+                    "en": {"value": "Ukrainian drama television series"},
+                },
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q5398426"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Школа (телесеріал, 2018)"}},
+            },
+            {
+                "id": "Q269770",
+                "labels": {"uk": {"value": "школа-інтернат"}, "en": {"value": "boarding school"}},
+                "descriptions": {"uk": {"value": "школа-інтернат"}, "en": {"value": "boarding school"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Школа-інтернат"}},
+            },
+            {
+                "id": "Q18280338",
+                "labels": {"uk": {"value": "Школа"}, "en": {"value": "The School"}},
+                "descriptions": {
+                    "uk": {"value": "повість Аркадія Гайдара"},
+                    "en": {"value": "novella by Arkady Gaidar"},
+                },
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q7725634"}}}}]},
+                "sitelinks": {},
+            },
+            {
+                "id": "Q273593",
+                "labels": {"uk": {"value": "Національна вища школа красних мистецтв"}, "en": {"value": "Beaux-Arts de Paris"}},
+                "descriptions": {},
+                "claims": {},
+                "sitelinks": {},
+            },
+        ],
+        "ампір": [
+            {
+                "id": "Q191105",
+                "labels": {"uk": {"value": "ампір"}, "en": {"value": "Empire style"}},
+                "descriptions": {
+                    "uk": {"value": "архітектурний стиль"},
+                    "en": {"value": "19th-century art movement and style of architecture and interior design"},
+                },
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q32880"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Ампір"}},
+            },
+            {
+                "id": "Q97159881",
+                "labels": {"uk": {"value": "Ампір"}, "en": {"value": "Cinema Theatre Ampir"}},
+                "descriptions": {},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q96083918"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Ампір (кінотеатр)"}},
+            },
+            {
+                "id": "Q3796845",
+                "labels": {"uk": {"value": "Ампір (фільм)"}, "en": {"value": "Empire"}},
+                "descriptions": {"uk": {"value": "фільм 1986 року"}, "en": {"value": "1986 film by Alexander Sokurov"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q11424"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Ампір (фільм)"}},
+            },
+            {
+                "id": "Q51449846",
+                "labels": {"en": {"value": "Empire V"}},
+                "descriptions": {"en": {"value": "2021 film directed by Victor Ginzburg"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q11424"}}}}]},
+                "sitelinks": {},
+            },
+            {
+                "id": "Q4064507",
+                "labels": {"uk": {"value": "Ампір (значення)"}},
+                "descriptions": {
+                    "uk": {"value": "сторінка значень у проєкті Вікімедіа"},
+                    "en": {"value": "Wikimedia disambiguation page"},
+                },
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q4167410"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Ампір (значення)"}},
+            },
+        ],
+        "аптечний": [
+            {
+                "id": "Q620576",
+                "labels": {"uk": {"value": "Аптечний сцинк"}, "en": {"value": "Scincus scincus"}},
+                "descriptions": {"uk": {"value": "вид плазунів"}, "en": {"value": "species of reptile"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q16521"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Аптечний сцинк"}},
+            },
+            {
+                "id": "Q1261193",
+                "labels": {"uk": {"value": "Аптечний ковбой (фільм)"}, "en": {"value": "Drugstore Cowboy"}},
+                "descriptions": {"uk": {"value": "фільм 1989 року"}, "en": {"value": "1989 film by Gus Van Sant"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q11424"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Аптечний ковбой (фільм)"}},
+            },
+            {
+                "id": "Q1780285",
+                "labels": {"uk": {"value": "Аптечний робот"}, "en": {"value": "pharmacy robot"}},
+                "descriptions": {"en": {"value": "order picking machine to be used in pharmacies"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Аптечний робот"}},
+            },
+            {
+                "id": "Q131982795",
+                "labels": {"uk": {"value": "Аптечний провулок"}},
+                "descriptions": {"en": {"value": "street in Donetsk"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q79007"}}}}]},
+                "sitelinks": {},
+            },
+        ],
+        "берегиня": [
+            {
+                "id": "Q2622635",
+                "labels": {"uk": {"value": "Берегиня"}, "en": {"value": "Berehynia"}},
+                "descriptions": {"uk": {"value": "істота слов'янської міфології"}, "en": {"value": "Slavic water spirit"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q55138169"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Берегиня"}},
+            },
+            {
+                "id": "Q4039798",
+                "labels": {"uk": {"value": "Берегиня"}, "en": {"value": "Berehynia"}},
+                "descriptions": {"uk": {"value": "зоря в сузір'ї Персея"}, "en": {"value": "G-type main-sequence star in Perseus"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q523"}}}}, {"mainsnak": {"datavalue": {"value": {"id": "Q67206785"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Берегиня (зоря)"}},
+            },
+            {
+                "id": "Q12110232",
+                "labels": {"uk": {"value": "Київський академічний театр українського фольклору «Берегиня»"}, "en": {"value": "Kyiv Academic Theatre of Ukrainian Folklore"}},
+                "descriptions": {},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Київський академічний театр українського фольклору «Берегиня»"}},
+            },
+            {
+                "id": "Q18600282",
+                "labels": {"uk": {"value": "Берегиня"}, "en": {"value": '"Bereginya" craft centre'}},
+                "descriptions": {"uk": {"value": "центр народних ремесел"}, "en": {"value": "in Russia"}},
+                "claims": {},
+                "sitelinks": {},
+            },
+            {
+                "id": "Q16692570",
+                "labels": {"uk": {"value": "Берегиня"}},
+                "descriptions": {"uk": {"value": "Чернігівська взуттєва фабрика"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q4830453"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Берегиня (фабрика)"}},
+            },
+        ],
+        "індус": [
+            {
+                "id": "Q10090",
+                "labels": {"uk": {"value": "індус"}, "en": {"value": "Hindu"}},
+                "descriptions": {"uk": {"value": "послідовник індуїзму"}, "en": {"value": "adherents of Hinduism"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q41710"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Індус"}},
+            },
+            {
+                "id": "Q8148",
+                "labels": {"uk": {"value": "Інд"}, "en": {"value": "Indus River"}},
+                "descriptions": {"uk": {"value": "річка в Азії"}, "en": {"value": "river in Asia"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Інд"}},
+            },
+            {
+                "id": "Q932586",
+                "labels": {"uk": {"value": "Індіанець"}, "en": {"value": "Indus"}},
+                "descriptions": {"uk": {"value": "сузір'я"}, "en": {"value": "constellation in the southern celestial hemisphere"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q8928"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Індіанець (сузір'я)"}},
+            },
+        ],
+        "безмежжя": [],
+        "істотно": [],
+    }
+
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: mock_data.get(lemma, []),
+    )
+
+    # 1. школа -> school (exact UK-label match, TV series & novella noise filtered)
+    res_shkola = enrich_manifest_module._wikidata_translation("школа")
+    assert res_shkola is not None
+    assert res_shkola["en"] == ["school"]
+    assert res_shkola["source"] == WIKIDATA_LABEL
+    assert res_shkola["source_url"] == "https://www.wikidata.org/wiki/Q3914"
+
+    # 2. ампір -> Empire style
+    res_ampir = enrich_manifest_module._wikidata_translation("ампір")
+    assert res_ampir is not None
+    assert res_ampir["en"] == ["Empire style"]
+    assert res_ampir["source"] == WIKIDATA_LABEL
+    assert res_ampir["source_url"] == "https://www.wikidata.org/wiki/Q191105"
+
+    # 3. аптечний -> None (all hits fail UK-label / sitelink exact match)
+    assert enrich_manifest_module._wikidata_translation("аптечний") is None
+
+    # 4. берегиня -> None (Berehynia is transliteration, star/theatre/craft centre filtered)
+    assert enrich_manifest_module._wikidata_translation("берегиня") is None
+
+    # 5. індус -> Hindu (Indus river/constellation filtered)
+    res_indus = enrich_manifest_module._wikidata_translation("індус")
+    assert res_indus is not None
+    assert res_indus["en"] == ["Hindu"]
+    assert res_indus["source"] == WIKIDATA_LABEL
+    assert res_indus["source_url"] == "https://www.wikidata.org/wiki/Q10090"
+
+    # 6. безмежжя -> None (empty search)
+    assert enrich_manifest_module._wikidata_translation("безмежжя") is None
+
+    # 7. істотно -> None (empty search)
+    assert enrich_manifest_module._wikidata_translation("істотно") is None
+
+
+def test_wikidata_translation_ambiguous_returns_none(monkeypatch) -> None:
+    """When Wikidata yields 2+ distinct English labels for a variant, return None."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q1",
+                "labels": {"uk": {"value": "термін"}, "en": {"value": "term"}},
+                "descriptions": {},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Термін"}},
+            },
+            {
+                "id": "Q2",
+                "labels": {"uk": {"value": "термін"}, "en": {"value": "deadline"}},
+                "descriptions": {},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Термін"}},
+            },
+        ],
+    )
+    assert enrich_manifest_module._wikidata_translation("термін") is None
+
+
+def test_wikidata_translation_binomial_rejected(monkeypatch) -> None:
+    """Scientific binomials and taxon items are rejected."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q100",
+                "labels": {"uk": {"value": "лисиця"}, "en": {"value": "Vulpes vulpes"}},
+                "descriptions": {"uk": {"value": "вид ссавців"}, "en": {"value": "species of mammal"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q16521"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Лисиця"}},
+            }
+        ],
+    )
+    assert enrich_manifest_module._wikidata_translation("лисиця") is None
+
+
+def test_wikidata_translation_transliteration_rejected(monkeypatch) -> None:
+    """Transliterations of the Ukrainian lemma are rejected."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q200",
+                "labels": {"uk": {"value": "кобзар"}, "en": {"value": "Kobzar"}},
+                "descriptions": {"uk": {"value": "виконавець"}, "en": {"value": "bard"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Кобзар"}},
+            }
+        ],
+    )
+    assert enrich_manifest_module._wikidata_translation("кобзар") is None
+
+
+def test_wikidata_translation_noise_entity_rejected(monkeypatch) -> None:
+    """Film, television, song, and star items are rejected."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q300",
+                "labels": {"uk": {"value": "тіні"}, "en": {"value": "Shadows"}},
+                "descriptions": {"uk": {"value": "фільм"}, "en": {"value": "1959 film"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q11424"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Тіні (фільм)"}},
+            }
+        ],
+    )
+    assert enrich_manifest_module._wikidata_translation("тіні") is None
+
+
+def test_wikidata_translation_sitelink_match_kept(monkeypatch) -> None:
+    """An item where ukwiki title equals variant (even if labels.uk differs) is matched."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q400",
+                "labels": {"en": {"value": "sculpture"}},
+                "descriptions": {"en": {"value": "branch of visual arts"}},
+                "claims": {},
+                "sitelinks": {"ukwiki": {"title": "Скульптура"}},
+            }
+        ],
+    )
+    res = enrich_manifest_module._wikidata_translation("скульптура")
+    assert res is not None
+    assert res["en"] == ["sculpture"]
+    assert res["source"] == WIKIDATA_LABEL
+    assert res["source_url"] == "https://www.wikidata.org/wiki/Q400"
+
+
+def test_wikidata_translation_offline_mode(monkeypatch) -> None:
+    """When offline mode is active, query_wikidata_uk_en returns empty list without calling network."""
+    called = False
+
+    def fake_search(query: str, **kwargs) -> list[dict[str, Any]]:
+        nonlocal called
+        called = True
+        return [{"id": "Q999"}]
+
+    monkeypatch.setattr("scripts.rag.source_query.wikidata_search_entities", fake_search)
+    monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: True)
+    enrich_manifest_module.query_wikidata_uk_en.cache_clear()
+    res = enrich_manifest_module.query_wikidata_uk_en("тест_offline_unique")
+    assert res == []
+    assert not called
+
 

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -13,6 +13,7 @@ from scripts.lexicon.source_attribution import (
     MIYKLAS_LABEL,
     PHRASEOLOGY_LABEL,
     SUM20_ACADEMIC_LABEL,
+    WIKIDATA_LABEL,
     apply_entry_attribution,
     join_academic_source_labels,
     learner_facing_mirror_violations,
@@ -254,3 +255,33 @@ def test_normalize_academic_label_maps_e2u() -> None:
     assert normalize_academic_label("e2u: Переклад") == E2U_LABEL
     assert normalize_academic_label("e2u (переклад)") == E2U_LABEL
     assert normalize_academic_label(E2U_LABEL) == E2U_LABEL
+
+
+def test_apply_entry_attribution_handles_wikidata_translation() -> None:
+    entry = {
+        "lemma": "школа",
+        "enrichment": {
+            "translation": {
+                "en": ["school"],
+                "source": "Wikidata",
+                "source_url": "https://www.wikidata.org/wiki/Q3914",
+            },
+            "sources": ["Wikidata"],
+        },
+    }
+    assert apply_entry_attribution(entry) is False
+    assert entry["enrichment"]["translation"]["source"] == WIKIDATA_LABEL
+    assert (
+        entry["enrichment"]["translation"]["source_url"]
+        == "https://www.wikidata.org/wiki/Q3914"
+    )
+    assert entry["enrichment"]["sources"] == [WIKIDATA_LABEL]
+    assert learner_facing_mirror_violations(entry) == []
+    assert learner_facing_unmapped_source_violations(entry) == []
+
+
+def test_normalize_academic_label_maps_wikidata() -> None:
+    assert normalize_academic_label("wikidata") == WIKIDATA_LABEL
+    assert normalize_academic_label("Wikidata") == WIKIDATA_LABEL
+    assert normalize_academic_label("wikidata.org") == WIKIDATA_LABEL
+    assert normalize_academic_label(WIKIDATA_LABEL) == WIKIDATA_LABEL


### PR DESCRIPTION
## Summary

Wikidata CC0 English **labels** as last-resort Atlas translation after e2u. Unique UK-label / ukwiki sitelink exact match only. Drops taxon/film/star/dab and transliterations (`берегиня`→Berehynia). Never first-hit.

Held-out: `школа`→school, `ампір`→Empire style, `індус`→Hindu; `аптечний`/`берегиня`/`безмежжя`→None.

No pointer flip. Refs #4387.

X-Agent: agy/atlas-wikidata-en