### PR TITLE
fix(cycle007): isolate AGY stream-input turns

### DIFF
--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -874,6 +874,8 @@ def stop(
 
 
 def _command(provider: Path, schema_path: Path, log_path: Path) -> list[str]:
+    # AGY stream-input mode reads turns only from stdin; --print would add a
+    # conflicting headless prompt and can yield SUCCESS with an empty result.
     return [
         str(provider),
         "--model",
@@ -888,8 +890,6 @@ def _command(provider: Path, schema_path: Path, log_path: Path) -> list[str]:
         "stream-json",
         "--json-schema",
         str(schema_path),
-        "--print",
-        "",
         "--log-file",
         str(log_path),
     ]
@@ -1018,6 +1018,7 @@ def _run_chunk(
                     stderr=subprocess.DEVNULL,
                     check=False,
                     shell=False,
+                    cwd=runtime,
                 )
             metadata = _attempt_metadata(
                 raw_path,

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -1026,6 +1026,8 @@ def invoke_canary(
                 raw=True,
             )
             _atomic(log_path, b"", raw=True)
+            # Stream-input turns come exclusively from stdin.  Supplying an
+            # empty --print prompt can make AGY terminate SUCCESS with no result.
             cmd = [
                 str(provider_bin),
                 "--model",
@@ -1040,8 +1042,6 @@ def invoke_canary(
                 "stream-json",
                 "--json-schema",
                 str(schema_path),
-                "--print",
-                "",
                 "--log-file",
                 str(log_path),
             ]
@@ -1086,6 +1086,7 @@ def invoke_canary(
                         stderr=subprocess.DEVNULL,
                         check=False,
                         shell=False,
+                        cwd=runtime,
                     )
                 if completed.returncode != 0:
                     raise CanaryStructuralError("provider_process_nonzero_exit")

--- a/batch_state/phase3-test-cycle007-gemini-transport-v1.py
+++ b/batch_state/phase3-test-cycle007-gemini-transport-v1.py
@@ -310,6 +310,9 @@ def make_package(root: Path, *, lane: str = "clean_label", index: int = 1, count
 FAKE_PROVIDER = r"""#!/usr/bin/env python3
 import json, os, pathlib, re, sys
 argv = sys.argv
+assert "--print" not in argv
+schema = pathlib.Path(argv[argv.index("--json-schema") + 1])
+assert pathlib.Path.cwd().samefile(schema.parent)
 log = pathlib.Path(argv[argv.index("--log-file") + 1])
 assert log.stat().st_mode & 0o777 == 0o600
 event = json.loads(sys.stdin.readline())

--- a/batch_state/phase3-test-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-test-cycle007-public-canaries-v1.py
@@ -253,10 +253,12 @@ def _make_gemini_fake_provider(tmp_path: Path, sidecar: dict[str, Any]) -> Path:
     script = tmp_path / "mock_gemini.py"
     labels_json = json.dumps(labels)
     code = f"""#!/usr/bin/env python3
-import sys, json
+import os, sys, json
 
 schema_idx = sys.argv.index("--json-schema")
 schema_path = sys.argv[schema_idx + 1]
+assert "--print" not in sys.argv
+assert os.path.samefile(os.getcwd(), os.path.dirname(schema_path))
 with open(schema_path) as f:
     schema = json.load(f)
 challenge = schema["properties"]["liveness_challenge"]["enum"][0]

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -105,3 +105,19 @@ def test_batch_runner_accepts_one_fenced_response_json() -> None:
     payload = {"labels_by_position": {"p01": {}, "p02": {}}}
 
     assert runner._strict_result_payload({"response": f"```json\n{json.dumps(payload)}\n```"}) == payload
+
+
+def test_batch_stream_input_command_has_no_print_prompt() -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_command_test", path)
+    assert spec is not None and spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+
+    command = runner._command(Path("/provider"), Path("/schema.json"), Path("/agy.log"))
+
+    assert command.count("--input-format") == 1
+    assert command[command.index("--input-format") + 1] == "stream-json"
+    assert command.count("--output-format") == 1
+    assert command[command.index("--output-format") + 1] == "stream-json"
+    assert "--print" not in command


### PR DESCRIPTION
Fixes the AGY 1.1.20 stream-input transport defect observed during the Cycle007 production canary.

- removes the conflicting empty `--print` prompt from stdin-driven stream sessions
- runs canary and packet provider calls from their private per-attempt runtime directory
- preserves the exact model, prompt, schema, endpoint, validators, custody, and retry limits
- adds command and working-directory regression assertions

Validation:
- Ruff passed
- 49 focused pytest tests passed
- 18 public-canary script tests passed
- 22 controller tests passed
- Gemini transport synthetic suite passed

Production remains fail-closed with zero committed labeling packets.

Refs #6375