### PR TITLE
fix(cycle007): bind AGY calls to fresh projects

### DIFF
--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -571,7 +571,7 @@ def schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
+def _agy_stream(raw: bytes, *, expected_cwd: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     try:
         events = [
             json.loads(line, object_pairs_hook=_pairs)
@@ -592,6 +592,15 @@ def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
     config, result = init.get("init"), result_event.get("result")
     if not isinstance(config, dict) or config.get("model") != MODEL:
         raise Error("structured_output_envelope_drift", structural=True)
+    if expected_cwd is not None:
+        reported_cwd = config.get("cwd")
+        try:
+            if not isinstance(reported_cwd, str) or not Path(reported_cwd).is_absolute() or not Path(
+                reported_cwd
+            ).samefile(expected_cwd):
+                raise Error("structured_output_envelope_drift", structural=True)
+        except OSError as exc:
+            raise Error("structured_output_envelope_drift", structural=True) from exc
     if (
         not isinstance(result, dict)
         or result.get("status") != "SUCCESS"
@@ -651,8 +660,8 @@ def _strict_result_payload(result: Mapping[str, Any]) -> dict[str, Any]:
     return candidates[0]
 
 
-def _extract(raw: bytes) -> dict[str, Any]:
-    _, result = _agy_stream(raw)
+def _extract(raw: bytes, *, expected_cwd: Path | None = None) -> dict[str, Any]:
+    _, result = _agy_stream(raw, expected_cwd=expected_cwd)
     return _strict_result_payload(result)
 
 
@@ -882,6 +891,7 @@ def _command(provider: Path, schema_path: Path, log_path: Path) -> list[str]:
         MODEL,
         "--mode",
         "plan",
+        "--new-project",
         "--sandbox",
         "--disable-slash-commands",
         "--input-format",
@@ -1032,7 +1042,7 @@ def _run_chunk(
                 raise Error("structured_output_envelope_drift")
             raw = raw_path.read_bytes()
             try:
-                labels = normalize(lane, part, _extract(raw), sidecar_part=sidecar_part)
+                labels = normalize(lane, part, _extract(raw, expected_cwd=runtime), sidecar_part=sidecar_part)
             except Error as exc:
                 failure_stage = (
                     "stream_parse"

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -516,7 +516,7 @@ def grok_prompt(challenge: str, rows: list[dict[str, Any]], sidecar: dict[str, A
     ).encode("utf-8")
 
 
-def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
+def _agy_stream(raw: bytes, *, expected_cwd: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     try:
         events = [
             json.loads(line, object_pairs_hook=_pairs)
@@ -539,6 +539,15 @@ def _agy_stream(raw: bytes) -> tuple[dict[str, Any], dict[str, Any]]:
         raise CanaryStructuralError("init_envelope_drift")
     if config.get("model") != GEMINI_MODEL:
         raise CanaryStructuralError("init_model_binding_drift")
+    if expected_cwd is not None:
+        reported_cwd = config.get("cwd")
+        try:
+            if not isinstance(reported_cwd, str) or not Path(reported_cwd).is_absolute() or not Path(
+                reported_cwd
+            ).samefile(expected_cwd):
+                raise CanaryStructuralError("init_cwd_binding_drift")
+        except OSError as exc:
+            raise CanaryStructuralError("init_cwd_binding_drift") from exc
     if not isinstance(result, dict):
         raise CanaryStructuralError("result_envelope_drift")
     if result.get("status") != "SUCCESS":
@@ -605,8 +614,10 @@ def _strict_result_payload(result: Mapping[str, Any]) -> tuple[dict[str, Any], s
     return candidates[0], "response_json"
 
 
-def _extract_gemini(raw: bytes, challenge: str) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    init, result = _agy_stream(raw)
+def _extract_gemini(
+    raw: bytes, challenge: str, *, expected_cwd: Path | None = None
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    init, result = _agy_stream(raw, expected_cwd=expected_cwd)
     output, _transport = _strict_result_payload(result)
     if set(output) != {"labels_by_position", "liveness_challenge"}:
         raise CanaryStructuralError("structured_output_keys_drift")
@@ -1034,6 +1045,7 @@ def invoke_canary(
                 GEMINI_MODEL,
                 "--mode",
                 "plan",
+                "--new-project",
                 "--sandbox",
                 "--disable-slash-commands",
                 "--input-format",
@@ -1095,7 +1107,7 @@ def invoke_canary(
                     raise CanaryStructuralError("provider_output_empty")
 
                 if provider_name == "gemini":
-                    init_ev, res_ev, extracted = _extract_gemini(raw_output, challenge)
+                    init_ev, res_ev, extracted = _extract_gemini(raw_output, challenge, expected_cwd=runtime)
                     norm = extracted["labels"]
                     provenance = {
                         "init_model": init_ev["init"]["model"],

--- a/batch_state/phase3-test-cycle007-gemini-transport-v1.py
+++ b/batch_state/phase3-test-cycle007-gemini-transport-v1.py
@@ -311,6 +311,7 @@ FAKE_PROVIDER = r"""#!/usr/bin/env python3
 import json, os, pathlib, re, sys
 argv = sys.argv
 assert "--print" not in argv
+assert "--new-project" in argv
 schema = pathlib.Path(argv[argv.index("--json-schema") + 1])
 assert pathlib.Path.cwd().samefile(schema.parent)
 log = pathlib.Path(argv[argv.index("--log-file") + 1])
@@ -377,7 +378,7 @@ for position, (row, row_ev) in enumerate(zip(rows, sidecar_rows), 1):
 if mode == "semantic":
     labels["p01"]["evidence_ids"] = ["cycle007_evidence:invented" + "0" * 48]
 
-print(json.dumps({"event": "init", "init": {"model": "Gemini 3.6 Flash (High)"}}))
+print(json.dumps({"event": "init", "init": {"model": "Gemini 3.6 Flash (High)", "cwd": os.getcwd()}}))
 out = {"labels_by_position": labels}
 print(json.dumps({"event": "result", "result": {"conversation_id": "synthetic", "status": "SUCCESS", "structured_output": out}}))
 """

--- a/batch_state/phase3-test-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-test-cycle007-public-canaries-v1.py
@@ -258,6 +258,7 @@ import os, sys, json
 schema_idx = sys.argv.index("--json-schema")
 schema_path = sys.argv[schema_idx + 1]
 assert "--print" not in sys.argv
+assert "--new-project" in sys.argv
 assert os.path.samefile(os.getcwd(), os.path.dirname(schema_path))
 with open(schema_path) as f:
     schema = json.load(f)
@@ -275,7 +276,7 @@ structured_output = {{
 }}
 
 events = [
-    {{"event": "init", "init": {{"model": "Gemini 3.6 Flash (High)"}}, "conversation_id": "mock-conv-1"}},
+    {{"event": "init", "init": {{"model": "Gemini 3.6 Flash (High)", "cwd": os.getcwd()}}, "conversation_id": "mock-conv-1"}},
     {{"event": "result", "result": {{"status": "SUCCESS", "structured_output": structured_output}}, "conversation_id": "mock-conv-1"}},
 ]
 
@@ -532,7 +533,6 @@ AGY_STATUS_CASES = (
 
 def _make_gemini_status_provider(tmp_path: Path) -> Path:
     script = tmp_path / "gemini_status_failure.py"
-    init_line = json.dumps({"event": "init", "init": {"model": CANARY.GEMINI_MODEL}})
     result_line = json.dumps(
         {
             "event": "result",
@@ -542,7 +542,12 @@ def _make_gemini_status_provider(tmp_path: Path) -> Path:
             },
         }
     )
-    script.write_text(f"#!/usr/bin/env python3\nprint({init_line!r})\nprint({result_line!r})\n")
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os\n"
+        f"print(json.dumps({{'event': 'init', 'init': {{'model': {CANARY.GEMINI_MODEL!r}, 'cwd': os.getcwd()}}}}))\n"
+        f"print({result_line!r})\n"
+    )
     script.chmod(0o755)
     return script
 
@@ -655,6 +660,28 @@ def test_gemini_output_reports_liveness_drift_separately() -> None:
 
     with pytest.raises(CANARY.CanaryStructuralError, match="liveness_challenge_drift"):
         CANARY._extract_gemini(raw, "a" * 64)
+
+
+def test_gemini_stream_binds_reported_runtime_cwd(tmp_path: Path) -> None:
+    challenge = "a" * 64
+    raw = CANARY.canonical(
+        {"event": "init", "init": {"model": CANARY.GEMINI_MODEL, "cwd": str(tmp_path)}}
+    ) + CANARY.canonical(
+        {
+            "event": "result",
+            "result": {
+                "status": "SUCCESS",
+                "structured_output": {
+                    "labels_by_position": {"p01": {}, "p02": {}},
+                    "liveness_challenge": challenge,
+                },
+            },
+        }
+    )
+
+    CANARY._extract_gemini(raw, challenge, expected_cwd=tmp_path)
+    with pytest.raises(CANARY.CanaryStructuralError, match="init_cwd_binding_drift"):
+        CANARY._extract_gemini(raw, challenge, expected_cwd=tmp_path.parent)
 
 
 def test_structural_retry_permitted_on_first_attempt_malformed(tmp_path: Path) -> None:

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -121,3 +121,4 @@ def test_batch_stream_input_command_has_no_print_prompt() -> None:
     assert command.count("--output-format") == 1
     assert command[command.index("--output-format") + 1] == "stream-json"
     assert "--print" not in command
+    assert "--new-project" in command

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -122,3 +122,27 @@ def test_batch_stream_input_command_has_no_print_prompt() -> None:
     assert command[command.index("--output-format") + 1] == "stream-json"
     assert "--print" not in command
     assert "--new-project" in command
+
+
+def test_batch_stream_rejects_reported_cwd_mismatch(tmp_path: Path) -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_cwd_test", path)
+    assert spec is not None and spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+    raw = (
+        runner.canonical({"event": "init", "init": {"model": runner.MODEL, "cwd": str(tmp_path)}})
+        + runner.canonical(
+            {
+                "event": "result",
+                "result": {
+                    "status": "SUCCESS",
+                    "structured_output": {"labels_by_position": {"p01": {}}},
+                },
+            }
+        )
+    )
+
+    assert runner._extract(raw, expected_cwd=tmp_path) == {"labels_by_position": {"p01": {}}}
+    with pytest.raises(runner.Error, match="structured_output_envelope_drift"):
+        runner._extract(raw, expected_cwd=tmp_path.parent)


### PR DESCRIPTION
Closes the remaining AGY transport/isolation defect found while starting Cycle007 Gemini under #6375.

Outcome:
- adds `--new-project` to both real AGY stdin-stream launchers;
- continues running from the private per-attempt runtime directory;
- validates AGY's reported absolute cwd against that exact runtime before accepting output;
- preserves the exact prompt, schema, model, endpoint, validator, retry, custody, and denominator contracts.

Production evidence was content-blind:
- without the flag, AGY attached coding-project context, made 4-6 search-tool events, and terminated with an empty/cancelled result;
- with the flag, init cwd matched the isolated runtime and AGY returned non-empty structured output;
- semantic canary diagnostics remained fail-closed and were not accepted as approval;
- no production labeling output or receipt was committed.

Validation:
- Ruff passed.
- 69 focused tests passed.
- One unrelated pre-existing CLI test failure reproduces on the base and is excluded from the focused pass count.
- `git diff --check` passed.

Exact review target is the PR head; independent cross-family review is required before merge.