### PR TITLE
fix(cycle007): parse Grok schema text strictly

### DIFF
--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -569,7 +569,15 @@ _GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE
 
 
 def _strict_grok_text_json(text: str) -> Any:
-    """Extract one schema-constrained JSON value and reject trailing prose."""
+    """Extract Grok's one terminal schema value and reject anything after it.
+
+    Native Grok JSON mode can prepend presentation text inside ``envelope.text``
+    even with ``--json-schema``. This deliberately matches the established
+    ``layerb_judge_bridge._strict_grok_json_value`` transport rule: ignore that
+    prefix, accept exactly one terminal JSON value plus an optional fence, and
+    reject trailing prose or multiple values. The unchanged packet validator
+    remains authoritative downstream.
+    """
     decoder = json.JSONDecoder(object_pairs_hook=pairs)
     for matched in re.finditer(r"[\[{]", text):
         candidate = text[matched.start() :]

--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -13,6 +13,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -564,18 +565,22 @@ def validate(
         raise _semantic_failure(exc) from exc
 
 
+_GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE)
+
+
 def _strict_grok_text_json(text: str) -> Any:
-    """Decode one schema-constrained JSON value, allowing only an optional fence."""
-    candidate = text.strip()
-    if candidate.startswith("```"):
-        lines = candidate.splitlines()
-        if len(lines) < 3 or lines[0].strip().lower() not in {"```", "```json"} or lines[-1].strip() != "```":
+    """Extract one schema-constrained JSON value and reject trailing prose."""
+    decoder = json.JSONDecoder(object_pairs_hook=pairs)
+    for matched in re.finditer(r"[\[{]", text):
+        candidate = text[matched.start() :]
+        try:
+            decoded, end = decoder.raw_decode(candidate)
+        except (json.JSONDecodeError, Invalid):
+            continue
+        if _GROK_TRAILING_FENCE_RE.fullmatch(candidate[end:]) is None:
             raise Invalid("stream_json_invalid")
