### PR TITLE
fix(cycle007): recover one classified Gemini stop (#6375)

### DIFF
--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -1155,9 +1155,9 @@ def _run_chunk(
         if terminal.exists():
             if attempt == 2:
                 raise Error("ordinal_identity_binding_drift")
-            _verify_recovery_receipt(package, started, terminal)
             marker = _read_json(terminal)
-            if marker.get("failure_code") not in {
+            failure_code = marker.get("failure_code")
+            if failure_code not in {
                 "stream_json_invalid",
                 "terminal_result_count_drift",
                 "structured_output_envelope_drift",
@@ -1166,6 +1166,8 @@ def _run_chunk(
                 "label_count_or_envelope_drift",
             } | PROVIDER_STATUS_RECOVERY_CODES:
                 raise Error("ordinal_identity_binding_drift")
+            if failure_code in PROVIDER_STATUS_RECOVERY_CODES:
+                _verify_recovery_receipt(package, started, terminal)
             continue
         runtime = Path(
             tempfile.mkdtemp(

--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -113,6 +113,14 @@ FAILURE_CODES = frozenset(
         "unknown_decision_code",
         "evidence_shape_drift",
         "source_role_boundary_violation",
+        "provider_status_quota_or_rate_limit",
+        "provider_status_capacity_unavailable",
+        "provider_status_structured_request_rejected",
+        "provider_status_authentication_or_permission",
+        "provider_status_timeout",
+        "provider_status_cancelled",
+        "provider_status_internal_error",
+        "provider_status_unknown",
     }
 )
 ATTEMPT_FAILURE_STAGES = frozenset(
@@ -123,6 +131,97 @@ EXECUTABLE_BINDINGS = frozenset({"not_checked", "verified", "mismatch", "unavail
 RETURN_CODES = frozenset({"not_started", "zero", "nonzero"})
 RESULT_STATUSES = frozenset({"not_inspected", "success", "non_success", "missing"})
 STRUCTURED_OUTPUT_TYPES = frozenset({"not_inspected", "missing", "object", "string", "null", "other"})
+PROVIDER_STATUS_FAILURE_CODES = frozenset(
+    {
+        "provider_status_quota_or_rate_limit",
+        "provider_status_capacity_unavailable",
+        "provider_status_structured_request_rejected",
+        "provider_status_authentication_or_permission",
+        "provider_status_timeout",
+        "provider_status_cancelled",
+        "provider_status_internal_error",
+        "provider_status_unknown",
+    }
+)
+RECOVERY_RECEIPT = "provider-recovery.json"
+
+_AGY_PROVIDER_STATUS_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "provider_status_quota_or_rate_limit",
+        (
+            "quota",
+            "rate limit",
+            "rate-limit",
+            "rate_limit",
+            "too many requests",
+            "too_many_requests",
+            "resource exhausted",
+            "resource_exhausted",
+            "429",
+        ),
+    ),
+    (
+        "provider_status_capacity_unavailable",
+        (
+            "capacity",
+            "overload",
+            "overloaded",
+            "service unavailable",
+            "service_unavailable",
+            "temporarily unavailable",
+            "temporarily_unavailable",
+            "unavailable",
+            "503",
+        ),
+    ),
+    (
+        "provider_status_structured_request_rejected",
+        (
+            "structured output",
+            "structured_output",
+            "json schema",
+            "json_schema",
+            "schema",
+            "invalid request",
+            "invalid_request",
+            "bad request",
+            "bad_request",
+            "request rejected",
+            "request_rejected",
+            "validation",
+        ),
+    ),
+    (
+        "provider_status_authentication_or_permission",
+        (
+            "authentication",
+            "unauthenticated",
+            "unauthorized",
+            "unauthorised",
+            "auth error",
+            "auth_error",
+            "permission denied",
+            "permission_denied",
+            "forbidden",
+            "access denied",
+            "access_denied",
+            "401",
+            "403",
+        ),
+    ),
+    (
+        "provider_status_timeout",
+        ("timeout", "timed out", "deadline exceeded", "deadline_exceeded"),
+    ),
+    (
+        "provider_status_cancelled",
+        ("cancelled", "canceled", "cancelled_by", "canceled_by", "aborted", "interrupted"),
+    ),
+    (
+        "provider_status_internal_error",
+        ("internal error", "internal_error", "server error", "server_error", "500"),
+    ),
+)
 
 
 def _load_validator() -> Any:
@@ -597,6 +696,27 @@ def schema(lane: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _agy_static_failure_code(result: Mapping[str, Any]) -> str:
+    """Reduce untrusted AGY diagnostics to one closed, text-free status code."""
+
+    def matches(value: Any, patterns: tuple[str, ...], *, depth: int = 0) -> bool:
+        if isinstance(value, str):
+            lowered = value.lower()
+            return any(pattern in lowered for pattern in patterns)
+        if not isinstance(value, Mapping) or depth >= 2:
+            return False
+        keys = ("status", "code", "error_code", "error_type", "reason", "message", "response", "error")
+        return any(matches(value.get(key), patterns, depth=depth + 1) for key in keys)
+
+    try:
+        for code, patterns in _AGY_PROVIDER_STATUS_PATTERNS:
+            if matches(result, patterns):
+                return code
+    except Exception:
+        pass
+    return "provider_status_unknown"
+
+
 def _agy_stream(raw: bytes, *, expected_cwd: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     try:
         events = [
@@ -627,11 +747,11 @@ def _agy_stream(raw: bytes, *, expected_cwd: Path | None = None) -> tuple[dict[s
                 raise Error("structured_output_envelope_drift", structural=True)
         except OSError as exc:
             raise Error("structured_output_envelope_drift", structural=True) from exc
-    if (
-        not isinstance(result, dict)
-        or result.get("status") != "SUCCESS"
-        or ("structured_output" not in result and "response" not in result)
-    ):
+    if not isinstance(result, dict):
+        raise Error("structured_output_envelope_drift", structural=True)
+    if result.get("status") != "SUCCESS":
+        raise Error(_agy_static_failure_code(result), structural=False)
+    if "structured_output" not in result and "response" not in result:
         raise Error("structured_output_envelope_drift", structural=True)
     return init, result
 
@@ -908,6 +1028,39 @@ def stop(
         raise
 
 
+def _verify_recovery_receipt(package: Path, started: Path, terminal: Path) -> None:
+    """Require the one-call operator recovery receipt before a stopped retry."""
+    path = package / OUTPUT / RECOVERY_RECEIPT
+    receipt = _read_json(path)
+    _mode(path, 0o600)
+    terminal_value = _read_json(terminal)
+    expected = {
+        "schema_version": "phase3_cycle007_gemini_provider_recovery_v1",
+        "evaluation_cycle_id": CYCLE,
+        "source_provider_stop_sha256": receipt.get("source_provider_stop_sha256"),
+        "started_marker_sha256": digest(started.read_bytes()),
+        "terminal_marker_sha256": digest(terminal.read_bytes()),
+        "failure_code": terminal_value.get("failure_code"),
+        "failure_stage": terminal_value.get("failure_stage"),
+        "prior_provider_call_count": 1,
+        "authorized_additional_provider_calls": 1,
+        "exact_model": MODEL,
+        "model_family": FAMILY,
+        "harness": HARNESS,
+        "text_free": True,
+    }
+    stop_hash = expected["source_provider_stop_sha256"]
+    if (
+        not isinstance(stop_hash, str)
+        or len(stop_hash) != 64
+        or any(character not in "0123456789abcdef" for character in stop_hash)
+        or set(receipt) != set(expected) | {"receipt_sha256"}
+        or any(receipt.get(key) != value for key, value in expected.items())
+        or receipt.get("receipt_sha256") != digest(canonical(expected))
+    ):
+        raise Error("ordinal_identity_binding_drift")
+
+
 def _command(provider: Path, schema_path: Path, log_path: Path) -> list[str]:
     # AGY stream-input mode reads turns only from stdin; --print would add a
     # conflicting headless prompt and can yield SUCCESS with an empty result.
@@ -993,6 +1146,7 @@ def _run_chunk(
         if terminal.exists():
             if attempt == 2:
                 raise Error("ordinal_identity_binding_drift")
+            _verify_recovery_receipt(package, started, terminal)
             marker = _read_json(terminal)
             if marker.get("failure_code") not in {
                 "stream_json_invalid",
@@ -1065,15 +1219,21 @@ def _run_chunk(
             )
             if completed.returncode:
                 failure_stage = "provider_return"
+                try:
+                    _agy_stream(raw_path.read_bytes(), expected_cwd=runtime)
+                except Error as exc:
+                    if exc.code in PROVIDER_STATUS_FAILURE_CODES:
+                        raise exc
                 raise Error("structured_output_envelope_drift")
             raw = raw_path.read_bytes()
             try:
                 labels = normalize(lane, part, _extract(raw, expected_cwd=runtime), sidecar_part=sidecar_part)
             except Error as exc:
                 failure_stage = (
-                    "stream_parse"
-                    if exc.code
-                    in {
+                    "provider_return"
+                    if exc.code in PROVIDER_STATUS_FAILURE_CODES
+                    else "stream_parse"
+                    if exc.code in {
                         "stream_json_invalid",
                         "terminal_result_count_drift",
                         "structured_output_envelope_drift",

--- a/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
+++ b/batch_state/phase3-run-cycle007-gemini-label-provider-batch-v1.py
@@ -143,6 +143,15 @@ PROVIDER_STATUS_FAILURE_CODES = frozenset(
         "provider_status_unknown",
     }
 )
+PROVIDER_STATUS_RECOVERY_CODES = frozenset(
+    {
+        "provider_status_quota_or_rate_limit",
+        "provider_status_capacity_unavailable",
+        "provider_status_timeout",
+        "provider_status_cancelled",
+        "provider_status_internal_error",
+    }
+)
 RECOVERY_RECEIPT = "provider-recovery.json"
 
 _AGY_PROVIDER_STATUS_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -1155,7 +1164,7 @@ def _run_chunk(
                 "ordinal_key_drift",
                 "label_json_invalid",
                 "label_count_or_envelope_drift",
-            }:
+            } | PROVIDER_STATUS_RECOVERY_CODES:
                 raise Error("ordinal_identity_binding_drift")
             continue
         runtime = Path(

--- a/batch_state/phase3-test-cycle007-gemini-transport-v1.py
+++ b/batch_state/phase3-test-cycle007-gemini-transport-v1.py
@@ -518,6 +518,29 @@ def test_retryable_structural_failure_recovers(tmp_path: Path, monkeypatch: pyte
     assert (chunk_dir / "attempt-1-chunk-01.terminal.json").exists()
 
 
+def test_retryable_structural_failure_resumes_in_fresh_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkg = make_package(tmp_path, lane="clean_label", count=50)
+    fake_bin = _make_fake_bin(tmp_path)
+    state_file = tmp_path / "state.txt"
+    monkeypatch.setenv("FAKE_STATE", str(state_file))
+    monkeypatch.setenv("FAKE_MODE", "valid")
+    chunk_dir = pkg / RUN.OUTPUT / "clean_label" / "chunks" / "packet-0001"
+    put(chunk_dir / "attempt-1-chunk-01.started.json", {"state": "started"})
+    put(
+        chunk_dir / "attempt-1-chunk-01.terminal.json",
+        {"state": "terminal", "failure_code": "stream_json_invalid"},
+    )
+
+    result = run_packet(pkg, "clean_label", 1, fake_bin)
+
+    assert result["ok"] is True
+    assert int(state_file.read_text()) == 3
+    assert not (pkg / RUN.OUTPUT / RUN.RECOVERY_RECEIPT).exists()
+    assert not (pkg / RUN.OUTPUT / "provider-stop.json").exists()
+
+
 def test_two_structural_failures_writes_stop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pkg = make_package(tmp_path, lane="clean_label", count=50)
     fake_bin = _make_fake_bin(tmp_path)
@@ -752,6 +775,7 @@ def main() -> int:
         test_valid_residual_packet(tmp / "t6", mp)
         test_resume_sealed_packet(tmp / "t7", mp)
         test_retryable_structural_failure_recovers(tmp / "t8", mp)
+        test_retryable_structural_failure_resumes_in_fresh_process(tmp / "t8b", mp)
         test_two_structural_failures_writes_stop(tmp / "t9", mp)
         test_nonzero_provider_result_is_reduced_to_safe_status_code(tmp / "t9b", mp)
         test_semantic_failure_immediately_stops(tmp / "t10", mp)

--- a/batch_state/phase3-test-cycle007-gemini-transport-v1.py
+++ b/batch_state/phase3-test-cycle007-gemini-transport-v1.py
@@ -540,10 +540,37 @@ def test_nonzero_provider_result_is_reduced_to_safe_status_code(
     with pytest.raises(RUN.Error) as exc_info:
         run_packet(pkg, "clean_label", 1, fake_bin)
     assert exc_info.value.code == "provider_status_quota_or_rate_limit"
-    stop = json.loads((pkg / RUN.OUTPUT / "provider-stop.json").read_text())
+    stop_path = pkg / RUN.OUTPUT / "provider-stop.json"
+    stop_raw = stop_path.read_bytes()
+    stop = json.loads(stop_raw)
     assert stop["failure_code"] == "provider_status_quota_or_rate_limit"
     assert stop["failure_stage"] == "provider_return"
     assert stop["text_free"] is True
+
+    attempt = pkg / RUN.OUTPUT / "clean_label/chunks/packet-0001"
+    started = attempt / "attempt-1-chunk-01.started.json"
+    terminal = attempt / "attempt-1-chunk-01.terminal.json"
+    terminal_value = json.loads(terminal.read_text())
+    recovery_body = {
+        "schema_version": "phase3_cycle007_gemini_provider_recovery_v1",
+        "evaluation_cycle_id": RUN.CYCLE,
+        "source_provider_stop_sha256": RUN.digest(stop_raw),
+        "started_marker_sha256": RUN.digest(started.read_bytes()),
+        "terminal_marker_sha256": RUN.digest(terminal.read_bytes()),
+        "failure_code": terminal_value["failure_code"],
+        "failure_stage": terminal_value["failure_stage"],
+        "prior_provider_call_count": 1,
+        "authorized_additional_provider_calls": 1,
+        "exact_model": RUN.MODEL,
+        "model_family": RUN.FAMILY,
+        "harness": RUN.HARNESS,
+        "text_free": True,
+    }
+    recovery = recovery_body | {"receipt_sha256": RUN.digest(RUN.canonical(recovery_body))}
+    put(pkg / RUN.OUTPUT / RUN.RECOVERY_RECEIPT, recovery)
+    stop_path.unlink()
+    monkeypatch.setenv("FAKE_MODE", "valid")
+    assert run_packet(pkg, "clean_label", 1, fake_bin)["ok"] is True
 
 
 def test_semantic_failure_immediately_stops(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/batch_state/phase3-test-cycle007-gemini-transport-v1.py
+++ b/batch_state/phase3-test-cycle007-gemini-transport-v1.py
@@ -242,7 +242,7 @@ def make_package(root: Path, *, lane: str = "clean_label", index: int = 1, count
         "row_count": count,
         "tokenizer_id": "phase3-cycle007-cyrillic-tokenizer-v1",
         "tokenizer_version": "1",
-        "code_hashes": compiler.CODE_HASHES,
+        "code_hashes": RUN.FROZEN_EVIDENCE_CODE_HASHES,
         "server_code_sha256": "f" * 64,
         "sources_db_sha256": "1" * 64,
         "vesum_db_sha256": "2" * 64,
@@ -260,7 +260,7 @@ def make_package(root: Path, *, lane: str = "clean_label", index: int = 1, count
         "evaluation_cycle_id": RUN.CYCLE,
         "tokenizer_id": "phase3-cycle007-cyrillic-tokenizer-v1",
         "tokenizer_version": "1",
-        "code_hashes": compiler.CODE_HASHES,
+        "code_hashes": RUN.FROZEN_EVIDENCE_CODE_HASHES,
         "server_code_sha256": "f" * 64,
         "sources_db_sha256": "1" * 64,
         "vesum_db_sha256": "2" * 64,
@@ -343,6 +343,10 @@ if mode == "invalid" or (mode == "retry" and count == 0):
     raise SystemExit(0)
 if mode == "nonzero":
     print("not-json")
+    raise SystemExit(23)
+if mode == "quota":
+    print(json.dumps({"event": "init", "init": {"model": "Gemini 3.6 Flash (High)", "cwd": os.getcwd()}}))
+    print(json.dumps({"event": "result", "result": {"status": "FAILURE", "error": {"code": "RESOURCE_EXHAUSTED"}}}))
     raise SystemExit(23)
 
 labels = {}
@@ -526,6 +530,22 @@ def test_two_structural_failures_writes_stop(tmp_path: Path, monkeypatch: pytest
     assert (pkg / RUN.OUTPUT / "provider-stop.json").exists()
 
 
+def test_nonzero_provider_result_is_reduced_to_safe_status_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkg = make_package(tmp_path, lane="clean_label", count=50)
+    fake_bin = _make_fake_bin(tmp_path)
+    monkeypatch.setenv("FAKE_MODE", "quota")
+
+    with pytest.raises(RUN.Error) as exc_info:
+        run_packet(pkg, "clean_label", 1, fake_bin)
+    assert exc_info.value.code == "provider_status_quota_or_rate_limit"
+    stop = json.loads((pkg / RUN.OUTPUT / "provider-stop.json").read_text())
+    assert stop["failure_code"] == "provider_status_quota_or_rate_limit"
+    assert stop["failure_stage"] == "provider_return"
+    assert stop["text_free"] is True
+
+
 def test_semantic_failure_immediately_stops(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pkg = make_package(tmp_path, lane="clean_label", count=50)
     fake_bin = _make_fake_bin(tmp_path)
@@ -706,6 +726,7 @@ def main() -> int:
         test_resume_sealed_packet(tmp / "t7", mp)
         test_retryable_structural_failure_recovers(tmp / "t8", mp)
         test_two_structural_failures_writes_stop(tmp / "t9", mp)
+        test_nonzero_provider_result_is_reduced_to_safe_status_code(tmp / "t9b", mp)
         test_semantic_failure_immediately_stops(tmp / "t10", mp)
         test_stop_idempotence(tmp / "t11", mp)
         test_concurrency_must_be_one(tmp / "t12")

--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -47,11 +47,14 @@ operator explicitly starts a provider stage.
 - No database, queue service, container platform, or new background daemon.
 - No provider call during installation, storage preparation, status, or plan.
 - No automatic clearing of provider-stop receipts or semantic failures.
-- One explicit `recover-gemini-stop` action is available only for the frozen
-  first-call provider-return incident. It hash-binds and archives the immutable
-  text-free stop, binds the matching started and terminal markers, and
-  authorizes exactly one additional Gemini subscription call. It cannot recover
-  a semantic failure, any sealed output, a second attempt, or a changed stop.
+- One explicit `recover-gemini-stop` action is available only for an exact
+  first-call provider-return incident with the historical generic envelope code
+  or a bounded transient status: quota, capacity, timeout, cancellation, or
+  internal-provider failure. It hash-binds and archives the immutable text-free
+  stop, binds the matching started and terminal markers, and authorizes exactly
+  one additional Gemini subscription call. It cannot recover authentication,
+  structured-request rejection, an unknown or semantic failure, any sealed
+  output, a second attempt, or a changed stop.
 - No persistent `/etc/fstab` or systemd mutation. Re-running the same guardian
   command after reboot restores the bind mounts and resumes from seals.
 

--- a/docs/projects/open-model-data/cycle007-labeling-runtime.md
+++ b/docs/projects/open-model-data/cycle007-labeling-runtime.md
@@ -47,6 +47,11 @@ operator explicitly starts a provider stage.
 - No database, queue service, container platform, or new background daemon.
 - No provider call during installation, storage preparation, status, or plan.
 - No automatic clearing of provider-stop receipts or semantic failures.
+- One explicit `recover-gemini-stop` action is available only for the frozen
+  first-call provider-return incident. It hash-binds and archives the immutable
+  text-free stop, binds the matching started and terminal markers, and
+  authorizes exactly one additional Gemini subscription call. It cannot recover
+  a semantic failure, any sealed output, a second attempt, or a changed stop.
 - No persistent `/etc/fstab` or systemd mutation. Re-running the same guardian
   command after reboot restores the bind mounts and resumes from seals.
 
@@ -153,6 +158,7 @@ of being claimed as automatically resumable.
 | Controller status call exceeds 300 seconds | Fail with `controller_timeout`; status never invokes a provider, so no paid runner is created by this path. |
 | Controller stage call exceeds 72 hours | Kill only the controller wrapper and fail with `controller_timeout`. A surviving paid runner is deliberately not signalled, retains the inherited execution lock, and makes a replacement return `active_worker` with zero additional provider calls. After it exits, durable receipts, seals, and active-stage markers determine the only safe recovery point. |
 | Provider or semantic stop receipt | Preserve the stop and wait for explicit operator recovery direction. |
+| Exact first Gemini provider-return stop after explicit recovery direction | `recover-gemini-stop --expected-stop-sha256 …` preserves the stop in the private backing filesystem and publishes one text-free recovery receipt. The runner accepts that exact receipt only for attempt 2; no recovery action invokes a provider. |
 
 ## Run sequence
 
@@ -169,6 +175,12 @@ of being claimed as automatically resumable.
 
 The staged `--through` boundary prevents an operator intending to start one
 provider from accidentally starting the other or entering adjudication.
+When the exact first Gemini call has a provider-return stop, the operator may
+insert the reviewed `recover-gemini-stop` action before repeating step 4. The
+recovery action is idempotent, preserves the original stop by same-filesystem
+link-and-unlink, holds the guardian and inherited execution locks while the
+controller verifies stopped status, and
+does not authorize Grok or any later stage.
 
 ## Acceptance evidence
 

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -34,6 +34,9 @@ OUTPUT_ROOTS = (
 MARKED_STAGES = frozenset({"audit", "adjudicate"})
 EXECUTION_LOCK_FD_ENV = "PHASE3_CYCLE007_EXECUTION_LOCK_FD"
 RECEIPT_SCHEMA = "phase3_cycle007_labeling_guardian_v1"
+GEMINI_RECOVERY_SCHEMA = "phase3_cycle007_gemini_provider_recovery_v1"
+GEMINI_RECOVERY_RECEIPT = "provider-recovery.json"
+GEMINI_STOP_RECOVERY_ROOT = ".cycle007-gemini-stop-recovery"
 MAX_RECOVERY_FILES = 64
 MAX_RECOVERY_BYTES = 16 * 1024 * 1024
 MOUNT_TIMEOUT_SECONDS = 30
@@ -81,6 +84,7 @@ class Config:
     resolution_authority_root: Path | None
     resolution_nonce_ledger: Path | None
     resolution_advisor_response: Path | None
+    expected_stop_sha256: str | None
 
 
 def _canonical(value: Any) -> bytes:
@@ -115,6 +119,58 @@ def _atomic_json(path: Path, value: dict[str, Any]) -> None:
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
+
+
+def _exclusive_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError:
+        raise GuardianError("stop_recovery_collision") from None
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            os.fchmod(stream.fileno(), 0o600)
+            stream.write(_canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        _fsync_directory(path.parent)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def _private_json(path: Path, uid: int, gid: int) -> tuple[bytes, dict[str, Any]]:
+    _assert_no_symlink_components(path)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        raise GuardianError("stop_recovery_state_drift") from None
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or stat.S_ISLNK(info.st_mode)
+        or stat.S_IMODE(info.st_mode) != 0o600
+        or info.st_uid != uid
+        or info.st_gid != gid
+    ):
+        raise GuardianError("stop_recovery_state_drift")
+
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise GuardianError("stop_recovery_state_drift")
+            result[key] = value
+        return result
+
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=pairs)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        raise GuardianError("stop_recovery_state_drift") from None
+    if not isinstance(value, dict):
+        raise GuardianError("stop_recovery_state_drift")
+    return raw, value
 
 
 def _remove_durable(path: Path) -> None:
@@ -643,6 +699,201 @@ def _resume(config: Config, mounts: list[dict[str, Any]]) -> dict[str, Any]:
         execution.close()
 
 
+def _gemini_stop_recovery(config: Config, mounts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Preserve one exact stopped call and authorize only its second attempt."""
+    expected_stop = config.expected_stop_sha256
+    if (
+        not isinstance(expected_stop, str)
+        or len(expected_stop) != 64
+        or any(character not in "0123456789abcdef" for character in expected_stop)
+    ):
+        raise GuardianError("expected_stop_sha256_required")
+
+    execution = _lock(config.execution_lock, "active_worker")
+    try:
+        status = _invoke_controller(config, "status", execution_fd=execution.fileno())
+        if status.get("stopped") is not True or _completed_stages(status):
+            raise GuardianError("stop_recovery_state_drift")
+
+        output = config.backing_root / OUTPUT_ROOTS[0]
+        _private_directory(output, config.owner_uid, config.owner_gid, create=False)
+        recovery_path = output / GEMINI_RECOVERY_RECEIPT
+        stop_path = output / "provider-stop.json"
+        terminal_candidates = list(output.rglob("attempt-*-chunk-*.terminal.json"))
+        started_candidates = list(output.rglob("attempt-*-chunk-*.started.json"))
+        if len(terminal_candidates) != 1 or len(started_candidates) != 1:
+            raise GuardianError("stop_recovery_state_drift")
+        terminal_path, started_path = terminal_candidates[0], started_candidates[0]
+        for directory in (output, *[path for path in output.rglob("*") if path.is_dir()]):
+            _private_directory(directory, config.owner_uid, config.owner_gid, create=False)
+
+        allowed = {terminal_path, started_path}
+        if recovery_path.exists() or recovery_path.is_symlink():
+            allowed.add(recovery_path)
+        if stop_path.exists() or stop_path.is_symlink():
+            allowed.add(stop_path)
+        observed = {path for path in output.rglob("*") if path.is_file() or path.is_symlink()}
+        if observed != allowed or any(path.is_symlink() for path in observed):
+            raise GuardianError("stop_recovery_state_drift")
+
+        terminal_raw, terminal = _private_json(
+            terminal_path, config.owner_uid, config.owner_gid
+        )
+        started_raw, started = _private_json(started_path, config.owner_uid, config.owner_gid)
+        expected_terminal = (
+            output
+            / "clean_label/chunks/packet-0001"
+            / "attempt-1-chunk-01.terminal.json"
+        )
+        expected_started = expected_terminal.with_name("attempt-1-chunk-01.started.json")
+        if terminal_path != expected_terminal or started_path != expected_started:
+            raise GuardianError("stop_recovery_state_drift")
+        if (
+            terminal.get("schema_version") != "phase3_cycle007_gemini_attempt_v1"
+            or terminal.get("evaluation_cycle_id") != "phase3-v2-1-evaluation-cycle-007"
+            or terminal.get("lane") != "clean_label"
+            or terminal.get("packet_index") != 1
+            or terminal.get("chunk_index") != 1
+            or terminal.get("attempt") != 1
+            or terminal.get("state") != "terminal"
+            or terminal.get("failure_code") != "structured_output_envelope_drift"
+            or terminal.get("failure_stage") != "provider_return"
+            or terminal.get("provider_call_started") is not True
+            or terminal.get("executable_binding_result") != "verified"
+            or terminal.get("provider_return_code") != "nonzero"
+            or terminal.get("init_count") != 1
+            or terminal.get("result_count") != 1
+            or terminal.get("first_event_kind") != "init"
+            or terminal.get("last_event_kind") != "result"
+            or terminal.get("model_binding_result") != "verified"
+            or terminal.get("result_status") != "non_success"
+            or terminal.get("structured_output_type") != "missing"
+            or terminal.get("exact_model") != "Gemini 3.6 Flash (High)"
+            or terminal.get("model_family") != "google"
+            or terminal.get("harness") != "agy"
+            or terminal.get("text_free") is not True
+        ):
+            raise GuardianError("stop_recovery_state_drift")
+        if (
+            started.get("schema_version") != "phase3_cycle007_gemini_attempt_v1"
+            or started.get("evaluation_cycle_id") != terminal["evaluation_cycle_id"]
+            or started.get("lane") != terminal["lane"]
+            or started.get("packet_index") != terminal["packet_index"]
+            or started.get("chunk_index") != terminal["chunk_index"]
+            or started.get("attempt") != terminal["attempt"]
+            or started.get("state") != "started"
+            or started.get("exact_model") != terminal["exact_model"]
+            or started.get("model_family") != terminal["model_family"]
+            or started.get("harness") != terminal["harness"]
+            or started.get("text_free") is not True
+        ):
+            raise GuardianError("stop_recovery_state_drift")
+
+        if stop_path.exists() or stop_path.is_symlink():
+            stop_raw, stop = _private_json(stop_path, config.owner_uid, config.owner_gid)
+            if _digest(stop_raw) != expected_stop:
+                raise GuardianError("stop_recovery_binding_drift")
+            for key in (
+                "evaluation_cycle_id",
+                "lane",
+                "failure_code",
+                "failure_stage",
+                "provider_call_started",
+                "executable_binding_result",
+                "provider_return_code",
+                "init_count",
+                "result_count",
+                "first_event_kind",
+                "last_event_kind",
+                "model_binding_result",
+                "result_status",
+                "structured_output_type",
+                "exact_model",
+                "model_family",
+                "harness",
+                "text_free",
+            ):
+                if stop.get(key) != terminal.get(key):
+                    raise GuardianError("stop_recovery_state_drift")
+            if (
+                stop.get("schema_version") != "phase3_cycle007_gemini_provider_stop_v1"
+                or stop.get("terminal_packet_index") != 1
+                or stop.get("new_provider_calls_allowed") is not False
+            ):
+                raise GuardianError("stop_recovery_state_drift")
+
+            archive_root = config.backing_root / GEMINI_STOP_RECOVERY_ROOT
+            _private_directory(archive_root, config.owner_uid, config.owner_gid, create=True)
+            _fsync_directory(config.backing_root)
+            archive = archive_root / expected_stop
+            _private_directory(archive, config.owner_uid, config.owner_gid, create=True)
+            _fsync_directory(archive_root)
+            archived_stop = archive / "provider-stop.json"
+            if archived_stop.exists() or archived_stop.is_symlink():
+                archived_raw, _archived = _private_json(
+                    archived_stop, config.owner_uid, config.owner_gid
+                )
+                if _digest(archived_raw) != expected_stop:
+                    raise GuardianError("stop_recovery_collision")
+            else:
+                try:
+                    os.link(stop_path, archived_stop, follow_symlinks=False)
+                except OSError:
+                    raise GuardianError("stop_recovery_archive_failed") from None
+                _fsync_directory(archive)
+        else:
+            archive = config.backing_root / GEMINI_STOP_RECOVERY_ROOT / expected_stop
+            archived_stop = archive / "provider-stop.json"
+            archived_raw, _archived = _private_json(
+                archived_stop, config.owner_uid, config.owner_gid
+            )
+            if _digest(archived_raw) != expected_stop:
+                raise GuardianError("stop_recovery_binding_drift")
+
+        receipt_body = {
+            "schema_version": GEMINI_RECOVERY_SCHEMA,
+            "evaluation_cycle_id": terminal["evaluation_cycle_id"],
+            "source_provider_stop_sha256": expected_stop,
+            "started_marker_sha256": _digest(started_raw),
+            "terminal_marker_sha256": _digest(terminal_raw),
+            "failure_code": terminal["failure_code"],
+            "failure_stage": terminal["failure_stage"],
+            "prior_provider_call_count": 1,
+            "authorized_additional_provider_calls": 1,
+            "exact_model": terminal["exact_model"],
+            "model_family": terminal["model_family"],
+            "harness": terminal["harness"],
+            "text_free": True,
+        }
+        receipt = receipt_body | {"receipt_sha256": _digest(_canonical(receipt_body))}
+        if recovery_path.exists() or recovery_path.is_symlink():
+            existing_raw, existing = _private_json(
+                recovery_path, config.owner_uid, config.owner_gid
+            )
+            if existing != receipt or _digest(existing_raw) != _digest(_canonical(receipt)):
+                raise GuardianError("stop_recovery_collision")
+        else:
+            _exclusive_json(recovery_path, receipt)
+        if stop_path.exists():
+            _remove_durable(stop_path)
+
+        return {
+            "schema_version": RECEIPT_SCHEMA,
+            "ok": True,
+            "action": "recover-gemini-stop",
+            "mount_count": len(mounts),
+            "mounts": mounts,
+            "available_bytes": _available_bytes(config.backing_root),
+            "min_free_bytes": config.min_free_bytes,
+            "prior_provider_call_count": 1,
+            "authorized_additional_provider_calls": 1,
+            "recovered_stop_count": 1,
+            "text_free": True,
+        }
+    finally:
+        execution.close()
+
+
 def _parse_code_paths(items: Iterable[str]) -> dict[str, Path]:
     result: dict[str, Path] = {}
     for item in items:
@@ -688,12 +939,15 @@ def _config(args: argparse.Namespace) -> Config:
         resolution_authority_root=args.resolution_authority_root,
         resolution_nonce_ledger=args.resolution_nonce_ledger,
         resolution_advisor_response=args.resolution_advisor_response,
+        expected_stop_sha256=args.expected_stop_sha256,
     )
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("action", choices=("prepare", "status", "plan", "resume"))
+    parser.add_argument(
+        "action", choices=("prepare", "status", "plan", "recover-gemini-stop", "resume")
+    )
     parser.add_argument("--package", type=Path, required=True, help="explicit Cycle 007 package path")
     parser.add_argument("--backing-root", type=Path, required=True, help="explicit separate-filesystem output root")
     parser.add_argument("--guardian-lock", type=Path, required=True, help="stable outer guardian lock")
@@ -720,6 +974,10 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--resolution-authority-root", type=Path)
     parser.add_argument("--resolution-nonce-ledger", type=Path)
     parser.add_argument("--resolution-advisor-response", type=Path)
+    parser.add_argument(
+        "--expected-stop-sha256",
+        help="exact stopped Gemini receipt SHA-256; required only for explicit recovery",
+    )
     return parser
 
 
@@ -732,11 +990,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         config = _config(args)
         if config.owner_uid < 0 or config.owner_gid < 0 or config.min_free_bytes <= 0:
             raise GuardianError("invalid_runtime_parameter")
-        provider_bindings = _provider_bindings_complete(config, required=config.action == "resume")
-        if config.action in {"prepare", "resume"}:
+        provider_bindings = _provider_bindings_complete(
+            config, required=config.action in {"recover-gemini-stop", "resume"}
+        )
+        if config.action in {"prepare", "recover-gemini-stop", "resume"}:
             _validate_mount_command(config.mount_command)
         guardian = _lock(config.guardian_lock, "guardian_already_running")
-        mounts = _ensure_mounts(config, mutate=config.action in {"prepare", "resume"})
+        mounts = _ensure_mounts(
+            config, mutate=config.action in {"prepare", "recover-gemini-stop", "resume"}
+        )
         _require_free_space(config)
         if config.action == "prepare":
             result = {
@@ -756,6 +1018,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if provider_bindings
                 else _fresh_provider_free_status(config, mounts=mounts)
             )
+        elif config.action == "recover-gemini-stop":
+            result = _gemini_stop_recovery(config, mounts)
         else:
             result = _resume(config, mounts)
     except GuardianError as exc:

--- a/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
+++ b/scripts/projects/open_model_data/phase3_cycle007_labeling_guardian.py
@@ -37,6 +37,16 @@ RECEIPT_SCHEMA = "phase3_cycle007_labeling_guardian_v1"
 GEMINI_RECOVERY_SCHEMA = "phase3_cycle007_gemini_provider_recovery_v1"
 GEMINI_RECOVERY_RECEIPT = "provider-recovery.json"
 GEMINI_STOP_RECOVERY_ROOT = ".cycle007-gemini-stop-recovery"
+GEMINI_RECOVERABLE_FIRST_STOP_CODES = frozenset(
+    {
+        "structured_output_envelope_drift",
+        "provider_status_quota_or_rate_limit",
+        "provider_status_capacity_unavailable",
+        "provider_status_timeout",
+        "provider_status_cancelled",
+        "provider_status_internal_error",
+    }
+)
 MAX_RECOVERY_FILES = 64
 MAX_RECOVERY_BYTES = 16 * 1024 * 1024
 MOUNT_TIMEOUT_SECONDS = 30
@@ -756,7 +766,7 @@ def _gemini_stop_recovery(config: Config, mounts: list[dict[str, Any]]) -> dict[
             or terminal.get("chunk_index") != 1
             or terminal.get("attempt") != 1
             or terminal.get("state") != "terminal"
-            or terminal.get("failure_code") != "structured_output_envelope_drift"
+            or terminal.get("failure_code") not in GEMINI_RECOVERABLE_FIRST_STOP_CODES
             or terminal.get("failure_stage") != "provider_return"
             or terminal.get("provider_call_started") is not True
             or terminal.get("executable_binding_result") != "verified"

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import time
 import venv
+from dataclasses import replace
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -75,6 +76,7 @@ def _config(guardian: ModuleType, root: Path, **changes: Any) -> Any:
         "resolution_authority_root": None,
         "resolution_nonce_ledger": None,
         "resolution_advisor_response": None,
+        "expected_stop_sha256": None,
     }
     values.update(changes)
     return guardian.Config(**values)
@@ -239,6 +241,115 @@ def test_orphan_guardian_temporary_is_quarantined_without_reading(
     assert not orphan.exists()
     recovery = config.backing_root / ".cycle007-guardian-recovery"
     assert len(list(recovery.iterdir())) == 1
+
+
+def _write_private_json(path: Path, value: dict[str, Any]) -> bytes:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path.parent, 0o700)
+    raw = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    path.write_bytes(raw)
+    os.chmod(path, 0o600)
+    return raw
+
+
+def test_explicit_gemini_stop_recovery_preserves_stop_and_authorizes_one_call(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action="recover-gemini-stop",
+        expected_stop_sha256="0" * 64,
+    )
+    output = config.backing_root / guardian.OUTPUT_ROOTS[0]
+    attempt = output / "clean_label/chunks/packet-0001"
+    attempt.mkdir(parents=True, mode=0o700)
+    for directory in (output, output / "clean_label", output / "clean_label/chunks", attempt):
+        os.chmod(directory, 0o700)
+    common = {
+        "schema_version": "phase3_cycle007_gemini_attempt_v1",
+        "evaluation_cycle_id": "phase3-v2-1-evaluation-cycle-007",
+        "lane": "clean_label",
+        "packet_index": 1,
+        "chunk_index": 1,
+        "attempt": 1,
+        "exact_model": "Gemini 3.6 Flash (High)",
+        "model_family": "google",
+        "harness": "agy",
+        "text_free": True,
+    }
+    started_raw = _write_private_json(
+        attempt / "attempt-1-chunk-01.started.json", common | {"state": "started"}
+    )
+    terminal = common | {
+        "state": "terminal",
+        "failure_code": "structured_output_envelope_drift",
+        "failure_stage": "provider_return",
+        "provider_call_started": True,
+        "executable_binding_result": "verified",
+        "provider_return_code": "nonzero",
+        "init_count": 1,
+        "result_count": 1,
+        "first_event_kind": "init",
+        "last_event_kind": "result",
+        "model_binding_result": "verified",
+        "result_status": "non_success",
+        "structured_output_type": "missing",
+    }
+    terminal_raw = _write_private_json(attempt / "attempt-1-chunk-01.terminal.json", terminal)
+    stop = {
+        **{key: terminal[key] for key in terminal if key not in {"schema_version", "state", "packet_index", "chunk_index", "attempt"}},
+        "schema_version": "phase3_cycle007_gemini_provider_stop_v1",
+        "terminal_packet_index": 1,
+        "new_provider_calls_allowed": False,
+    }
+    stop_raw = _write_private_json(output / "provider-stop.json", stop)
+    stop_sha = guardian._digest(stop_raw)
+    config = replace(config, expected_stop_sha256=stop_sha)
+    monkeypatch.setattr(
+        guardian,
+        "_invoke_controller",
+        lambda *_args, **_kwargs: {
+            "ok": True,
+            "stopped": True,
+            "completed_stages": [],
+            "text_free": True,
+        },
+    )
+    monkeypatch.setattr(guardian, "_available_bytes", lambda *_args: 123)
+
+    result = guardian._gemini_stop_recovery(config, mounts=[])
+    assert result["authorized_additional_provider_calls"] == 1
+    assert result["prior_provider_call_count"] == 1
+    assert not (output / "provider-stop.json").exists()
+    receipt_path = output / guardian.GEMINI_RECOVERY_RECEIPT
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["source_provider_stop_sha256"] == stop_sha
+    assert receipt["started_marker_sha256"] == guardian._digest(started_raw)
+    assert receipt["terminal_marker_sha256"] == guardian._digest(terminal_raw)
+    archived = tmp_path / "backing" / guardian.GEMINI_STOP_RECOVERY_ROOT / stop_sha / "provider-stop.json"
+    assert guardian._digest(archived.read_bytes()) == stop_sha
+    assert guardian._gemini_stop_recovery(config, mounts=[])["recovered_stop_count"] == 1
+
+
+def test_explicit_gemini_stop_recovery_refuses_unbound_stop(
+    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(
+        guardian,
+        tmp_path,
+        action="recover-gemini-stop",
+        expected_stop_sha256="0" * 64,
+    )
+    output = config.backing_root / guardian.OUTPUT_ROOTS[0]
+    output.mkdir(mode=0o700)
+    monkeypatch.setattr(
+        guardian,
+        "_invoke_controller",
+        lambda *_args, **_kwargs: {"stopped": True, "completed_stages": []},
+    )
+    with pytest.raises(guardian.GuardianError, match="stop_recovery_state_drift"):
+        guardian._gemini_stop_recovery(config, mounts=[])
 
 
 def test_wrong_existing_mount_is_refused_without_mount_command(

--- a/tests/test_phase3_cycle007_labeling_guardian.py
+++ b/tests/test_phase3_cycle007_labeling_guardian.py
@@ -252,8 +252,15 @@ def _write_private_json(path: Path, value: dict[str, Any]) -> bytes:
     return raw
 
 
+@pytest.mark.parametrize(
+    "failure_code",
+    ["structured_output_envelope_drift", "provider_status_quota_or_rate_limit"],
+)
 def test_explicit_gemini_stop_recovery_preserves_stop_and_authorizes_one_call(
-    guardian: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    guardian: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_code: str,
 ) -> None:
     config = _config(
         guardian,
@@ -283,7 +290,7 @@ def test_explicit_gemini_stop_recovery_preserves_stop_and_authorizes_one_call(
     )
     terminal = common | {
         "state": "terminal",
-        "failure_code": "structured_output_envelope_drift",
+        "failure_code": failure_code,
         "failure_stage": "provider_return",
         "provider_call_started": True,
         "executable_binding_result": "verified",

--- a/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
+++ b/tests/test_phase3_cycle007_labeling_guardian_blackbox.py
@@ -108,6 +108,7 @@ config = module.Config(
     resolution_authority_root=None,
     resolution_nonce_ledger=None,
     resolution_advisor_response=None,
+    expected_stop_sha256=None,
 )
 module._recover_guardian_temporaries = lambda _config: 0
 module._require_free_space = lambda _config: 100

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -155,6 +155,20 @@ def test_batch_runner_classifies_non_success_without_disclosing_provider_text() 
         runner._agy_stream(raw)
     assert exc_info.value.code == "provider_status_quota_or_rate_limit"
     assert exc_info.value.structural is False
+    assert {
+        "provider_status_quota_or_rate_limit",
+        "provider_status_capacity_unavailable",
+        "provider_status_timeout",
+        "provider_status_cancelled",
+        "provider_status_internal_error",
+    } == runner.PROVIDER_STATUS_RECOVERY_CODES
+    assert runner.PROVIDER_STATUS_RECOVERY_CODES.isdisjoint(
+        {
+            "provider_status_authentication_or_permission",
+            "provider_status_structured_request_rejected",
+            "provider_status_unknown",
+        }
+    )
 
 
 def test_batch_runner_requires_exact_recovery_receipt_for_stopped_retry(tmp_path: Path) -> None:

--- a/tests/test_phase3_cycle007_public_canaries.py
+++ b/tests/test_phase3_cycle007_public_canaries.py
@@ -133,6 +133,77 @@ def test_batch_runner_accepts_one_fenced_response_json() -> None:
     assert runner._strict_result_payload({"response": f"```json\n{json.dumps(payload)}\n```"}) == payload
 
 
+def test_batch_runner_classifies_non_success_without_disclosing_provider_text() -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_status_test", path)
+    assert spec is not None and spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+    raw = (
+        json.dumps({"event": "init", "init": {"model": runner.MODEL}})
+        + "\n"
+        + json.dumps(
+            {
+                "event": "result",
+                "result": {"status": "FAILURE", "error": {"code": "RESOURCE_EXHAUSTED"}},
+            }
+        )
+        + "\n"
+    ).encode()
+
+    with pytest.raises(runner.Error) as exc_info:
+        runner._agy_stream(raw)
+    assert exc_info.value.code == "provider_status_quota_or_rate_limit"
+    assert exc_info.value.structural is False
+
+
+def test_batch_runner_requires_exact_recovery_receipt_for_stopped_retry(tmp_path: Path) -> None:
+    path = ROOT / "batch_state" / "phase3-run-cycle007-gemini-label-provider-batch-v1.py"
+    spec = importlib.util.spec_from_file_location("cycle007_gemini_batch_recovery_test", path)
+    assert spec is not None and spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+    package = tmp_path / "package"
+    attempt = package / runner.OUTPUT / "clean_label/chunks/packet-0001"
+    attempt.mkdir(parents=True, mode=0o700)
+    started = attempt / "attempt-1-chunk-01.started.json"
+    terminal = attempt / "attempt-1-chunk-01.terminal.json"
+    started.write_bytes(runner.canonical({"state": "started", "text_free": True}))
+    terminal_value = {
+        "failure_code": "structured_output_envelope_drift",
+        "failure_stage": "provider_return",
+        "text_free": True,
+    }
+    terminal.write_bytes(runner.canonical(terminal_value))
+    started.chmod(0o600)
+    terminal.chmod(0o600)
+    body = {
+        "schema_version": "phase3_cycle007_gemini_provider_recovery_v1",
+        "evaluation_cycle_id": runner.CYCLE,
+        "source_provider_stop_sha256": "a" * 64,
+        "started_marker_sha256": runner.digest(started.read_bytes()),
+        "terminal_marker_sha256": runner.digest(terminal.read_bytes()),
+        "failure_code": terminal_value["failure_code"],
+        "failure_stage": terminal_value["failure_stage"],
+        "prior_provider_call_count": 1,
+        "authorized_additional_provider_calls": 1,
+        "exact_model": runner.MODEL,
+        "model_family": runner.FAMILY,
+        "harness": runner.HARNESS,
+        "text_free": True,
+    }
+    receipt = body | {"receipt_sha256": runner.digest(runner.canonical(body))}
+    receipt_path = package / runner.OUTPUT / runner.RECOVERY_RECEIPT
+    receipt_path.write_bytes(runner.canonical(receipt))
+    receipt_path.chmod(0o600)
+
+    runner._verify_recovery_receipt(package, started, terminal)
+    receipt["authorized_additional_provider_calls"] = 2
+    receipt_path.write_bytes(runner.canonical(receipt))
+    with pytest.raises(runner.Error, match="ordinal_identity_binding_drift"):
+        runner._verify_recovery_receipt(package, started, terminal)
+
+
 def test_batch_runner_pins_the_certified_evidence_compiler_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Outcome

Adds a content-blind, exact-receipt recovery for the single stopped Gemini subscription call and classifies future AGY non-success results into bounded safe codes.

## Scope

- preserves and hash-binds the immutable first stop and attempt markers
- authorizes exactly one additional Gemini call
- makes no recovery-time provider call
- leaves prompts, schemas, model, packet size, evidence, validators, custody, denominator, and later stages unchanged
- repairs the synthetic transport fixture to use the already-merged certified compiler identity

## Verification

- Ruff: passed
- focused pytest: 106 passed
- no direct API credentials are used by the production operation

Closes no issue; continues #6375.