### PR TITLE
fix(cycle007): bind Grok prompts explicitly

### DIFF
--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -789,8 +789,8 @@ def _run_provider(provider: Path, prompt_bytes: bytes, package: Path) -> subproc
     descriptor, raw_prompt_path = tempfile.mkstemp(prefix=".cycle007-grok-prompt-", dir=package)
     prompt_path = Path(raw_prompt_path)
     try:
-        os.fchmod(descriptor, 0o600)
         with os.fdopen(descriptor, "wb") as handle:
+            os.fchmod(handle.fileno(), 0o600)
             handle.write(prompt_bytes)
             handle.flush()
             os.fsync(handle.fileno())

--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -765,9 +765,11 @@ def _verify_sealed(
     }
 
 
-def _provider_command(provider: Path) -> list[str]:
+def _provider_command(provider: Path, prompt_path: Path) -> list[str]:
     return [
         str(provider),
+        "--prompt-file",
+        str(prompt_path),
         "--model",
         "grok-4.5",
         "--reasoning-effort",
@@ -781,6 +783,26 @@ def _provider_command(provider: Path) -> list[str]:
         "--disable-web-search",
         "--verbatim",
     ]
+
+
+def _run_provider(provider: Path, prompt_bytes: bytes, package: Path) -> subprocess.CompletedProcess[bytes]:
+    descriptor, raw_prompt_path = tempfile.mkstemp(prefix=".cycle007-grok-prompt-", dir=package)
+    prompt_path = Path(raw_prompt_path)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(prompt_bytes)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return subprocess.run(
+            _provider_command(provider, prompt_path),
+            input=prompt_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    finally:
+        prompt_path.unlink(missing_ok=True)
 
 
 def _provider_mode(
@@ -891,13 +913,7 @@ def run_packet(
             )
             raw_capture: bytes | None = None
             try:
-                run = subprocess.run(
-                    _provider_command(provider),
-                    input=prompt_bytes,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
-                    check=False,
-                )
+                run = _run_provider(provider, prompt_bytes, package)
                 if run.returncode != 0:
                     raise Invalid("stream_json_invalid")
                 raw_capture = run.stdout

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -516,10 +516,12 @@ def grok_prompt(challenge: str, rows: list[dict[str, Any]], sidecar: dict[str, A
     ).encode("utf-8")
 
 
-def _grok_command(provider_bin: Path) -> list[str]:
+def _grok_command(provider_bin: Path, prompt_path: Path) -> list[str]:
     """Build the reviewed native Grok CLI invocation."""
     return [
         str(provider_bin),
+        "--prompt-file",
+        str(prompt_path),
         "--model",
         GROK_MODEL,
         "--reasoning-effort",
@@ -1080,7 +1082,7 @@ def invoke_canary(
             prompt_bytes = grok_prompt(challenge, rows, sidecar)
             stdin_path = runtime / "prompt.stdin"
             _atomic(stdin_path, prompt_bytes, raw=True)
-            cmd = _grok_command(provider_bin)
+            cmd = _grok_command(provider_bin, stdin_path)
 
         attempt = 1
         provider_calls = 0

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -145,9 +145,41 @@ def test_grok_commands_use_only_the_reviewed_cli_isolation_flags() -> None:
     spec.loader.exec_module(batch)
 
     expected_isolation_flags = {"--permission-mode", "--no-alt-screen", "--no-subagents", "--disable-web-search"}
-    for command in (canary._grok_command(Path("/provider")), batch._provider_command(Path("/provider"))):
+    prompt_path = Path("/private/prompt")
+    for command in (
+        canary._grok_command(Path("/provider"), prompt_path),
+        batch._provider_command(Path("/provider"), prompt_path),
+    ):
         assert expected_isolation_flags <= set(command)
         assert "--no-memory" not in command
+        assert command.count("--prompt-file") == 1
+        assert command[command.index("--prompt-file") + 1] == str(prompt_path)
+
+
+def test_grok_batch_binds_and_removes_private_prompt_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_grok_batch_prompt_test", path)
+    assert spec is not None and spec.loader is not None
+    batch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(batch)
+    observed: dict[str, Path] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> object:
+        prompt_path = Path(command[command.index("--prompt-file") + 1])
+        observed["prompt_path"] = prompt_path
+        assert prompt_path.parent == tmp_path
+        assert prompt_path.read_bytes() == b"public prompt"
+        assert prompt_path.stat().st_mode & 0o777 == 0o600
+        assert kwargs["input"] == b"public prompt"
+        return batch.subprocess.CompletedProcess(command, 0, stdout=b"{}", stderr=b"")
+
+    monkeypatch.setattr(batch.subprocess, "run", fake_run)
+    result = batch._run_provider(Path("/provider"), b"public prompt", tmp_path)
+
+    assert result.returncode == 0
+    assert not observed["prompt_path"].exists()
 
 
 def test_batch_stream_rejects_reported_cwd_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome
Bind Cycle007 Grok prompts through the native CLI's reviewed prompt-file interface instead of unsupported stdin-only invocation.

## Scope
- pass the existing canary prompt file explicitly to the Grok command
- create a private mode-0600 batch prompt file per attempt
- remove the batch prompt file after the provider call
- retain existing stdin payload for synthetic-fixture compatibility
- test exact prompt-file command binding, mode, bytes, and cleanup

No prompt text, provider schema, model, endpoint, validator, evidence, custody identity, retry policy, or labeling data changed.

## Verification
- Ruff: pass
- Focused pytest: 72 pass
- Exact reviewed CLI confirms prompt-file support and no stdin prompt contract
- Real failure motivating the fix: provider_process_nonzero_exit

Refs #6375