-        candidate = "\n".join(lines[1:-1]).strip()
-    try:
-        return json.loads(candidate, object_pairs_hook=pairs)
-    except (UnicodeDecodeError, json.JSONDecodeError, Invalid):
-        raise Invalid("stream_json_invalid") from None
+        return decoded
+    raise Invalid("stream_json_invalid")
 
 
 def _decode_provider(

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -686,7 +686,15 @@ _GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE
 
 
 def _strict_grok_text_json(text: str) -> Any:
-    """Extract one schema-constrained JSON value and reject trailing prose."""
+    """Extract Grok's one terminal schema value and reject anything after it.
+
+    Native Grok JSON mode can prepend presentation text inside ``envelope.text``
+    even with ``--json-schema``. This deliberately matches the established
+    ``layerb_judge_bridge._strict_grok_json_value`` transport rule: ignore that
+    prefix, accept exactly one terminal JSON value plus an optional fence, and
+    reject trailing prose or multiple values. Schema, liveness, and semantic
+    validation remain authoritative downstream.
+    """
     decoder = json.JSONDecoder(object_pairs_hook=_pairs)
     for matched in re.finditer(r"[\[{]", text):
         candidate = text[matched.start() :]

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -17,6 +17,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import secrets
 import shutil
 import socket
@@ -681,18 +682,22 @@ def _extract_gemini(
     return init, result, {"labels": labels}
 
 
+_GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE)
+
+
 def _strict_grok_text_json(text: str) -> Any:
-    """Decode one schema-constrained JSON value, allowing only an optional fence."""
-    candidate = text.strip()
-    if candidate.startswith("```"):
-        lines = candidate.splitlines()
-        if len(lines) < 3 or lines[0].strip().lower() not in {"```", "```json"} or lines[-1].strip() != "```":
+    """Extract one schema-constrained JSON value and reject trailing prose."""
+    decoder = json.JSONDecoder(object_pairs_hook=_pairs)
+    for matched in re.finditer(r"[\[{]", text):
+        candidate = text[matched.start() :]
+        try:
+            decoded, end = decoder.raw_decode(candidate)
+        except (json.JSONDecodeError, CanaryError):
+            continue
+        if _GROK_TRAILING_FENCE_RE.fullmatch(candidate[end:]) is None:
             raise CanaryStructuralError("stream_json_invalid")
-        candidate = "\n".join(lines[1:-1]).strip()
-    try:
-        return json.loads(candidate, object_pairs_hook=_pairs)
-    except (json.JSONDecodeError, CanaryError) as exc:
-        raise CanaryStructuralError("stream_json_invalid") from exc
+        return decoded
+    raise CanaryStructuralError("stream_json_invalid")
 
 
 def _extract_grok(raw: bytes, challenge: str, expected_session_id: str) -> dict[str, Any]:

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -327,6 +327,21 @@ def test_grok_batch_decodes_only_documented_matching_session_envelope(
         )
 
 
+def test_grok_terminal_json_rule_rejects_multiple_values_but_skips_malformed_decoys() -> None:
+    canary = _load_runner()
+    path = ROOT / "batch_state" / "phase3-run-cycle007-grok-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_grok_batch_terminal_json_test", path)
+    assert spec is not None and spec.loader is not None
+    batch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(batch)
+    value = {"labels": []}
+
+    for runner in (canary, batch):
+        assert runner._strict_grok_text_json(f"presentation {{broken\n{json.dumps(value)}") == value
+        with pytest.raises((canary.CanaryStructuralError, batch.Invalid), match="stream_json_invalid"):
+            runner._strict_grok_text_json(f"{json.dumps(value)}\n{json.dumps(value)}")
+
+
 def test_batch_stream_rejects_reported_cwd_mismatch(tmp_path: Path) -> None:
     path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
     spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_cwd_test", path)

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -232,7 +232,7 @@ def test_grok_canary_requires_documented_json_envelope_and_matching_session() ->
     payload = {"labels": [{"one": 1}, {"two": 2}], "liveness_challenge": "challenge"}
     session_id = "00000000-0000-4000-8000-000000000007"
     envelope = {
-        "text": f"```json\n{json.dumps(payload)}\n```",
+        "text": f"Schema result follows.\n```json\n{json.dumps(payload)}\n```",
         "sessionId": session_id,
         "stopReason": "end_turn",
         "requestId": "request-7",
@@ -245,6 +245,9 @@ def test_grok_canary_requires_documented_json_envelope_and_matching_session() ->
         runner._extract_grok(json.dumps(envelope).encode(), "challenge", "wrong-session")
     with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
         runner._extract_grok(json.dumps(payload).encode(), "challenge", session_id)
+    trailing = envelope | {"text": f"{json.dumps(payload)}\nuntrusted trailing prose"}
+    with pytest.raises(runner.CanaryStructuralError, match="stream_json_invalid"):
+        runner._extract_grok(json.dumps(trailing).encode(), "challenge", session_id)
 
 
 def test_grok_canary_retry_mints_a_fresh_session(
@@ -287,7 +290,7 @@ def test_grok_batch_decodes_only_documented_matching_session_envelope(
     payload = {"labels": [{"unit_id": "one"}]}
     session_id = "00000000-0000-4000-8000-000000000007"
     envelope = {
-        "text": json.dumps(payload),
+        "text": f"Schema result follows.\n{json.dumps(payload)}",
         "sessionId": session_id,
         "stopReason": "end_turn",
         "requestId": "request-7",
@@ -314,6 +317,13 @@ def test_grok_batch_decodes_only_documented_matching_session_envelope(
             json.dumps(envelope).encode(),
             {"lane": "clean_label"},
             expected_session_id="wrong-session",
+        )
+    trailing = envelope | {"text": f"{json.dumps(payload)}\nuntrusted trailing prose"}
+    with pytest.raises(batch.Invalid, match="stream_json_invalid"):
+        batch._decode_provider(
+            json.dumps(trailing).encode(),
+            {"lane": "clean_label"},
+            expected_session_id=session_id,
         )
 
 


### PR DESCRIPTION
Follow-up for #6375 after the live public Grok canary exposed documented native-CLI presentation text around schema-constrained JSON.

The canary and batch runner now use the repository's proven single-JSON-value extraction rule: leading presentation text is ignored, while trailing prose or multiple values fail closed. The documented JSON envelope, unique session binding, JSON schema, unchanged official semantic validator, models, prompts, endpoints, packet sizing, evidence, and custody controls remain intact.

Verification:
- Ruff: pass
- 63 focused tests: pass
- provider-free Grok static canary: pass