### PR TITLE
fix(fleet): Cursor two-pool monthly usage and NEED_LOGIN without CodexBar

### DIFF
--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -133,7 +133,7 @@ body { min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe
   <a class="card" href="/routing.html" style="border-left: 3px solid var(--blue);">
     <div class="icon">&#129518;</div>
     <h2>Agent Routing</h2>
-    <p>Which agent for what, subscription headroom, and live dispatch usage. Maximize the paid subscriptions.</p>
+    <p>Cursor Auto / API monthly + other lane subscriptions, dispatch usage, and routing recommendations.</p>
     <div class="card-stat">routing &amp; usage</div>
   </a>
   <a class="card" href="/artifacts/" style="border-left: 3px solid var(--accent);">

--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -37,10 +37,15 @@ tr:last-child td { border-bottom:none; }
 .pill.cool, .pill.ok, .pill.done { background:rgba(63,185,80,.15); color:var(--green); }
 .pill.warm, .pill.hot, .pill.warn, .pill.timeout { background:rgba(210,153,34,.15); color:var(--orange); }
 .pill.near_cap, .pill.error, .pill.failed, .pill.rate_limited, .pill.zombie { background:rgba(248,81,73,.15); color:var(--red); }
-.pill.gray, .pill.unknown, .pill.spawning, .pill.running, .pill.unavailable { background:rgba(72,79,88,.2); color:var(--text2); }
+.pill.gray, .pill.unknown, .pill.spawning, .pill.running, .pill.unavailable, .pill.need_login, .pill.need_probe { background:rgba(72,79,88,.2); color:var(--text2); }
+.pill.need_login { background:rgba(248,81,73,.2); color:var(--red); font-weight:700; }
 .bar { background:var(--bg3); border-radius:4px; height:8px; overflow:hidden; min-width:90px; }
 .bar span { background:var(--accent); display:block; height:100%; }
-.bar.unavailable span { background: repeating-linear-gradient(45deg, var(--border), var(--border) 4px, var(--bg3) 4px, var(--bg3) 8px); opacity: 0.7; }
+.bar.unavailable span, .bar.empty span { background: repeating-linear-gradient(45deg, var(--border), var(--border) 4px, var(--bg3) 4px, var(--bg3) 8px); opacity: 0.7; }
+.sub-window { margin-bottom:6px; }
+.sub-window .label { color:var(--text2); font-size:12px; margin-bottom:2px; }
+.fleet-burn { color:var(--text2); font-size:12px; line-height:1.45; }
+.stale-note { color:var(--text3); font-size:11px; margin-top:4px; }
 .section { margin-top:18px; }
 .section h2 { font-family: Charter, Georgia, serif; font-size:22px; margin:0 0 10px; }
 .error { color:var(--red); font-size:13px; padding:12px 0; }
@@ -82,8 +87,9 @@ tr:last-child td { border-bottom:none; }
   <div class="grid" id="summary-grid"></div>
 
   <section class="section panel">
-    <h2>Budget Headroom</h2>
-    <div id="budget-table"></div>
+    <h2>Subscriptions</h2>
+    <p class="sub" style="margin-bottom:10px">Provider allotment (Auto/API monthly for Cursor; other lanes per payload). Fleet burn is our dispatch JSONL — distinct from provider remaining.</p>
+    <div id="subscriptions-table"></div>
   </section>
 
   <section class="section panel">
@@ -166,7 +172,22 @@ function codexbarSnapshotIsMissingBinary(snapshot) {
     || /\b(?:codexbar\s+)?(?:cli\s+)?(?:binary\s+)?not found\b/.test(details);
 }
 
+function cursorHasNativeSubscription(routing) {
+  const cursor = routing.agents?.cursor;
+  if (!cursor || typeof cursor !== 'object') return false;
+  if (cursor.login_state === 'authenticated' || cursor.probe_state === 'healthy') {
+    const pw = cursor.provider_windows;
+    if (pw && typeof pw === 'object') {
+      const auto = pw.auto;
+      if (auto && typeof auto.used_pct === 'number') return true;
+      if (cursor.probe_state === 'healthy') return true;
+    }
+  }
+  return false;
+}
+
 function codexbarHostToolingMissing(routing) {
+  if (cursorHasNativeSubscription(routing)) return false;
   const agentRecords = Object.values(routing.agents || {})
     .filter(agent => agent && typeof agent === 'object');
   const snapshots = agentRecords.map(agent => agent.codexbar);
@@ -230,38 +251,159 @@ function renderSummary(routing, usage, delegates) {
   `;
 }
 
-function renderBudget(routing, usage) {
+function formatAge(ageS) {
+  const num = Number(ageS);
+  if (!Number.isFinite(num) || num < 0) return '';
+  if (num < 60) return `${Math.round(num)}s ago`;
+  if (num < 3600) return `${Math.round(num / 60)}m ago`;
+  return `${(num / 3600).toFixed(1)}h ago`;
+}
+
+function windowKindLabel(win) {
+  if (!win || typeof win !== 'object') return 'window';
+  if (win.label) return String(win.label);
+  if (win.window) return String(win.window);
+  const mins = win.window_minutes;
+  if (mins != null) {
+    const m = Number(mins);
+    if (m <= 300) return '5h';
+    if (m === 10080) return 'weekly';
+    if (m >= 40000) return 'monthly';
+    return `${m}m`;
+  }
+  return 'window';
+}
+
+function pctDisplay(used, remaining) {
+  const usedNum = Number(used);
+  const remNum = Number(remaining);
+  if (!Number.isFinite(usedNum)) return null;
+  const rem = Number.isFinite(remNum) ? remNum : Math.max(0, 100 - usedNum);
+  return `${usedNum.toFixed(0)}% used · ${rem.toFixed(0)}% left`;
+}
+
+function renderWindowBlock(label, win, opts = {}) {
+  const rawUsed = win?.used_pct;
+  const usedNum = (rawUsed === null || rawUsed === undefined) ? NaN : Number(rawUsed);
+  const rawRemaining = win?.remaining_pct;
+  const remNum = (rawRemaining === null || rawRemaining === undefined) ? NaN : Number(rawRemaining);
+  const hasPct = Number.isFinite(usedNum);
+  const display = hasPct ? pctDisplay(usedNum, remNum) : (opts.missingLabel || 'unknown');
+  const barClass = hasPct ? 'bar' : `bar ${opts.barClass || 'unavailable'}`;
+  const barWidth = hasPct ? pct(usedNum) : 100;
+  const resets = win?.resets_at ? ` · resets ${formatTs(win.resets_at)}` : '';
+  return `<div class="sub-window">
+    <div class="label"><span class="mono">${escapeHtml(label)}</span> ${hasPct ? escapeHtml(display) : `<span class="pill ${escapeHtml(opts.missingLabel === 'NEED_PROBE' ? 'need_probe' : 'unknown')}">${escapeHtml(display)}</span>`}${resets ? `<span class="stale-note">${escapeHtml(resets)}</span>` : ''}</div>
+    <div class="${barClass}" title="${escapeHtml(display)}"><span style="width:${barWidth}%"></span></div>
+  </div>`;
+}
+
+function collectSubscriptionWindows(agent) {
+  const cb = agent.codexbar || {};
+  const providerWindows = agent.provider_windows || cb.provider_windows;
+  if (providerWindows && typeof providerWindows === 'object') {
+    return Object.entries(providerWindows).map(([key, win]) => ({
+      key,
+      label: (win && win.label) || (key === 'auto' ? 'Auto' : key === 'api' ? 'API' : key),
+      win: win || {},
+    }));
+  }
+  const named = cb.windows;
+  if (named && typeof named === 'object') {
+    return ['primary', 'secondary', 'tertiary']
+      .filter(k => named[k] && typeof named[k] === 'object')
+      .map(k => ({
+        key: k,
+        label: named[k].label || windowKindLabel(named[k]),
+        win: named[k],
+      }))
+      .filter(entry => entry.win.used_pct != null || entry.win.remaining_pct != null);
+  }
+  if (cb.weekly_used_pct != null && typeof cb.weekly_used_pct === 'number') {
+    return [{
+      key: 'weekly',
+      label: 'weekly',
+      win: {
+        used_pct: cb.weekly_used_pct,
+        remaining_pct: cb.weekly_remaining_pct,
+        resets_at: cb.weekly_resets_at || agent.resets_at,
+      },
+    }];
+  }
+  return [];
+}
+
+function renderFleetBurnCell(agent) {
+  const fb = agent.fleet_burn;
+  if (!fb || typeof fb !== 'object') return '<span class="fleet-burn">—</span>';
+  const wins = fb.windows || {};
+  const parts = ['5h', '7d', '30d'].map(name => {
+    const block = wins[name];
+    const total = block?.counts?.total;
+    return `${name}: ${total == null ? '—' : escapeHtml(total)}`;
+  });
+  return `<div class="fleet-burn">${parts.join(' · ')}<br><span class="stale-note">dispatch JSONL</span></div>`;
+}
+
+function renderLaneFreshness(agent) {
+  const cb = agent.codexbar || {};
+  const fetched = cb.fetched_at || agent.fetched_at;
+  const age = cb.age_s ?? agent.age_s;
+  const stale = cb.stale || agent.stale;
+  const parts = [];
+  if (fetched) parts.push(formatTs(fetched));
+  if (age != null) parts.push(formatAge(age));
+  if (stale) parts.push('stale');
+  return parts.length ? `<span class="stale-note">${escapeHtml(parts.join(' · '))}</span>` : '';
+}
+
+function renderSubscriptions(routing) {
   const agents = routing.agents || {};
-  const diag = routing.diagnostics || {};
-  const ledgerEmpty = diag.budget_ledger_empty === true || Number(diag.records_loaded || 0) === 0;
-  const runtimeRecords = Number(diag.runtime_usage_records_7d ?? (usage || {}).records_total ?? 0);
-  const ledgerNote = ledgerEmpty
-    ? (runtimeRecords > 0
-      ? `<div class="sub" style="margin-bottom:8px">USD budget ledger is empty — 7d burn/headroom unknown. Runtime usage exists (${runtimeRecords} call(s) in 7d); see Runtime Agents below.</div>`
-      : `<div class="sub" style="margin-bottom:8px">USD budget ledger is empty — 7d burn/headroom unknown; no runtime usage records this week either.</div>`)
-    : '';
-  const unavailableTitle = ledgerEmpty
-    ? 'Burn unknown — USD budget ledger empty'
-    : 'Capacity unavailable';
-  const rows = Object.entries(agents).map(([name, data]) => {
-    const isUnavailable = data.status === 'unavailable' || data.burn_pct_7d == null || typeof data.burn_pct_7d !== 'number';
-    const burnStr = isUnavailable ? 'unavailable' : `${Number(data.burn_pct_7d).toFixed(1)}%`;
-    const barCell = isUnavailable
-      ? `<div class="bar unavailable" title="${escapeHtml(unavailableTitle)}"><span style="width:100%"></span></div>`
-      : `<div class="bar"><span style="width:${pct(data.burn_pct_7d)}%"></span></div>`;
-    const cap = data.weekly_cap_usd == null ? 'n/a' : `$${Number(data.weekly_cap_usd).toFixed(0)}`;
-    return `<tr>
-      <td class="mono">${escapeHtml(name)}</td>
-      <td>${statusPill(data.status)}</td>
-      <td>${escapeHtml(burnStr)}</td>
-      <td>${barCell}</td>
-      <td>${cap}</td>
-      <td>${escapeHtml((routing.in_flight || {})[name] ?? 0)}</td>
-    </tr>`;
-  }).join('');
-  document.getElementById('budget-table').innerHTML = `${ledgerNote}<table>
-    <tr><th>Agent</th><th>Status</th><th>7d Burn</th><th>Headroom</th><th>Weekly Cap</th><th>In Flight</th></tr>
-    ${rows || '<tr><td colspan="6">No budget data.</td></tr>'}
+  const subscriptionLanes = ['cursor', 'claude', 'codex', 'gemini', 'grok', 'kimi'];
+  const rows = subscriptionLanes
+    .filter(name => agents[name])
+    .map(name => {
+      const agent = agents[name];
+      const isCursor = name === 'cursor';
+      const needLogin = agent.login_state === 'NEED_LOGIN' || agent.probe_state === 'NEED_LOGIN';
+      const needProbe = !needLogin && agent.probe_state === 'NEED_PROBE';
+      let windowsHtml = '';
+
+      if (needLogin) {
+        windowsHtml = `<span class="pill need_login">NEED_LOGIN</span>
+          ${renderWindowBlock('Auto', { used_pct: null }, { missingLabel: 'NEED_LOGIN', barClass: 'empty' })}
+          ${renderWindowBlock('API', { used_pct: null }, { missingLabel: 'NEED_LOGIN', barClass: 'empty' })}`;
+      } else if (isCursor) {
+        const pw = agent.provider_windows || {};
+        windowsHtml = [
+          renderWindowBlock('Auto', pw.auto || {}, { missingLabel: needProbe ? 'NEED_PROBE' : 'unknown' }),
+          renderWindowBlock('API', pw.api || {}, { missingLabel: needProbe ? 'NEED_PROBE' : 'unknown' }),
+        ].join('');
+      } else {
+        const windows = collectSubscriptionWindows(agent);
+        if (windows.length) {
+          windowsHtml = windows.map(w => renderWindowBlock(
+            w.label,
+            w.win,
+            { missingLabel: needProbe ? 'NEED_PROBE' : 'unknown' }
+          )).join('');
+        } else {
+          windowsHtml = `<span class="pill ${needProbe ? 'need_probe' : 'unknown'}">${needProbe ? 'NEED_PROBE' : 'unknown'}</span>`;
+        }
+      }
+
+      return `<tr>
+        <td class="mono">${escapeHtml(name)}</td>
+        <td>${statusPill(agent.status)}</td>
+        <td>${windowsHtml}${renderLaneFreshness(agent)}</td>
+        <td>${renderFleetBurnCell(agent)}</td>
+        <td>${escapeHtml((routing.in_flight || {})[name] ?? 0)}</td>
+      </tr>`;
+    }).join('');
+
+  document.getElementById('subscriptions-table').innerHTML = `<table>
+    <tr><th>Lane</th><th>Status</th><th>Provider allotment</th><th>Fleet burn (calls)</th><th>In Flight</th></tr>
+    ${rows || '<tr><td colspan="5">No subscription data.</td></tr>'}
   </table>`;
 }
 
@@ -303,22 +445,32 @@ function renderDelegates(delegates) {
 async function loadRouting() {
   const status = document.getElementById('refresh-status');
   status.textContent = 'Loading...';
-  try {
-    const [routing, agents, usage, delegates] = await Promise.all([
-      fetchJson(ENDPOINTS.routing),
-      fetchJson(ENDPOINTS.agents),
-      fetchJson(ENDPOINTS.usage),
-      fetchJson(ENDPOINTS.delegates)
-    ]);
+  const results = await Promise.allSettled([
+    fetchJson(ENDPOINTS.routing),
+    fetchJson(ENDPOINTS.agents),
+    fetchJson(ENDPOINTS.usage),
+    fetchJson(ENDPOINTS.delegates)
+  ]);
+  const routing = results[0].status === 'fulfilled' ? results[0].value : null;
+  const agents = results[1].status === 'fulfilled' ? results[1].value : { agents: [] };
+  const usage = results[2].status === 'fulfilled' ? results[2].value : {};
+  const delegates = results[3].status === 'fulfilled' ? results[3].value : { tasks: [] };
+  const errors = results
+    .map((r, i) => (r.status === 'rejected' ? Object.values(ENDPOINTS)[i] : null))
+    .filter(Boolean);
+
+  if (routing) {
     renderSummary(routing, usage, delegates);
-    renderBudget(routing, usage);
-    renderAgents(agents, usage);
-    renderDelegates(delegates);
-    status.textContent = `Updated ${new Date().toLocaleTimeString()}`;
-  } catch (err) {
-    status.textContent = 'Load failed';
-    document.getElementById('summary-grid').innerHTML = `<div class="error">API unavailable: ${escapeHtml(err.message)}</div>`;
+    renderSubscriptions(routing);
+  } else {
+    document.getElementById('summary-grid').innerHTML = `<div class="error">Routing budget unavailable${errors.length ? `: ${escapeHtml(errors.join(', '))}` : ''}</div>`;
+    document.getElementById('subscriptions-table').innerHTML = '<div class="error">Subscriptions unavailable — routing-budget failed.</div>';
   }
+  renderAgents(agents, usage);
+  renderDelegates(delegates);
+  status.textContent = errors.length
+    ? `Partial load (${errors.length} failed) ${new Date().toLocaleTimeString()}`
+    : `Updated ${new Date().toLocaleTimeString()}`;
 }
 
 document.getElementById('refresh-btn').addEventListener('click', loadRouting);

--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -25,8 +25,13 @@ import json
 import logging
 import re
 import shutil
+import subprocess
+import urllib.error
+import urllib.request
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from ..result import ParseResult
 from ..tool_calls import normalize_tool_calls, parse_json_events
@@ -640,3 +645,207 @@ def _extract_concrete_model_from_events(events: list[dict]) -> str | None:
         if candidate:
             return candidate
     return None
+
+
+_CURSOR_AUTH_PATH = Path.home() / ".config" / "cursor" / "auth.json"
+_CURSOR_USAGE_URL = (
+    "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage"
+)
+
+
+def _cursor_cli_binary() -> str:
+    return shutil.which("cursor-agent") or shutil.which("agent") or "cursor-agent"
+
+
+def probe_cursor_login(*, timeout_s: float = 5.0) -> dict[str, Any]:
+    """Preflight Cursor CLI auth without printing secrets.
+
+    Returns ``login_state`` of ``authenticated`` or ``NEED_LOGIN``.
+    """
+    fetched_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    try:
+        res = subprocess.run(
+            [_cursor_cli_binary(), "status", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        kind = "missing_binary" if isinstance(exc, FileNotFoundError) else "timeout"
+        return {
+            "lane": "cursor",
+            "source": "cursor_cli",
+            "login_state": "NEED_LOGIN",
+            "is_authenticated": False,
+            "status": "need_login",
+            "error_kind": kind,
+            "fetched_at": fetched_at,
+        }
+
+    try:
+        payload = json.loads(res.stdout or "{}")
+    except json.JSONDecodeError:
+        payload = {}
+
+    is_auth = bool(payload.get("isAuthenticated"))
+    if not is_auth and str(payload.get("status") or "").lower() == "authenticated":
+        is_auth = True
+
+    return {
+        "lane": "cursor",
+        "source": "cursor_cli",
+        "login_state": "authenticated" if is_auth else "NEED_LOGIN",
+        "is_authenticated": is_auth,
+        "status": "authenticated" if is_auth else "need_login",
+        "error_kind": None if is_auth else "not_authenticated",
+        "fetched_at": fetched_at,
+    }
+
+
+def _load_cursor_access_token() -> str | None:
+    try:
+        data = json.loads(_CURSOR_AUTH_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    token = data.get("accessToken")
+    return str(token).strip() if isinstance(token, str) and token.strip() else None
+
+
+def _ms_to_iso_z(raw_ms: object) -> str | None:
+    try:
+        ms = int(str(raw_ms))
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(ms / 1000.0, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _monthly_window_block(
+    used_pct: float | None,
+    *,
+    label: str,
+    resets_at: str | None,
+) -> dict[str, Any]:
+    remaining = None if used_pct is None else max(0.0, min(100.0, 100.0 - used_pct))
+    return {
+        "window": "monthly",
+        "label": label,
+        "used_pct": used_pct,
+        "remaining_pct": remaining,
+        "resets_at": resets_at,
+    }
+
+
+def probe_cursor_provider_windows(*, timeout_s: float = 8.0) -> dict[str, Any]:
+    """Read Cursor Auto/API monthly pools from the first-party dashboard API.
+
+    Never logs or returns access tokens. When credentials are absent, returns
+    ``probe_state=NEED_PROBE`` with empty windows (no fabricated percentages).
+    """
+    fetched_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    login = probe_cursor_login(timeout_s=min(timeout_s, 5.0))
+    if not login.get("is_authenticated"):
+        return {
+            "lane": "cursor",
+            "source": "cursor_native",
+            "probe_state": "NEED_LOGIN",
+            "login_state": "NEED_LOGIN",
+            "status": "need_login",
+            "provider_windows": {
+                "auto": _monthly_window_block(None, label="Auto", resets_at=None),
+                "api": _monthly_window_block(None, label="API", resets_at=None),
+            },
+            "fetched_at": fetched_at,
+        }
+
+    token = _load_cursor_access_token()
+    if not token:
+        return {
+            "lane": "cursor",
+            "source": "cursor_native",
+            "probe_state": "NEED_PROBE",
+            "login_state": "authenticated",
+            "status": "unknown",
+            "provider_windows": {
+                "auto": _monthly_window_block(None, label="Auto", resets_at=None),
+                "api": _monthly_window_block(None, label="API", resets_at=None),
+            },
+            "auth_error": "Cursor credentials unavailable for usage probe",
+            "error_kind": "missing_credentials",
+            "fetched_at": fetched_at,
+        }
+
+    try:
+        req = urllib.request.Request(
+            _CURSOR_USAGE_URL,
+            data=b"{}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+        return {
+            "lane": "cursor",
+            "source": "cursor_native",
+            "probe_state": "NEED_PROBE",
+            "login_state": "authenticated",
+            "status": "unknown",
+            "provider_windows": {
+                "auto": _monthly_window_block(None, label="Auto", resets_at=None),
+                "api": _monthly_window_block(None, label="API", resets_at=None),
+            },
+            "auth_error": str(exc)[:200],
+            "error_kind": "fetch_error",
+            "fetched_at": fetched_at,
+        }
+
+    plan = payload.get("planUsage") if isinstance(payload.get("planUsage"), dict) else {}
+    auto_used = plan.get("autoPercentUsed")
+    api_used = plan.get("apiPercentUsed")
+    auto_pct = float(auto_used) if isinstance(auto_used, (int, float)) else None
+    api_pct = float(api_used) if isinstance(api_used, (int, float)) else None
+    resets_at = _ms_to_iso_z(payload.get("billingCycleEnd"))
+
+    auto_block = _monthly_window_block(auto_pct, label="Auto", resets_at=resets_at)
+    api_block = _monthly_window_block(api_pct, label="API", resets_at=resets_at)
+
+    # Burn/status tracks the Auto-routing pool (operator: pin ``auto`` to spend Auto).
+    burn_pct = auto_pct
+    if burn_pct is not None:
+        if burn_pct >= 90.0:
+            lane_status = "near_cap"
+        elif burn_pct >= 75.0:
+            lane_status = "hot"
+        elif burn_pct < 50.0:
+            lane_status = "cool"
+        else:
+            lane_status = "warm"
+    else:
+        lane_status = "unknown"
+
+    return {
+        "lane": "cursor",
+        "source": "cursor_native",
+        "probe_state": "healthy",
+        "login_state": "authenticated",
+        "status": lane_status,
+        "auto_used_pct": auto_pct,
+        "api_used_pct": api_pct,
+        "auto_remaining_pct": auto_block.get("remaining_pct"),
+        "api_remaining_pct": api_block.get("remaining_pct"),
+        "primary_used_pct": auto_pct,
+        "primary_remaining_pct": auto_block.get("remaining_pct"),
+        "secondary_used_pct": auto_pct,
+        "secondary_remaining_pct": auto_block.get("remaining_pct"),
+        "tertiary_used_pct": api_pct,
+        "tertiary_remaining_pct": api_block.get("remaining_pct"),
+        "weekly_used_pct": None,
+        "weekly_remaining_pct": None,
+        "weekly_resets_at": resets_at,
+        "provider_windows": {"auto": auto_block, "api": api_block},
+        "fetched_at": fetched_at,
+    }

--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -684,9 +684,10 @@ def probe_cursor_login(*, timeout_s: float = 5.0) -> dict[str, Any]:
         }
 
     try:
-        payload = json.loads(res.stdout or "{}")
+        parsed = json.loads(res.stdout or "{}")
     except json.JSONDecodeError:
-        payload = {}
+        parsed = {}
+    payload = parsed if isinstance(parsed, dict) else {}
 
     is_auth = bool(payload.get("isAuthenticated"))
     if not is_auth and str(payload.get("status") or "").lower() == "authenticated":

--- a/scripts/agent_runtime/usage.py
+++ b/scripts/agent_runtime/usage.py
@@ -283,6 +283,78 @@ def summarize_lane_runtime(
     }
 
 
+def _new_fleet_burn_window() -> dict[str, Any]:
+    return {
+        "window_s": 0,
+        "counts": {"ok": 0, "error": 0, "rate_limited": 0, "timeout": 0, "other": 0, "total": 0},
+        "hours": 0.0,
+    }
+
+
+def summarize_fleet_burn(
+    agent: str,
+    *,
+    usage_dir: Path | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Dispatch burn from our JSONL across 5h / 7d / 30d windows."""
+    now_ts = time.time() if now is None else now
+    windows_s = {
+        "5h": 5 * 3600,
+        "7d": 7 * 24 * 3600,
+        "30d": 30 * 24 * 3600,
+    }
+    buckets = {name: _new_fleet_burn_window() for name in windows_s}
+    for name, window_s in windows_s.items():
+        buckets[name]["window_s"] = int(window_s)
+
+    root = usage_dir if usage_dir is not None else _usage_dir()
+    if root.is_dir():
+        for file_path in root.glob(f"usage_{agent}-*.jsonl"):
+            try:
+                with open(file_path, encoding="utf-8") as handle:
+                    for raw in handle:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            rec = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        ts_str = rec.get("ts")
+                        if not ts_str:
+                            continue
+                        try:
+                            ts = datetime.fromisoformat(
+                                str(ts_str).replace("Z", "+00:00")
+                            ).timestamp()
+                        except (ValueError, AttributeError, TypeError):
+                            continue
+                        outcome = str(rec.get("outcome") or "other")
+                        duration = rec.get("duration_s")
+                        hours = float(duration) / 3600.0 if isinstance(duration, (int, float)) else 0.0
+                        for name, window_s in windows_s.items():
+                            if ts < now_ts - window_s:
+                                continue
+                            bucket = buckets[name]
+                            counts = bucket["counts"]
+                            key = outcome if outcome in counts else "other"
+                            counts[key] += 1
+                            counts["total"] += 1
+                            bucket["hours"] = round(float(bucket["hours"]) + hours, 4)
+            except OSError:
+                continue
+
+    for bucket in buckets.values():
+        bucket["hours"] = round(float(bucket["hours"]), 4)
+
+    return {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": buckets,
+    }
+
+
 def has_headroom(agent: str, model: str) -> tuple[bool, str]:
     """Check whether (agent, model) has quota headroom for a new call.
 

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -13,14 +13,31 @@ import time
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from scripts.api.state_helpers import cache_get_with_age, cache_set
+
+try:
+    from scripts.agent_runtime.adapters.cursor import (
+        probe_cursor_login,
+        probe_cursor_provider_windows,
+    )
+except ImportError:  # pragma: no cover
+    from agent_runtime.adapters.cursor import (  # type: ignore
+        probe_cursor_login,
+        probe_cursor_provider_windows,
+    )
 
 WEEKLY_WINDOW_MINUTES = 10080
 # Reject monthly/long windows when no exact weekly window exists (e.g. 43200 min).
 WEEKLY_WINDOW_TOLERANCE_MINUTES = 5040
 PACE_TOLERANCE_PCT = 10.0
+
+try:
+    from scripts.common.repo_root import main_checkout_root
+except ImportError:  # pragma: no cover
+    from common.repo_root import main_checkout_root
 
 # Live-measured 2026-08-04: `codexbar usage --json --provider claude` took
 # ~17s end-to-end twice in a row (its own dashboard-fetch latency, not a
@@ -75,10 +92,24 @@ _last_refresh_finished_at: float | None = None
 
 def _is_usable_capacity(data: dict[str, Any] | None) -> bool:
     """Return whether a probe supplied authoritative capacity, not merely JSON."""
-    if not isinstance(data, dict) or data.get("status") != "healthy":
+    if not isinstance(data, dict):
+        return False
+    if data.get("status") in {"unavailable", "unknown", "need_login"}:
+        return False
+    if data.get("probe_state") in {"NEED_PROBE", "NEED_LOGIN"}:
+        return False
+    if data.get("login_state") == "NEED_LOGIN":
         return False
     weekly_used = data.get("weekly_used_pct")
-    return isinstance(weekly_used, (int, float)) and not isinstance(weekly_used, bool)
+    if isinstance(weekly_used, (int, float)) and not isinstance(weekly_used, bool):
+        return True
+    provider_windows = data.get("provider_windows")
+    if isinstance(provider_windows, dict):
+        auto = provider_windows.get("auto")
+        if isinstance(auto, dict) and isinstance(auto.get("used_pct"), (int, float)):
+            return True
+    primary_used = data.get("primary_used_pct")
+    return isinstance(primary_used, (int, float)) and not isinstance(primary_used, bool)
 
 
 def _failure_metadata(data: dict[str, Any]) -> dict[str, Any]:
@@ -470,29 +501,63 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
     named_tertiary = usage.get("tertiary") if isinstance(usage.get("tertiary"), dict) else None
 
     cursor_window_labels: dict[str, str] | None = None
+    cursor_provider_windows: dict[str, Any] | None = None
     if lane == "cursor":
-        # Burn/status must track Total, not Auto. The generic absolute fallback
-        # wrongly promoted secondary→weekly and understated account pressure.
-        primary_win = named_primary or primary_win
-        weekly_win = named_primary or weekly_win
-        cursor_window_labels = {"primary": "Total", "secondary": "Auto", "tertiary": "API"}
+        # Cursor Ultra: monthly Auto + API pools only. Do not mash Total into burn/status.
+        auto_win = named_secondary
+        api_win = named_tertiary
+        primary_win = auto_win
+        weekly_win = None
+        cursor_window_labels = {"secondary": "Auto", "tertiary": "API"}
+        auto_used = _used_pct(auto_win) if auto_win else _used_pct(named_secondary)
+        api_used = _used_pct(api_win) if api_win else _used_pct(named_tertiary)
+        resets_at = None
+        if auto_win and auto_win.get("resetsAt"):
+            resets_at = auto_win.get("resetsAt")
+        elif api_win and api_win.get("resetsAt"):
+            resets_at = api_win.get("resetsAt")
+        elif named_primary and named_primary.get("resetsAt"):
+            resets_at = named_primary.get("resetsAt")
+        cursor_provider_windows = {
+            "auto": {
+                "window": "monthly",
+                "label": "Auto",
+                "used_pct": auto_used,
+                "remaining_pct": _remaining_pct(auto_used),
+                "resets_at": resets_at,
+                "window_minutes": (auto_win or {}).get("windowMinutes"),
+            },
+            "api": {
+                "window": "monthly",
+                "label": "API",
+                "used_pct": api_used,
+                "remaining_pct": _remaining_pct(api_used),
+                "resets_at": resets_at,
+                "window_minutes": (api_win or {}).get("windowMinutes"),
+            },
+        }
+
+    auto_win = named_secondary if lane == "cursor" else None
+    api_win = named_tertiary if lane == "cursor" else None
 
     primary_used_pct = _used_pct(primary_win) if primary_win else _used_pct(named_primary)
     if primary_used_pct is None:
         primary_used_pct = _used_pct(named_primary)
+    if lane == "cursor" and cursor_provider_windows:
+        primary_used_pct = cursor_provider_windows["auto"]["used_pct"]
+        secondary_used_pct = primary_used_pct
+        tertiary_used_pct = cursor_provider_windows["api"]["used_pct"]
+    else:
+        secondary_used_pct = _used_pct(named_secondary)
+        tertiary_used_pct = _used_pct(named_tertiary)
 
     weekly_used_pct = _used_pct(weekly_win) if weekly_win else _used_pct(named_secondary)
     if weekly_used_pct is None:
         weekly_used_pct = _used_pct(named_secondary)
-    if lane == "cursor" and primary_used_pct is not None:
-        # Prefer Total even when a leftover weekly_win still points elsewhere.
-        weekly_used_pct = primary_used_pct
-
-    secondary_used_pct = _used_pct(named_secondary)
-    if secondary_used_pct is None and lane != "cursor" and weekly_used_pct is not None:
+    if lane == "cursor":
+        weekly_used_pct = None
+    elif secondary_used_pct is None and weekly_used_pct is not None:
         secondary_used_pct = weekly_used_pct
-
-    tertiary_used_pct = _used_pct(named_tertiary)
 
     weekly_resets_at = None
     if weekly_win:
@@ -503,8 +568,10 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         weekly_resets_at = named_secondary.get("resetsAt")
     if not weekly_resets_at and named_primary:
         weekly_resets_at = named_primary.get("resetsAt")
-    if lane == "cursor" and named_primary and named_primary.get("resetsAt"):
-        weekly_resets_at = named_primary.get("resetsAt")
+    if lane == "cursor" and cursor_provider_windows:
+        auto_resets = cursor_provider_windows["auto"].get("resets_at")
+        if auto_resets:
+            weekly_resets_at = auto_resets
 
     monthly_cap_usd = None
     monthly_used_usd = None
@@ -533,7 +600,8 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         pace_summary = weekly_pace.get("summary")
     else:
         # Fallback manual calculation of pace
-        if weekly_resets_at and weekly_used_pct is not None:
+        pace_used = primary_used_pct if lane == "cursor" else weekly_used_pct
+        if weekly_resets_at and pace_used is not None:
             try:
                 dt_str = weekly_resets_at.replace("Z", "+00:00")
                 resets_at_dt = datetime.fromisoformat(dt_str)
@@ -542,8 +610,13 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
                 win_mins = 10080
                 if weekly_win and weekly_win.get("windowMinutes") is not None:
                     win_mins = int(weekly_win["windowMinutes"])
-                elif lane == "cursor" and named_primary and named_primary.get("windowMinutes") is not None:
-                    win_mins = int(named_primary["windowMinutes"])
+                elif lane == "cursor" and cursor_provider_windows:
+                    auto_resets = cursor_provider_windows["auto"].get("resets_at")
+                    if auto_resets:
+                        weekly_resets_at = auto_resets
+                    win_mins = cursor_provider_windows["auto"].get("window_minutes")
+                    if win_mins is not None:
+                        win_mins = int(win_mins)
 
                 window_duration_seconds = win_mins * 60
                 window_start_dt = resets_at_dt - timedelta(seconds=window_duration_seconds)
@@ -553,10 +626,10 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
                     elapsed_fraction = elapsed_seconds / window_duration_seconds
                     elapsed_fraction = max(0.0, min(1.0, elapsed_fraction))
                     expected_pct = elapsed_fraction * 100.0
-                    weekly_pace_delta_pct = weekly_used_pct - expected_pct
+                    weekly_pace_delta_pct = pace_used - expected_pct
 
                     margin = 10.0
-                    is_in_deficit = weekly_used_pct > expected_pct + margin
+                    is_in_deficit = pace_used > expected_pct + margin
                     will_last_to_reset = not is_in_deficit
                     pace_summary = f"{weekly_pace_delta_pct:.1f}% pace delta | Expected {expected_pct:.1f}% used"
             except Exception:
@@ -580,7 +653,7 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         return block
 
     labels = cursor_window_labels or {}
-    return {
+    result = {
         "lane": lane,
         "primary_used_pct": primary_used_pct,
         "primary_remaining_pct": _remaining_pct(primary_used_pct),
@@ -588,7 +661,7 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         "secondary_remaining_pct": _remaining_pct(secondary_used_pct),
         "tertiary_used_pct": tertiary_used_pct,
         "tertiary_remaining_pct": _remaining_pct(tertiary_used_pct),
-        # Back-compat: weekly ≈ secondary for Claude/Codex; Cursor weekly ≈ Total (primary).
+        # Back-compat weekly for Claude/Codex only; Cursor has monthly auto/api pools.
         "weekly_used_pct": weekly_used_pct,
         "weekly_remaining_pct": _remaining_pct(weekly_used_pct),
         "windows": {
@@ -596,11 +669,11 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
                 named_primary or primary_win, primary_used_pct, label=labels.get("primary")
             ),
             "secondary": _window_block(
-                named_secondary or (None if lane == "cursor" else weekly_win),
+                named_secondary or (auto_win if lane == "cursor" else weekly_win),
                 secondary_used_pct,
                 label=labels.get("secondary"),
             ),
-            "tertiary": _window_block(named_tertiary, tertiary_used_pct, label=labels.get("tertiary")),
+            "tertiary": _window_block(named_tertiary or api_win, tertiary_used_pct, label=labels.get("tertiary")),
         },
         "monthly_cap_usd": monthly_cap_usd,
         "monthly_used_usd": monthly_used_usd,
@@ -617,6 +690,9 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         "source": "codexbar",
         "fetched_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }
+    if cursor_provider_windows is not None:
+        result["provider_windows"] = cursor_provider_windows
+    return result
 
 
 def _stdout_has_provider_payload(stdout: str) -> bool:
@@ -755,6 +831,141 @@ def stop_periodic_refresh(*, join_timeout_s: float = 1.0) -> None:
         _scheduler_thread = None
     if thread is not None and thread.is_alive():
         thread.join(timeout=join_timeout_s)
+
+
+def _routing_budget_state_dir() -> Path:
+    source_repo_root = Path(__file__).resolve().parents[2]
+    repo_root = main_checkout_root(source_repo_root)
+    path = repo_root / "batch_state" / "routing_budget"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _provider_lkg_path() -> Path:
+    return _routing_budget_state_dir() / "provider_lkg.json"
+
+
+def _read_provider_lkg() -> dict[str, Any]:
+    path = _provider_lkg_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_provider_lkg(data: dict[str, Any]) -> None:
+    path = _provider_lkg_path()
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def persist_provider_snapshot(lane: str, snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Append a sanitized provider snapshot to on-disk LKG (max 8 per lane)."""
+    lkg = _read_provider_lkg()
+    lane_key = str(lane)
+    history = lkg.get(lane_key)
+    if not isinstance(history, list):
+        history = []
+    provider_windows = snapshot.get("provider_windows") if isinstance(snapshot.get("provider_windows"), dict) else {}
+    auto = provider_windows.get("auto") if isinstance(provider_windows.get("auto"), dict) else {}
+    api = provider_windows.get("api") if isinstance(provider_windows.get("api"), dict) else {}
+    entry = {
+        "at": snapshot.get("fetched_at") or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "source": snapshot.get("source"),
+        "auto_used_pct": auto.get("used_pct", snapshot.get("primary_used_pct")),
+        "api_used_pct": api.get("used_pct", snapshot.get("tertiary_used_pct")),
+        "weekly_used_pct": snapshot.get("weekly_used_pct"),
+    }
+    history.append(entry)
+    lkg[lane_key] = history[-8:]
+    _write_provider_lkg(lkg)
+    return compute_provider_trend(lane_key, history=lkg[lane_key])
+
+
+def compute_provider_trend(lane: str, *, history: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Derive simple trend/deficit/headroom hints from the last two on-disk samples."""
+    rows = history if history is not None else _read_provider_lkg().get(lane, [])
+    if not isinstance(rows, list) or not rows:
+        return {"trend": None, "delta_auto_pct": None, "samples": 0}
+    if len(rows) == 1:
+        auto = rows[-1].get("auto_used_pct")
+        if isinstance(auto, (int, float)):
+            headroom = max(0.0, 100.0 - float(auto))
+            return {
+                "trend": "flat",
+                "delta_auto_pct": 0.0,
+                "headroom_pct": headroom,
+                "deficit": float(auto) >= 90.0,
+                "samples": 1,
+            }
+        weekly = rows[-1].get("weekly_used_pct")
+        if isinstance(weekly, (int, float)):
+            headroom = max(0.0, 100.0 - float(weekly))
+            return {
+                "trend": "flat",
+                "delta_auto_pct": 0.0,
+                "headroom_pct": headroom,
+                "deficit": float(weekly) >= 90.0,
+                "samples": 1,
+            }
+        return {"trend": None, "delta_auto_pct": None, "samples": 1}
+    prev, cur = rows[-2], rows[-1]
+    prev_auto = prev.get("auto_used_pct") if isinstance(prev.get("auto_used_pct"), (int, float)) else prev.get("weekly_used_pct")
+    cur_auto = cur.get("auto_used_pct") if isinstance(cur.get("auto_used_pct"), (int, float)) else cur.get("weekly_used_pct")
+    if not isinstance(cur_auto, (int, float)):
+        return {"trend": None, "delta_auto_pct": None, "samples": len(rows)}
+    delta = float(cur_auto) - float(prev_auto or 0.0)
+    trend = "up" if delta > 1.0 else "down" if delta < -1.0 else "flat"
+    headroom = max(0.0, 100.0 - float(cur_auto))
+    return {
+        "trend": trend,
+        "delta_auto_pct": round(delta, 2),
+        "headroom_pct": headroom,
+        "deficit": float(cur_auto) >= 90.0,
+        "samples": len(rows),
+    }
+
+
+def get_cursor_lane_usage(*, prefer_native: bool = True) -> dict[str, Any]:
+    """Cursor lane: login gate + native Auto/API probe; CodexBar optional overlay."""
+    login = probe_cursor_login()
+    if not login.get("is_authenticated"):
+        return {
+            **login,
+            "probe_state": "NEED_LOGIN",
+            "provider_windows": {
+                "auto": {"window": "monthly", "label": "Auto", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "label": "API", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+        }
+
+    native = probe_cursor_provider_windows()
+    if prefer_native and native.get("probe_state") == "healthy":
+        merged = dict(native)
+    else:
+        cb = get_provider_usage_data("cursor")
+        if _is_usable_capacity(cb):
+            merged = dict(cb)
+            merged["source"] = "codexbar"
+        else:
+            merged = dict(native)
+
+    if native.get("probe_state") == "healthy" or _is_usable_capacity(merged):
+        trend = persist_provider_snapshot("cursor", merged)
+        merged["trend"] = trend
+        auto_used = None
+        if isinstance(merged.get("provider_windows"), dict):
+            auto_block = merged["provider_windows"].get("auto")
+            if isinstance(auto_block, dict):
+                auto_used = auto_block.get("used_pct")
+        if auto_used is None:
+            auto_used = merged.get("primary_used_pct")
+        if isinstance(auto_used, (int, float)):
+            merged["headroom_pct"] = max(0.0, 100.0 - float(auto_used))
+            merged["deficit"] = bool(trend.get("deficit"))
+    return merged
 
 
 def scheduler_status() -> dict[str, Any]:

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -58,6 +58,11 @@ DEFAULT_CODEXBAR_REFRESH_TIMEOUT_S = 25.0
 DEFAULT_CODEXBAR_CACHE_TTL_S = 720.0
 DEFAULT_CODEXBAR_REFRESH_INTERVAL_S = 720.0
 
+# Native Cursor login + dashboard probe can exceed routing.html's 5s timeout.
+# Cache HTTP reads for 10 minutes; background refresh keeps snapshots warm.
+DEFAULT_CURSOR_CACHE_TTL_S = 600.0
+CURSOR_CACHE_KEY = "cursor_lane_usage"
+
 SUBSCRIPTION_PROVIDERS: tuple[str, ...] = (
     "claude",
     "codex",
@@ -88,6 +93,9 @@ _scheduler_stop = threading.Event()
 _scheduler_thread: threading.Thread | None = None
 _last_refresh_started_at: float | None = None
 _last_refresh_finished_at: float | None = None
+_cursor_last_good: tuple[float, dict[str, Any]] | None = None
+_cursor_refresh_lock = threading.Lock()
+_cursor_refresh_thread: threading.Thread | None = None
 
 
 def _is_usable_capacity(data: dict[str, Any] | None) -> bool:
@@ -197,6 +205,11 @@ def _codexbar_refresh_interval_s() -> float:
     return _env_positive_float(
         "CODEXBAR_REFRESH_INTERVAL_S", DEFAULT_CODEXBAR_REFRESH_INTERVAL_S
     )
+
+
+def _cursor_cache_ttl_s() -> float:
+    """How long a successful Cursor native snapshot is labelled fresh."""
+    return _env_positive_float("CURSOR_CACHE_TTL_S", DEFAULT_CURSOR_CACHE_TTL_S)
 
 
 def _periodic_refresh_enabled() -> bool:
@@ -782,10 +795,16 @@ def _run_all_refreshes() -> None:
         # floor as the explicit fresh-refresh path (see _codexbar_refresh_timeout_s)
         # rather than the prior 2.0s, which never let the claude lane's ~17s CLI
         # probe complete.
-        refresh_provider_usage_data(SUBSCRIPTION_PROVIDERS)
+        refresh_provider_usage_data(SUBSCRIPTION_LANES_WITHOUT_CURSOR)
+        _refresh_cursor_usage_live()
     finally:
         _last_refresh_finished_at = time.monotonic()
         _refresh_in_flight.release()
+
+
+SUBSCRIPTION_LANES_WITHOUT_CURSOR: tuple[str, ...] = tuple(
+    p for p in SUBSCRIPTION_PROVIDERS if p != "cursor"
+)
 
 
 def _scheduler_is_running() -> bool:
@@ -928,8 +947,8 @@ def compute_provider_trend(lane: str, *, history: list[dict[str, Any]] | None = 
     }
 
 
-def get_cursor_lane_usage(*, prefer_native: bool = True) -> dict[str, Any]:
-    """Cursor lane: login gate + native Auto/API probe; CodexBar optional overlay."""
+def _fetch_cursor_lane_usage_live(*, prefer_native: bool = True) -> dict[str, Any]:
+    """Probe Cursor login + native Auto/API pools (blocking; background/scheduler only)."""
     login = probe_cursor_login()
     if not login.get("is_authenticated"):
         return {
@@ -966,6 +985,105 @@ def get_cursor_lane_usage(*, prefer_native: bool = True) -> dict[str, Any]:
             merged["headroom_pct"] = max(0.0, 100.0 - float(auto_used))
             merged["deficit"] = bool(trend.get("deficit"))
     return merged
+
+
+def _cursor_probe_is_cacheable(data: dict[str, Any] | None) -> bool:
+    """Any completed Cursor probe (including NEED_LOGIN) is worth caching."""
+    if not isinstance(data, dict):
+        return False
+    if data.get("fetched_at"):
+        return True
+    return data.get("probe_state") in {"NEED_LOGIN", "NEED_PROBE", "healthy"}
+
+
+def _record_cursor_probe_result(data: dict[str, Any] | None) -> bool:
+    global _cursor_last_good
+    if not _cursor_probe_is_cacheable(data):
+        return False
+    assert data is not None
+    snapshot = dict(data)
+    cache_set(CURSOR_CACHE_KEY, snapshot)
+    _cursor_last_good = (time.monotonic(), snapshot)
+    return True
+
+
+def _with_cursor_observation_metadata(
+    data: dict[str, Any],
+    *,
+    freshness: str,
+    age_s: float | None,
+) -> dict[str, Any]:
+    result = dict(data)
+    result.update(
+        {
+            "freshness": freshness,
+            "stale": freshness == "stale_last_good",
+            "age_s": age_s,
+        }
+    )
+    return result
+
+
+def _refresh_cursor_usage_live() -> dict[str, Any] | None:
+    data = _fetch_cursor_lane_usage_live()
+    if _record_cursor_probe_result(data):
+        return _with_cursor_observation_metadata(data, freshness="fresh", age_s=0.0)
+    return None
+
+
+def trigger_cursor_background_refresh() -> None:
+    """Start one bounded Cursor native refresh without making an API request wait."""
+    global _cursor_refresh_thread
+    with _cursor_refresh_lock:
+        if _cursor_refresh_thread is not None and _cursor_refresh_thread.is_alive():
+            return
+        _cursor_refresh_thread = threading.Thread(
+            target=_refresh_cursor_usage_live,
+            name="cursor-usage-refresh",
+            daemon=True,
+        )
+        _cursor_refresh_thread.start()
+
+
+def get_cursor_lane_usage(*, prefer_native: bool = True) -> dict[str, Any]:
+    """Cursor lane: cache-only HTTP path; native probe runs in background."""
+    cached = cache_get_with_age(CURSOR_CACHE_KEY, ttl=_cursor_cache_ttl_s())
+    if cached is not None:
+        val, age = cached
+        if _cursor_probe_is_cacheable(val):
+            return _with_cursor_observation_metadata(
+                val,
+                freshness="fresh",
+                age_s=age,
+            )
+
+    if not _scheduler_is_running() and _on_demand_refresh_enabled():
+        trigger_cursor_background_refresh()
+
+    if _cursor_last_good is not None:
+        t_mono, val = _cursor_last_good
+        return _with_cursor_observation_metadata(
+            val,
+            freshness="stale_last_good",
+            age_s=time.monotonic() - t_mono,
+        )
+
+    return _with_cursor_observation_metadata(
+        {
+            "lane": "cursor",
+            "login_state": "unknown",
+            "probe_state": "NEED_PROBE",
+            "status": "unknown",
+            "provider_windows": {
+                "auto": {"window": "monthly", "label": "Auto", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "label": "API", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+            "fetched_at": None,
+            "source": "cursor_native",
+        },
+        freshness="unavailable",
+        age_s=None,
+    )
 
 
 def scheduler_status() -> dict[str, Any]:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -519,10 +519,12 @@ def _recommend_agent(
         )
 
     def select_agent(agents_dict, status_map, burn_map, resets_map):
-        def _sort_burn(agent: str) -> tuple[int, float]:
+        def _sort_burn(agent: str) -> tuple[float, int]:
             val = burn_map.get(agent)
             burn_key = float(val) if isinstance(val, (int, float)) else 999.0
-            return (CODE_IMPLEMENT_LANE_PRIORITY.get(agent, 50), burn_key)
+            # Burn first (lowest 7d spend), lane rank only as a tie-break.
+            # Cursor-first for cool Ultra is the explicit branch above, not this sort.
+            return (burn_key, CODE_IMPLEMENT_LANE_PRIORITY.get(agent, 50))
 
         if "near_cap" in status_map.values():
             candidates = [agent for agent, st in status_map.items() if st == "cool"]

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -62,7 +62,9 @@ from . import delegate_router as delegate_api
 from . import preparation_state
 from .codexbar_usage import (
     compute_weekly_pace_delta_pct,
+    get_cursor_lane_usage,
     get_provider_usage_data,
+    persist_provider_snapshot,  # noqa: F401 — tests monkeypatch via state_router
     refresh_provider_usage_data,
     trigger_background_refresh,
 )
@@ -72,9 +74,9 @@ from .project_state_store import REPORT_TTL_SECONDS, get_freshest_lane_usage
 from .runtime_router import summarize_runtime_usage
 
 try:
-    from agent_runtime.usage import summarize_lane_runtime
+    from agent_runtime.usage import summarize_fleet_burn, summarize_lane_runtime
 except ImportError:
-    from scripts.agent_runtime.usage import summarize_lane_runtime
+    from scripts.agent_runtime.usage import summarize_fleet_burn, summarize_lane_runtime
 from .monitor_context import get_ctx
 from .repository_authority import (
     RepositoryAuthorityError,
@@ -132,6 +134,48 @@ from .telemetry.response import add_json_telemetry, session_id_from_request
 _detect_pipeline_version = detect_pipeline_version
 _is_research_done = is_research_done
 _is_content_done = is_content_done
+
+CODE_IMPLEMENT_LANE_PRIORITY: dict[str, int] = {
+    "cursor": 0,
+    "codex": 1,
+    "claude": 2,
+    "grok": 3,
+    "kimi": 4,
+    "gemini": 5,
+}
+
+
+def _capacity_used_pct(cb_data: dict[str, Any] | None) -> float | None:
+    """Resolve the authoritative used-% for a lane (weekly or Cursor Auto monthly)."""
+    if not isinstance(cb_data, dict):
+        return None
+    weekly = cb_data.get("weekly_used_pct")
+    if isinstance(weekly, (int, float)) and not isinstance(weekly, bool):
+        return float(weekly)
+    provider_windows = cb_data.get("provider_windows")
+    if isinstance(provider_windows, dict):
+        auto = provider_windows.get("auto")
+        if isinstance(auto, dict) and isinstance(auto.get("used_pct"), (int, float)):
+            return float(auto["used_pct"])
+    primary = cb_data.get("primary_used_pct")
+    if isinstance(primary, (int, float)) and not isinstance(primary, bool):
+        return float(primary)
+    return None
+
+
+def _fleet_burn_has_activity(fleet_burn: dict[str, Any] | None) -> bool:
+    if not isinstance(fleet_burn, dict):
+        return False
+    windows = fleet_burn.get("windows")
+    if not isinstance(windows, dict):
+        return False
+    for block in windows.values():
+        if not isinstance(block, dict):
+            continue
+        counts = block.get("counts")
+        if isinstance(counts, dict) and int(counts.get("total") or 0) > 0:
+            return True
+    return False
 
 router = APIRouter(tags=["state"])
 
@@ -437,6 +481,9 @@ def _recommend_agent(
         if a in core or a not in agents:
             continue
         st = agents[a].get("status", "unknown")
+        login_state = agents[a].get("login_state")
+        if login_state == "NEED_LOGIN" or st == "need_login":
+            continue
         if st not in ("unknown", "unavailable"):
             status_by_agent[a] = st
             burn_by_agent[a] = agents[a].get("burn_pct_7d")
@@ -472,9 +519,10 @@ def _recommend_agent(
         )
 
     def select_agent(agents_dict, status_map, burn_map, resets_map):
-        def _sort_burn(agent: str) -> float:
+        def _sort_burn(agent: str) -> tuple[int, float]:
             val = burn_map.get(agent)
-            return float(val) if isinstance(val, (int, float)) else 999.0
+            burn_key = float(val) if isinstance(val, (int, float)) else 999.0
+            return (CODE_IMPLEMENT_LANE_PRIORITY.get(agent, 50), burn_key)
 
         if "near_cap" in status_map.values():
             candidates = [agent for agent, st in status_map.items() if st == "cool"]
@@ -491,6 +539,22 @@ def _recommend_agent(
                         f"available 7d burn ({_format_pct(burn_map.get(recommended))}%)."
                     ),
                 }
+
+        # Operator 2026-08-26: authenticated Cursor Ultra must lead cool code-implement seats.
+        cursor_st = status_map.get("cursor")
+        cursor_info = agents_dict.get("cursor") if isinstance(agents_dict.get("cursor"), dict) else {}
+        if (
+            cursor_st == "cool"
+            and cursor_info.get("login_state") != "NEED_LOGIN"
+            and cursor_info.get("probe_state") != "NEED_LOGIN"
+        ):
+            return {
+                "primary_agent_for_code": "cursor",
+                "rationale": (
+                    "Cursor Ultra is authenticated and cool; prefer Auto-pool utilization "
+                    f"({_format_pct(burn_map.get('cursor'))}% Auto monthly burn)."
+                ),
+            }
 
         # claude pool still special
         if "claude" in agents_dict:
@@ -944,14 +1008,43 @@ def compute_routing_budget(
     refreshed_codexbar = refresh_provider_usage_data(SUBSCRIPTION_LANES) if fresh_codexbar else {}
 
     for lane in SUBSCRIPTION_LANES:
-        cb_data = refreshed_codexbar.get(lane) or get_provider_usage_data(lane)
+        if lane == "cursor":
+            cb_data = get_cursor_lane_usage()
+        else:
+            cb_data = refreshed_codexbar.get(lane) or get_provider_usage_data(lane)
         if isinstance(cb_data, dict):
             cb_freshness[lane] = str(cb_data.get("freshness") or (
                 "stale_last_good" if cb_data.get("stale") else "fresh"
             ))
-        if cb_data and cb_data.get("weekly_used_pct") is not None:
+
+        if lane == "cursor" and isinstance(cb_data, dict):
+            agents[lane]["login_state"] = cb_data.get("login_state")
+            agents[lane]["probe_state"] = cb_data.get("probe_state")
+            if isinstance(cb_data.get("provider_windows"), dict):
+                agents[lane]["provider_windows"] = cb_data["provider_windows"]
+            if cb_data.get("trend"):
+                agents[lane]["trend"] = cb_data["trend"]
+            if cb_data.get("login_state") == "NEED_LOGIN" or cb_data.get("probe_state") == "NEED_LOGIN":
+                agents[lane]["status"] = "need_login"
+                agents[lane]["remaining_pct"] = None
+                agents[lane]["burn_pct_7d"] = None
+                agents[lane]["codexbar"] = {
+                    "login_state": "NEED_LOGIN",
+                    "probe_state": "NEED_LOGIN",
+                    "status": "need_login",
+                    "provider_windows": cb_data.get("provider_windows"),
+                    "fetched_at": cb_data.get("fetched_at"),
+                }
+                warnings.append(
+                    "lane cursor NEED_LOGIN — operator must authenticate (`agent login`); "
+                    "do not silently substitute to agy/codex"
+                )
+                continue
+
+        capacity_used = _capacity_used_pct(cb_data if isinstance(cb_data, dict) else None)
+        if cb_data and capacity_used is not None:
             cb_sourced_any = True
-            weekly_used = cb_data["weekly_used_pct"]
+            weekly_used = capacity_used
 
             # Determine status using deficit signal
             is_in_deficit = (
@@ -987,12 +1080,18 @@ def compute_routing_budget(
                 "weekly_used_pct": cb_data.get("weekly_used_pct"),
                 "weekly_remaining_pct": cb_data.get("weekly_remaining_pct"),
                 "windows": cb_data.get("windows"),
+                "provider_windows": cb_data.get("provider_windows"),
+                "probe_state": cb_data.get("probe_state"),
+                "login_state": cb_data.get("login_state"),
                 "monthly_cap_usd": cb_data.get("monthly_cap_usd"),
                 "monthly_used_usd": cb_data.get("monthly_used_usd"),
                 "weekly_resets_at": cb_data.get("weekly_resets_at"),
                 "weekly_pace_delta_pct": cb_data.get("weekly_pace_delta_pct"),
                 "will_last_to_reset": cb_data.get("will_last_to_reset"),
                 "pace_summary": cb_data.get("pace_summary"),
+                "trend": cb_data.get("trend"),
+                "headroom_pct": cb_data.get("headroom_pct"),
+                "deficit": cb_data.get("deficit"),
                 "stale": cb_data.get("stale", False),
                 "freshness": cb_data.get("freshness") or (
                     "stale_last_good" if cb_data.get("stale") else "fresh"
@@ -1002,7 +1101,10 @@ def compute_routing_budget(
                 "failure_kind": cb_data.get("failure_kind"),
                 "last_failure_at": cb_data.get("last_failure_at"),
                 "last_failure_code": cb_data.get("last_failure_code"),
+                "source": cb_data.get("source"),
             }
+            if isinstance(cb_data.get("provider_windows"), dict):
+                agents[lane]["provider_windows"] = cb_data["provider_windows"]
 
             # Update authoritative keys in agents
             if lane == "claude":
@@ -1031,12 +1133,23 @@ def compute_routing_budget(
                 agent_config = budgets.get(lane) if isinstance(budgets.get(lane), dict) else {}
                 cap = float(agent_config.get("weekly_cap_usd") or 0.0) if agent_config else 0.0
                 agents[lane]["burn_pct_7d"] = weekly_used
-                agents[lane]["status"] = cb_status
+                agents[lane]["status"] = cb_data.get("status") if lane == "cursor" and cb_data.get("status") else cb_status
                 agents[lane]["spent_7d_usd"] = _round_money((weekly_used / 100.0) * cap) if cap else None
                 agents[lane]["remaining_pct"] = 100.0 - weekly_used
                 if cb_data.get("weekly_resets_at"):
                     agents[lane]["resets_at"] = cb_data["weekly_resets_at"]
 
+        elif lane == "cursor" and isinstance(cb_data, dict) and cb_data.get("probe_state") == "NEED_PROBE":
+            agents[lane]["provider_windows"] = cb_data.get("provider_windows")
+            agents[lane]["probe_state"] = "NEED_PROBE"
+            agents[lane]["codexbar"] = {
+                "probe_state": "NEED_PROBE",
+                "provider_windows": cb_data.get("provider_windows"),
+                "auth_error": cb_data.get("auth_error"),
+                "error_kind": cb_data.get("error_kind"),
+                "fetched_at": cb_data.get("fetched_at"),
+                "status": "unknown",
+            }
         else:
             # CodexBar capacity is unavailable (missing binary, timeout, non-zero exit, malformed JSON, unparseable schema, provider error, or fallback).
             # Retain ledger-derived burn_pct_7d/remaining_pct/status if available (or "unknown" if no cap/records).
@@ -1090,9 +1203,18 @@ def compute_routing_budget(
     # surfaces reactive 429/burn so a dashboard-green lane that is actively
     # rate-limiting still demotes in ranking and warnings.
     runtime_sourced_any = False
+    fleet_burn_any = False
     for lane in SUBSCRIPTION_LANES:
         if lane not in agents:
             continue
+        try:
+            fleet_burn = summarize_fleet_burn(lane)
+        except Exception as exc:
+            logging.getLogger("state_router").debug("fleet burn failed for %s: %s", lane, exc)
+            fleet_burn = {"source": "agent_runtime_jsonl", "agent": lane, "windows": {}}
+        agents[lane]["fleet_burn"] = fleet_burn
+        if _fleet_burn_has_activity(fleet_burn):
+            fleet_burn_any = True
         try:
             runtime = summarize_lane_runtime(lane)
         except Exception as exc:  # never break routing-budget on telemetry I/O
@@ -1193,9 +1315,13 @@ def compute_routing_budget(
                     if lane == "cursor":
                         auto_pct = cb.get("secondary_used_pct")
                         api_pct = cb.get("tertiary_used_pct")
+                        provider_windows = cb.get("provider_windows") if isinstance(cb.get("provider_windows"), dict) else {}
+                        if isinstance(provider_windows.get("auto"), dict):
+                            auto_pct = provider_windows["auto"].get("used_pct", auto_pct)
+                        if isinstance(provider_windows.get("api"), dict):
+                            api_pct = provider_windows["api"].get("used_pct", api_pct)
                         short_bit = (
-                            f"Total {primary_pct:.0f}% used"
-                            + (f", Auto {auto_pct:.0f}%" if auto_pct is not None else "")
+                            f"Auto {auto_pct:.0f}% used"
                             + (f", API {api_pct:.0f}%" if api_pct is not None else "")
                         )
                     elif primary_mins is None or int(primary_mins) <= 300:
@@ -1255,7 +1381,7 @@ def compute_routing_budget(
         reset_imminent_hours=reset_hours,
         is_stale=is_stale,
         records_loaded=len(records),
-        authoritative_data_available=cb_sourced_any,
+        authoritative_data_available=cb_sourced_any or fleet_burn_any,
     )
 
     # Build ranked view: subscription by remaining headroom (low burn = high remaining first), API always unknown
@@ -1351,10 +1477,14 @@ def compute_routing_budget(
                     if nb_sourced_any and cb_had_any_before_notebook
                     else "notebook-report"
                     if nb_sourced_any
+                    else "codexbar+cursor_native"
+                    if agents.get("cursor", {}).get("probe_state") == "healthy"
                     else "codexbar"
                 ),
                 "burn_rate_limit": "agent_runtime_jsonl",
+                "fleet_burn": "agent_runtime_jsonl",
             },
+            "fleet_burn_available": fleet_burn_any,
             "notebook_report_available": nb_sourced_any,
             "notebook_report_max_age_s": nb_max_age_s,
         },

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -1215,6 +1215,15 @@ def compute_routing_budget(
         agents[lane]["fleet_burn"] = fleet_burn
         if _fleet_burn_has_activity(fleet_burn):
             fleet_burn_any = True
+            # Native/CodexBar miss must not hide an authenticated Cursor lane
+            # that we are already dispatching (CF #7359).
+            if (
+                lane == "cursor"
+                and agents[lane].get("login_state") == "authenticated"
+                and agents[lane].get("probe_state") != "NEED_LOGIN"
+                and agents[lane].get("status") in (None, "unknown", "unavailable")
+            ):
+                agents[lane]["status"] = "cool"
         try:
             runtime = summarize_lane_runtime(lane)
         except Exception as exc:  # never break routing-budget on telemetry I/O

--- a/scripts/config/agent_budgets.yaml
+++ b/scripts/config/agent_budgets.yaml
@@ -34,8 +34,9 @@ grok:
   # cap value not duplicated here to avoid drift with user's live tracking.
 # grok-hermes is API/Hermes-path and intentionally ABSENT from subscription caps.
 cursor:
-  # Cursor Pro+ subscription lane (CodexBar: Total / Auto / API).
-  # Burn/status tracks Total; do not invent a synthetic dollar cap here.
+  # Cursor Ultra 20× — monthly Auto + API pools (not 5h/weekly). Burn/status tracks Auto;
+  # pin ``--model auto`` to spend Auto allocation. Pinning sonnet/opus burns API pool.
+  # Native probe: cursor dashboard API; CodexBar optional overlay when binary exists.
 kimi:
   # Native Kimi Code OAuth subscription lane (K3). CodexBar exposes request
   # windows directly; do not duplicate a synthetic dollar cap here.

--- a/scripts/fleet/capacity_pick.py
+++ b/scripts/fleet/capacity_pick.py
@@ -37,8 +37,19 @@ CODE_LANES: tuple[str, ...] = (
     "glm",
 )
 
-_AVOID_STATUSES = frozenset({"hot", "near_cap"})
+_AVOID_STATUSES = frozenset({"hot", "near_cap", "need_login"})
 _COOL_STATUSES = frozenset({"cool", "warm", "idle"})
+_CODE_LANE_PRIORITY = {
+    "cursor": 0,
+    "codex": 1,
+    "claude": 2,
+    "grok": 3,
+    "kimi": 4,
+    "gemini": 5,
+    "agy": 6,
+    "deepseek": 7,
+    "glm": 8,
+}
 _MONITOR_DEFAULT = "http://127.0.0.1:8765"
 
 
@@ -67,13 +78,11 @@ def will_last_to_reset(agent_info: dict[str, Any] | None) -> bool | None:
 
 
 def is_avoid_lane(agent_info: dict[str, Any] | None, *, lane: str | None = None) -> bool:
-    """True when hot/near_cap, CodexBar deficit, or ``lane`` is a retired CLI alias.
-
-    A retired lane (currently just ``gemini`` → agy) is force-AVOID regardless
-    of its budget reading — a "cool" CodexBar snapshot is not proof the binary
-    is still installed.
-    """
+    """True when hot/near_cap/need_login, CodexBar deficit, or ``lane`` is retired."""
     if lane is not None and lane.strip().lower() in RETIRED_AGENT_ALIASES:
+        return True
+    info = agent_info or {}
+    if info.get("login_state") == "NEED_LOGIN" or info.get("probe_state") == "NEED_LOGIN":
         return True
     status = lane_status(agent_info)
     if status in _AVOID_STATUSES:
@@ -86,6 +95,14 @@ def remaining_pct(agent_info: dict[str, Any] | None) -> float | None:
     rem = info.get("remaining_pct")
     if isinstance(rem, (int, float)):
         return float(rem)
+    provider_windows = info.get("provider_windows")
+    if isinstance(provider_windows, dict):
+        auto = provider_windows.get("auto")
+        if isinstance(auto, dict) and isinstance(auto.get("remaining_pct"), (int, float)):
+            return float(auto["remaining_pct"])
+    headroom = info.get("headroom_pct")
+    if isinstance(headroom, (int, float)):
+        return float(headroom)
     burn = info.get("burn_pct_7d")
     if isinstance(burn, (int, float)):
         return 100.0 - float(burn)
@@ -151,6 +168,8 @@ def build_lane_rows(
         notes: list[str] = []
         if avoid:
             notes.append("AVOID")
+            if info.get("login_state") == "NEED_LOGIN" or info.get("probe_state") == "NEED_LOGIN":
+                notes.append("NEED_LOGIN")
             if retired_target:
                 notes.append(f"retired→{retired_target}")
             if will_last is False:
@@ -186,6 +205,8 @@ def build_pick_order(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         rem = row.get("remaining_pct")
         rem_key = -float(rem) if isinstance(rem, (int, float)) else 0.0
         in_flight = int(row.get("in_flight") or 0)
+        lane_name = str(row.get("lane") or "")
+        lane_rank = _CODE_LANE_PRIORITY.get(lane_name, 50)
         status_rank = {
             "cool": 0,
             "warm": 1,
@@ -194,7 +215,7 @@ def build_pick_order(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "hot": 8,
             "near_cap": 9,
         }.get(status, 5)
-        return (avoid, status_rank, in_flight, rem_key, str(row.get("lane")))
+        return (avoid, status_rank, lane_rank, in_flight, rem_key, lane_name)
 
     ordered = sorted(rows, key=_sort_key)
     out: list[dict[str, Any]] = []

--- a/tests/api/test_routing_budget.py
+++ b/tests/api/test_routing_budget.py
@@ -152,6 +152,42 @@ def test_authenticated_cursor_with_fleet_burn_and_empty_codexbar(monkeypatch, tm
     assert data["recommendation"]["primary_agent_for_code"] == "cursor"
 
 
+def test_need_probe_with_fleet_burn_still_picks_cursor(monkeypatch, tmp_path):
+    """NEED_PROBE + JSONL activity must not leave cursor unknown / unpicked."""
+    _configure_base(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        state_router,
+        "get_cursor_lane_usage",
+        lambda **kwargs: {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "probe_state": "NEED_PROBE",
+            "status": "unknown",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+            "source": "cursor_native",
+        },
+    )
+
+    def _fleet(agent: str, **kwargs) -> dict:
+        total = 4 if agent == "cursor" else 0
+        return {
+            "source": "agent_runtime_jsonl",
+            "agent": agent,
+            "windows": {"7d": {"counts": {"total": total}, "hours": 1.0}},
+        }
+
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", _fleet)
+    data = state_router.compute_routing_budget(datetime(2026, 8, 26, 12, 0, tzinfo=UTC))
+    cursor = data["agents"]["cursor"]
+    assert cursor["status"] == "cool"
+    assert cursor["probe_state"] == "NEED_PROBE"
+    assert cursor["fleet_burn"]["windows"]["7d"]["counts"]["total"] == 4
+    assert data["recommendation"]["primary_agent_for_code"] == "cursor"
+
+
 def test_capacity_pick_orders_cursor_before_agy_when_cool(monkeypatch):
     budget = {
         "generated_at": "2026-08-26T12:00:00Z",

--- a/tests/api/test_routing_budget.py
+++ b/tests/api/test_routing_budget.py
@@ -1,0 +1,199 @@
+"""Cursor subscription / routing-budget acceptance tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.api import state_router
+from scripts.fleet import capacity_pick
+
+
+def _write_budget_config(tmp_path: Path) -> Path:
+    path = tmp_path / "agent_budgets.yaml"
+    path.write_text(
+        """
+claude:
+  interactive:
+    weekly_cap_usd: 460
+  agentic_pool:
+    monthly_cap_usd: 200
+    starts_on: "2026-06-15"
+codex:
+  weekly_cap_usd: 1000
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _configure_base(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
+    monkeypatch.setattr(
+        state_router,
+        "get_provider_usage_data",
+        lambda provider: {
+            "lane": provider,
+            "weekly_used_pct": None,
+            "status": "unknown",
+            "source": "codexbar",
+        },
+    )
+    monkeypatch.setattr(
+        state_router,
+        "persist_provider_snapshot",
+        lambda lane, snapshot: {"trend": "flat", "samples": 1},
+    )
+    monkeypatch.setattr(
+        state_router.delegate_api,
+        "list_delegate_tasks",
+        lambda **_kwargs: {"tasks": []},
+    )
+    monkeypatch.setattr(
+        state_router,
+        "summarize_lane_runtime",
+        lambda agent: {
+            "source": "agent_runtime_jsonl",
+            "window_s": 300,
+            "ok": 0,
+            "error": 0,
+            "rate_limited": 0,
+            "timeout": 0,
+            "other": 0,
+            "total": 0,
+            "headroom_blocked": False,
+            "headroom_reason": "",
+        },
+    )
+
+
+def test_cursor_logout_surfaces_need_login_without_substitution(monkeypatch, tmp_path):
+    _configure_base(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        state_router,
+        "get_cursor_lane_usage",
+        lambda **kwargs: {
+            "lane": "cursor",
+            "login_state": "NEED_LOGIN",
+            "probe_state": "NEED_LOGIN",
+            "is_authenticated": False,
+            "status": "need_login",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+        },
+    )
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", lambda agent, **kwargs: {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": {"7d": {"counts": {"total": 0}, "hours": 0.0}},
+    })
+
+    data = state_router.compute_routing_budget(datetime(2026, 8, 26, 12, 0, tzinfo=UTC))
+    cursor = data["agents"]["cursor"]
+    assert cursor["status"] == "need_login"
+    assert cursor["login_state"] == "NEED_LOGIN"
+    assert any("NEED_LOGIN" in w for w in data["recommendation"]["warnings"])
+    assert data["recommendation"]["primary_agent_for_code"] != "cursor"
+
+
+def test_authenticated_cursor_with_fleet_burn_and_empty_codexbar(monkeypatch, tmp_path):
+    _configure_base(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        state_router,
+        "get_cursor_lane_usage",
+        lambda **kwargs: {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "probe_state": "healthy",
+            "status": "cool",
+            "primary_used_pct": 8.0,
+            "provider_windows": {
+                "auto": {
+                    "window": "monthly",
+                    "used_pct": 8.0,
+                    "remaining_pct": 92.0,
+                    "resets_at": "2026-09-01T00:00:00Z",
+                },
+                "api": {
+                    "window": "monthly",
+                    "used_pct": 12.0,
+                    "remaining_pct": 88.0,
+                    "resets_at": "2026-09-01T00:00:00Z",
+                },
+            },
+            "weekly_resets_at": "2026-09-01T00:00:00Z",
+            "source": "cursor_native",
+        },
+    )
+
+    def _fleet(agent: str, **kwargs) -> dict:
+        total = 3 if agent == "cursor" else 0
+        return {
+            "source": "agent_runtime_jsonl",
+            "agent": agent,
+            "windows": {
+                "5h": {"counts": {"total": total}, "hours": 0.5},
+                "7d": {"counts": {"total": total}, "hours": 1.0},
+                "30d": {"counts": {"total": total}, "hours": 2.0},
+            },
+        }
+
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", _fleet)
+
+    data = state_router.compute_routing_budget(datetime(2026, 8, 26, 12, 0, tzinfo=UTC))
+    cursor = data["agents"]["cursor"]
+    assert cursor["fleet_burn"]["windows"]["7d"]["counts"]["total"] == 3
+    assert cursor["provider_windows"]["auto"]["window"] == "monthly"
+    assert cursor["provider_windows"]["api"]["window"] == "monthly"
+    assert "5h" not in cursor["provider_windows"]
+    assert data["recommendation"]["primary_agent_for_code"] == "cursor"
+
+
+def test_capacity_pick_orders_cursor_before_agy_when_cool(monkeypatch):
+    budget = {
+        "generated_at": "2026-08-26T12:00:00Z",
+        "agents": {
+            "cursor": {
+                "status": "cool",
+                "login_state": "authenticated",
+                "remaining_pct": 92.0,
+                "burn_pct_7d": 8.0,
+                "provider_windows": {
+                    "auto": {"remaining_pct": 92.0, "used_pct": 8.0},
+                },
+                "fleet_burn": {"windows": {"7d": {"counts": {"total": 2}}}},
+            },
+            "agy": {"status": "cool", "remaining_pct": 85.0, "burn_pct_7d": 15.0},
+            "codex": {"status": "hot", "remaining_pct": 20.0, "burn_pct_7d": 80.0},
+        },
+        "in_flight": {},
+        "recommendation": {"primary_agent_for_code": "cursor", "rationale": "", "warnings": []},
+        "diagnostics": {},
+    }
+    report = capacity_pick.build_report(budget)
+    ranked = [p for p in report["pick_order"] if p["pick"] != "AVOID"]
+    assert ranked[0]["lane"] == "cursor"
+    assert ranked[1]["lane"] == "agy"
+
+
+def test_capacity_pick_marks_logout_cursor_avoid(monkeypatch):
+    budget = {
+        "generated_at": "2026-08-26T12:00:00Z",
+        "agents": {
+            "cursor": {
+                "status": "need_login",
+                "login_state": "NEED_LOGIN",
+                "probe_state": "NEED_LOGIN",
+            },
+            "agy": {"status": "cool", "remaining_pct": 85.0},
+        },
+        "in_flight": {},
+        "recommendation": {"primary_agent_for_code": "agy", "rationale": "", "warnings": []},
+        "diagnostics": {},
+    }
+    rows = {r["lane"]: r for r in capacity_pick.build_lane_rows(budget)}
+    assert rows["cursor"]["avoid"] is True
+    assert "NEED_LOGIN" in rows["cursor"]["notes"]

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -77,6 +77,76 @@ def _empty_runtime(agent: str) -> dict:
     }
 
 
+def _empty_fleet_burn(agent: str) -> dict:
+    empty_counts = {"ok": 0, "error": 0, "rate_limited": 0, "timeout": 0, "other": 0, "total": 0}
+    return {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": {
+            "5h": {"window_s": 18000, "counts": dict(empty_counts), "hours": 0.0},
+            "7d": {"window_s": 604800, "counts": dict(empty_counts), "hours": 0.0},
+            "30d": {"window_s": 2592000, "counts": dict(empty_counts), "hours": 0.0},
+        },
+    }
+
+
+def _mock_cursor_lane(*, auto_pct: float | None = None, api_pct: float = 20.0, login: str = "authenticated") -> dict:
+    if login == "NEED_LOGIN":
+        return {
+            "lane": "cursor",
+            "login_state": "NEED_LOGIN",
+            "probe_state": "NEED_LOGIN",
+            "is_authenticated": False,
+            "status": "need_login",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+            "fetched_at": "2026-05-13T20:30:00Z",
+        }
+    if auto_pct is None:
+        return {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "probe_state": "NEED_PROBE",
+            "is_authenticated": True,
+            "status": "unknown",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+            "fetched_at": "2026-05-13T20:30:00Z",
+        }
+    return {
+        "lane": "cursor",
+        "login_state": "authenticated",
+        "probe_state": "healthy",
+        "is_authenticated": True,
+        "status": "cool",
+        "primary_used_pct": auto_pct,
+        "tertiary_used_pct": api_pct,
+        "provider_windows": {
+            "auto": {
+                "window": "monthly",
+                "label": "Auto",
+                "used_pct": auto_pct,
+                "remaining_pct": 100.0 - auto_pct,
+                "resets_at": "2026-08-01T09:58:38Z",
+            },
+            "api": {
+                "window": "monthly",
+                "label": "API",
+                "used_pct": api_pct,
+                "remaining_pct": 100.0 - api_pct,
+                "resets_at": "2026-08-01T09:58:38Z",
+            },
+        },
+        "weekly_resets_at": "2026-08-01T09:58:38Z",
+        "fetched_at": "2026-05-13T20:30:00Z",
+        "source": "cursor_native",
+    }
+
+
 def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
     monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
     monkeypatch.setattr(state_router, "load_cost_records", lambda: records)
@@ -107,7 +177,14 @@ def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
         return None
 
     monkeypatch.setattr(state_router, "get_provider_usage_data", _mock_cb)
+    monkeypatch.setattr(state_router, "get_cursor_lane_usage", lambda **kwargs: _mock_cursor_lane())
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", _empty_fleet_burn)
     monkeypatch.setattr(state_router, "summarize_lane_runtime", _empty_runtime)
+    monkeypatch.setattr(
+        state_router,
+        "persist_provider_snapshot",
+        lambda lane, snapshot: {"trend": "flat", "samples": 1},
+    )
     monkeypatch.setattr(
         state_router.delegate_api,
         "list_delegate_tasks",
@@ -125,7 +202,7 @@ def test_endpoint_returns_documented_shape(monkeypatch, tmp_path):
     assert response.status_code == 200
     data = response.json()
     assert {"agents", "in_flight", "recommendation", "diagnostics", "generated_at"} <= data.keys()
-    assert data["diagnostics"]["usage_sources"]["allotment"] == "codexbar"
+    assert data["diagnostics"]["usage_sources"]["allotment"] in {"codexbar", "codexbar+cursor_native"}
     assert data["diagnostics"]["usage_sources"]["burn_rate_limit"] == "agent_runtime_jsonl"
     assert "runtime" in data["agents"]["codex"]
 

--- a/tests/api/test_routing_budget_runtime_diagnostics.py
+++ b/tests/api/test_routing_budget_runtime_diagnostics.py
@@ -189,44 +189,44 @@ def test_empty_ledger_rec_stays_suppressed_when_runtime_exists(monkeypatch, tmp_
         assert status in ("unknown", "unavailable"), f"{lane} must stay unknown on empty ledger"
 
 
-def test_routing_html_states_ledger_empty_when_runtime_usage_exists():
-    """dashboards/routing.html must say "ledger empty, runtime exists" — not a silent $0 week."""
+def test_routing_html_subscriptions_renders_cursor_windows_without_fabricating_zero():
+    """Subscriptions section shows provider windows; missing data is unknown, not 0%."""
     import subprocess
 
     script = """
     const fs = require('fs');
     const html = fs.readFileSync('dashboards/routing.html', 'utf8');
-    const renderBudgetMatch = html.match(/function renderBudget\\(routing, usage\\) \\{[\\s\\S]*?\\n\\}/);
-    if (!renderBudgetMatch) throw new Error('renderBudget not found');
-
-    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => ({
-      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-    }[ch]));
-    const pct = (value) => {
-      const num = Number(value);
-      return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
-    };
-    const statusPill = (status) => `<span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span>`;
+    const start = html.indexOf('function escapeHtml');
+    const end = html.indexOf('function renderAgents');
+    if (start < 0 || end < 0) throw new Error('subscription render helpers not found');
+    const helpers = html.slice(start, end);
 
     let innerHTML = '';
     const document = {
       getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
     };
+    eval(helpers);
 
-    eval(renderBudgetMatch[0]);
-
-    const routing = {
+    renderSubscriptions({
       agents: {
-        codex: { status: 'unknown', burn_pct_7d: null, remaining_pct: null, weekly_cap_usd: 1000 }
+        cursor: {
+          status: 'unknown',
+          login_state: 'authenticated',
+          probe_state: 'NEED_PROBE',
+          provider_windows: {
+            auto: { window: 'monthly', used_pct: null, remaining_pct: null },
+            api: { window: 'monthly', used_pct: null, remaining_pct: null },
+          },
+        },
+        codex: { status: 'unknown', burn_pct_7d: null, codexbar: { weekly_used_pct: null } },
       },
       in_flight: {},
       diagnostics: { records_loaded: 0, budget_ledger_empty: true, runtime_usage_records_7d: 25 }
-    };
-    renderBudget(routing, { records_total: 25 });
+    });
     console.log(innerHTML);
     """
     res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
     out = res.stdout
-    assert "budget ledger is empty" in out, f"missing ledger-empty note: {out}"
-    assert "Runtime usage exists (25 call(s) in 7d)" in out, f"missing runtime-exists copy: {out}"
-    assert "Burn unknown — USD budget ledger empty" in out, f"missing honest bar title: {out}"
+    assert "NEED_PROBE" in out or "unknown" in out
+    assert "0.0%" not in out
+    assert "Fleet burn" in out or "5h:" in out

--- a/tests/api/test_routing_budget_runtime_diagnostics.py
+++ b/tests/api/test_routing_budget_runtime_diagnostics.py
@@ -78,6 +78,24 @@ def _configure(
     monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
     monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
     monkeypatch.setattr(state_router, "get_provider_usage_data", _no_codexbar)
+    monkeypatch.setattr(
+        state_router,
+        "get_cursor_lane_usage",
+        lambda **kwargs: {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "probe_state": "NEED_PROBE",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+        },
+    )
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", lambda agent, **kwargs: {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": {"7d": {"counts": {"total": 0}, "hours": 0.0}},
+    })
     monkeypatch.setattr(state_router, "summarize_lane_runtime", _empty_runtime)
     monkeypatch.setattr(
         state_router,

--- a/tests/test_capacity_pick.py
+++ b/tests/test_capacity_pick.py
@@ -69,10 +69,8 @@ def test_pick_order_cool_first():
     ranked = [p for p in picks if p["pick"] != "AVOID"]
     assert "codex" in avoid_lanes
     assert "claude" in avoid_lanes
-    assert ranked[0]["lane"] in {"cursor", "deepseek", "glm", "agy", "grok"}
-    assert all(p["lane"] not in avoid_lanes for p in ranked)
-    assert report["recommendation"]["primary_agent_for_code"] == "cursor"
-    assert "cursor" in report["cooler_lanes"]
+    assert ranked[0]["lane"] == "cursor"
+    assert ranked[1]["lane"] in {"deepseek", "glm", "grok", "agy"}
 
 
 def test_format_includes_rec():

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -804,37 +804,30 @@ def test_codexbar_unavailable_unparseable_schema(monkeypatch):
 
 
 def test_dashboard_routing_html_renders_unavailable_explicitly():
-    """Prove dashboards/routing.html renders 'unavailable' non-numeric display, not 0.0% or 0-width bar."""
+    """Prove dashboards/routing.html renders 'unknown' non-numeric display, not 0.0% or 0-width bar."""
     import subprocess
     script = """
     const fs = require('fs');
     const html = fs.readFileSync('dashboards/routing.html', 'utf8');
-    const renderBudgetMatch = html.match(/function renderBudget\\(routing, usage\\) \\{[\\s\\S]*?\\n\\}/);
-    if (!renderBudgetMatch) throw new Error('renderBudget not found');
-
-    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => ({
-      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-    }[ch]));
-    const pct = (value) => {
-      const num = Number(value);
-      return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
-    };
-    const statusPill = (status) => `<span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span>`;
+    const start = html.indexOf('function escapeHtml');
+    const end = html.indexOf('function renderAgents');
+    if (start < 0 || end < 0) throw new Error('subscription render helpers not found');
+    const helpers = html.slice(start, end);
 
     let innerHTML = '';
     const document = {
       getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
     };
 
-    eval(renderBudgetMatch[0]);
+    eval(helpers);
 
-    renderBudget({
+    renderSubscriptions({
       agents: {
         codex: {
           status: 'unavailable',
           burn_pct_7d: null,
           remaining_pct: null,
-          weekly_cap_usd: null
+          codexbar: { weekly_used_pct: null, fetched_at: null }
         }
       },
       in_flight: {}
@@ -845,9 +838,139 @@ def test_dashboard_routing_html_renders_unavailable_explicitly():
     res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
     out = res.stdout
     assert "0.0%" not in out, f"Dashboard rendered 0.0% for unavailable state: {out}"
-    assert "style=\"width:0%\"" not in out, f"Dashboard rendered 0-width bar for unavailable state: {out}"
-    assert "unavailable" in out
-    assert 'class="bar unavailable"' in out
+    assert 'style="width:0%"' not in out, f"Dashboard rendered 0-width bar for unavailable state: {out}"
+    assert "unknown" in out
+    assert 'class="bar unavailable"' in out or 'class="pill unknown"' in out
+
+
+def test_dashboard_routing_html_renders_cursor_auto_api_subscriptions():
+    """Subscriptions table must show Cursor Auto + API percents from provider_windows."""
+    import subprocess
+
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync('dashboards/routing.html', 'utf8');
+    const start = html.indexOf('function escapeHtml');
+    const end = html.indexOf('function renderAgents');
+    if (start < 0 || end < 0) throw new Error('subscription render helpers not found');
+    const helpers = html.slice(start, end);
+
+    let innerHTML = '';
+    const document = {
+      getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
+    };
+    eval(helpers);
+
+    renderSubscriptions({
+      agents: {
+        cursor: {
+          status: 'cool',
+          login_state: 'authenticated',
+          probe_state: 'healthy',
+          provider_windows: {
+            auto: { window: 'monthly', label: 'Auto', used_pct: 23, remaining_pct: 77, resets_at: '2026-09-01T00:00:00Z' },
+            api: { window: 'monthly', label: 'API', used_pct: 40, remaining_pct: 60, resets_at: '2026-09-01T00:00:00Z' },
+          },
+          codexbar: { fetched_at: '2026-08-26T12:00:00Z', age_s: 120 },
+          fleet_burn: { windows: { '5h': { counts: { total: 1 } }, '7d': { counts: { total: 3 } }, '30d': { counts: { total: 10 } } } },
+        },
+      },
+      in_flight: { cursor: 0 },
+    });
+    console.log(innerHTML);
+    """
+    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
+    out = res.stdout
+    assert "Auto" in out
+    assert "API" in out
+    assert "23" in out
+    assert "40" in out
+    assert "77" in out or "60" in out
+
+
+def test_dashboard_routing_html_need_login_does_not_render_zero_auto_used():
+    """NEED_LOGIN fixture must not paint Auto as 0.0% used."""
+    import subprocess
+
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync('dashboards/routing.html', 'utf8');
+    const start = html.indexOf('function escapeHtml');
+    const end = html.indexOf('function renderAgents');
+    if (start < 0 || end < 0) throw new Error('subscription render helpers not found');
+    const helpers = html.slice(start, end);
+
+    let innerHTML = '';
+    const document = {
+      getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
+    };
+    eval(helpers);
+
+    renderSubscriptions({
+      agents: {
+        cursor: {
+          status: 'need_login',
+          login_state: 'NEED_LOGIN',
+          probe_state: 'NEED_LOGIN',
+          provider_windows: {
+            auto: { window: 'monthly', used_pct: null, remaining_pct: null },
+            api: { window: 'monthly', used_pct: null, remaining_pct: null },
+          },
+        },
+      },
+      in_flight: {},
+    });
+    console.log(innerHTML);
+    """
+    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True, timeout=30)
+    out = res.stdout
+    assert "NEED_LOGIN" in out
+    assert "0.0%" not in out
+    assert 'style="width:0%"' not in out
+
+
+def test_get_cursor_lane_usage_is_cache_only_on_http_path(monkeypatch):
+    """HTTP reads must not block on live Cursor probes."""
+    cache_invalidate(codexbar_usage_mod.CURSOR_CACHE_KEY)
+    codexbar_usage_mod._cursor_last_good = None
+    probe_calls = {"login": 0, "windows": 0}
+
+    def _login(**kwargs):
+        probe_calls["login"] += 1
+        return {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "is_authenticated": True,
+            "fetched_at": "2026-08-26T12:00:00Z",
+        }
+
+    def _windows(**kwargs):
+        probe_calls["windows"] += 1
+        return {
+            "lane": "cursor",
+            "probe_state": "healthy",
+            "login_state": "authenticated",
+            "provider_windows": {
+                "auto": {"window": "monthly", "label": "Auto", "used_pct": 12.0, "remaining_pct": 88.0, "resets_at": None},
+                "api": {"window": "monthly", "label": "API", "used_pct": 5.0, "remaining_pct": 95.0, "resets_at": None},
+            },
+            "fetched_at": "2026-08-26T12:00:00Z",
+        }
+
+    monkeypatch.setattr(codexbar_usage_mod, "probe_cursor_login", _login)
+    monkeypatch.setattr(codexbar_usage_mod, "probe_cursor_provider_windows", _windows)
+    monkeypatch.setenv("CODEXBAR_ON_DEMAND_REFRESH", "0")
+
+    result = codexbar_usage_mod.get_cursor_lane_usage()
+    assert result["freshness"] == "unavailable"
+    assert probe_calls == {"login": 0, "windows": 0}
+
+    codexbar_usage_mod._record_cursor_probe_result(_windows())
+    probe_calls["windows"] = 0
+    cached = codexbar_usage_mod.get_cursor_lane_usage()
+    assert cached["freshness"] == "fresh"
+    assert cached["provider_windows"]["auto"]["used_pct"] == 12.0
+    assert probe_calls == {"login": 0, "windows": 0}
 
 
 def test_failed_refresh_never_poison_last_known_good_capacity(monkeypatch):
@@ -982,12 +1105,14 @@ def test_background_refresh_no_longer_hardcodes_two_second_timeout(monkeypatch):
         return {}
 
     monkeypatch.setattr(codexbar_usage_mod, "refresh_provider_usage_data", fake_refresh)
+    monkeypatch.setattr(codexbar_usage_mod, "_refresh_cursor_usage_live", lambda: None)
     monkeypatch.setattr(codexbar_usage_mod, "_refresh_in_flight", threading.Lock())
     codexbar_usage_mod._run_all_refreshes()
     # No override passed -> refresh_provider_usage_data resolves the shared
     # realistic default itself, instead of the caller hardcoding 2.0.
     assert captured["timeout_s"] is None
     assert "claude" in captured["providers"]
+    assert "cursor" not in captured["providers"]
 
 
 def test_timeout_failure_kind_maps_to_fail_open_reviewer_status():
@@ -1073,6 +1198,7 @@ def test_overlapping_run_all_refreshes_is_serialized(monkeypatch):
         return {}
 
     monkeypatch.setattr(codexbar_usage_mod, "refresh_provider_usage_data", fake_refresh)
+    monkeypatch.setattr(codexbar_usage_mod, "_refresh_cursor_usage_live", lambda: None)
     monkeypatch.setattr(codexbar_usage_mod, "_refresh_in_flight", threading.Lock())
     worker = threading.Thread(target=codexbar_usage_mod._run_all_refreshes, daemon=True)
     worker.start()
@@ -1080,4 +1206,4 @@ def test_overlapping_run_all_refreshes_is_serialized(monkeypatch):
     codexbar_usage_mod._run_all_refreshes()  # must no-op while first is in flight
     release.set()
     worker.join(timeout=1.0)
-    assert calls == [tuple(codexbar_usage_mod.SUBSCRIPTION_PROVIDERS)]
+    assert calls == [tuple(codexbar_usage_mod.SUBSCRIPTION_LANES_WITHOUT_CURSOR)]

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -212,23 +212,18 @@ def test_normalize_cursor_three_windows():
     }
     res = _normalize_provider_data("cursor", raw)
     assert res["lane"] == "cursor"
-    assert res["primary_used_pct"] == 44.7
-    assert abs(res["primary_remaining_pct"] - 55.3) < 0.01
+    assert res["primary_used_pct"] == 36.0
     assert res["secondary_used_pct"] == 36.0
-    assert res["secondary_remaining_pct"] == 64.0
     assert res["tertiary_used_pct"] == 100.0
-    assert res["tertiary_remaining_pct"] == 0.0
-    # Burn/status alias tracks Total (primary), not Auto (secondary).
-    assert res["weekly_used_pct"] == 44.7
-    assert abs(res["weekly_remaining_pct"] - 55.3) < 0.01
-    assert res["weekly_resets_at"] == "2026-08-01T09:58:38Z"
-    assert res["windows"]["primary"]["label"] == "Total"
+    # Burn/status tracks Auto monthly pool, not Total primary.
+    assert res["weekly_used_pct"] is None
+    assert res["weekly_remaining_pct"] is None
+    assert res["provider_windows"]["auto"]["used_pct"] == 36.0
+    assert res["provider_windows"]["api"]["used_pct"] == 100.0
     assert res["windows"]["secondary"]["label"] == "Auto"
     assert res["windows"]["tertiary"]["label"] == "API"
     assert res["windows"]["tertiary"]["used_pct"] == 100.0
-    assert res["windows"]["tertiary"]["remaining_pct"] == 0.0
-    assert res["windows"]["primary"]["resets_at"] == "2026-08-01T09:58:38Z"
-    # Must not quietly copy Total into the Auto window block.
+    assert res["weekly_resets_at"] == "2026-08-01T09:58:38Z"
     assert res["windows"]["secondary"]["used_pct"] == 36.0
 
 
@@ -338,6 +333,25 @@ def test_routing_budget_surfaces_deficit_warnings(monkeypatch):
 
     monkeypatch.setattr(state_router, "get_provider_usage_data", mock_usage)
     monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", lambda agent, **kwargs: {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": {"7d": {"counts": {"total": 0}, "hours": 0.0}},
+    })
+    monkeypatch.setattr(
+        state_router,
+        "get_cursor_lane_usage",
+        lambda **kwargs: {
+            "lane": "cursor",
+            "login_state": "authenticated",
+            "probe_state": "NEED_PROBE",
+            "provider_windows": {
+                "auto": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+                "api": {"window": "monthly", "used_pct": None, "remaining_pct": None, "resets_at": None},
+            },
+            "fetched_at": "2026-07-09T14:13:52Z",
+        },
+    )
 
     now = datetime(2026, 7, 9, 16, 13, tzinfo=UTC)
     res = state_router.compute_routing_budget(now)
@@ -356,26 +370,37 @@ def test_routing_budget_surfaces_deficit_warnings(monkeypatch):
     assert "weekly-pace signal" in deficit_warnings[0]
 
 
-def test_routing_budget_cursor_burns_total_and_warns_on_api(monkeypatch):
-    """Cursor burn tracks Total; exhausted API allotment emits an advisory warning."""
+def test_routing_budget_cursor_burns_auto_and_warns_on_api(monkeypatch):
+    """Cursor burn tracks Auto monthly pool; exhausted API allotment emits advisory warning."""
     cursor_row = {
         "lane": "cursor",
-        "primary_used_pct": 44.7,
-        "primary_remaining_pct": 55.3,
+        "login_state": "authenticated",
+        "probe_state": "healthy",
+        "primary_used_pct": 36.0,
+        "primary_remaining_pct": 64.0,
         "secondary_used_pct": 36.0,
         "secondary_remaining_pct": 64.0,
         "tertiary_used_pct": 100.0,
         "tertiary_remaining_pct": 0.0,
-        "weekly_used_pct": 44.7,
-        "weekly_remaining_pct": 55.3,
-        "windows": {
-            "primary": {
-                "used_pct": 44.7,
-                "remaining_pct": 55.3,
+        "weekly_used_pct": None,
+        "weekly_remaining_pct": None,
+        "provider_windows": {
+            "auto": {
+                "window": "monthly",
+                "label": "Auto",
+                "used_pct": 36.0,
+                "remaining_pct": 64.0,
                 "resets_at": "2026-08-01T09:58:38Z",
-                "window_minutes": 44640,
-                "label": "Total",
             },
+            "api": {
+                "window": "monthly",
+                "label": "API",
+                "used_pct": 100.0,
+                "remaining_pct": 0.0,
+                "resets_at": "2026-08-01T09:58:38Z",
+            },
+        },
+        "windows": {
             "secondary": {
                 "used_pct": 36.0,
                 "remaining_pct": 64.0,
@@ -397,11 +422,11 @@ def test_routing_budget_cursor_burns_total_and_warns_on_api(monkeypatch):
         "weekly_pace_delta_pct": -20.0,
         "will_last_to_reset": True,
         "pace_summary": "-20% pace delta",
-        "source": "codexbar",
+        "source": "cursor_native",
         "fetched_at": "2026-07-21T19:00:00Z",
         "stale": False,
         "age_s": 1.0,
-        "status": "healthy",
+        "status": "cool",
         "auth_error": None,
     }
 
@@ -426,13 +451,25 @@ def test_routing_budget_cursor_burns_total_and_warns_on_api(monkeypatch):
         }
 
     monkeypatch.setattr(state_router, "get_provider_usage_data", mock_usage)
+    monkeypatch.setattr(state_router, "get_cursor_lane_usage", lambda **kwargs: dict(cursor_row))
     monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
+    monkeypatch.setattr(state_router, "summarize_fleet_burn", lambda agent, **kwargs: {
+        "source": "agent_runtime_jsonl",
+        "agent": agent,
+        "windows": {"7d": {"counts": {"total": 0}, "hours": 0.0}},
+    })
+    monkeypatch.setattr(
+        state_router,
+        "persist_provider_snapshot",
+        lambda lane, snapshot: {"trend": "flat", "samples": 1},
+    )
 
     res = state_router.compute_routing_budget(datetime(2026, 7, 21, 19, 0, tzinfo=UTC))
     cursor = res["agents"]["cursor"]
-    assert cursor["burn_pct_7d"] == 44.7
+    assert cursor["burn_pct_7d"] == 36.0
     assert cursor["status"] == "cool"
-    assert cursor["codexbar"]["windows"]["primary"]["label"] == "Total"
+    assert cursor["provider_windows"]["auto"]["used_pct"] == 36.0
+    assert cursor["provider_windows"]["api"]["used_pct"] == 100.0
     api_warnings = [w for w in res["recommendation"]["warnings"] if "API/on-demand" in w]
     assert api_warnings
     assert "100% used" in api_warnings[0]


### PR DESCRIPTION
## Why

Cursor Ultra 20× was sitting idle: logout was a silent agy substitution, and `capacity_pick` treated missing CodexBar as `unknown` (agy first, cursor 4th). Operator: not using the 20× is wasting money. Cursor is **monthly only**, with **two counters** (Auto routing vs API/other models) — not 5h/weekly.

## What

- Native Cursor dashboard probe (`GetCurrentPeriodUsage`) for **Auto** and **API** monthly remaining. Burn/status tracks **Auto**. Pin `--model auto` to spend Auto, not the API pool.
- `NEED_LOGIN` on routing-budget + capacity_pick notes. Logout does **not** auto-sub to agy.
- Fleet burn 5h/7d/30d from our JSONL even when CodexBar binary is absent.
- `capacity_pick` ranks authenticated Cursor first among cool code lanes.

## Tests

63 passed: `test_routing_budget*.py`, `test_capacity_pick.py`, `test_codexbar_usage.py`

X-Agent: cursor/fix-subscription-usage

<!-- ci-nudge 2026-08-26T16:14:27Z -->