### PR TITLE
fix(taxonomy): sync fleet areas with issue streams (#7306)

### DIFF
--- a/scripts/config/area_assignments.yaml
+++ b/scripts/config/area_assignments.yaml
@@ -23,6 +23,9 @@ assignments:
       - gemini-devops
       - grok-devops
       - kimi-devops
+  monitor:
+    driver_agent_type: infra-orchestrator
+    slots: []
   harness:
     driver_agent_type: infra-orchestrator
     slots:
@@ -31,6 +34,9 @@ assignments:
       - gemini-corpus
       - grok-corpus
       - kimi-corpus
+  open-model-data:
+    driver_agent_type: infra-orchestrator
+    slots: []
   atlas:
     driver_agent_type: infra-orchestrator
     slots:

--- a/scripts/config/fleet_taxonomy.yaml
+++ b/scripts/config/fleet_taxonomy.yaml
@@ -19,7 +19,7 @@ areas:
     aliases:
       - infra-harness
     epics:
-      - number: 4707
+      - number: 6943  # successor to closed #4707
         name: "Infra & fleet reliability (hooks, dispatch, routing)"
   devops:
     id: devops
@@ -28,6 +28,13 @@ areas:
     epics:
       - number: 5703
         name: "DevOps automation, CI, release & launcher reliability"
+  monitor:
+    id: monitor
+    aliases:
+      - monitor
+    epics:
+      - number: 7177
+        name: "Monitor API + UI — fleet & host observability"
   harness:
     id: harness
     aliases:
@@ -41,6 +48,13 @@ areas:
         name: "Ukrainian LLM factuality benchmark — community release"
       - number: 4706  # operator ruling: corpus->harness, datasets mission
         name: "Corpus channels — acquisition & ingestion"
+  open-model-data:
+    id: open-model-data
+    aliases:
+      - open-model-data
+    epics:
+      - number: 6321
+        name: "Ukrainian open-model data infrastructure"
   atlas:
     id: atlas
     aliases:

--- a/tests/test_fleet_taxonomy_aliases.py
+++ b/tests/test_fleet_taxonomy_aliases.py
@@ -52,6 +52,8 @@ def test_load_fleet_taxonomy_structure() -> None:
     assert "core" in registry.areas
     assert "seminars" in registry.areas
     assert "hramatka" in registry.areas
+    assert "monitor" in registry.areas
+    assert "open-model-data" in registry.areas
 
 
 def test_resolve_area_canonical_ids() -> None:
@@ -59,7 +61,7 @@ def test_resolve_area_canonical_ids() -> None:
     assert isinstance(infra, ResolvedArea)
     assert infra.id == "infra"
     assert "infra-harness" in infra.aliases
-    assert EpicInfo(number=4707, name="Infra & fleet reliability (hooks, dispatch, routing)") in infra.epics
+    assert EpicInfo(number=6943, name="Infra & fleet reliability (hooks, dispatch, routing)") in infra.epics
 
     harness = resolve_area("harness")
     assert harness.id == "harness"
@@ -67,6 +69,14 @@ def test_resolve_area_canonical_ids() -> None:
 
     devops = resolve_area("devops")
     assert devops.id == "devops"
+
+    monitor = resolve_area("monitor")
+    assert monitor.id == "monitor"
+    assert monitor.epics == (EpicInfo(7177, "Monitor API + UI — fleet & host observability"),)
+
+    open_model_data = resolve_area("open-model-data")
+    assert open_model_data.id == "open-model-data"
+    assert open_model_data.epics == (EpicInfo(6321, "Ukrainian open-model data infrastructure"),)
 
 
 def test_resolve_area_aliases() -> None:
@@ -93,7 +103,7 @@ def test_resolve_area_aliases() -> None:
 
 def test_resolve_area_by_epic_number() -> None:
     # int epic lookup
-    infra = resolve_area(4707)
+    infra = resolve_area(6943)
     assert infra.id == "infra"
 
     devops = resolve_area(5703)
@@ -103,10 +113,12 @@ def test_resolve_area_by_epic_number() -> None:
     assert harness.id == "harness"
 
     # string epic lookup
-    assert resolve_area("4707").id == "infra"
-    assert resolve_area("epic:4707").id == "infra"  # allow-hardcoded-epic: taxonomy alias reverse lookup
-    assert resolve_area_by_epic(4707).id == "infra"
+    assert resolve_area("6943").id == "infra"
+    assert resolve_area("epic:6943").id == "infra"  # allow-hardcoded-epic: taxonomy alias reverse lookup
+    assert resolve_area_by_epic(6943).id == "infra"
     assert resolve_area_by_epic("epic:5703").id == "devops"  # allow-hardcoded-epic: taxonomy alias reverse lookup
+    assert resolve_area(7177).id == "monitor"
+    assert resolve_area(6321).id == "open-model-data"
 
 
 def test_resolve_area_unknown_raises_typed_error() -> None:
@@ -134,6 +146,8 @@ def test_list_valid_names() -> None:
     assert "harness" in names
     assert "eval-harness" in names
     assert "devops" in names
+    assert "monitor" in names
+    assert "open-model-data" in names
     assert names == tuple(sorted(names))
 
 
@@ -145,7 +159,7 @@ def test_list_valid_names() -> None:
 def test_inventory_session_streams_wiring() -> None:
     """Verify session_streams inventory uses fleet_taxonomy resolution."""
     # infra-harness is keyed by stream name so succession keeps harness-epic paths
-    cands_infra = _handoff_candidates_for("infra-harness", 4707)
+    cands_infra = _handoff_candidates_for("infra-harness", 6943)
     assert any("harness-epic" in path for path in cands_infra)
     cands_successor = _handoff_candidates_for("infra-harness", 888001)
     assert any("harness-epic" in path for path in cands_successor)

--- a/tests/test_validate_fleet_taxonomy.py
+++ b/tests/test_validate_fleet_taxonomy.py
@@ -33,9 +33,9 @@ def test_happy_path_real_files() -> None:
     """Validate real fleet_taxonomy.yaml and area_assignments.yaml."""
     res = validate_fleet_taxonomy()
     assert res["ok"] is True
-    assert res["areas_count"] == 7
-    assert res["epics_count"] == 18
-    assert res["assignments_count"] == 7
+    assert res["areas_count"] == 9
+    assert res["epics_count"] == 20
+    assert res["assignments_count"] == 9
 
 
 def test_negative_duplicate_alias_across_areas(tmp_path: Any) -> None:
@@ -68,8 +68,8 @@ def test_negative_epic_in_two_areas(tmp_path: Any) -> None:
     tax_data = yaml.safe_load(TAXONOMY_PATH.read_text(encoding="utf-8"))
     ass_data = yaml.safe_load(ASSIGNMENTS_PATH.read_text(encoding="utf-8"))
 
-    # Break taxonomy by adding epic 4707 (from infra) into devops as well
-    tax_data["areas"]["devops"]["epics"].append({"number": 4707, "name": "Duplicate 4707"})
+    # Break taxonomy by adding epic 6943 (from infra) into devops as well
+    tax_data["areas"]["devops"]["epics"].append({"number": 6943, "name": "Duplicate 6943"})
 
     tax_file = tmp_path / "fleet_taxonomy.yaml"
     ass_file = tmp_path / "area_assignments.yaml"
@@ -84,7 +84,7 @@ def test_negative_epic_in_two_areas(tmp_path: Any) -> None:
             assignments_schema_path=ASSIGNMENTS_SCHEMA_PATH,
         )
 
-    assert "Epic number 4707 belongs to multiple areas" in str(exc_info.value)
+    assert "Epic number 6943 belongs to multiple areas" in str(exc_info.value)
 
 
 def test_negative_assignment_for_unknown_area(tmp_path: Any) -> None:


### PR DESCRIPTION
## Summary
- Add `monitor` area epic #7177 and `open-model-data` area epic #6321 to `fleet_taxonomy.yaml`
- Point `infra` at successor epic #6943 (was closed #4707)
- Keep assignment parity; update taxonomy validator/alias tests

## Test plan
- [x] Taxonomy validator: 9 areas / 20 epics / 9 assignments (worker evidence)
- [x] Targeted suites: 102 + 52 + 82 passed (worker evidence)
- [x] Ruff clean (worker evidence)
- [ ] Cross-family review of record
- [ ] Confirm Work API projection stops `TRIAGE_ORPHAN` for monitor #7269 children after deploy

Refs #7306 #7177


Made with [Cursor](https://cursor.com)