### PR TITLE
fix(cycle007): constrain Grok JSON transport

### DIFF
--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -17,6 +17,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -563,34 +564,40 @@ def validate(
         raise _semantic_failure(exc) from exc
 
 
-def _decode_provider(raw: bytes, packet_value: dict[str, Any], sidecar_value: dict[str, Any] | None = None) -> bytes:
+def _strict_grok_text_json(text: str) -> Any:
+    """Decode one schema-constrained JSON value, allowing only an optional fence."""
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        lines = candidate.splitlines()
+        if len(lines) < 3 or lines[0].strip().lower() not in {"```", "```json"} or lines[-1].strip() != "```":
+            raise Invalid("stream_json_invalid")
+        candidate = "\n".join(lines[1:-1]).strip()
     try:
-        direct = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=pairs)
+        return json.loads(candidate, object_pairs_hook=pairs)
     except (UnicodeDecodeError, json.JSONDecodeError, Invalid):
-        lines = [line for line in raw.splitlines() if line.strip()]
-        if not lines:
-            raise Invalid("stream_json_invalid") from None
-        events: list[Any] = []
-        for line in lines:
-            try:
-                events.append(json.loads(line.decode("utf-8", "strict"), object_pairs_hook=pairs))
-            except (UnicodeDecodeError, json.JSONDecodeError, Invalid):
-                raise Invalid("stream_json_invalid") from None
-        results = [item for item in events if isinstance(item, dict) and item.get("event") == "result"]
-        if len(results) != 1:
-            raise Invalid("terminal_result_count_drift") from None
-        result = results[0]
-        if result.get("status") != "SUCCESS" or not isinstance(result.get("structured_output"), dict):
-            raise Invalid("structured_output_envelope_drift") from None
-        direct = result["structured_output"]
-    if isinstance(direct, dict) and "structured_output" in direct:
-        if (
-            set(direct) != {"status", "structured_output"}
-            or direct.get("status") != "SUCCESS"
-            or not isinstance(direct["structured_output"], dict)
-        ):
-            raise Invalid("structured_output_envelope_drift")
-        direct = direct["structured_output"]
+        raise Invalid("stream_json_invalid") from None
+
+
+def _decode_provider(
+    raw: bytes,
+    packet_value: dict[str, Any],
+    *,
+    expected_session_id: str,
+    sidecar_value: dict[str, Any] | None = None,
+) -> bytes:
+    try:
+        envelope = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError, Invalid):
+        raise Invalid("stream_json_invalid") from None
+    if (
+        not isinstance(envelope, dict)
+        or envelope.get("sessionId") != expected_session_id
+        or not isinstance(envelope.get("stopReason"), str)
+        or not isinstance(envelope.get("requestId"), str)
+        or not isinstance(envelope.get("text"), str)
+    ):
+        raise Invalid("structured_output_envelope_drift")
+    direct = _strict_grok_text_json(envelope["text"])
     canonical_value = canonical(direct)
     validate(packet_value["lane"], packet_value, canonical_value, sidecar=sidecar_value)
     return canonical_value
@@ -765,7 +772,83 @@ def _verify_sealed(
     }
 
 
