### PR TITLE
fix(cycle007): classify Grok envelope failures

### DIFF
--- a/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-grok-label-provider-batch-v1.py
@@ -85,6 +85,10 @@ DEC = SOURCE.DEC
 FAILURE_CODES = frozenset(
     {
         "stream_json_invalid",
+        "outer_json_missing",
+        "outer_json_trailing_drift",
+        "schema_json_missing",
+        "schema_json_trailing_drift",
         "terminal_result_count_drift",
         "structured_output_envelope_drift",
         "ordinal_key_drift",
@@ -120,6 +124,10 @@ FAILURE_CODES = frozenset(
 STRUCTURAL_CODES = frozenset(
     {
         "stream_json_invalid",
+        "outer_json_missing",
+        "outer_json_trailing_drift",
+        "schema_json_missing",
+        "schema_json_trailing_drift",
         "terminal_result_count_drift",
         "structured_output_envelope_drift",
         "ordinal_key_drift",
@@ -568,7 +576,12 @@ def validate(
 _GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE)
 
 
-def _strict_grok_text_json(text: str) -> Any:
+def _strict_grok_text_json(
+    text: str,
+    *,
+    missing_code: str = "schema_json_missing",
+    trailing_code: str = "schema_json_trailing_drift",
+) -> Any:
     """Extract Grok's one terminal schema value and reject anything after it.
 
     Native Grok JSON mode can prepend presentation text inside ``envelope.text``
@@ -586,9 +599,9 @@ def _strict_grok_text_json(text: str) -> Any:
         except (json.JSONDecodeError, Invalid):
             continue
         if _GROK_TRAILING_FENCE_RE.fullmatch(candidate[end:]) is None:
-            raise Invalid("stream_json_invalid")
+            raise Invalid(trailing_code)
         return decoded
-    raise Invalid("stream_json_invalid")
+    raise Invalid(missing_code)
 
 
 def _decode_provider(
@@ -599,9 +612,14 @@ def _decode_provider(
     sidecar_value: dict[str, Any] | None = None,
 ) -> bytes:
     try:
-        envelope = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=pairs)
-    except (UnicodeDecodeError, json.JSONDecodeError, Invalid):
-        raise Invalid("stream_json_invalid") from None
+        raw_text = raw.decode("utf-8", "strict")
+    except UnicodeDecodeError:
+        raise Invalid("outer_json_missing") from None
+    envelope = _strict_grok_text_json(
+        raw_text,
+        missing_code="outer_json_missing",
+        trailing_code="outer_json_trailing_drift",
+    )
     if (
         not isinstance(envelope, dict)
         or envelope.get("sessionId") != expected_session_id

--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -685,7 +685,12 @@ def _extract_gemini(
 _GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE)
 
 
-def _strict_grok_text_json(text: str) -> Any:
+def _strict_grok_text_json(
+    text: str,
+    *,
+    missing_code: str = "schema_json_missing",
+    trailing_code: str = "schema_json_trailing_drift",
+) -> Any:
     """Extract Grok's one terminal schema value and reject anything after it.
 
     Native Grok JSON mode can prepend presentation text inside ``envelope.text``
@@ -703,16 +708,21 @@ def _strict_grok_text_json(text: str) -> Any:
         except (json.JSONDecodeError, CanaryError):
             continue
         if _GROK_TRAILING_FENCE_RE.fullmatch(candidate[end:]) is None:
-            raise CanaryStructuralError("stream_json_invalid")
+            raise CanaryStructuralError(trailing_code)
         return decoded
-    raise CanaryStructuralError("stream_json_invalid")
+    raise CanaryStructuralError(missing_code)
 
 
 def _extract_grok(raw: bytes, challenge: str, expected_session_id: str) -> dict[str, Any]:
     try:
-        envelope = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=_pairs)
-    except (UnicodeDecodeError, json.JSONDecodeError, CanaryError) as exc:
-        raise CanaryStructuralError("stream_json_invalid") from exc
+        raw_text = raw.decode("utf-8", "strict")
+    except UnicodeDecodeError as exc:
+        raise CanaryStructuralError("outer_json_missing") from exc
+    envelope = _strict_grok_text_json(
+        raw_text,
+        missing_code="outer_json_missing",
+        trailing_code="outer_json_trailing_drift",
+    )
     if (
         not isinstance(envelope, dict)
         or envelope.get("sessionId") != expected_session_id

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -238,7 +238,7 @@ def test_grok_canary_requires_documented_json_envelope_and_matching_session() ->
         "requestId": "request-7",
     }
 
-    assert runner._extract_grok(json.dumps(envelope).encode(), "challenge", session_id) == {
+    assert runner._extract_grok(("CLI presentation\n" + json.dumps(envelope)).encode(), "challenge", session_id) == {
         "labels": payload["labels"]
     }
     with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
@@ -246,8 +246,11 @@ def test_grok_canary_requires_documented_json_envelope_and_matching_session() ->
     with pytest.raises(runner.CanaryStructuralError, match="structured_output_envelope_drift"):
         runner._extract_grok(json.dumps(payload).encode(), "challenge", session_id)
     trailing = envelope | {"text": f"{json.dumps(payload)}\nuntrusted trailing prose"}
-    with pytest.raises(runner.CanaryStructuralError, match="stream_json_invalid"):
+    with pytest.raises(runner.CanaryStructuralError, match="schema_json_trailing_drift"):
         runner._extract_grok(json.dumps(trailing).encode(), "challenge", session_id)
+    doubled = (json.dumps(envelope) + "\n" + json.dumps(envelope)).encode()
+    with pytest.raises(runner.CanaryStructuralError, match="outer_json_trailing_drift"):
+        runner._extract_grok(doubled, "challenge", session_id)
 
 
 def test_grok_canary_retry_mints_a_fresh_session(
@@ -305,7 +308,7 @@ def test_grok_batch_decodes_only_documented_matching_session_envelope(
 
     monkeypatch.setattr(batch, "validate", fake_validate)
     decoded = batch._decode_provider(
-        json.dumps(envelope).encode(),
+        ("CLI presentation\n" + json.dumps(envelope)).encode(),
         {"lane": "clean_label"},
         expected_session_id=session_id,
     )
@@ -319,7 +322,7 @@ def test_grok_batch_decodes_only_documented_matching_session_envelope(
             expected_session_id="wrong-session",
         )
     trailing = envelope | {"text": f"{json.dumps(payload)}\nuntrusted trailing prose"}
-    with pytest.raises(batch.Invalid, match="stream_json_invalid"):
+    with pytest.raises(batch.Invalid, match="schema_json_trailing_drift"):
         batch._decode_provider(
             json.dumps(trailing).encode(),
             {"lane": "clean_label"},
@@ -338,7 +341,9 @@ def test_grok_terminal_json_rule_rejects_multiple_values_but_skips_malformed_dec
 
     for runner in (canary, batch):
         assert runner._strict_grok_text_json(f"presentation {{broken\n{json.dumps(value)}") == value
-        with pytest.raises((canary.CanaryStructuralError, batch.Invalid), match="stream_json_invalid"):
+        with pytest.raises(
+            (canary.CanaryStructuralError, batch.Invalid), match="schema_json_trailing_drift"
+        ):
             runner._strict_grok_text_json(f"{json.dumps(value)}\n{json.dumps(value)}")
 
 


### PR DESCRIPTION
Follow-up for #6375. The live public Grok canary still returned only the content-blind stream_json_invalid code after the strict inner-schema parser merged.

This change applies the already-reviewed terminal-JSON rule to the outer native-CLI envelope and emits stage-specific safe structural codes for outer-vs-schema missing/trailing failures. It never records or exposes response content. The same codes are retryable in the batch runner. Session binding, schemas, validators, prompts, models, endpoints, packet sizing, evidence, and custody controls are unchanged.

Verification:
- Ruff: pass
- 64 focused tests: pass