### PR TITLE
fix(cycle007): align clean decisions with evidence gate

### DIFF
--- a/scripts/projects/open_model_data/phase3_cycle007_evidence_validator.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_evidence_validator.py
@@ -25,10 +25,30 @@ from typing import Any
 from scripts.projects.open_model_data import phase3_cycle007_evidence_contract as contract
 
 # Decisions that require sufficient normative/attestation evidence (amendment
-# model-contract section). Any other outcome is the fail-closed uncertainty
-# path and never needs sufficiency.
+# model-contract section). Clean-label rejections and residual abstention or
+# disagreement are the closed fail-closed uncertainty paths and never need
+# sufficiency. Keep the clean-label set aligned with the frozen public label
+# semantics; otherwise a schema-valid provider response can fail later as an
+# unknown decision.
 SUFFICIENT_REQUIRED_DECISIONS = frozenset({"agree", "positive", "acceptable_control", "protected"})
-UNCERTAINTY_DECISIONS = frozenset({"reject_insufficient_locator_evidence", "abstention", "disagreement"})
+CLEAN_REJECTION_DECISIONS = frozenset(
+    {
+        "reject_fragment_or_too_short",
+        "reject_exercise_or_task_prompt",
+        "reject_error_or_contrast_example",
+        "reject_table_list_formula_code",
+        "reject_metalinguistic_or_grammar_talk",
+        "reject_quoted_literary_or_anthology",
+        "reject_archaic_historical_language",
+        "reject_dialectal_regional_surzhyk",
+        "reject_foreign_or_translation_artifact",
+        "reject_learner_or_simplified_broken",
+        "reject_parallel_norm_or_pre2026_only",
+        "reject_mixed_or_uncertain",
+        "reject_insufficient_locator_evidence",
+    }
+)
+UNCERTAINTY_DECISIONS = CLEAN_REJECTION_DECISIONS | {"abstention", "disagreement"}
 KNOWN_DECISIONS = SUFFICIENT_REQUIRED_DECISIONS | UNCERTAINTY_DECISIONS
 
 # Channels whose absence/ambiguity actually drives a sufficiency classification.

--- a/tests/test_phase3_cycle007_evidence_validator.py
+++ b/tests/test_phase3_cycle007_evidence_validator.py
@@ -347,11 +347,12 @@ def test_validate_label_evidence_refs_rejects_insufficient_agree_decision():
     assert excinfo.value.code == "insufficient_evidence_for_decision"
 
 
-def test_validate_label_evidence_refs_uncertainty_path_never_needs_sufficiency():
+@pytest.mark.parametrize("decision_code", sorted(validator.CLEAN_REJECTION_DECISIONS))
+def test_validate_label_evidence_refs_clean_rejection_paths_never_need_sufficiency(decision_code: str):
     record = _vesum_record(ROW_A, status="not_found")
     row_evidence = _row_evidence(ROW_A, [record])
     validator.validate_label_evidence_refs(
-        row_evidence, decision_code="reject_insufficient_locator_evidence", evidence_ids=[record["evidence_id"]]
+        row_evidence, decision_code=decision_code, evidence_ids=[record["evidence_id"]]
     )
 
 

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -38,6 +38,18 @@ def test_real_cli_requires_explicit_provider_bin(
     }
 
 
+def test_gemini_schema_decisions_are_all_known_to_evidence_validator() -> None:
+    runner = _load_runner()
+    rows = runner.fixture_rows()
+    schema = runner.gemini_schema(rows, "challenge")
+
+    positions = schema["properties"]["labels_by_position"]["properties"]
+    for position in ("p01", "p02"):
+        decision_enum = set(positions[position]["properties"]["decision_code"]["enum"])
+        assert decision_enum == runner.SOURCE.REJECTS
+        assert decision_enum <= runner.validator.KNOWN_DECISIONS
+
+
 def test_real_cli_passes_explicit_provider_bin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     runner = _load_runner()
     provider = (tmp_path / "agy").resolve()


### PR DESCRIPTION
## Outcome
Align the Cycle007 evidence-reference gate with the already-frozen clean-label decision schema so schema-valid provider decisions are not rejected as unknown.

## Scope
- recognize all frozen clean-label rejection decisions as fail-closed uncertainty outcomes
- retain sufficient-evidence requirements for affirmative decisions
- retain rejection of arbitrary unknown decision codes
- add schema-to-validator drift coverage and all-rejection behavior coverage

No prompt, provider schema, model, endpoint, evidence, custody, retry policy, or labeling data changed.

## Verification
- Ruff: pass
- Focused pytest: 142 pass
- One unrelated pre-existing CLI test failure reproduced on the base
- Real canary failure motivating the fix: unknown_decision_code (content-blind)

Refs #6375