-def _provider_command(provider: Path, prompt_path: Path) -> list[str]:
+def _label_schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    # Keep the CLI argument comfortably below the kernel's per-argument limit.
+    # The schema constrains identities to this packet; the unchanged official
+    # validator below remains authoritative for ordinal ID/hash pairing.
+    identity = {
+        "unit_id": {"enum": [row["unit_id"] for row in rows]},
+        "unit_sha256": {"enum": [row["unit_sha256"] for row in rows]},
+    }
+    if lane == "clean_label":
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "unit_id",
+                "unit_sha256",
+                "decision_code",
+                "clean_modern_standard_prose",
+                "modern_genre_id",
+                "evidence_ids",
+            ],
+            "properties": identity
+            | {
+                "decision_code": {"enum": sorted(SOURCE.REJECTS)},
+                "clean_modern_standard_prose": {"type": "boolean"},
+                "modern_genre_id": {"anyOf": [{"enum": sorted(SOURCE.GENRES)}, {"type": "null"}]},
+                "evidence_ids": {"type": "array", "items": {"type": "string"}},
+            },
+        }
+    phenomenon = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["phenomenon_id", "decision_code", "evidence_sufficiency", "evidence_ids"],
+        "properties": {
+            "phenomenon_id": {"enum": list(SOURCE.TAX)},
+            "decision_code": {"enum": sorted(SOURCE.DEC)},
+            "evidence_sufficiency": {"enum": ["sufficient", "insufficient"]},
+            "evidence_ids": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["unit_id", "unit_sha256", "phenomena", "primary_phenomenon_id", "item_decision_rollup"],
+        "properties": identity
+        | {
+            "phenomena": {"type": "array", "minItems": 1, "items": phenomenon},
+            "primary_phenomenon_id": {"anyOf": [{"enum": list(SOURCE.TAX)}, {"type": "null"}]},
+            "item_decision_rollup": {"enum": sorted(SOURCE.DEC)},
+        },
+    }
+
+
+def _provider_schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if lane not in LANES or not 1 <= len(rows) <= PACKET_SIZE:
+        raise Error("label_count_or_envelope_drift")
+    label = _label_schema(lane, rows)
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["labels"],
+        "properties": {
+            "labels": {
+                "type": "array",
+                "items": label,
+                "minItems": len(rows),
+                "maxItems": len(rows),
+            }
+        },
+    }
+
+
+def _provider_command(
+    provider: Path,
+    prompt_path: Path,
+    output_schema: dict[str, Any],
+    session_id: str,
+) -> list[str]:
     return [
         str(provider),
         "--prompt-file",
@@ -775,7 +858,11 @@ def _provider_command(provider: Path, prompt_path: Path) -> list[str]:
         "--reasoning-effort",
         "high",
         "--output-format",
-        "plain",
+        "json",
+        "--json-schema",
+        canonical(output_schema).decode("utf-8"),
+        "--session-id",
+        session_id,
         "--permission-mode",
         "plan",
         "--no-alt-screen",
@@ -785,7 +872,9 @@ def _provider_command(provider: Path, prompt_path: Path) -> list[str]:
     ]
 
 
-def _run_provider(provider: Path, prompt_bytes: bytes, package: Path) -> subprocess.CompletedProcess[bytes]:
+def _run_provider(
+    provider: Path, prompt_bytes: bytes, package: Path, output_schema: dict[str, Any]
+) -> tuple[subprocess.CompletedProcess[bytes], str]:
     descriptor, raw_prompt_path = tempfile.mkstemp(prefix=".cycle007-grok-prompt-", dir=package)
     prompt_path = Path(raw_prompt_path)
     try:
@@ -794,13 +883,15 @@ def _run_provider(provider: Path, prompt_bytes: bytes, package: Path) -> subproc
             handle.write(prompt_bytes)
             handle.flush()
             os.fsync(handle.fileno())
