### PR TITLE
fix(dashboards): fail-open Fleet and Home when one API is slow

### DIFF
--- a/dashboards/fleet.html
+++ b/dashboards/fleet.html
@@ -691,31 +691,84 @@ function renderMessages(data) {
 
 async function refreshFleet() {
   setError('');
-  try {
-    const common = ['state', 'agent', 'source', 'conversation'];
-    const contextStatusRequest = fetchJson('/api/ops/entire-context/status').catch(() => ({
-      recall: { available: false, reason: 'projection_request_failed', projection: { available: false, reason: 'projection_request_failed' } },
-      use: {},
-    }));
-    const [health, overview, operations, requests, authorityJobs, reviews, acp, deadLetters, workers, occupancy, projects, activity, messages, contextStatus] = await Promise.all([
-      fetchJson('/api/fleet/health'), fetchJson('/api/fleet/overview'), fetchJson('/api/fleet/operations'),
-      fetchJson(query('/api/fleet/authority/jobs', ['state', 'agent', 'source', 'conversation'], { kind: 'request' })),
-      fetchJson(query('/api/fleet/authority/jobs', ['kind', 'state', 'agent', 'source', 'pr', 'conversation'])),
-      fetchJson(query('/api/fleet/reviews', ['kind', 'state', 'source', 'pr'])),
-      fetchJson(query('/api/fleet/acp/conversations', common)),
-      fetchJson(query('/api/fleet/dead-letters', ['state', 'agent', 'source'])),
-      fetchJson('/api/fleet/workers/v1'),
-      fetchJson('/api/occupancy'),
-      fetchJson('/api/fleet/projects/v1'),
-      fetchJson(query('/api/fleet/activity', ['state', 'agent', 'source'])),
-      fetchJson(query('/api/fleet/messages', ['kind', ...common])),
-      contextStatusRequest,
-    ]);
-    renderHealth(health); renderOverview(overview); renderOperations(operations); renderRequests(requests); renderAuthorityJobs(authorityJobs); renderReviews(reviews);
-    renderAcp(acp); renderDeadLetters(deadLetters); renderWorkers(workers); renderOccupancy(occupancy); renderOccupancyAttention(occupancy.attention); renderProjects(projects); renderActivity(activity); renderMessages(messages);
-    await refreshConversationContext(contextStatus);
-  } catch (error) {
-    setError(`Observer data could not be read: ${error.message}`);
+  const common = ['state', 'agent', 'source', 'conversation'];
+  const contextStatusFallback = {
+    recall: { available: false, reason: 'projection_request_failed', projection: { available: false, reason: 'projection_request_failed' } },
+    use: {},
+  };
+  // Each load applies on success as soon as its fetch settles so a slow/aborted
+  // endpoint (e.g. workers/v1) cannot block health/overview paint.
+  const loads = [
+    { label: '/api/fleet/health', url: '/api/fleet/health', apply: (data) => { renderHealth(data); } },
+    { label: '/api/fleet/overview', url: '/api/fleet/overview', apply: (data) => { renderOverview(data); } },
+    { label: '/api/fleet/operations', url: '/api/fleet/operations', apply: (data) => { renderOperations(data); } },
+    {
+      label: '/api/fleet/authority/jobs?kind=request',
+      url: query('/api/fleet/authority/jobs', ['state', 'agent', 'source', 'conversation'], { kind: 'request' }),
+      apply: (data) => { renderRequests(data); },
+    },
+    {
+      label: '/api/fleet/authority/jobs',
+      url: query('/api/fleet/authority/jobs', ['kind', 'state', 'agent', 'source', 'pr', 'conversation']),
+      apply: (data) => { renderAuthorityJobs(data); },
+    },
+    {
+      label: '/api/fleet/reviews',
+      url: query('/api/fleet/reviews', ['kind', 'state', 'source', 'pr']),
+      apply: (data) => { renderReviews(data); },
+    },
+    {
+      label: '/api/fleet/acp/conversations',
+      url: query('/api/fleet/acp/conversations', common),
+      apply: (data) => { renderAcp(data); },
+    },
+    {
+      label: '/api/fleet/dead-letters',
+      url: query('/api/fleet/dead-letters', ['state', 'agent', 'source']),
+      apply: (data) => { renderDeadLetters(data); },
+    },
+    { label: '/api/fleet/workers/v1', url: '/api/fleet/workers/v1', apply: (data) => { renderWorkers(data); } },
+    {
+      label: '/api/occupancy',
+      url: '/api/occupancy',
+      apply: (data) => { renderOccupancy(data); renderOccupancyAttention(data.attention); },
+    },
+    { label: '/api/fleet/projects/v1', url: '/api/fleet/projects/v1', apply: (data) => { renderProjects(data); } },
+    {
+      label: '/api/fleet/activity',
+      url: query('/api/fleet/activity', ['state', 'agent', 'source']),
+      apply: (data) => { renderActivity(data); },
+    },
+    {
+      label: '/api/fleet/messages',
+      url: query('/api/fleet/messages', ['kind', ...common]),
+      apply: (data) => { renderMessages(data); },
+    },
+    {
+      label: '/api/ops/entire-context/status',
+      url: '/api/ops/entire-context/status',
+      softFail: true,
+      apply: async (data) => { await refreshConversationContext(data); },
+    },
+  ];
+  const settled = await Promise.allSettled(loads.map(async ({ label, url, apply, softFail }) => {
+    try {
+      const data = await fetchJson(url);
+      await apply(data);
+    } catch (error) {
+      if (softFail) {
+        await apply(contextStatusFallback);
+        return label;
+      }
+      throw error;
+    }
+    return label;
+  }));
+  const failed = settled
+    .map((result, index) => (result.status === 'rejected' ? loads[index].label : null))
+    .filter(Boolean);
+  if (failed.length) {
+    setError(`Observer data could not be read: ${failed.join(', ')}`);
   }
 }
 

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -337,15 +337,21 @@ function resolveOperationalBuildState(pv, summary) {
   return buildStateSummary(pv, trackIds);
 }
 
+async function loadWeakPointsStat() {
+  const weakPoints = await safeFetch('/api/state/weak-points?limit=1');
+  if (!weakPoints) return;
+  document.getElementById('quality-stat').textContent = `${weakPoints.count} modules need attention`;
+}
+
 async function loadStats() {
   let buildState = { pending: true, current: null, backlog: null, builtPct: null };
   let pendingConsultations = 0;
-  const [data, pv, cMetrics, summary, weakPoints, orient, runtimeAgents, delegate, buildEvents, wiki, cost, contracts] = await Promise.all([
+  // Quality card is often >5s; defer it so it cannot gate first paint of the fast cards.
+  const [data, pv, cMetrics, summary, orient, runtimeAgents, delegate, buildEvents, wiki, cost, contracts] = await Promise.all([
     safeFetch('/api/dashboard/overview'),
     safeFetch('/api/state/pipeline-versions?fresh=true'),
     safeFetch('/api/consultation/metrics'),
     safeFetch('/api/state/summary?fresh=true'),
-    safeFetch('/api/state/weak-points?limit=1'),
     safeFetch('/api/orient'),
     safeFetch('/api/runtime/agents'),
     safeFetch('/api/delegate/tasks?limit=100'),
@@ -354,6 +360,7 @@ async function loadStats() {
     safeFetch('/api/analytics/cost'),
     safeFetch('/api/contracts/routes'),
   ]);
+  void loadWeakPointsStat();
 
   try {
     if (!data) throw new Error('overview unavailable');
@@ -394,11 +401,6 @@ async function loadStats() {
     const stale = t.audit_stale ? ` · ${t.audit_stale} stale audit` : '';
     document.getElementById('progress-stat').textContent =
       `${displayBuildCount(buildState.current)} current · ${formatBacklogSegment(buildState)} · ${t.dossier_done ?? 0} dossiers · ${t.published_mdx ?? 0} published${stale}`;
-  } catch(e) {}
-
-  try {
-    if (!weakPoints) throw new Error('weak points unavailable');
-    document.getElementById('quality-stat').textContent = `${weakPoints.count} modules need attention`;
   } catch(e) {}
 
   if (orient) {

--- a/tests/test_fleet_dashboard_contract.py
+++ b/tests/test_fleet_dashboard_contract.py
@@ -64,6 +64,24 @@ def test_fleet_page_is_a_read_only_consolidated_observer() -> None:
     assert "['conversation', 'filter-conversation']" in html
 
 
+def test_fleet_refresh_fail_opens_per_endpoint() -> None:
+    """One aborted fleet fetch must not blank the whole observer page."""
+    html = (DASHBOARDS / "fleet.html").read_text(encoding="utf-8")
+    refresh = html[html.index("async function refreshFleet") : html.index("function queueRefresh")]
+
+    assert "Promise.allSettled" in refresh
+    assert "Promise.all([" not in refresh
+    assert "/api/fleet/workers/v1" in refresh
+    assert "failed.join" in refresh or "failed.length" in refresh
+    assert "Observer data could not be read:" in refresh
+
+    index = (DASHBOARDS / "index.html").read_text(encoding="utf-8")
+    assert "async function loadWeakPointsStat" in index
+    assert "void loadWeakPointsStat()" in index
+    load_stats = index[index.index("async function loadStats") :]
+    assert "weak-points" not in load_stats.split("void loadWeakPointsStat()")[0]
+
+
 def test_fleet_page_exposes_body_free_context_and_safe_acp_navigation() -> None:
     html = (DASHBOARDS / "fleet.html").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Outcome

`/fleet.html` no longer blanks the whole observer when one backend exceeds the 5s abort. Each section paints as its fetch settles (`Promise.allSettled`). Home defers `/api/state/weak-points` so a 5.8s call cannot stall first paint.

Does not make `/api/fleet/workers/v1` faster (separate Cursor job).

## Evidence

```
pytest tests/test_fleet_dashboard_contract.py -q
6 passed
```

Live: workers/v1 ~5.1s every GET; health/overview/projects are tens of ms.

X-Agent: cursor/fix-fleet-html-failopen