### PR TITLE
fix(cycle007): preserve venv launcher identity (#6375)

### DIFF
--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -14,6 +14,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -25,7 +26,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 HERE = Path(__file__).resolve().parent
-PRIMARY_PYTHON = Path(sys.executable).resolve()
+# Keep the launcher path exactly as supplied by the active interpreter.  A
+# venv launcher is commonly a symlink whose path is significant to Python's
+# environment discovery, so resolving it here would silently leave the venv.
+PRIMARY_PYTHON = Path(sys.executable)
 AMENDMENT = HERE / "phase3-cycle007-source-grounded-amendment-v1.md"
 AMENDMENT_SHA256 = "4f2e3e58964cae391c3933ffdce531296a0744808b0154231ca513049602fea0"
 CYCLE = "phase3-v2-1-evaluation-cycle-007"
@@ -531,20 +535,33 @@ def _validate_canary_receipt(
     return sha256(receipt_path), exe_sha256, sources_id, receipt
 
 
-def _python_executable_sha256() -> str:
+def _python_executable_target() -> Path:
+    """Return the launcher target after strict absolute/regular-file checks."""
+    if not PRIMARY_PYTHON.is_absolute():
+        raise ControllerError("preflight_binding_drift")
     try:
-        if PRIMARY_PYTHON.is_symlink():
-            raise ControllerError("preflight_binding_drift")
-        executable = PRIMARY_PYTHON.resolve(strict=True)
-        if not executable.is_file() or executable.is_symlink():
-            raise ControllerError("preflight_binding_drift")
-        return sha256(executable)
-    except OSError as exc:
+        target = PRIMARY_PYTHON.resolve(strict=True)
+        target_stat = target.stat()
+    except (OSError, RuntimeError) as exc:
         raise ControllerError("preflight_binding_drift") from exc
+    if target.is_symlink() or not stat.S_ISREG(target_stat.st_mode):
+        raise ControllerError("preflight_binding_drift")
+    return target
+
+
+def _python_launcher() -> Path:
+    """Return the validated absolute launcher without resolving its path."""
+    _python_executable_target()
+    return PRIMARY_PYTHON
+
+
+def _python_executable_sha256() -> str:
+    return sha256(_python_executable_target())
 
 
 def _require_python_binding(expected_sha256: str) -> None:
-    if not _hex64(expected_sha256) or _python_executable_sha256() != expected_sha256:
+    actual_sha256 = _python_executable_sha256()
+    if not _hex64(expected_sha256) or actual_sha256 != expected_sha256:
         raise ControllerError("preflight_binding_drift")
 
 
@@ -1236,7 +1253,7 @@ def _commands_for_stage(
         return (
             [
                 [
-                    str(PRIMARY_PYTHON),
+                    str(_python_launcher()),
                     str(code_paths["gemini_runner"]),
                     "--package",
                     str(package),
@@ -1283,7 +1300,7 @@ def _commands_for_stage(
         for lane, lane_ranges in ranges.items():
             for start, end in lane_ranges:
                 cmd = [
-                    str(PRIMARY_PYTHON),
+                    str(_python_launcher()),
                     str(runner),
                     "--package",
                     str(package),
@@ -1310,7 +1327,7 @@ def _commands_for_stage(
                     cmd.extend(["--expected-grok-executable-sha", expected_grok_executable_sha256])
                 commands.append(cmd)
         return (commands, grok)
-    common = [str(PRIMARY_PYTHON), str(runner), "--package", str(package)]
+    common = [str(_python_launcher()), str(runner), "--package", str(package)]
     if stage == "compare":
         return ([[*common, "--all"]], None)
     if stage == "audit":

--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -544,14 +544,15 @@ def _python_executable_target() -> Path:
         target_stat = target.stat()
     except (OSError, RuntimeError) as exc:
         raise ControllerError("preflight_binding_drift") from exc
-    if target.is_symlink() or not stat.S_ISREG(target_stat.st_mode):
+    if not stat.S_ISREG(target_stat.st_mode):
         raise ControllerError("preflight_binding_drift")
     return target
 
 
 def _python_launcher() -> Path:
-    """Return the validated absolute launcher without resolving its path."""
-    _python_executable_target()
+    """Return the absolute venv launcher used as the child argv[0]."""
+    if not PRIMARY_PYTHON.is_absolute():
+        raise ControllerError("preflight_binding_drift")
     return PRIMARY_PYTHON
 
 
@@ -559,10 +560,12 @@ def _python_executable_sha256() -> str:
     return sha256(_python_executable_target())
 
 
-def _require_python_binding(expected_sha256: str) -> None:
-    actual_sha256 = _python_executable_sha256()
+def _require_python_binding(expected_sha256: str) -> Path:
+    target = _python_executable_target()
+    actual_sha256 = sha256(target)
     if not _hex64(expected_sha256) or actual_sha256 != expected_sha256:
         raise ControllerError("preflight_binding_drift")
+    return target
 
 
 def preflight(
@@ -1525,9 +1528,10 @@ def run_stage(
             "text_free": True,
         }
     for command in commands:
-        _require_python_binding(expected_python_executable_sha256 or "")
+        python_target = _require_python_binding(expected_python_executable_sha256 or "")
         completed = subprocess.run(
             command,
+            executable=str(python_target),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -1529,6 +1529,8 @@ def run_stage(
         }
     for command in commands:
         python_target = _require_python_binding(expected_python_executable_sha256 or "")
+        # Bind exec to the verified target while argv[0] retains the venv launcher
+        # that CPython uses to locate pyvenv.cfg and its installed dependencies.
         completed = subprocess.run(
             command,
             executable=str(python_target),

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -442,7 +442,6 @@ def test_controller_preserves_python_launcher_for_stage_subprocesses(
 ) -> None:
     target = tmp_path / "base-python"
     target.write_bytes(b"base interpreter")
-    os.chmod(target, 0o755)
     launcher = tmp_path / "venv/bin/python"
     launcher.parent.mkdir(mode=0o700, parents=True)
     launcher.symlink_to(target)
@@ -533,8 +532,6 @@ def test_controller_rejects_python_target_drift(
     second_target = tmp_path / "python-second"
     first_target.write_bytes(b"first interpreter")
     second_target.write_bytes(b"different interpreter")
-    os.chmod(first_target, 0o755)
-    os.chmod(second_target, 0o755)
     launcher = tmp_path / "venv/bin/python"
     launcher.parent.mkdir(mode=0o700, parents=True)
     launcher.symlink_to(first_target)

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import venv
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -400,7 +401,9 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     captured: dict[str, Any] = {}
 
     monkeypatch.setattr(controller, "_require_contiguous", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(controller, "_require_python_binding", lambda *_args, **_kwargs: None)
+    python_target = tmp_path / "python-target"
+    python_target.write_bytes(b"fixture interpreter")
+    monkeypatch.setattr(controller, "_require_python_binding", lambda *_args, **_kwargs: python_target)
     monkeypatch.setattr(controller, "_commands_for_stage", lambda *_args, **_kwargs: ([['fixture']], None))
     monkeypatch.setattr(controller, "_revalidate_compare_receipts", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(controller, "_stage_stop_paths", lambda *_args, **_kwargs: ())
@@ -430,6 +433,7 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     )
     assert result["ok"] is True
     assert captured["pass_fds"] == (lock_file.fileno(),)
+    assert captured["executable"] == os.fspath(python_target)
     lock_file.close()
 
 
@@ -472,6 +476,54 @@ def test_controller_preserves_python_launcher_for_stage_subprocesses(
     assert commands[0][0] == os.fspath(launcher)
     assert commands[0][0] != os.fspath(target)
     assert expected_python_sha256 == controller._python_executable_sha256()
+    assert controller._require_python_binding(expected_python_sha256) == target
+
+
+def test_controller_executes_bound_target_with_venv_launcher_semantics(
+    controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_root = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=False).create(venv_root)
+    launcher = venv_root / "bin/python"
+    marker = tmp_path / "venv-active"
+    runner = tmp_path / "probe.py"
+    runner.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        "Path(sys.argv[1]).write_text('1' if sys.prefix != sys.base_prefix else '0')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(controller, "PRIMARY_PYTHON", launcher)
+    expected_python_sha256 = controller._python_executable_sha256()
+    monkeypatch.setattr(controller, "_require_contiguous", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        controller,
+        "_commands_for_stage",
+        lambda *_args, **_kwargs: ([[os.fspath(launcher), os.fspath(runner), os.fspath(marker)]], None),
+    )
+    monkeypatch.setattr(controller, "_revalidate_compare_receipts", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(controller, "_stage_stop_paths", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(controller, "_seal", lambda *_args, **_kwargs: None)
+
+    result = controller.run_stage(
+        tmp_path,
+        "compare",
+        runner,
+        "a" * 64,
+        dry_run=False,
+        expected_python_executable_sha256=expected_python_sha256,
+        expected_label_prompt_sha256s={
+            "gemini": {"clean_label": "b" * 64, "residual_label": "c" * 64},
+            "grok": {"clean_label": "d" * 64, "residual_label": "e" * 64},
+        },
+        expected_custody_sha256="f" * 64,
+        expected_label_manifest_sha256="1" * 64,
+        expected_evidence_manifest_sha256="2" * 64,
+        code_paths={"compare_runner": runner.resolve()},
+    )
+
+    assert result["ok"] is True
+    assert marker.read_text(encoding="utf-8") == "1"
 
 
 def test_controller_rejects_python_target_drift(

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -433,6 +433,69 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     lock_file.close()
 
 
+def test_controller_preserves_python_launcher_for_stage_subprocesses(
+    controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "base-python"
+    target.write_bytes(b"base interpreter")
+    os.chmod(target, 0o755)
+    launcher = tmp_path / "venv/bin/python"
+    launcher.parent.mkdir(mode=0o700, parents=True)
+    launcher.symlink_to(target)
+    monkeypatch.setattr(controller, "PRIMARY_PYTHON", launcher)
+    expected_python_sha256 = controller._python_executable_sha256()
+    runner = tmp_path / "gemini.py"
+    runner.write_text("# public fixture\n", encoding="utf-8")
+    labels = {
+        "gemini": {"clean_label": "a" * 64, "residual_label": "b" * 64},
+        "grok": {"clean_label": "c" * 64, "residual_label": "d" * 64},
+    }
+    monkeypatch.setattr(
+        controller,
+        "gemini_missing_ranges",
+        lambda *_args, **_kwargs: {"clean_label": [(1, 1)], "residual_label": []},
+    )
+
+    commands, _runner = controller._commands_for_stage(
+        tmp_path,
+        "gemini",
+        None,
+        code_paths={"gemini_runner": runner},
+        expected_agy_executable_sha256="e" * 64,
+        agy_executable=tmp_path / "agy",
+        expected_label_prompt_sha256s=labels,
+        expected_custody_sha256="f" * 64,
+        expected_label_manifest_sha256="1" * 64,
+        expected_evidence_manifest_sha256="2" * 64,
+    )
+
+    assert commands[0][0] == os.fspath(launcher)
+    assert commands[0][0] != os.fspath(target)
+    assert expected_python_sha256 == controller._python_executable_sha256()
+
+
+def test_controller_rejects_python_target_drift(
+    controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_target = tmp_path / "python-first"
+    second_target = tmp_path / "python-second"
+    first_target.write_bytes(b"first interpreter")
+    second_target.write_bytes(b"different interpreter")
+    os.chmod(first_target, 0o755)
+    os.chmod(second_target, 0o755)
+    launcher = tmp_path / "venv/bin/python"
+    launcher.parent.mkdir(mode=0o700, parents=True)
+    launcher.symlink_to(first_target)
+    monkeypatch.setattr(controller, "PRIMARY_PYTHON", launcher)
+    expected_python_sha256 = controller._python_executable_sha256()
+
+    launcher.unlink()
+    launcher.symlink_to(second_target)
+
+    with pytest.raises(controller.ControllerError, match="preflight_binding_drift"):
+        controller._require_python_binding(expected_python_sha256)
+
+
 def test_controller_rejects_invalid_inherited_descriptor(
     controller: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -483,7 +483,7 @@ def test_controller_executes_bound_target_with_venv_launcher_semantics(
     controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     venv_root = tmp_path / "venv"
-    venv.EnvBuilder(with_pip=False).create(venv_root)
+    venv.EnvBuilder(with_pip=False, symlinks=True).create(venv_root)
     launcher = venv_root / "bin/python"
     marker = tmp_path / "venv-active"
     runner = tmp_path / "probe.py"


### PR DESCRIPTION
Closes #6375\n\nPreserves the Cycle007 controller's virtual-environment launcher for child argv[0] while binding execution to the hash-verified resolved interpreter target.\n\nValidation:\n- Ruff: pass\n- Focused guardian/controller tests: 46 passed\n- Production Linux symlinked-venv behavior probe: pass\n- Independent cross-family exact-head review: clean, zero findings\n- Reviewed head: 6ef6fc08b5b093b9833ef1baa1419807062ccd1e\n- Canonical review receipt: clean\n\nNo schema, prompt, model, endpoint, provider, evidence, validator, custody, denominator, packet-size, or production-state changes.\n\nX-Agent: codex/6375-preserve-venv-interpreter