### PR TITLE
fix(cycle007): match reviewed Grok CLI surface

### DIFF
--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -777,7 +777,6 @@ def _provider_command(provider: Path) -> list[str]:
         "--permission-mode",
         "plan",
         "--no-alt-screen",
-        "--no-memory",
         "--no-subagents",
         "--disable-web-search",
         "--verbatim",

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -516,6 +516,25 @@ def grok_prompt(challenge: str, rows: list[dict[str, Any]], sidecar: dict[str, A
     ).encode("utf-8")
 
 
+def _grok_command(provider_bin: Path) -> list[str]:
+    """Build the reviewed native Grok CLI invocation."""
+    return [
+        str(provider_bin),
+        "--model",
+        GROK_MODEL,
+        "--reasoning-effort",
+        "high",
+        "--output-format",
+        "plain",
+        "--permission-mode",
+        "plan",
+        "--no-alt-screen",
+        "--no-subagents",
+        "--disable-web-search",
+        "--verbatim",
+    ]
+
+
 def _agy_stream(raw: bytes, *, expected_cwd: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     try:
         events = [
@@ -1061,22 +1080,7 @@ def invoke_canary(
             prompt_bytes = grok_prompt(challenge, rows, sidecar)
             stdin_path = runtime / "prompt.stdin"
             _atomic(stdin_path, prompt_bytes, raw=True)
-            cmd = [
-                str(provider_bin),
-                "--model",
-                GROK_MODEL,
-                "--reasoning-effort",
-                "high",
-                "--output-format",
-                "plain",
-                "--permission-mode",
-                "plan",
-                "--no-alt-screen",
-                "--no-memory",
-                "--no-subagents",
-                "--disable-web-search",
-                "--verbatim",
-            ]
+            cmd = _grok_command(provider_bin)
 
         attempt = 1
         provider_calls = 0

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -136,6 +136,20 @@ def test_batch_stream_input_command_has_no_print_prompt() -> None:
     assert "--new-project" in command
 
 
+def test_grok_commands_use_only_the_reviewed_cli_isolation_flags() -> None:
+    canary = _load_runner()
+    path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_grok_batch_command_test", path)
+    assert spec is not None and spec.loader is not None
+    batch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(batch)
+
+    expected_isolation_flags = {"--permission-mode", "--no-alt-screen", "--no-subagents", "--disable-web-search"}
+    for command in (canary._grok_command(Path("/provider")), batch._provider_command(Path("/provider"))):
+        assert expected_isolation_flags <= set(command)
+        assert "--no-memory" not in command
+
+
 def test_batch_stream_rejects_reported_cwd_mismatch(tmp_path: Path) -> None:
     path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
     spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_cwd_test", path)


### PR DESCRIPTION
## Outcome
Match the Cycle007 Grok canary and labeling commands to the exact reviewed native CLI surface.

## Scope
- remove the unsupported no-memory flag from both Grok commands
- share the canary command shape through a testable helper
- add an exact regression covering required isolation flags and excluding the unsupported flag

No prompt, provider schema, model, endpoint, validator, evidence, custody, retry policy, or labeling data changed.

## Verification
- Ruff: pass
- Focused pytest: 71 pass
- Real canary failure motivating the fix: provider_process_nonzero_exit
- Reviewed executable help confirms every retained flag and rejects only the removed flag

Refs #6375