-        return subprocess.run(
-            _provider_command(provider, prompt_path),
+        session_id = str(uuid.uuid4())
+        completed = subprocess.run(
+            _provider_command(provider, prompt_path, output_schema, session_id),
             input=prompt_bytes,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,
         )
+        return completed, session_id
     finally:
         prompt_path.unlink(missing_ok=True)
 
@@ -913,11 +1004,18 @@ def run_packet(
             )
             raw_capture: bytes | None = None
             try:
-                run = _run_provider(provider, prompt_bytes, package)
+                run, session_id = _run_provider(
+                    provider, prompt_bytes, package, _provider_schema(lane, packet_value["rows"])
+                )
                 if run.returncode != 0:
                     raise Invalid("stream_json_invalid")
                 raw_capture = run.stdout
-                canonical_labels = _decode_provider(raw_capture, packet_value, sidecar_value=sidecar_value)
+                canonical_labels = _decode_provider(
+                    raw_capture,
+                    packet_value,
+                    expected_session_id=session_id,
+                    sidecar_value=sidecar_value,
+                )
             except Invalid as exc:
                 retryable = attempt == 1 and exc.failure_code in STRUCTURAL_CODES
                 _mark(out, lane, index, attempt, exc.failure_code, retryable=retryable)

--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -772,13 +772,13 @@ def _verify_sealed(
     }
 
 
-def _label_schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
-    # Keep the CLI argument comfortably below the kernel's per-argument limit.
-    # The schema constrains identities to this packet; the unchanged official
-    # validator below remains authoritative for ordinal ID/hash pairing.
+def _label_schema(lane: str) -> dict[str, Any]:
+    # Keep private packet identities out of process argv. The schema constrains
+    # their shape; the unchanged official validator below remains authoritative
+    # for exact ordinal ID/hash pairing against the private packet.
     identity = {
-        "unit_id": {"enum": [row["unit_id"] for row in rows]},
-        "unit_sha256": {"enum": [row["unit_sha256"] for row in rows]},
+        "unit_id": {"type": "string", "minLength": 1},
+        "unit_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     }
     if lane == "clean_label":
         return {
@@ -827,7 +827,7 @@ def _label_schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
 def _provider_schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
     if lane not in LANES or not 1 <= len(rows) <= PACKET_SIZE:
         raise Error("label_count_or_envelope_drift")
-    label = _label_schema(lane, rows)
+    label = _label_schema(lane)
     return {
         "type": "object",
         "additionalProperties": False,
@@ -860,7 +860,7 @@ def _provider_command(
         "--output-format",
         "json",
         "--json-schema",
-        canonical(output_schema).decode("utf-8"),
+        json.dumps(output_schema, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
         "--session-id",
         session_id,
         "--permission-mode",

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -27,6 +27,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -449,31 +450,34 @@ def compile_public_sidecar(
     return sidecar
 
 
+def _clean_label_schema(row: dict[str, Any]) -> dict[str, Any]:
+    """Return the existing clean-label contract pinned to one row identity."""
+    identity = {"unit_id": {"enum": [row["unit_id"]]}, "unit_sha256": {"enum": [row["unit_sha256"]]}}
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "unit_id",
+            "unit_sha256",
+            "decision_code",
+            "clean_modern_standard_prose",
+            "modern_genre_id",
+            "evidence_ids",
+        ],
+        "properties": identity
+        | {
+            "decision_code": {"enum": sorted(SOURCE.REJECTS)},
+            "clean_modern_standard_prose": {"type": "boolean"},
+            "modern_genre_id": {"anyOf": [{"enum": sorted(SOURCE.GENRES)}, {"type": "null"}]},
+            "evidence_ids": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+
+
 def gemini_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
     """Generate Gemini JSON schema requiring liveness_challenge."""
-    def label_for(row: dict[str, Any]) -> dict[str, Any]:
-        identity = {"unit_id": {"enum": [row["unit_id"]]}, "unit_sha256": {"enum": [row["unit_sha256"]]}}
-        return {
-            "type": "object",
-            "additionalProperties": False,
-            "required": [
-                "unit_id",
-                "unit_sha256",
-                "decision_code",
-                "clean_modern_standard_prose",
-                "modern_genre_id",
-                "evidence_ids",
-            ],
-            "properties": identity
-            | {
-                "decision_code": {"enum": sorted(SOURCE.REJECTS)},
-                "clean_modern_standard_prose": {"type": "boolean"},
-                "modern_genre_id": {"anyOf": [{"enum": sorted(SOURCE.GENRES)}, {"type": "null"}]},
-                "evidence_ids": {"type": "array", "items": {"type": "string"}},
-            },
-        }
 
-    properties = {f"p{position:02d}": label_for(row) for position, row in enumerate(rows, 1)}
+    properties = {f"p{position:02d}": _clean_label_schema(row) for position, row in enumerate(rows, 1)}
     return {
         "type": "object",
         "additionalProperties": False,
@@ -484,6 +488,26 @@ def gemini_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
                 "additionalProperties": False,
                 "required": list(properties),
                 "properties": properties,
+            },
+            "liveness_challenge": {"enum": [challenge]},
+        },
+    }
+
+
+def grok_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
+    """Express the existing Grok list envelope as a strict CLI output schema."""
+    labels = [_clean_label_schema(row) for row in rows]
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["labels", "liveness_challenge"],
+        "properties": {
+            "labels": {
+                "type": "array",
+                "items": labels,
+                "additionalItems": False,
+                "minItems": len(labels),
+                "maxItems": len(labels),
             },
             "liveness_challenge": {"enum": [challenge]},
         },
@@ -516,7 +540,9 @@ def grok_prompt(challenge: str, rows: list[dict[str, Any]], sidecar: dict[str, A
     ).encode("utf-8")
 
 
-def _grok_command(provider_bin: Path, prompt_path: Path) -> list[str]:
+def _grok_command(
+    provider_bin: Path, prompt_path: Path, output_schema: Mapping[str, Any], session_id: str
+) -> list[str]:
     """Build the reviewed native Grok CLI invocation."""
     return [
         str(provider_bin),
@@ -527,7 +553,11 @@ def _grok_command(provider_bin: Path, prompt_path: Path) -> list[str]:
         "--reasoning-effort",
         "high",
         "--output-format",
-        "plain",
+        "json",
+        "--json-schema",
+        canonical(output_schema).decode("utf-8"),
+        "--session-id",
+        session_id,
         "--permission-mode",
         "plan",
         "--no-alt-screen",
@@ -651,11 +681,34 @@ def _extract_gemini(
     return init, result, {"labels": labels}
 
 
-def _extract_grok(raw: bytes, challenge: str) -> dict[str, Any]:
+def _strict_grok_text_json(text: str) -> Any:
+    """Decode one schema-constrained JSON value, allowing only an optional fence."""
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        lines = candidate.splitlines()
+        if len(lines) < 3 or lines[0].strip().lower() not in {"```", "```json"} or lines[-1].strip() != "```":
+            raise CanaryStructuralError("stream_json_invalid")
+        candidate = "\n".join(lines[1:-1]).strip()
     try:
-        direct = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=_pairs)
+        return json.loads(candidate, object_pairs_hook=_pairs)
+    except (json.JSONDecodeError, CanaryError) as exc:
+        raise CanaryStructuralError("stream_json_invalid") from exc
+
+
+def _extract_grok(raw: bytes, challenge: str, expected_session_id: str) -> dict[str, Any]:
+    try:
+        envelope = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=_pairs)
     except (UnicodeDecodeError, json.JSONDecodeError, CanaryError) as exc:
         raise CanaryStructuralError("stream_json_invalid") from exc
+    if (
+        not isinstance(envelope, dict)
+        or envelope.get("sessionId") != expected_session_id
+        or not isinstance(envelope.get("stopReason"), str)
+        or not isinstance(envelope.get("requestId"), str)
+        or not isinstance(envelope.get("text"), str)
+    ):
+        raise CanaryStructuralError("structured_output_envelope_drift")
+    direct = _strict_grok_text_json(envelope["text"])
     if (
         not isinstance(direct, dict)
         or set(direct) != {"labels", "liveness_challenge"}
@@ -1045,6 +1098,7 @@ def invoke_canary(
         sources_identity = sources_client.server_identity()
 
         challenge = secrets.token_hex(32)
+        grok_session_id: str | None = None
         if provider_name == "gemini":
             prompt_bytes = gemini_prompt(challenge, rows, sidecar)
             schema_dict = gemini_schema(rows, challenge)
@@ -1082,7 +1136,8 @@ def invoke_canary(
             prompt_bytes = grok_prompt(challenge, rows, sidecar)
             stdin_path = runtime / "prompt.stdin"
             _atomic(stdin_path, prompt_bytes, raw=True)
-            cmd = _grok_command(provider_bin, stdin_path)
+            grok_session_id = str(uuid.uuid4())
+            cmd = _grok_command(provider_bin, stdin_path, grok_schema(rows, challenge), grok_session_id)
 
         attempt = 1
         provider_calls = 0
@@ -1127,7 +1182,8 @@ def invoke_canary(
                         "raw_stream_sha256": digest(raw_output),
                     }
                 else:
-                    extracted = _extract_grok(raw_output, challenge)
+                    assert grok_session_id is not None
+                    extracted = _extract_grok(raw_output, challenge, grok_session_id)
                     norm = extracted["labels"]
                     provenance = {
                         "challenge_sha256": digest(challenge.encode("utf-8")),

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -555,7 +555,7 @@ def _grok_command(
         "--output-format",
         "json",
         "--json-schema",
-        canonical(output_schema).decode("utf-8"),
+        json.dumps(output_schema, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
         "--session-id",
         session_id,
         "--permission-mode",
@@ -1099,6 +1099,7 @@ def invoke_canary(
 
         challenge = secrets.token_hex(32)
         grok_session_id: str | None = None
+        grok_output_schema: dict[str, Any] | None = None
         if provider_name == "gemini":
             prompt_bytes = gemini_prompt(challenge, rows, sidecar)
             schema_dict = gemini_schema(rows, challenge)
@@ -1136,8 +1137,8 @@ def invoke_canary(
             prompt_bytes = grok_prompt(challenge, rows, sidecar)
             stdin_path = runtime / "prompt.stdin"
             _atomic(stdin_path, prompt_bytes, raw=True)
-            grok_session_id = str(uuid.uuid4())
-            cmd = _grok_command(provider_bin, stdin_path, grok_schema(rows, challenge), grok_session_id)
+            grok_output_schema = grok_schema(rows, challenge)
+            cmd = []
 
         attempt = 1
         provider_calls = 0
@@ -1147,6 +1148,10 @@ def invoke_canary(
         provenance: dict[str, Any] = {}
 
         while attempt <= max_attempts:
+            if provider_name == "grok":
+                assert grok_output_schema is not None
+                grok_session_id = str(uuid.uuid4())
+                cmd = _grok_command(provider_bin, stdin_path, grok_output_schema, grok_session_id)
             provider_calls += 1
             raw_path = runtime / f"provider-{attempt}.raw"
             try:

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -50,6 +50,20 @@ def test_gemini_schema_decisions_are_all_known_to_evidence_validator() -> None:
         assert decision_enum <= runner.validator.KNOWN_DECISIONS
 
 
+def test_grok_schema_preserves_ordered_row_identity_and_liveness() -> None:
+    runner = _load_runner()
+    rows = runner.fixture_rows()
+    schema = runner.grok_schema(rows, "challenge")
+
+    labels = schema["properties"]["labels"]
+    assert labels["minItems"] == labels["maxItems"] == 2
+    assert labels["additionalItems"] is False
+    assert [item["properties"]["unit_id"]["enum"][0] for item in labels["items"]] == [
+        row["unit_id"] for row in rows
+    ]
+    assert schema["properties"]["liveness_challenge"] == {"enum": ["challenge"]}
+
+
 def test_real_cli_passes_explicit_provider_bin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     runner = _load_runner()
     provider = (tmp_path / "agy").resolve()
@@ -146,14 +160,37 @@ def test_grok_commands_use_only_the_reviewed_cli_isolation_flags() -> None:
 
     expected_isolation_flags = {"--permission-mode", "--no-alt-screen", "--no-subagents", "--disable-web-search"}
     prompt_path = Path("/private/prompt")
+    output_schema = {"type": "object"}
+    session_id = "00000000-0000-4000-8000-000000000007"
     for command in (
-        canary._grok_command(Path("/provider"), prompt_path),
-        batch._provider_command(Path("/provider"), prompt_path),
+        canary._grok_command(Path("/provider"), prompt_path, output_schema, session_id),
+        batch._provider_command(Path("/provider"), prompt_path, output_schema, session_id),
     ):
         assert expected_isolation_flags <= set(command)
         assert "--no-memory" not in command
         assert command.count("--prompt-file") == 1
         assert command[command.index("--prompt-file") + 1] == str(prompt_path)
+        assert command[command.index("--output-format") + 1] == "json"
+        assert json.loads(command[command.index("--json-schema") + 1]) == output_schema
+        assert command[command.index("--session-id") + 1] == session_id
+
+
+def test_grok_batch_schema_constrains_packet_identity_without_oversized_argument() -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_grok_batch_schema_test", path)
+    assert spec is not None and spec.loader is not None
+    batch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(batch)
+    rows = [{"unit_id": f"unit-{index:02d}", "unit_sha256": f"{index:064x}"} for index in range(50)]
+
+    for lane in ("clean_label", "residual_label"):
+        schema = batch._provider_schema(lane, rows)
+        labels = schema["properties"]["labels"]
+        identity = labels["items"]["properties"]
+        assert labels["minItems"] == labels["maxItems"] == 50
+        assert identity["unit_id"]["enum"] == [row["unit_id"] for row in rows]
+        assert identity["unit_sha256"]["enum"] == [row["unit_sha256"] for row in rows]
+        assert len(batch.canonical(schema)) < 32_768
 
 
 def test_grok_batch_binds_and_removes_private_prompt_file(
@@ -176,10 +213,74 @@ def test_grok_batch_binds_and_removes_private_prompt_file(
         return batch.subprocess.CompletedProcess(command, 0, stdout=b"{}", stderr=b"")
 
     monkeypatch.setattr(batch.subprocess, "run", fake_run)
-    result = batch._run_provider(Path("/provider"), b"public prompt", tmp_path)
+    result, session_id = batch._run_provider(
+        Path("/provider"), b"public prompt", tmp_path, {"type": "object"}
+    )
 
     assert result.returncode == 0
+    assert session_id
     assert not observed["prompt_path"].exists()
+
+
+def test_grok_canary_requires_documented_json_envelope_and_matching_session() -> None:
+    runner = _load_runner()
+    payload = {"labels": [{"one": 1}, {"two": 2}], "liveness_challenge": "challenge"}
+    session_id = "00000000-0000-4000-8000-000000000007"
+    envelope = {
+        "text": f"```json\n{json.dumps(payload)}\n```",
+        "sessionId": session_id,
+        "stopReason": "end_turn",
+        "requestId": "request-7",
+    }
+
+    assert runner._extract_grok(json.dumps(envelope).encode(), "challenge", session_id) == {
+        "labels": payload["labels"]
+    }
+    with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
+        runner._extract_grok(json.dumps(envelope).encode(), "challenge", "wrong-session")
+    with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
+        runner._extract_grok(json.dumps(payload).encode(), "challenge", session_id)
+
+
+def test_grok_batch_decodes_only_documented_matching_session_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_grok_batch_decode_test", path)
+    assert spec is not None and spec.loader is not None
+    batch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(batch)
+    payload = {"labels": [{"unit_id": "one"}]}
+    session_id = "00000000-0000-4000-8000-000000000007"
+    envelope = {
+        "text": json.dumps(payload),
+        "sessionId": session_id,
+        "stopReason": "end_turn",
+        "requestId": "request-7",
+    }
+    validated: list[bytes] = []
+
+    def fake_validate(lane: str, packet: dict[str, object], raw: bytes, **kwargs: object) -> dict[str, object]:
+        assert lane == "clean_label"
+        assert packet == {"lane": "clean_label"}
+        validated.append(raw)
+        return payload
+
+    monkeypatch.setattr(batch, "validate", fake_validate)
+    decoded = batch._decode_provider(
+        json.dumps(envelope).encode(),
+        {"lane": "clean_label"},
+        expected_session_id=session_id,
+    )
+
+    assert decoded == batch.canonical(payload)
+    assert validated == [batch.canonical(payload)]
+    with pytest.raises(batch.Invalid, match="structured_output_envelope_drift"):
+        batch._decode_provider(
+            json.dumps(envelope).encode(),
+            {"lane": "clean_label"},
+            expected_session_id="wrong-session",
+        )
 
 
 def test_batch_stream_rejects_reported_cwd_mismatch(tmp_path: Path) -> None:

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -171,26 +171,31 @@ def test_grok_commands_use_only_the_reviewed_cli_isolation_flags() -> None:
         assert command.count("--prompt-file") == 1
         assert command[command.index("--prompt-file") + 1] == str(prompt_path)
         assert command[command.index("--output-format") + 1] == "json"
-        assert json.loads(command[command.index("--json-schema") + 1]) == output_schema
+        schema_argument = command[command.index("--json-schema") + 1]
+        assert json.loads(schema_argument) == output_schema
+        assert not schema_argument.endswith("\n")
         assert command[command.index("--session-id") + 1] == session_id
 
 
-def test_grok_batch_schema_constrains_packet_identity_without_oversized_argument() -> None:
+def test_grok_batch_schema_keeps_private_identity_out_of_bounded_argument() -> None:
     path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
     spec = importlib.util.spec_from_file_location("cycle007_grok_batch_schema_test", path)
     assert spec is not None and spec.loader is not None
     batch = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(batch)
-    rows = [{"unit_id": f"unit-{index:02d}", "unit_sha256": f"{index:064x}"} for index in range(50)]
+    rows = [{"unit_id": f"private-unit-{index:02d}", "unit_sha256": f"{index:064x}"} for index in range(50)]
 
     for lane in ("clean_label", "residual_label"):
         schema = batch._provider_schema(lane, rows)
         labels = schema["properties"]["labels"]
         identity = labels["items"]["properties"]
         assert labels["minItems"] == labels["maxItems"] == 50
-        assert identity["unit_id"]["enum"] == [row["unit_id"] for row in rows]
-        assert identity["unit_sha256"]["enum"] == [row["unit_sha256"] for row in rows]
-        assert len(batch.canonical(schema)) < 32_768
+        assert identity["unit_id"] == {"type": "string", "minLength": 1}
+        assert identity["unit_sha256"] == {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        argument = json.dumps(schema, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        assert all(row["unit_id"] not in argument and row["unit_sha256"] not in argument for row in rows)
+        assert len(argument.encode()) < 16_384
+        assert not argument.endswith("\n")
 
 
 def test_grok_batch_binds_and_removes_private_prompt_file(
@@ -240,6 +245,35 @@ def test_grok_canary_requires_documented_json_envelope_and_matching_session() ->
         runner._extract_grok(json.dumps(envelope).encode(), "challenge", "wrong-session")
     with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
         runner._extract_grok(json.dumps(payload).encode(), "challenge", session_id)
+
+
+def test_grok_canary_retry_mints_a_fresh_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner()
+    provider = tmp_path / "grok"
+    provider.write_bytes(b"#!/bin/sh\n")
+    provider.chmod(0o700)
+    sources = runner.make_synthetic_mcp_client(tmp_path / "sources")
+    observed_sessions: list[str] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> object:
+        observed_sessions.append(command[command.index("--session-id") + 1])
+        kwargs["stdout"].write(b"{}")
+        return runner.subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+    with pytest.raises(runner.CanaryError, match="structural_retry_exhausted"):
+        runner.invoke_canary(
+            "grok",
+            provider,
+            execution_mode="synthetic",
+            sources_client=sources,
+            max_attempts=2,
+        )
+
+    assert len(observed_sessions) == 2
+    assert len(set(observed_sessions)) == 2
 
 
 def test_grok_batch_decodes_only_documented_matching_session_envelope(


### PR DESCRIPTION
Fixes the Cycle007 Grok transport preflight for #6375.

The native Grok CLI is now bound to its documented JSON-schema output mode and a unique session identity. Both the public canary and resumable batch runner validate the documented JSON envelope before the unchanged semantic validator runs. Prompts, models, endpoints, packet sizing, evidence, and custody controls are unchanged.

Verification:
- Ruff: pass
- 62 focused tests: pass
- Gemini and Grok provider-free static canaries: pass