### PR TITLE
perf(fleet): cache API host project-state self-report (#7267)

### DIFF
--- a/scripts/api/fleet_workers_router.py
+++ b/scripts/api/fleet_workers_router.py
@@ -5,14 +5,28 @@ from __future__ import annotations
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
+from scripts.api import fleet_workers_collect as workers_collect
 from scripts.api.fleet_workers_collect import WORKERS_SCHEMA, workers_payload
+from scripts.api.project_state_router import LocalDocumentSnapshot, get_cached_local_document
 
 router = APIRouter(prefix="/workers/v1", tags=["fleet-workers"])
 
 
 @router.get("")
 async def get_workers(host_id: str | None = Query(default=None)) -> JSONResponse:
+    self_report_ids = workers_collect._self_host_ids()
+    if host_id is not None:
+        self_report_ids &= {host_id}
+    self_reports: dict[str, LocalDocumentSnapshot] = {
+        opaque: get_cached_local_document(opaque) for opaque in self_report_ids
+    }
     payload = workers_payload(host_id=host_id)
+    for host in payload.get("hosts", []):
+        snapshot = self_reports.get(host.get("host_id"))
+        if snapshot is None:
+            continue
+        host["freshness"] = snapshot.freshness
+        host["age_s"] = snapshot.age_s
     return JSONResponse(
         content=payload,
         headers={"Cache-Control": "no-store", "X-Workers-Schema": WORKERS_SCHEMA},

--- a/scripts/api/project_state_router.py
+++ b/scripts/api/project_state_router.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import threading
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -34,6 +36,164 @@ from scripts.api.project_state_store import (
 router = APIRouter(prefix="/projects/v1", tags=["fleet-projects"])
 
 EXTRA_REPORTER_HOST_IDS = frozenset({"mac-operator"})
+
+# The API host is the only project-state reporter that is collected on the
+# request path. Keep its snapshot short-lived, but retain a bounded last-good
+# value while one refresh is in flight, matching the occupancy host-load
+# stale-while-revalidate behavior.
+LOCAL_DOCUMENT_FRESH_S = 30.0
+LOCAL_DOCUMENT_MAX_STALE_S = 300.0
+LOCAL_DOCUMENT_REFRESH_BACKOFF_S = 30.0
+
+
+@dataclass(frozen=True)
+class LocalDocumentSnapshot:
+    document: dict[str, Any] | None
+    age_s: float | None
+    freshness: str
+
+
+@dataclass(frozen=True)
+class _LocalDocumentCacheEntry:
+    document: dict[str, Any]
+    stored_at_mono: float
+
+
+_LOCAL_DOCUMENT_CACHE: dict[str, _LocalDocumentCacheEntry] = {}
+_LOCAL_DOCUMENT_REFRESH_THREADS: dict[str, threading.Thread] = {}
+_LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL: dict[str, float] = {}
+_LOCAL_DOCUMENT_MISS_EVENTS: dict[str, threading.Event] = {}
+_LOCAL_DOCUMENT_GENERATION = 0
+_LOCAL_DOCUMENT_LOCK = threading.Lock()
+
+
+def _local_document_snapshot(
+    entry: _LocalDocumentCacheEntry,
+    *,
+    now_mono: float,
+) -> LocalDocumentSnapshot:
+    age = max(0.0, now_mono - entry.stored_at_mono)
+    age_s = round(age, 2)
+    if age <= LOCAL_DOCUMENT_FRESH_S:
+        return LocalDocumentSnapshot(entry.document, age_s, "fresh")
+    if age <= LOCAL_DOCUMENT_MAX_STALE_S:
+        return LocalDocumentSnapshot(entry.document, age_s, "stale")
+    return LocalDocumentSnapshot(None, age_s, "unknown")
+
+
+def _peek_local_document_snapshot(host_id: str) -> LocalDocumentSnapshot | None:
+    now_mono = time.monotonic()
+    with _LOCAL_DOCUMENT_LOCK:
+        entry = _LOCAL_DOCUMENT_CACHE.get(host_id)
+        if entry is None:
+            return None
+        return _local_document_snapshot(entry, now_mono=now_mono)
+
+
+def _refresh_local_document(host_id: str, generation: int) -> None:
+    document: dict[str, Any] | None = None
+    try:
+        collected = collect_local_document(host_id)
+        if isinstance(collected, dict):
+            document = collected
+    except Exception:
+        # A failed refresh must not take down a read that has a last-good
+        # snapshot. The caller will expose its age and stale/unknown state.
+        document = None
+
+    current_thread = threading.current_thread()
+    with _LOCAL_DOCUMENT_LOCK:
+        if generation != _LOCAL_DOCUMENT_GENERATION:
+            return
+        if document is not None:
+            _LOCAL_DOCUMENT_CACHE[host_id] = _LocalDocumentCacheEntry(document, time.monotonic())
+            _LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL.pop(host_id, None)
+        else:
+            _LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL[host_id] = time.monotonic() + LOCAL_DOCUMENT_REFRESH_BACKOFF_S
+        if _LOCAL_DOCUMENT_REFRESH_THREADS.get(host_id) is current_thread:
+            _LOCAL_DOCUMENT_REFRESH_THREADS.pop(host_id, None)
+
+
+def _schedule_local_document_refresh(host_id: str) -> None:
+    now_mono = time.monotonic()
+    with _LOCAL_DOCUMENT_LOCK:
+        existing = _LOCAL_DOCUMENT_REFRESH_THREADS.get(host_id)
+        if existing is not None and existing.is_alive():
+            return
+        backoff_until = _LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL.get(host_id)
+        if backoff_until is not None and now_mono < backoff_until:
+            return
+        thread = threading.Thread(
+            target=_refresh_local_document,
+            args=(host_id, _LOCAL_DOCUMENT_GENERATION),
+            daemon=True,
+            name=f"project-state-refresh-{host_id}",
+        )
+        _LOCAL_DOCUMENT_REFRESH_THREADS[host_id] = thread
+        thread.start()
+
+
+def _collect_missing_local_document(host_id: str) -> LocalDocumentSnapshot:
+    """Synchronously fill a cold cache, with one collector per host."""
+    with _LOCAL_DOCUMENT_LOCK:
+        event = _LOCAL_DOCUMENT_MISS_EVENTS.get(host_id)
+        owner = event is None
+        if owner:
+            event = threading.Event()
+            _LOCAL_DOCUMENT_MISS_EVENTS[host_id] = event
+            generation = _LOCAL_DOCUMENT_GENERATION
+
+    if not owner:
+        event.wait()
+        snapshot = _peek_local_document_snapshot(host_id)
+        if snapshot is not None:
+            return snapshot
+        return LocalDocumentSnapshot(None, None, "unknown")
+
+    document: dict[str, Any] | None = None
+    try:
+        collected = collect_local_document(host_id)
+        if isinstance(collected, dict):
+            document = collected
+    except Exception:
+        document = None
+    finally:
+        with _LOCAL_DOCUMENT_LOCK:
+            if generation == _LOCAL_DOCUMENT_GENERATION and document is not None:
+                _LOCAL_DOCUMENT_CACHE[host_id] = _LocalDocumentCacheEntry(document, time.monotonic())
+                _LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL.pop(host_id, None)
+            if _LOCAL_DOCUMENT_MISS_EVENTS.get(host_id) is event:
+                _LOCAL_DOCUMENT_MISS_EVENTS.pop(host_id, None)
+            event.set()
+
+    snapshot = _peek_local_document_snapshot(host_id)
+    if snapshot is not None:
+        return snapshot
+    return LocalDocumentSnapshot(None, None, "unknown")
+
+
+def get_cached_local_document(host_id: str) -> LocalDocumentSnapshot:
+    """Return the API host's cached report, refreshing stale data in background."""
+    snapshot = _peek_local_document_snapshot(host_id)
+    if snapshot is None:
+        return _collect_missing_local_document(host_id)
+    if snapshot.freshness != "fresh":
+        _schedule_local_document_refresh(host_id)
+    return snapshot
+
+
+def reset_local_document_cache() -> None:
+    """Clear cached self-reports and wait briefly for test refreshes to finish."""
+    global _LOCAL_DOCUMENT_GENERATION
+    with _LOCAL_DOCUMENT_LOCK:
+        _LOCAL_DOCUMENT_GENERATION += 1
+        threads = list(_LOCAL_DOCUMENT_REFRESH_THREADS.values())
+        _LOCAL_DOCUMENT_CACHE.clear()
+        _LOCAL_DOCUMENT_REFRESH_THREADS.clear()
+        _LOCAL_DOCUMENT_REFRESH_BACKOFF_UNTIL.clear()
+        _LOCAL_DOCUMENT_MISS_EVENTS.clear()
+    for thread in threads:
+        thread.join(timeout=2.0)
 
 
 def allowed_reporter_host_ids() -> frozenset[str]:
@@ -68,7 +228,16 @@ def _self_host_ids() -> set[str]:
 
 
 def _live_local_document(host_id: str) -> dict[str, Any] | None:
-    return collect_local_document(host_id)
+    return get_cached_local_document(host_id).document
+
+
+def _local_document_metadata(host_id: str, document: dict[str, Any]) -> tuple[float, str]:
+    snapshot = _peek_local_document_snapshot(host_id)
+    if snapshot is not None and snapshot.document is document:
+        return snapshot.age_s or 0.0, snapshot.freshness
+    # Keep the existing private seam useful for tests and callers that inject
+    # a document without going through the in-process cache.
+    return 0.0, "fresh"
 
 
 def _payload_for_host(host_id: str, *, now_mono: float) -> dict[str, Any]:
@@ -76,10 +245,11 @@ def _payload_for_host(host_id: str, *, now_mono: float) -> dict[str, Any]:
         document = _live_local_document(host_id)
         if document is None:
             return unknown_host_payload(host_id)
+        age_s, freshness = _local_document_metadata(host_id, document)
         return shape_host_payload(
             document,
-            age_s=0.0,
-            freshness="fresh",
+            age_s=age_s,
+            freshness=freshness,
             collected_at=document["collected_at"],
         )
 

--- a/tests/api/test_fleet_workers.py
+++ b/tests/api/test_fleet_workers.py
@@ -21,6 +21,7 @@ from scripts.api.fleet_workers_sanitize import validate_workers_list
 from scripts.api.main import app
 from scripts.api.observer_presence import PresenceRequest, reset_observer_presence, upsert_presence
 from scripts.api.occupancy_local import _marker_fresh
+from scripts.api.project_state_router import reset_local_document_cache
 from scripts.api.project_state_sanitize import ProjectStateValidationError
 from scripts.api.project_state_store import get_stored_report, reset_project_state_store
 
@@ -109,9 +110,11 @@ def _worker_row(**overrides: Any) -> dict[str, Any]:
 def _reset_stores() -> None:
     reset_project_state_store()
     reset_observer_presence()
+    reset_local_document_cache()
     yield
     reset_project_state_store()
     reset_observer_presence()
+    reset_local_document_cache()
 
 
 def test_workers_route_schema(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/api/test_fleet_workers_unmocked.py
+++ b/tests/api/test_fleet_workers_unmocked.py
@@ -14,6 +14,7 @@ from scripts.api.fleet_workers_collect import UNATTRIBUTED_HOST_ID
 from scripts.api.main import app
 from scripts.api.observer_presence import PresenceRequest, reset_observer_presence, upsert_presence
 from scripts.api.occupancy_local import write_marker
+from scripts.api.project_state_router import reset_local_document_cache
 from scripts.api.project_state_store import reset_project_state_store
 
 client = TestClient(app, raise_server_exceptions=False)
@@ -32,6 +33,7 @@ def test_unmocked_workers_route_with_fixture_stores(tmp_path: Path, monkeypatch)
     """Exercise real adapters on fixture stores without monkeypatching the collector."""
     reset_project_state_store()
     reset_observer_presence()
+    reset_local_document_cache()
 
     tasks = tmp_path / "tasks"
     tasks.mkdir()
@@ -123,6 +125,7 @@ def test_unmocked_local_host_driver_lease_in_unattributed_bucket(tmp_path: Path,
     """Driver lease with holder_host_id local must surface under unattributed, not vanish."""
     reset_project_state_store()
     reset_observer_presence()
+    reset_local_document_cache()
 
     db = tmp_path / "session_streams.db"
     _seed_local_driver_lease(db)

--- a/tests/api/test_project_state.py
+++ b/tests/api/test_project_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -88,8 +89,10 @@ def _document(
 @pytest.fixture(autouse=True)
 def _clear_store() -> None:
     reset_project_state_store()
+    router_mod.reset_local_document_cache()
     yield
     reset_project_state_store()
+    router_mod.reset_local_document_cache()
 
 
 def _post_report(document: dict[str, Any]) -> Any:
@@ -247,6 +250,76 @@ def test_in_process_self_host_is_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
     host = client.get("/api/fleet/projects/v1?host_id=host-job").json()["hosts"]["host-job"]
     assert host["freshness"] == "fresh"
     assert host["age_s"] == 0.0
+
+
+def test_self_report_cache_is_shared_by_project_and_worker_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    monkeypatch.setenv("LU_MONITOR_HOST_ID", "host-job")
+    document = _document("host-job")
+    calls = 0
+
+    def collect(host_id: str) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        assert host_id == "host-job"
+        return document
+
+    monkeypatch.setattr(router_mod, "collect_local_document", collect)
+    monkeypatch.setattr("scripts.api.fleet_workers_collect._self_host_ids", lambda: {"host-job"})
+    monkeypatch.setattr("scripts.api.fleet_workers_collect.collect_driver_workers", lambda **_: ([], []))
+    monkeypatch.setattr("scripts.api.fleet_workers_collect.collect_delegate_workers", lambda *_, **__: [])
+    monkeypatch.setattr("scripts.api.fleet_workers_collect.collect_job_workers", lambda **_: ([], None))
+    monkeypatch.setattr("scripts.api.fleet_workers_collect.collect_marker_workers", lambda **_: [])
+
+    project = client.get("/api/fleet/projects/v1?host_id=host-job")
+    workers = client.get("/api/fleet/workers/v1?host_id=host-job")
+
+    assert project.status_code == 200
+    assert workers.status_code == 200
+    assert calls == 1
+    project_host = project.json()["hosts"]["host-job"]
+    worker_host = workers.json()["hosts"][0]
+    assert project_host["freshness"] == "fresh"
+    assert project_host["age_s"] == 0.0
+    assert worker_host["freshness"] == "fresh"
+    assert worker_host["age_s"] == 0.0
+
+
+def test_self_report_cache_serves_stale_while_refreshing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    monkeypatch.setenv("LU_MONITOR_HOST_ID", "host-job")
+    document = _document("host-job")
+    calls = 0
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+
+    def collect(_host_id: str) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return document
+        refresh_started.set()
+        release_refresh.wait(timeout=2.0)
+        return {**document, "collected_at": datetime.now(UTC).isoformat().replace("+00:00", "Z")}
+
+    monkeypatch.setattr(router_mod, "collect_local_document", collect)
+    first = router_mod.get_cached_local_document("host-job")
+    assert first.document is document
+    cached_entry = router_mod._LOCAL_DOCUMENT_CACHE["host-job"]
+    router_mod._LOCAL_DOCUMENT_CACHE["host-job"] = router_mod._LocalDocumentCacheEntry(
+        document,
+        cached_entry.stored_at_mono - router_mod.LOCAL_DOCUMENT_FRESH_S - 1.0,
+    )
+
+    try:
+        stale = router_mod.get_cached_local_document("host-job")
+        assert refresh_started.wait(timeout=1.0)
+        assert stale.document is document
+        assert stale.freshness == "stale"
+        assert stale.age_s is not None and stale.age_s > router_mod.LOCAL_DOCUMENT_FRESH_S
+        assert calls == 2
+    finally:
+        release_refresh.set()
 
 
 def test_self_host_live_collection_unmocked(


### PR DESCRIPTION
## Outcome

GET `/api/fleet/projects/v1` and GET `/api/fleet/workers/v1` share a short-lived in-process cache of the API host's `collect_local_document` snapshot (fresh ≤30s, stale-while-revalidate ≤300s). Response shape is unchanged; self-report `age_s` / freshness now reflect cache age.

Fixes #7267.

The implementer was SIGKILL'd after committing locally (`needs_finalize`, the #7311 detector). Driver re-ran tests and pushed.

## Evidence

```
pytest tests/api/test_project_state.py tests/api/test_fleet_workers.py tests/api/test_fleet_workers_unmocked.py -q
44 passed
ruff check scripts/api/project_state_router.py scripts/api/fleet_workers_router.py tests/api/test_project_state.py tests/api/test_fleet_workers.py tests/api/test_fleet_workers_unmocked.py
All checks passed
```

X-Agent: codex/fix-7267-project-state-cache