### PR TITLE
fix(cycle007): use supported Grok schema items

### DIFF
--- a/batch_state/phase3-run-cycle007-public-canaries-v1.py
+++ b/batch_state/phase3-run-cycle007-public-canaries-v1.py
@@ -497,7 +497,13 @@ def gemini_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
 
 def grok_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
     """Express the existing Grok list envelope as a strict CLI output schema."""
-    labels = [_clean_label_schema(row) for row in rows]
+    # xAI structured outputs rejects Draft-07 tuple syntax (``items`` as an
+    # array). Constrain the packet identity set in one supported item schema;
+    # the unchanged official validator remains authoritative for ordinal
+    # identity pairing and order.
+    label = _clean_label_schema(rows[0])
+    label["properties"]["unit_id"] = {"enum": [row["unit_id"] for row in rows]}
+    label["properties"]["unit_sha256"] = {"enum": [row["unit_sha256"] for row in rows]}
     return {
         "type": "object",
         "additionalProperties": False,
@@ -505,10 +511,9 @@ def grok_schema(rows: list[dict[str, Any]], challenge: str) -> dict[str, Any]:
         "properties": {
             "labels": {
                 "type": "array",
-                "items": labels,
-                "additionalItems": False,
-                "minItems": len(labels),
-                "maxItems": len(labels),
+                "items": label,
+                "minItems": len(rows),
+                "maxItems": len(rows),
             },
             "liveness_challenge": {"enum": [challenge]},
         },

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -57,10 +57,10 @@ def test_grok_schema_preserves_ordered_row_identity_and_liveness() -> None:
 
     labels = schema["properties"]["labels"]
     assert labels["minItems"] == labels["maxItems"] == 2
-    assert labels["additionalItems"] is False
-    assert [item["properties"]["unit_id"]["enum"][0] for item in labels["items"]] == [
-        row["unit_id"] for row in rows
-    ]
+    assert "additionalItems" not in labels
+    assert isinstance(labels["items"], dict)
+    assert labels["items"]["properties"]["unit_id"]["enum"] == [row["unit_id"] for row in rows]
+    assert labels["items"]["properties"]["unit_sha256"]["enum"] == [row["unit_sha256"] for row in rows]
     assert schema["properties"]["liveness_challenge"] == {"enum": ["challenge"]}
 
 


### PR DESCRIPTION
Follow-up for #6375. The content-blind Grok canary diagnostic proved the outer envelope is valid but schema JSON is absent. Current xAI structured-output documentation identifies the root cause: schemas with items as an array are rejected; tuple schemas must use prefixItems.

The public canary now uses the same supported single-item schema form as the batch runner, constraining the public packet identity set and exact label count. The unchanged official validator still enforces ordinal identity pairing, order, liveness, evidence, and semantics. No prompt, model, endpoint, packet size, evidence, or custody control changes.

Verification:
- Ruff: pass
- 64 focused tests: pass
- provider-free Grok static canary: pass