### PR TITLE
perf(fleet): cache workers/v1 payload so warm GETs stay under 500ms

### DIFF
--- a/scripts/api/fleet_workers_collect.py
+++ b/scripts/api/fleet_workers_collect.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import sqlite3
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -45,6 +47,31 @@ from scripts.lexicon.runner import atlas_job
 
 WORKERS_SCHEMA = "monitor-fleet-workers.v1"
 UNATTRIBUTED_HOST_ID = "unattributed"
+
+# Self-host collection re-reads every delegate task JSON. On the API host that
+# directory can be hundreds of MB, so warm GETs reuse a short-lived payload
+# snapshot in the same 15–30s family as occupancy / project-state SWR.
+WORKERS_PAYLOAD_CACHE_TTL_S = 20.0
+
+
+@dataclass(frozen=True)
+class _WorkersPayloadCacheEntry:
+    payload: dict[str, Any]
+    stored_at_mono: float
+
+
+_WORKERS_PAYLOAD_CACHE: dict[str, _WorkersPayloadCacheEntry] = {}
+_WORKERS_PAYLOAD_LOCK = threading.Lock()
+
+
+def reset_workers_payload_cache() -> None:
+    """Clear the in-process workers payload cache (tests / forced refresh)."""
+    with _WORKERS_PAYLOAD_LOCK:
+        _WORKERS_PAYLOAD_CACHE.clear()
+
+
+def _workers_payload_cache_key(host_id: str | None) -> str:
+    return host_id if host_id is not None else ""
 
 MARKER_KIND_NORMALIZE = {
     "worker": "service",
@@ -595,7 +622,7 @@ def collect_local_workers_for_reporter(
     return [worker_row_dict(item.row) for item in workers[:200]]
 
 
-def workers_payload(
+def _build_workers_payload(
     *,
     host_id: str | None = None,
     tasks_dir: Path | None = None,
@@ -715,3 +742,42 @@ def workers_payload(
         "attention": attention,
         "hosts": hosts,
     }
+
+
+def workers_payload(
+    *,
+    host_id: str | None = None,
+    tasks_dir: Path | None = None,
+    session_db: Path | None = None,
+    markers_root: Path | None = None,
+    now_mono: float | None = None,
+) -> dict[str, Any]:
+    """Join live workers. Production GETs reuse a short in-process snapshot.
+
+    Explicit fixture paths / ``now_mono`` bypass the cache so tests stay hermetic.
+    """
+    use_cache = (
+        tasks_dir is None and session_db is None and markers_root is None and now_mono is None
+    )
+    key = _workers_payload_cache_key(host_id)
+    if use_cache:
+        now = time.monotonic()
+        with _WORKERS_PAYLOAD_LOCK:
+            entry = _WORKERS_PAYLOAD_CACHE.get(key)
+            if entry is not None and (now - entry.stored_at_mono) < WORKERS_PAYLOAD_CACHE_TTL_S:
+                return copy.deepcopy(entry.payload)
+
+    payload = _build_workers_payload(
+        host_id=host_id,
+        tasks_dir=tasks_dir,
+        session_db=session_db,
+        markers_root=markers_root,
+        now_mono=now_mono,
+    )
+    if use_cache:
+        with _WORKERS_PAYLOAD_LOCK:
+            _WORKERS_PAYLOAD_CACHE[key] = _WorkersPayloadCacheEntry(
+                copy.deepcopy(payload),
+                time.monotonic(),
+            )
+    return payload

--- a/tests/api/test_fleet_workers.py
+++ b/tests/api/test_fleet_workers.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sqlite3
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -20,7 +21,7 @@ from scripts.api.fleet_workers_models import WorkerRow
 from scripts.api.fleet_workers_sanitize import validate_workers_list
 from scripts.api.main import app
 from scripts.api.observer_presence import PresenceRequest, reset_observer_presence, upsert_presence
-from scripts.api.occupancy_local import _marker_fresh
+from scripts.api.occupancy_local import OccupancyRead, _marker_fresh
 from scripts.api.project_state_router import reset_local_document_cache
 from scripts.api.project_state_sanitize import ProjectStateValidationError
 from scripts.api.project_state_store import get_stored_report, reset_project_state_store
@@ -111,10 +112,12 @@ def _reset_stores() -> None:
     reset_project_state_store()
     reset_observer_presence()
     reset_local_document_cache()
+    collect_mod.reset_workers_payload_cache()
     yield
     reset_project_state_store()
     reset_observer_presence()
     reset_local_document_cache()
+    collect_mod.reset_workers_payload_cache()
 
 
 def test_workers_route_schema(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -593,3 +596,70 @@ def test_workers_opsec_no_sensitive_tokens(monkeypatch: pytest.MonkeyPatch) -> N
         assert alias not in text
     assert "run_nonce" not in text
     assert "pid" not in text
+
+
+def test_workers_payload_warm_cache_skips_delegate_collector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm GET must not re-enter collect_delegate_workers within the TTL window."""
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    now = datetime.now(UTC)
+    (tasks / "warm-task.json").write_text(
+        json.dumps(
+            {
+                "task_id": "warm-task",
+                "agent": "cursor",
+                "status": "running",
+                "pid": os.getpid(),
+                "started_at": now.isoformat(),
+                "run_nonce": "warm-cache-nonce",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MONITOR_OCCUPANCY_HOST_IDS", _PLACEHOLDER_MAP)
+    monkeypatch.setenv("LU_MONITOR_HOST_ID", "host-job")
+    monkeypatch.setattr("scripts.api.delegate_router.TASKS_DIR", tasks)
+    monkeypatch.setattr(collect_mod, "_self_host_ids", lambda: {"host-job"})
+    monkeypatch.setattr(
+        collect_mod,
+        "collect_job_workers",
+        lambda **_kwargs: ([], None),
+    )
+    monkeypatch.setattr(collect_mod, "collect_marker_workers", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        collect_mod,
+        "read_session_streams",
+        lambda **_kwargs: OccupancyRead([], True, 0.0),
+    )
+
+    calls = {"delegate": 0}
+    real_delegate = collect_mod.collect_delegate_workers
+
+    def _counting_delegate(*args: Any, **kwargs: Any) -> Any:
+        calls["delegate"] += 1
+        return real_delegate(*args, **kwargs)
+
+    monkeypatch.setattr(collect_mod, "collect_delegate_workers", _counting_delegate)
+
+    first = workers_payload()
+    assert calls["delegate"] == 1
+    assert any(
+        row.get("id") == "warm-task"
+        for host in first["hosts"]
+        for row in host.get("workers", [])
+    )
+
+    t0 = time.perf_counter()
+    second = workers_payload()
+    warm_s = time.perf_counter() - t0
+    assert calls["delegate"] == 1
+    assert warm_s < 0.5
+    assert second["counts"] == first["counts"]
+    assert second["hosts"] == first["hosts"]
+
+    # Fixture overrides must bypass the cache (hermetic collectors).
+    third = workers_payload(tasks_dir=tasks)
+    assert calls["delegate"] == 2

--- a/tests/api/test_fleet_workers_unmocked.py
+++ b/tests/api/test_fleet_workers_unmocked.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from scripts.api.fleet_workers_collect import UNATTRIBUTED_HOST_ID
+from scripts.api.fleet_workers_collect import UNATTRIBUTED_HOST_ID, reset_workers_payload_cache
 from scripts.api.main import app
 from scripts.api.observer_presence import PresenceRequest, reset_observer_presence, upsert_presence
 from scripts.api.occupancy_local import write_marker
@@ -34,6 +34,7 @@ def test_unmocked_workers_route_with_fixture_stores(tmp_path: Path, monkeypatch)
     reset_project_state_store()
     reset_observer_presence()
     reset_local_document_cache()
+    reset_workers_payload_cache()
 
     tasks = tmp_path / "tasks"
     tasks.mkdir()
@@ -126,6 +127,7 @@ def test_unmocked_local_host_driver_lease_in_unattributed_bucket(tmp_path: Path,
     reset_project_state_store()
     reset_observer_presence()
     reset_local_document_cache()
+    reset_workers_payload_cache()
 
     db = tmp_path / "session_streams.db"
     _seed_local_driver_lease(db)


### PR DESCRIPTION
## Outcome

Warm `GET /api/fleet/workers/v1` no longer re-reads every delegate task JSON (~3.6s / hundreds of MB on this API host). 20s in-process snapshot; tests prove the second call skips `collect_delegate_workers`.

Pairs with PR #7346 (Fleet fail-open). Live cold GET was ~5.1s twice; that aborted the 5s dashboard fetch.

## Evidence

```
pytest tests/api/test_fleet_workers.py tests/api/test_fleet_workers_unmocked.py -q
30 passed
ruff check scripts/api/fleet_workers_collect.py tests/api/test_fleet_workers.py
```

X-Agent: cursor/fix-workers-v1-latency