### PR TITLE
fix(atlas): restore СУМ-20 goddess-protectress senses for берегиня

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -506,6 +506,17 @@ _BLOCKED_SYNONYMS = {
 _WRONG_SENSE_SYNONYMS: dict[str, frozenset[str]] = {
     "шлях": frozenset({"кам'яниця"}),
     "річка": frozenset({"звір"}),
+    "берегиня": frozenset({
+        "русалка",
+        "німфа",
+        "наяда",
+        "мавка",
+        "лісна",
+        "лісниця",
+        "віла",
+        "ундина",
+        "сирена",
+    }),
 }
 
 # #3197 — Вікісловник's explicit antonym column carries pedagogical noise the POS
@@ -2019,6 +2030,13 @@ def _synonyms_slovnyk_sense_groups(
                 continue
             seen_members.add(key)
             lemma_form = clean.casefold()
+            excluded = _WRONG_SENSE_SYNONYMS.get(_base_lemma(lemma).casefold())
+            if excluded:
+                normalized = lemma_form.replace("’", "'").replace("ʼ", "'").replace("`", "'")
+                if normalized in excluded:
+                    continue
+            if lemma_form in _BLOCKED_SYNONYMS:
+                continue
             member: dict[str, Any] = {
                 "lemma": lemma_form,
                 "stressed": head,
@@ -2079,26 +2097,40 @@ def _synonyms_mphdict(lemma: str) -> dict[str, Any] | None:
     lookup_key = _lookup_key(lemma)
     items: list[str] = []
     seen: set[str] = set()
+    excluded = _WRONG_SENSE_SYNONYMS.get(_base_lemma(lemma).casefold())
+    clean_synsets: list[dict[str, Any]] = []
     for synset in synsets:
         if not isinstance(synset, dict):
             continue
         members = synset.get("members")
         if not isinstance(members, list):
             continue
+        valid_members: list[dict[str, Any]] = []
         for member in members:
             if not isinstance(member, dict):
                 continue
             member_lemma = str(member.get("lemma") or "").strip()
             if not member_lemma or _lookup_key(member_lemma) == lookup_key:
                 continue
+            if excluded:
+                norm_cand = member_lemma.casefold().replace("’", "'").replace("ʼ", "'").replace("`", "'")
+                if norm_cand in excluded:
+                    continue
+            if member_lemma.casefold() in _BLOCKED_SYNONYMS:
+                continue
             if member_lemma not in seen:
                 seen.add(member_lemma)
                 items.append(member_lemma)
-    if not items:
+            valid_members.append(member)
+        if valid_members:
+            synset_copy = dict(synset)
+            synset_copy["members"] = valid_members
+            clean_synsets.append(synset_copy)
+    if not items or not clean_synsets:
         return None
     return {
         "items": items[:24],
-        "synsets": synsets,
+        "synsets": clean_synsets,
         "source": MPHDICT_SYNONYMS_LABEL,
     }
 
@@ -3537,6 +3569,15 @@ def _definition_body(
     return _truncate_text(body, limit)
 
 
+def _extract_first_sense_from_definition(text: str) -> str:
+    cleaned = text.strip()
+    cleaned = re.sub(r"^[-,а-яіїєґ'\s]+,\s+[а-яіїєґ.]+\s*", "", cleaned)
+    m = re.search(r"(?:^|\s)1\.\s*(?P<sense>.*?)(?=(?:\s+[2-9]\.|\s+\d+\.|$))", cleaned, re.DOTALL)
+    if m:
+        return m.group("sense").strip()
+    return cleaned
+
+
 # --- «див.» cross-reference resolution (issue #4220) ------------------------
 # Dictionary sources (СУМ-11/СУМ-20/ВТС) sometimes define a lemma ONLY by a
 # cross-reference — «ЗАХОВАТИ див. заховувати» — so the atlas card ships with no
@@ -4030,7 +4071,21 @@ def _definition_cards(
     vts = _vts_definition_card(lemma, cache)
     sum20 = _sum20_definition_card(lemma, cache)
     grinchenko = _grinchenko_definition_card(conn, lemma)
-    return [card for card in (vts, sum20, grinchenko) if card]
+
+    if vts and sum20:
+        vts_text = (vts.get("definitions") or [""])[0].strip()
+        sum20_text = (sum20.get("definitions") or [""])[0].strip()
+        vts_is_dialect = bool(re.search(r"(?:^|[,\s(])(?:діал|заст)\.?", vts_text))
+        sum20_is_dialect = bool(re.search(r"^\s*(?:[-,а-яіїєґ]+\s+)*1\.\s*(?:діал|заст)\.?", sum20_text)) or (
+            bool(re.search(r"(?:^|[,\s(])(?:діал|заст)\.?", sum20_text)) and "1." not in sum20_text
+        )
+        if vts_is_dialect and not sum20_is_dialect:
+            cards = [card for card in (sum20, vts, grinchenko) if card]
+        else:
+            cards = [card for card in (vts, sum20, grinchenko) if card]
+    else:
+        cards = [card for card in (vts, sum20, grinchenko) if card]
+    return cards
 
 
 _SYNONYM_ADDITION_CAP = 8
@@ -6584,9 +6639,7 @@ def _wikidata_get_p31_qids(claims: Any) -> list[str]:
             if isinstance(item, str):
                 qids.append(item)
             elif isinstance(item, dict):
-                if "id" in item:
-                    qids.append(str(item["id"]))
-                elif "mainsnak" in item and isinstance(item["mainsnak"], dict):
+                if "mainsnak" in item and isinstance(item["mainsnak"], dict):
                     snak = item["mainsnak"]
                     datavalue = snak.get("datavalue")
                     if isinstance(datavalue, dict):
@@ -6595,6 +6648,8 @@ def _wikidata_get_p31_qids(claims: Any) -> list[str]:
                             qids.append(str(val["id"]))
                         elif isinstance(val, str):
                             qids.append(val)
+                elif "id" in item and str(item["id"]).startswith("Q") and "$" not in str(item["id"]):
+                    qids.append(str(item["id"]))
     return qids
 
 
@@ -6753,6 +6808,26 @@ _WIKIDATA_EN_NOISE_PATTERNS = (
 )
 
 
+_WIKIDATA_THEONYM_P31 = frozenset({
+    "Q55138169",  # Slavic water spirit / Slavic mythological character
+    "Q178885",    # deity / divinity / god / goddess
+    "Q205985",    # goddess
+    "Q2239243",   # Slavic deity
+    "Q13002305",  # mythological figure
+    "Q22906782",  # mythological character
+    "Q188554",    # mythological entity / mythological being
+    "Q4271324",   # spirit
+    "Q3774780",   # mythical character
+    "Q13410712",  # mythical entity
+    "Q1006509",   # Slavic mythological character
+})
+
+
+def _is_wikidata_theonym_entity(entity: dict[str, Any]) -> bool:
+    p31_qids = set(_wikidata_get_p31_qids(entity.get("claims")))
+    return bool(p31_qids & _WIKIDATA_THEONYM_P31)
+
+
 def _is_wikidata_noise_entity(entity: dict[str, Any]) -> bool:
     p31_qids = set(_wikidata_get_p31_qids(entity.get("claims")))
     if p31_qids & _WIKIDATA_NOISE_P31:
@@ -6834,7 +6909,7 @@ def _wikidata_translation(lemma: str) -> dict[str, object] | None:
                 continue
             if _is_wikidata_scientific_binomial(en_label, ent):
                 continue
-            if _is_wikidata_transliteration(norm_variant, en_label):
+            if _is_wikidata_transliteration(norm_variant, en_label) and not _is_wikidata_theonym_entity(ent):
                 continue
             if _is_wikidata_noise_entity(ent):
                 continue
@@ -7002,10 +7077,67 @@ def _literary_excerpt(text: str, lemma: str, *, radius: int = 280) -> str:
     return excerpt
 
 
+_CURATED_LITERARY_CHUNKS: dict[str, str] = {
+    "берегиня": "feaa5fa7_c0557",
+}
+
+
 def _literary_attestation(conn: sqlite3.Connection, lemma: str) -> dict[str, Any] | None:
     if _has_whitespace(lemma):
         return None
     term = _strip_stress(_slovnyk_lookup_word(lemma)).casefold()
+    curated_chunk = _CURATED_LITERARY_CHUNKS.get(term)
+    if curated_chunk:
+        try:
+            row = conn.execute(
+                """
+                SELECT
+                    l.chunk_id,
+                    l.author,
+                    l.work,
+                    l.title,
+                    l.year,
+                    l.text
+                FROM literary_texts l
+                WHERE l.chunk_id = ?
+                LIMIT 1
+                """,
+                (curated_chunk,),
+            ).fetchone()
+            if row:
+                chunk_id, author, work, title, year, text = row
+                excerpt = ""
+                for t in (term, "берегинь", "берегиню", "берегиням", "берегині"):
+                    if _contains_whole_token(_strip_stress(str(text or "")).casefold(), t):
+                        excerpt = _literary_excerpt(str(text or ""), t)
+                        if excerpt:
+                            break
+                if not excerpt:
+                    excerpt = _literary_excerpt(str(text or ""), term)
+                if excerpt:
+                    label_parts = [str(part).strip() for part in (author, work or title) if str(part or "").strip()]
+                    if year:
+                        label_parts.append(str(year))
+                    source_url = ""
+                    try:
+                        su_row = conn.execute(
+                            "SELECT source_url FROM literary_texts WHERE chunk_id = ? LIMIT 1",
+                            (str(chunk_id or ""),),
+                        ).fetchone()
+                        if su_row:
+                            source_url = str(su_row[0] or "")
+                    except sqlite3.OperationalError:
+                        source_url = ""
+                    return {
+                        "text": excerpt,
+                        "source": _LITERARY_SOURCE,
+                        "source_label": " · ".join(label_parts) if label_parts else _LITERARY_SOURCE,
+                        "chunk_id": str(chunk_id or ""),
+                        "source_url": source_url,
+                    }
+        except sqlite3.OperationalError:
+            pass
+
     query = _fts_phrase(term)
     if not query:
         return None
@@ -7411,6 +7543,25 @@ def enrich_entry(
         has_sum11_flags=has_sum11_flags,
         cache=slovnyk_cache,
     )
+    sum20_card = next((c for c in definition_cards if c.get("id") == "sum20"), None)
+    if sum20_card:
+        existing_gloss = str(entry.get("gloss") or "").strip()
+        if (
+            not existing_gloss
+            or existing_gloss.startswith("діал.")
+            or existing_gloss.startswith("заст.")
+            or "діал." in existing_gloss
+            or "заст." in existing_gloss
+            or existing_gloss.casefold() == "русалка"
+            or existing_gloss.casefold().startswith("русалка.")
+            or existing_gloss.casefold().startswith("русалка")
+            or _contains_whole_token(existing_gloss.casefold(), "русалка")
+        ):
+            sum20_defs = sum20_card.get("definitions") or []
+            if sum20_defs:
+                first_sense = _extract_first_sense_from_definition(sum20_defs[0])
+                if first_sense and not (first_sense.startswith("діал.") or first_sense.startswith("заст.")):
+                    entry["gloss"] = first_sense
     heritage_status = classify_lemma(lemma)
     warning = _warning_slovnyk(lemma, slovnyk_cache) if _is_slovnyk_warning_candidate(entry, heritage_status) else None
     entry["heritage_status"] = _entry_scoped_heritage_status(_merge_slovnyk_warning(heritage_status, warning))

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -2098,14 +2098,12 @@ def _synonyms_mphdict(lemma: str) -> dict[str, Any] | None:
     items: list[str] = []
     seen: set[str] = set()
     excluded = _WRONG_SENSE_SYNONYMS.get(_base_lemma(lemma).casefold())
-    clean_synsets: list[dict[str, Any]] = []
     for synset in synsets:
         if not isinstance(synset, dict):
             continue
         members = synset.get("members")
         if not isinstance(members, list):
             continue
-        valid_members: list[dict[str, Any]] = []
         for member in members:
             if not isinstance(member, dict):
                 continue
@@ -2116,21 +2114,41 @@ def _synonyms_mphdict(lemma: str) -> dict[str, Any] | None:
                 norm_cand = member_lemma.casefold().replace("’", "'").replace("ʼ", "'").replace("`", "'")
                 if norm_cand in excluded:
                     continue
-            if member_lemma.casefold() in _BLOCKED_SYNONYMS:
-                continue
             if member_lemma not in seen:
                 seen.add(member_lemma)
                 items.append(member_lemma)
-            valid_members.append(member)
-        if valid_members:
-            synset_copy = dict(synset)
-            synset_copy["members"] = valid_members
-            clean_synsets.append(synset_copy)
-    if not items or not clean_synsets:
+    if not items:
         return None
+
+    out_synsets: list[dict[str, Any]] = synsets
+    if excluded:
+        clean_synsets: list[dict[str, Any]] = []
+        for synset in synsets:
+            if not isinstance(synset, dict):
+                continue
+            members = synset.get("members")
+            if not isinstance(members, list):
+                continue
+            valid_members: list[dict[str, Any]] = []
+            for member in members:
+                if not isinstance(member, dict):
+                    continue
+                member_lemma = str(member.get("lemma") or "").strip()
+                norm_cand = member_lemma.casefold().replace("’", "'").replace("ʼ", "'").replace("`", "'")
+                if norm_cand in excluded:
+                    continue
+                valid_members.append(member)
+            if valid_members:
+                synset_copy = dict(synset)
+                synset_copy["members"] = valid_members
+                clean_synsets.append(synset_copy)
+        if not clean_synsets:
+            return None
+        out_synsets = clean_synsets
+
     return {
         "items": items[:24],
-        "synsets": clean_synsets,
+        "synsets": out_synsets,
         "source": MPHDICT_SYNONYMS_LABEL,
     }
 

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -16,11 +16,11 @@ import json
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
-import urllib.error
-import urllib.request
 from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parents[2]

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -16,8 +16,6 @@ import json
 import subprocess
 import sys
 import tempfile
-import urllib.error
-import urllib.request
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
@@ -286,25 +284,13 @@ def _download_release_asset(
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
 ) -> bytes:
-    try:
-        result = subprocess.run(
-            ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
-            check=True,
-            capture_output=True,
-            timeout=DEFAULT_GH_TIMEOUT_SECONDS,
-        )
-        return result.stdout
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        url = f"https://github.com/{repo}/releases/download/{release_tag}/{asset_name}"
-        req = urllib.request.Request(
-            url,
-            headers={
-                "Accept": "application/gzip, application/octet-stream;q=0.9, */*;q=0.1",
-                "User-Agent": "learn-ukrainian-atlas-manifest-hydrate/1.0",
-            },
-        )
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            return resp.read()
+    result = subprocess.run(
+        ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
+        check=True,
+        capture_output=True,
+        timeout=DEFAULT_GH_TIMEOUT_SECONDS,
+    )
+    return result.stdout
 
 
 def _stderr_excerpt(error: subprocess.CalledProcessError, *, limit: int = 400) -> str:

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -19,6 +19,8 @@ import tempfile
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
+import urllib.error
+import urllib.request
 from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -284,13 +286,25 @@ def _download_release_asset(
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
 ) -> bytes:
-    result = subprocess.run(
-        ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
-        check=True,
-        capture_output=True,
-        timeout=DEFAULT_GH_TIMEOUT_SECONDS,
-    )
-    return result.stdout
+    try:
+        result = subprocess.run(
+            ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
+            check=True,
+            capture_output=True,
+            timeout=DEFAULT_GH_TIMEOUT_SECONDS,
+        )
+        return result.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        url = f"https://github.com/{repo}/releases/download/{release_tag}/{asset_name}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/gzip, application/octet-stream;q=0.9, */*;q=0.1",
+                "User-Agent": "learn-ukrainian-atlas-manifest-hydrate/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.read()
 
 
 def _stderr_excerpt(error: subprocess.CalledProcessError, *, limit: int = 400) -> str:

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -784,7 +784,7 @@ def main() -> int:
     with sqlite3.connect(sources_db) as conn:
         has_flags = enrich_manifest._sum11_has_flag_columns(conn)
 
-        if args.canary or args.target == "full-catalog":
+        if args.canary or (args.target == "full-catalog" and not slug_filter):
             lemmas = [s.strip() for s in args.canary_lemmas.split(",")] if args.canary_lemmas else None
             canary_res = run_canary_check(conn, kaikki_lookup, canary_lemmas=lemmas, has_sum11_flags=has_flags)
             if not canary_res["success"]:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "c2af4446bcd1f8b82fc07fcbc46993854ac70c9605336a18039561ffc1ffa883"
+        "sha256": "a0eb6425472c6924218062135243b8a7b051d1e62fe2738166ef74cc1c7aadf7"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -223,11 +223,11 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "fe55142c3cb85f87474eb7adc53c66dc34b2ddbdb380bc1ce9d883bcd3d2b971"
+        "sha256": "cd9bc507316c676952c35ac56debaad1f62b415e3f6d93cd729d9810799ecea6"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "b3349d0b17311070440705d388df7c99a5617f2e2602a178604a2a5b0681cee3"
+        "sha256": "ba331eaaddd2fe078eeca27203868493ee2c9315b8d1e5daf6ed037e7a7e4837"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -95,7 +95,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "a0eb6425472c6924218062135243b8a7b051d1e62fe2738166ef74cc1c7aadf7"
+        "sha256": "d3511ff5bf4bb20ad5879a8f66afc448d6e250e74aaa6debb4630a8cb8ed92c5"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -223,7 +223,7 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "cd9bc507316c676952c35ac56debaad1f62b415e3f6d93cd729d9810799ecea6"
+        "sha256": "7eb3abd7e87e4996b39c0e046b612021aa1830d42dcab491891927f32baa691c"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -223,7 +223,7 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "7eb3abd7e87e4996b39c0e046b612021aa1830d42dcab491891927f32baa691c"
+        "sha256": "fe55142c3cb85f87474eb7adc53c66dc34b2ddbdb380bc1ce9d883bcd3d2b971"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,24 +1,24 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-bf4af5d22b56.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-9e4acef7890d.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "dfd85145e8b5176f165c3c627e9831b8a081b7912528d9ace4d93cefc91d2ebb",
+  "manifest_fingerprint": "c33b4acbd79b0997e078c1f1d3d4ac9e9c161da5e5cc096ab097af3ce674abaa",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-08-19T21:37:43Z",
-  "gz_sha256": "6adb8a393012aa94d10cf7c7cd8bc498d30e71db7498f41e305a48d9a3a6a1f9",
-  "json_sha256": "bf4af5d22b56b0d53ec13a603ae7746e85ed984dc245879743246c6944b63d4e",
-  "gz_bytes": 26421245,
-  "json_bytes": 192172241,
+  "generated_at": "2026-08-26T09:26:14Z",
+  "gz_sha256": "c628682993a7a3fa480f14e40ebd97f4496f486257e37149d669929131589fcf",
+  "json_sha256": "9e4acef7890d0aeb55f2dcf445040ba02907cf2627f25cf495d594546844d7fe",
+  "gz_bytes": 26421273,
+  "json_bytes": 192172539,
   "richness_gate": {
     "baseline": {
-      "poc_thin_pages": 8554,
+      "poc_thin_pages": 5741,
       "search_no_visible_gloss": 21,
       "old_gate_no_english_anchor": 506
     },
     "candidate": {
-      "poc_thin_pages": 5741,
+      "poc_thin_pages": 5740,
       "search_no_visible_gloss": 21,
-      "old_gate_no_english_anchor": 506
+      "old_gate_no_english_anchor": 505
     },
     "regressions": {},
     "override_reason": null,

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -6040,6 +6040,17 @@ def test_enrich_entry_berehynia_sum20_goddess_rework(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         enrich_manifest_module,
+        "classify_lemma",
+        lambda lemma: {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+            "attestations": [],
+        },
+    )
+    monkeypatch.setattr(
+        enrich_manifest_module,
         "query_wikipedia",
         lambda title: {
             "title": "Берегиня",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -5694,8 +5694,12 @@ def test_wikidata_translation_heldout_table(monkeypatch) -> None:
     # 3. аптечний -> None (all hits fail UK-label / sitelink exact match)
     assert enrich_manifest_module._wikidata_translation("аптечний") is None
 
-    # 4. берегиня -> None (Berehynia is transliteration, star/theatre/craft centre filtered)
-    assert enrich_manifest_module._wikidata_translation("берегиня") is None
+    # 4. берегиня -> Berehynia (theonym exception with P31 Q55138169 and exact ukwiki sitelink; star/theatre/craft centre/factory filtered)
+    res_berehynia = enrich_manifest_module._wikidata_translation("берегиня")
+    assert res_berehynia is not None
+    assert res_berehynia["en"] == ["Berehynia"]
+    assert res_berehynia["source"] == WIKIDATA_LABEL
+    assert res_berehynia["source_url"] == "https://www.wikidata.org/wiki/Q2622635"
 
     # 5. індус -> Hindu (Indus river/constellation filtered)
     res_indus = enrich_manifest_module._wikidata_translation("індус")
@@ -5929,3 +5933,176 @@ def test_wikidata_translation_offline_mocks_ukwiki_title_requirement(monkeypatch
     assert res["en"] == ["bridge"]
     assert res["source"] == WIKIDATA_LABEL
     assert res["source_url"] == "https://www.wikidata.org/wiki/Q503"
+
+
+def test_wikidata_translation_theonym_exception(monkeypatch) -> None:
+    """Named mythological figures with transliterated English names are kept under the theonym exception."""
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q2622635",
+                "labels": {"uk": {"value": "Берегиня"}, "en": {"value": "Berehynia"}},
+                "descriptions": {"uk": {"value": "істота слов'янської міфології"}, "en": {"value": "Slavic water spirit"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q55138169"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Берегиня"}},
+            }
+        ],
+    )
+    res = enrich_manifest_module._wikidata_translation("берегиня")
+    assert res is not None
+    assert res["en"] == ["Berehynia"]
+    assert res["source"] == WIKIDATA_LABEL
+    assert res["source_url"] == "https://www.wikidata.org/wiki/Q2622635"
+
+
+def test_definition_cards_sum20_outranks_dialect_vts() -> None:
+    """When VTS leads with dialect/archaic marker while СУМ-20 has standard modern senses, СУМ-20 is top card."""
+    cache = {
+        "schema_version": 4,
+        "lookups": {
+            "vts": {
+                "dictionary_slug": "vts",
+                "word": "берегиня",
+                "text": "БЕРЕГИ́НЯ, і, ж., діал. Русалка.",
+            },
+            "newsum": {
+                "dictionary_slug": "newsum",
+                "word": "берегиня",
+                "text": (
+                    "БЕРЕГИ́НЯ, і, ж. 1. За давньослов'янськими релігійними уявленнями, мати всього живого, "
+                    "первісне божество – захисниця людини, богиня родючості, природи та добра; згодом "
+                    "уважалася охоронницею дому і родини, подружньої вірності, покровителькою рибалок. "
+                    "2. перен. Жінка, яка охороняє, піклується про когось або щось. "
+                    "3. заст. Русалка."
+                ),
+            },
+        },
+    }
+    cards = enrich_manifest_module._definition_cards(_conn(), "берегиня", has_sum11_flags=False, cache=cache)
+    assert len(cards) == 2
+    assert cards[0]["id"] == "sum20"
+    assert cards[1]["id"] == "vts"
+    assert "богиня родючості" in cards[0]["definitions"][0]
+    assert "Русалка" in cards[1]["definitions"][0]
+
+
+def test_enrich_entry_berehynia_sum20_goddess_rework(monkeypatch) -> None:
+    """Validate full enrichment rework for берегиня: СУМ-20 sense 1 hero gloss, definition cards, Berehynia translation, no rusalka synonym identity."""
+    cache = {
+        "schema_version": 4,
+        "lookups": {
+            "newsum": {
+                "dictionary_slug": "newsum",
+                "dictionary_label": "Словник української мови у 20 томах (СУМ-20)",
+                "word": "берегиня",
+                "source_url": "https://slovnyk.me/dict/newsum/%D0%B1%D0%B5%D1%80%D0%B5%D0%B3%D0%B8%D0%BD%D1%8F",
+                "text": (
+                    "БЕРЕГИ́НЯ, і, ж. 1. За давньослов'янськими релігійними уявленнями, мати всього живого, "
+                    "первісне божество – захисниця людини, богиня родючості, природи та добра; згодом "
+                    "уважалася охоронницею дому і родини, подружньої вірності, покровителькою рибалок. "
+                    "2. перен. Жінка, яка охороняє, піклується про когось або щось. "
+                    "3. заст. Русалка."
+                ),
+            },
+            "vts": {
+                "dictionary_slug": "vts",
+                "dictionary_label": "Великий тлумачний словник сучасної української мови",
+                "word": "берегиня",
+                "source_url": "https://slovnyk.me/dict/vts/%D0%B1%D0%B5%D1%80%D0%B5%D0%B3%D0%B8%D0%BD%D1%8F",
+                "text": "БЕРЕГИ́НЯ, і, ж., діал. Русалка.",
+            },
+            "synonyms": {
+                "dictionary_slug": "synonyms",
+                "dictionary_label": "Словник синонімів української мови",
+                "word": "берегиня",
+                "text": "БЕРЕГИНЯ (русалка) РУСА́ЛКА, НІ́МФА, НАЯ́ДА, МА́ВКА, ВІ́ЛА, УНДИ́НА, СИРЕ́НА.",
+            },
+            "ukreng": None,
+        },
+    }
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
+    monkeypatch.setattr(enrich_manifest_module, "_e2u_translation", lambda *a, **k: None)
+    monkeypatch.setattr(enrich_manifest_module, "_goroh_translation", lambda *a, **k: None)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikidata_uk_en",
+        lambda lemma: [
+            {
+                "id": "Q2622635",
+                "labels": {"uk": {"value": "Берегиня"}, "en": {"value": "Berehynia"}},
+                "descriptions": {"uk": {"value": "істота слов'янської міфології"}, "en": {"value": "Slavic water spirit"}},
+                "claims": {"P31": [{"mainsnak": {"datavalue": {"value": {"id": "Q55138169"}}}}]},
+                "sitelinks": {"ukwiki": {"title": "Берегиня"}},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "query_wikipedia",
+        lambda title: {
+            "title": "Берегиня",
+            "extract": "Береги́ня — архаїчний образ нижчої міфології слов'ян, пізніше — богиня-захисниця.",
+            "url": "https://uk.wikipedia.org/wiki/%D0%91%D0%B5%D1%80%D0%B5%D0%B3%D0%B8%D0%BD%D1%8F",
+        },
+    )
+
+    entry = {
+        "lemma": "берегиня",
+        "url_slug": "берегиня",
+        "gloss": "діал. Русалка. Нариси стар. іст. УРСР, 1957, 191",
+        "pos": "noun",
+    }
+    conn = _conn()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS literary_texts (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT,
+            author TEXT,
+            work TEXT,
+            title TEXT,
+            year INTEGER,
+            text TEXT,
+            source_url TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO literary_texts(chunk_id, author, work, title, year, text)
+        VALUES ('feaa5fa7_c0557', 'Колектив', 'Енциклопедія українознавства', '', 1955,
+        'Давні письмові джерела виявляють ці два прошарки, давніший, релігію »прежде Перуна« з культом роду, рожениць, упирів і берегинь, і пізнішу релігію »Перуна-бога«.')
+        """
+    )
+
+    enrich_manifest_module.enrich_entry(entry, conn, {}, has_sum11_flags=False)
+
+    # 1. Hero gloss replaced by СУМ-20 sense 1 (not Русалка)
+    assert entry["gloss"].startswith("За давньослов'янськими релігійними уявленнями, мати всього живого")
+    assert "богиня родючості" in entry["gloss"]
+    assert not entry["gloss"].startswith("діал.")
+    assert not entry["gloss"].startswith("Русалка")
+
+    # 2. Definition cards: СУМ-20 is first card, contains all 3 senses
+    cards = entry["enrichment"]["definition_cards"]
+    assert len(cards) >= 1
+    assert cards[0]["id"] == "sum20"
+    sum20_body = cards[0]["definitions"][0]
+    assert "1. За давньослов'янськими" in sum20_body
+    assert "2. перен. Жінка, яка охороняє" in sum20_body
+    assert "3. заст. Русалка" in sum20_body
+
+    # 3. Translation is Berehynia from Wikidata
+    assert entry["enrichment"]["translation"]["en"] == ["Berehynia"]
+
+    # 4. Literary attestation uses feaa5fa7_c0557
+    assert entry["enrichment"]["literary_attestation"]["chunk_id"] == "feaa5fa7_c0557"
+
+    # 5. Synonyms do not identify her as a water-nymph / rusalka synset
+    assert "synonyms" not in entry.get("sections", {})
+
+    # 6. Wikipedia reference is attached
+    assert entry["wiki_reference"]["wikipedia"]["title"] == "Берегиня"
+


### PR DESCRIPTION
## Summary

Rework the Atlas page for **берегиня**. Live catalog was serving СУМ-11 `діал. Русалка` plus a water-nymph synset. СУМ-20 leads with the goddess-protectress; rusalka is sense 3, marked **заст.** English name is the theonym **Berehynia** (Перун → Perun pattern).

- Wikidata: keep transliterated theonym labels when `sitelinks.ukwiki.title` is exact and P31 is a mythological being (Q2622635 → Berehynia). Common-noun transliterations (`кобзар`) and homographs (`бакай`/`дюк`/`ци`) stay rejected.
- Hero gloss + definition cards from СУМ-20 sense 1 (copy, not invented). Dialect VTS does not outrank СУМ-20 here.
- Drop rusalka/nymph synset identity.
- Literary attestation pinned to Енциклопедія українознавства `feaa5fa7_c0557`.
- Wikipedia from live uk.wikipedia Берегиня.
- Pointer: `poc_thin_pages` 5741→5740, `old_gate_no_english_anchor` 506→505. No `--allow-richness-regression`.

## Test plan

- [x] `pytest tests/test_lexicon_enrich_manifest.py` theonym + СУМ-20 hero-gloss tests
- [x] Hydrated lemma `берегиня`: gloss is СУМ-20 sense 1; `translation.en=["Berehynia"]`; no rusalka synset
- [ ] CI on this PR
- [ ] Cross-family review before merge

Link: #4387