### PR TITLE
fix(cycle007): propagate safe runner failures (#6375)

### DIFF
--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -14,6 +14,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import selectors
 import stat
 import subprocess
 import sys
@@ -154,11 +155,40 @@ def _run_stage_subprocess(
         pass_fds=pass_fds,
     ) as process:
         assert process.stdout is not None
+        descriptor = process.stdout.fileno()
+        os.set_blocking(descriptor, False)
         status = bytearray()
-        for chunk in iter(lambda: process.stdout.read(64 * 1024), b""):
-            remaining = MAX_RUNNER_STATUS_BYTES + 1 - len(status)
-            if remaining > 0:
-                status.extend(chunk[:remaining])
+        selector = selectors.DefaultSelector()
+        selector.register(descriptor, selectors.EVENT_READ)
+
+        def drain(*, single_read: bool = False) -> bool:
+            while True:
+                try:
+                    chunk = os.read(descriptor, 64 * 1024)
+                except BlockingIOError:
+                    return True
+                if not chunk:
+                    return False
+                remaining = MAX_RUNNER_STATUS_BYTES + 1 - len(status)
+                if remaining > 0:
+                    status.extend(chunk[:remaining])
+                if single_read:
+                    return True
+
+        try:
+            pipe_open = True
+            while process.poll() is None:
+                if pipe_open and selector.select(timeout=0.1):
+                    pipe_open = drain()
+                    if not pipe_open:
+                        selector.unregister(descriptor)
+                elif not pipe_open:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=0.1)
+            if pipe_open:
+                drain(single_read=True)
+        finally:
+            selector.close()
         return_code = process.wait()
     return return_code, b"" if return_code == 0 else bytes(status)
 

--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -122,10 +122,10 @@ def _runner_failure_code(stdout: bytes) -> str:
     if len(stdout) > MAX_RUNNER_STATUS_BYTES:
         return "stage_execution_failed"
     try:
-        value = json.loads(stdout.decode("utf-8", "strict"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
+        value = json.loads(stdout.decode("utf-8", "strict"), object_pairs_hook=_pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError, ControllerError):
         return "stage_execution_failed"
-    if not isinstance(value, dict):
+    if not isinstance(value, dict) or set(value) != {"failure_code", "ok", "text_free"}:
         return "stage_execution_failed"
     code = value.get("failure_code")
     if (

--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -110,10 +110,34 @@ STAGE_RUNNER_LABELS = {
     "certify": "certify_runner",
 }
 EXECUTION_LOCK_FD_ENV = "PHASE3_CYCLE007_EXECUTION_LOCK_FD"
+MAX_RUNNER_STATUS_BYTES = 4096
 
 
 class ControllerError(ValueError):
     pass
+
+
+def _runner_failure_code(stdout: bytes) -> str:
+    """Return only a bounded text-free child failure code."""
+    if len(stdout) > MAX_RUNNER_STATUS_BYTES:
+        return "stage_execution_failed"
+    try:
+        value = json.loads(stdout.decode("utf-8", "strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return "stage_execution_failed"
+    if not isinstance(value, dict):
+        return "stage_execution_failed"
+    code = value.get("failure_code")
+    if (
+        value.get("ok") is not False
+        or value.get("text_free") is not True
+        or not isinstance(code, str)
+        or not 1 <= len(code) <= 64
+        or not code.isascii()
+        or any(not (character.islower() or character.isdigit() or character == "_") for character in code)
+    ):
+        return "stage_execution_failed"
+    return code
 
 
 def _inherited_execution_lock_fd() -> int | None:
@@ -1535,14 +1559,14 @@ def run_stage(
             command,
             executable=str(python_target),
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,
             shell=False,
             pass_fds=() if execution_lock_fd is None else (execution_lock_fd,),
         )
         if completed.returncode != 0:
-            raise ControllerError("stage_execution_failed")
+            raise ControllerError(_runner_failure_code(completed.stdout))
         _require_python_binding(expected_python_executable_sha256 or "")
         if any(path.exists() for path in _stage_stop_paths(package)):
             raise ControllerError("provider_stop_present")

--- a/batch_state/phase3-run-cycle007-controller-v1.py
+++ b/batch_state/phase3-run-cycle007-controller-v1.py
@@ -140,6 +140,29 @@ def _runner_failure_code(stdout: bytes) -> str:
     return code
 
 
+def _run_stage_subprocess(
+    command: list[str], *, executable: Path, pass_fds: tuple[int, ...]
+) -> tuple[int, bytes]:
+    """Drain child stdout while retaining only one bounded failure status."""
+    with subprocess.Popen(
+        command,
+        executable=str(executable),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        shell=False,
+        pass_fds=pass_fds,
+    ) as process:
+        assert process.stdout is not None
+        status = bytearray()
+        for chunk in iter(lambda: process.stdout.read(64 * 1024), b""):
+            remaining = MAX_RUNNER_STATUS_BYTES + 1 - len(status)
+            if remaining > 0:
+                status.extend(chunk[:remaining])
+        return_code = process.wait()
+    return return_code, b"" if return_code == 0 else bytes(status)
+
+
 def _inherited_execution_lock_fd() -> int | None:
     raw = os.environ.get(EXECUTION_LOCK_FD_ENV)
     if raw is None:
@@ -1555,18 +1578,13 @@ def run_stage(
         python_target = _require_python_binding(expected_python_executable_sha256 or "")
         # Bind exec to the verified target while argv[0] retains the venv launcher
         # that CPython uses to locate pyvenv.cfg and its installed dependencies.
-        completed = subprocess.run(
+        return_code, failure_status = _run_stage_subprocess(
             command,
-            executable=str(python_target),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            shell=False,
+            executable=python_target,
             pass_fds=() if execution_lock_fd is None else (execution_lock_fd,),
         )
-        if completed.returncode != 0:
-            raise ControllerError(_runner_failure_code(completed.stdout))
+        if return_code != 0:
+            raise ControllerError(_runner_failure_code(failure_status))
         _require_python_binding(expected_python_executable_sha256 or "")
         if any(path.exists() for path in _stage_stop_paths(package)):
             raise ControllerError("provider_stop_present")

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -434,7 +434,64 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     assert result["ok"] is True
     assert captured["pass_fds"] == (lock_file.fileno(),)
     assert captured["executable"] == os.fspath(python_target)
+    assert captured["stdout"] is subprocess.PIPE
     lock_file.close()
+
+
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        (
+            b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":true}\n',
+            "sidecar_binding_drift",
+        ),
+        (b'{"failure_code":"PRIVATE CONTENT","ok":false,"text_free":true}\n', "stage_execution_failed"),
+        (b"not-json", "stage_execution_failed"),
+        (b"x" * (4096 + 1), "stage_execution_failed"),
+    ],
+)
+def test_controller_accepts_only_bounded_text_free_runner_failure_codes(
+    controller: ModuleType, stdout: bytes, expected: str
+) -> None:
+    assert controller._runner_failure_code(stdout) == expected
+
+
+def test_controller_propagates_safe_runner_failure_code(
+    controller: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = tmp_path / "compare.py"
+    runner.write_text("# public fixture\n", encoding="utf-8")
+    python_target = tmp_path / "python-target"
+    python_target.write_bytes(b"fixture interpreter")
+    monkeypatch.setattr(controller, "_require_contiguous", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(controller, "_require_python_binding", lambda *_args, **_kwargs: python_target)
+    monkeypatch.setattr(controller, "_commands_for_stage", lambda *_args, **_kwargs: ([["fixture"]], None))
+    monkeypatch.setattr(
+        controller.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=2,
+            stdout=b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":true}\n',
+        ),
+    )
+
+    with pytest.raises(controller.ControllerError, match=r"^sidecar_binding_drift$"):
+        controller.run_stage(
+            tmp_path,
+            "compare",
+            runner,
+            "a" * 64,
+            dry_run=False,
+            expected_python_executable_sha256="b" * 64,
+            expected_label_prompt_sha256s={
+                "gemini": {"clean_label": "c" * 64, "residual_label": "d" * 64},
+                "grok": {"clean_label": "e" * 64, "residual_label": "f" * 64},
+            },
+            expected_custody_sha256="1" * 64,
+            expected_label_manifest_sha256="2" * 64,
+            expected_evidence_manifest_sha256="3" * 64,
+            code_paths={"compare_runner": runner.resolve()},
+        )
 
 
 def test_controller_preserves_python_launcher_for_stage_subprocesses(

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -446,6 +446,14 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
             "sidecar_binding_drift",
         ),
         (b'{"failure_code":"PRIVATE CONTENT","ok":false,"text_free":true}\n', "stage_execution_failed"),
+        (
+            b'{"failure_code":"sidecar_binding_drift","ok":false,"private":"x","text_free":true}\n',
+            "stage_execution_failed",
+        ),
+        (
+            b'{"failure_code":"sidecar_binding_drift","ok":true,"ok":false,"text_free":true}\n',
+            "stage_execution_failed",
+        ),
         (b"not-json", "stage_execution_failed"),
         (b"x" * (4096 + 1), "stage_execution_failed"),
     ],

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import os
 import subprocess
 import sys
 import tempfile
+import time
 import venv
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -456,6 +458,10 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
         ),
         (b'{"failure_code":"sidecar_binding_drift","ok":true,"text_free":true}\n', "stage_execution_failed"),
         (b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":false}\n', "stage_execution_failed"),
+        (b'{"failure_code":"","ok":false,"text_free":true}\n', "stage_execution_failed"),
+        (b'{"failure_code":123,"ok":false,"text_free":true}\n', "stage_execution_failed"),
+        (b'{"failure_code":null,"ok":false,"text_free":true}\n', "stage_execution_failed"),
+        (b'{"failure_code":"a","invalid":true,"ok":false}\n', "stage_execution_failed"),
         (
             b'{"failure_code":"' + b"a" * 65 + b'","ok":false,"text_free":true}\n',
             "stage_execution_failed",
@@ -490,6 +496,32 @@ def test_controller_discards_successful_stage_stdout(controller: ModuleType) -> 
     )
     assert return_code == 0
     assert status == b""
+
+
+def test_controller_does_not_wait_for_grandchild_inherited_stdout(
+    controller: ModuleType, tmp_path: Path
+) -> None:
+    pid_file = tmp_path / "grandchild.pid"
+    child = (
+        "import pathlib,subprocess,sys; "
+        "p=subprocess.Popen([sys.executable,'-c',"
+        "\"import os; b=b'x'*65536; exec('while True:\\\\n os.write(1,b)')\"]); "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(p.pid)); "
+        "raise SystemExit(2)"
+    )
+    started = time.monotonic()
+    try:
+        return_code, _status = controller._run_stage_subprocess(
+            [sys.executable, "-c", child],
+            executable=Path(sys.executable).resolve(),
+            pass_fds=(),
+        )
+        assert return_code == 2
+        assert time.monotonic() - started < 5
+    finally:
+        if pid_file.exists():
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(int(pid_file.read_text(encoding="utf-8")), 15)
 
 
 def test_controller_propagates_safe_runner_failure_code(

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -409,11 +409,12 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     monkeypatch.setattr(controller, "_stage_stop_paths", lambda *_args, **_kwargs: ())
     monkeypatch.setattr(controller, "_seal", lambda *_args, **_kwargs: None)
 
-    def run(*_args: Any, **kwargs: Any) -> Any:
+    def run(command: list[str], **kwargs: Any) -> tuple[int, bytes]:
+        captured["command"] = command
         captured.update(kwargs)
-        return SimpleNamespace(returncode=0)
+        return 0, b""
 
-    monkeypatch.setattr(controller.subprocess, "run", run)
+    monkeypatch.setattr(controller, "_run_stage_subprocess", run)
     result = controller.run_stage(
         tmp_path,
         "compare",
@@ -433,8 +434,7 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
     )
     assert result["ok"] is True
     assert captured["pass_fds"] == (lock_file.fileno(),)
-    assert captured["executable"] == os.fspath(python_target)
-    assert captured["stdout"] is subprocess.PIPE
+    assert captured["executable"] == python_target
     lock_file.close()
 
 
@@ -454,6 +454,12 @@ def test_controller_passes_execution_descriptor_to_stage_runner(
             b'{"failure_code":"sidecar_binding_drift","ok":true,"ok":false,"text_free":true}\n',
             "stage_execution_failed",
         ),
+        (b'{"failure_code":"sidecar_binding_drift","ok":true,"text_free":true}\n', "stage_execution_failed"),
+        (b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":false}\n', "stage_execution_failed"),
+        (
+            b'{"failure_code":"' + b"a" * 65 + b'","ok":false,"text_free":true}\n',
+            "stage_execution_failed",
+        ),
         (b"not-json", "stage_execution_failed"),
         (b"x" * (4096 + 1), "stage_execution_failed"),
     ],
@@ -462,6 +468,28 @@ def test_controller_accepts_only_bounded_text_free_runner_failure_codes(
     controller: ModuleType, stdout: bytes, expected: str
 ) -> None:
     assert controller._runner_failure_code(stdout) == expected
+
+
+def test_controller_stage_subprocess_capture_is_bounded(controller: ModuleType) -> None:
+    command = [sys.executable, "-c", "import sys; sys.stdout.write('x' * 8192); raise SystemExit(2)"]
+    return_code, status = controller._run_stage_subprocess(
+        command,
+        executable=Path(sys.executable).resolve(),
+        pass_fds=(),
+    )
+    assert return_code == 2
+    assert len(status) == controller.MAX_RUNNER_STATUS_BYTES + 1
+
+
+def test_controller_discards_successful_stage_stdout(controller: ModuleType) -> None:
+    command = [sys.executable, "-c", "print('ignored')"]
+    return_code, status = controller._run_stage_subprocess(
+        command,
+        executable=Path(sys.executable).resolve(),
+        pass_fds=(),
+    )
+    assert return_code == 0
+    assert status == b""
 
 
 def test_controller_propagates_safe_runner_failure_code(
@@ -475,11 +503,11 @@ def test_controller_propagates_safe_runner_failure_code(
     monkeypatch.setattr(controller, "_require_python_binding", lambda *_args, **_kwargs: python_target)
     monkeypatch.setattr(controller, "_commands_for_stage", lambda *_args, **_kwargs: ([["fixture"]], None))
     monkeypatch.setattr(
-        controller.subprocess,
-        "run",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            returncode=2,
-            stdout=b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":true}\n',
+        controller,
+        "_run_stage_subprocess",
+        lambda *_args, **_kwargs: (
+            2,
+            b'{"failure_code":"sidecar_binding_drift","ok":false,"text_free":true}\n',
         ),
     )
 


### PR DESCRIPTION
## Summary

- propagate only bounded, minimal, text-free child failure codes
- cap status capture and stop reading when the direct runner exits
- reject malformed, oversized, duplicated, or unsafe status payloads

## Verification

- Ruff: passed
- focused pytest: 63 passed
- source-blind subprocess proofs cover bounded capture, discarded success output, and inherited-writer termination

Author: OpenAI/Codex
Issue: #6375