### PR TITLE
feat(control-plane): Phase 0 storage seam and sqlite ratchet (#7365)

### DIFF
--- a/docs/design/control-plane-storage-seam.md
+++ b/docs/design/control-plane-storage-seam.md
@@ -1,0 +1,24 @@
+# Phase 0 control-plane storage seam (#7365)
+
+Stamped packet v3 SHA-256:
+`d29a13cedcdc50c6e97516b237155dad9f53116051aba29211b73bfb058c3bcc`
+
+Sqlite remains the live authority in this slice. `scripts/control_plane/storage.py`
+is the single resolver for durable control-plane stores:
+
+| Store id | Canonical sqlite path |
+| --- | --- |
+| `fleet_comms` | `batch_state/fleet-comms/v1/comms.sqlite3` |
+| `session_streams` | `.agent/session-streams/v1/session-streams.sqlite3` |
+| `write_ownership` | `batch_state/tasks/write-ownership.sqlite3` |
+| `task_index` | *(no sqlite in Phase 0)* |
+
+Authority per store: `sqlite` (default) · `shadow` · `pg`. Env vars are documented
+in the module docstring. Postgres DSNs are env-only; pg authority refuses sqlite
+opens and fails closed without `LEARN_UKRAINIAN_CP_PG_DSN`.
+
+First consumer: `scripts/guardrails/delegate_ownership.py` routes `_connect()`
+through the seam. Fleet-comms and session-streams direct opens remain allowlisted
+in `scripts/hygiene/lint_control_plane_sqlite.py` until later slices migrate them.
+
+No Patroni, dual-write, or public bind in Phase 0.

--- a/scripts/ci/fastlane_always_tests.txt
+++ b/scripts/ci/fastlane_always_tests.txt
@@ -3,6 +3,7 @@ tests/api/opsec_sweep/test_opsec_route_sweep.py
 tests/api/opsec_sweep/test_opsec_scan.py
 tests/api/test_app_factory.py
 tests/api/test_import_pinning.py
+tests/control_plane/test_storage.py
 tests/test_ask_opencode.py
 tests/test_bio_preparation_ci_routing.py
 tests/test_ci_changed_tests.py

--- a/scripts/control_plane/__init__.py
+++ b/scripts/control_plane/__init__.py
@@ -1,0 +1,25 @@
+"""Control-plane storage seam (Phase 0 — sqlite remains authority)."""
+
+from scripts.control_plane.storage import (
+    Authority,
+    ControlPlaneError,
+    ControlPlanePgDsnMissingError,
+    ControlPlaneSqliteRefusedError,
+    ControlPlaneStoreUnavailableError,
+    StoreId,
+    connect,
+    resolve_authority,
+    sqlite_path,
+)
+
+__all__ = [
+    "Authority",
+    "ControlPlaneError",
+    "ControlPlanePgDsnMissingError",
+    "ControlPlaneSqliteRefusedError",
+    "ControlPlaneStoreUnavailableError",
+    "StoreId",
+    "connect",
+    "resolve_authority",
+    "sqlite_path",
+]

--- a/scripts/control_plane/storage.py
+++ b/scripts/control_plane/storage.py
@@ -1,0 +1,179 @@
+"""Control-plane storage resolver (Phase 0 — sqlite authority, pg-ready seam).
+
+Issue #7365 · stamped packet v3
+``d29a13cedcdc50c6e97516b237155dad9f53116051aba29211b73bfb058c3bcc``
+
+Sqlite remains the live brain in this slice. This module is a small resolver —
+not a dialect-neutral SQL switchboard. Callers that need durable control-plane
+state open storage here instead of hard-coding ``sqlite3.connect`` against the
+canonical paths.
+
+Stores (closed enum)
+--------------------
+``fleet_comms``, ``session_streams``, ``write_ownership``, ``task_index``
+
+Per-store authority: ``sqlite`` (default) | ``shadow`` | ``pg``.
+
+Environment
+-----------
+``LEARN_UKRAINIAN_CP_AUTHORITY``
+    Global default authority (``sqlite`` unless overridden).
+
+``LEARN_UKRAINIAN_CP_AUTHORITY_<STORE>``
+    Per-store override where ``<STORE>`` is the uppercased enum name, e.g.
+    ``LEARN_UKRAINIAN_CP_AUTHORITY_WRITE_OWNERSHIP``.
+
+``LEARN_UKRAINIAN_CP_PG_DSN``
+    Postgres DSN for stores with authority ``pg``. Never committed; fail closed
+    when missing. No hostnames appear in raised errors — only the store id.
+
+Existing path overrides (honored before connect):
+``FLEET_COMMS_ROOT``, ``LEARN_UKRAINIAN_OWNERSHIP_LEDGER``.
+
+Tests may redirect the primary checkout via ``LEARN_UK_REPO_ROOT`` (same as the
+Monitor API) or the store-specific overrides above.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from scripts.common.repo_root import resolve_repo_root
+
+_MODULE_ROOT = resolve_repo_root(Path(__file__), 2)
+
+_ENV_AUTHORITY = "LEARN_UKRAINIAN_CP_AUTHORITY"
+_ENV_PG_DSN = "LEARN_UKRAINIAN_CP_PG_DSN"
+_ENV_AUTHORITY_PREFIX = "LEARN_UKRAINIAN_CP_AUTHORITY_"
+
+
+class StoreId(StrEnum):
+    FLEET_COMMS = "fleet_comms"
+    SESSION_STREAMS = "session_streams"
+    WRITE_OWNERSHIP = "write_ownership"
+    TASK_INDEX = "task_index"
+
+
+class Authority(StrEnum):
+    SQLITE = "sqlite"
+    SHADOW = "shadow"
+    PG = "pg"
+
+
+class ControlPlaneError(RuntimeError):
+    """Base error for control-plane storage resolution."""
+
+
+class ControlPlaneSqliteRefusedError(ControlPlaneError):
+    """Raised when authority is ``pg`` and a sqlite open was requested."""
+
+
+class ControlPlanePgDsnMissingError(ControlPlaneError):
+    """Raised when authority is ``pg`` but no DSN is configured."""
+
+
+class ControlPlaneStoreUnavailableError(ControlPlaneError):
+    """Raised when a store has no sqlite backing in this slice."""
+
+
+def _repo_root(repo_root: Path | None) -> Path:
+    if repo_root is not None:
+        return repo_root
+    configured = (os.environ.get("LEARN_UK_REPO_ROOT") or "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return _MODULE_ROOT
+
+
+def _parse_authority(raw: str) -> Authority:
+    try:
+        return Authority(raw.strip().lower())
+    except ValueError as exc:
+        raise ControlPlaneError(f"unknown control-plane authority: {raw!r}") from exc
+
+
+def resolve_authority(store: StoreId) -> Authority:
+    """Return the configured authority for ``store``."""
+    per_store = (os.environ.get(f"{_ENV_AUTHORITY_PREFIX}{store.name}") or "").strip()
+    if per_store:
+        return _parse_authority(per_store)
+    global_default = (os.environ.get(_ENV_AUTHORITY) or "").strip()
+    if global_default:
+        return _parse_authority(global_default)
+    return Authority.SQLITE
+
+
+def sqlite_path(store: StoreId, *, repo_root: Path | None = None) -> Path:
+    """Resolve the canonical sqlite file for ``store`` without opening it."""
+    root = _repo_root(repo_root)
+    if store is StoreId.FLEET_COMMS:
+        from scripts.fleet_comms.paths import default_plane_root
+
+        plane_root = default_plane_root(repo_root=root)
+        return plane_root / "comms.sqlite3"
+    if store is StoreId.SESSION_STREAMS:
+        from agents_extensions.shared.session_streams.db import default_database_path
+
+        return default_database_path(root)
+    if store is StoreId.WRITE_OWNERSHIP:
+        override = (os.environ.get("LEARN_UKRAINIAN_OWNERSHIP_LEDGER") or "").strip()
+        if override:
+            return Path(override).expanduser().resolve()
+        return root / "batch_state" / "tasks" / "write-ownership.sqlite3"
+    if store is StoreId.TASK_INDEX:
+        raise ControlPlaneStoreUnavailableError(
+            "task_index has no sqlite backing in Phase 0; use a later slice"
+        )
+    raise ControlPlaneStoreUnavailableError(f"unknown store: {store}")
+
+
+def _pg_dsn() -> str:
+    return (os.environ.get(_ENV_PG_DSN) or "").strip()
+
+
+def connect(
+    store: StoreId,
+    *,
+    path: Path | str | None = None,
+    read_only: bool = False,
+    repo_root: Path | None = None,
+    **sqlite_kwargs: Any,
+) -> sqlite3.Connection | Any:
+    """Open the configured backend for ``store``.
+
+    ``sqlite`` and ``shadow`` open the existing canonical sqlite files.
+    ``pg`` refuses sqlite for that store and requires ``LEARN_UKRAINIAN_CP_PG_DSN``.
+    """
+    authority = resolve_authority(store)
+    if authority is Authority.PG:
+        if not _pg_dsn():
+            raise ControlPlanePgDsnMissingError(
+                f"control-plane store {store.value!r} requires {_ENV_PG_DSN}"
+            )
+        raise ControlPlaneSqliteRefusedError(
+            f"control-plane store {store.value!r} uses pg authority; sqlite is refused"
+        )
+
+    if authority not in {Authority.SQLITE, Authority.SHADOW}:
+        raise ControlPlaneError(f"unsupported authority for store {store.value!r}")
+
+    db_path = (
+        Path(path).expanduser().resolve()
+        if path is not None
+        else sqlite_path(store, repo_root=repo_root)
+    )
+    if read_only:
+        if not db_path.is_file():
+            raise ControlPlaneStoreUnavailableError(
+                f"control-plane store {store.value!r} database does not exist"
+            )
+        uri = f"file:{db_path.resolve().as_posix()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, **sqlite_kwargs)
+    else:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path), **sqlite_kwargs)
+    return conn

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -30,6 +30,9 @@ try:
 except ImportError:  # pragma: no cover - flat script path
     from common.repo_root import resolve_repo_root  # type: ignore
 
+from scripts.control_plane.storage import StoreId
+from scripts.control_plane.storage import connect as cp_connect
+
 # File lives at scripts/guardrails/… → parents[2] is the checkout root.
 _REPO_ROOT = resolve_repo_root(Path(__file__), 2)
 DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
@@ -421,7 +424,13 @@ class OwnershipLedger:
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self.path), timeout=30.0, isolation_level=None)
+        conn = cp_connect(
+            StoreId.WRITE_OWNERSHIP,
+            path=self.path,
+            read_only=False,
+            timeout=30.0,
+            isolation_level=None,
+        )
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")

--- a/scripts/hygiene/lint_control_plane_sqlite.py
+++ b/scripts/hygiene/lint_control_plane_sqlite.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Ratchet: direct ``sqlite3.connect`` opens of control-plane stores (#7365).
+
+Scans ``scripts/`` and ``agents_extensions/shared/session_streams/`` for
+``sqlite3.connect`` calls that target the four control-plane sqlite files.
+New opens outside ``scripts/control_plane/`` fail; existing call sites are
+allowlisted by ``(path, snippet, max_occurrences)`` so later slices can shrink
+the list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SCAN_ROOTS: tuple[str, ...] = (
+    "scripts",
+    "agents_extensions/shared/session_streams",
+)
+_CONTROL_PLANE_PACKAGE = "scripts/control_plane"
+_SKIP_PATH_PREFIXES: tuple[str, ...] = ("tests/",)
+
+# Exact ``(path, stripped snippet, max_occurrences)`` for remaining direct opens.
+_ALLOWLIST: tuple[tuple[str, str, int], ...] = (
+    (
+        "agents_extensions/shared/session_streams/db.py",
+        "connection = sqlite3.connect(",
+        2,
+    ),
+    (
+        "scripts/agent_runtime/acpx_discuss.py",
+        'connection = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/api/fleet_router.py",
+        "connection = sqlite3.connect(",
+        1,
+    ),
+    (
+        "scripts/api/fleet_workers_collect.py",
+        "conn = sqlite3.connect(str(path))",
+        1,
+    ),
+    (
+        "scripts/api/runtime_router.py",
+        'connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/entire_context/reconcile.py",
+        'with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:',
+        1,
+    ),
+    (
+        "scripts/entire_context/resolvers.py",
+        'with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:',
+        1,
+    ),
+    (
+        "scripts/fleet_comms/artifacts.py",
+        "self._conn = sqlite3.connect(",
+        1,
+    ),
+    (
+        "scripts/fleet_comms/cli.py",
+        'conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/fleet_comms/cold_start_board.py",
+        'conn = sqlite3.connect(f"file:{plane_db.resolve().as_posix()}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/fleet_comms/message_plane.py",
+        'conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/fleet_comms/routing_reservations.py",
+        'connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)',
+        1,
+    ),
+    (
+        "scripts/orchestration/slot_routing.py",
+        'conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)',
+        1,
+    ),
+)
+
+_WRITE_OWNERSHIP = re.compile(r"write[-_]ownership")
+_SESSION_STREAMS = re.compile(
+    r"session[-_]streams|SessionStreamDatabase|session_streams_db_path|stream_leases"
+)
+_FLEET_COMMS = re.compile(
+    r"comms\.sqlite3|default_plane_root|_plane_db_path|comms_plane_store|plane_db"
+)
+_LEGACY = re.compile(
+    r"legacy_broker|legacy_db|MESSAGE_DB|import_legacy|_probe_inbox_legacy|source_path"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    rel_path: str
+    line_no: int
+    snippet: str
+    store: str
+
+
+def _rel(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _allowlist_lookup() -> dict[tuple[str, str], int]:
+    return {(path, snippet): max_count for path, snippet, max_count in _ALLOWLIST}
+
+
+def iter_scan_paths(repo_root: Path | None = None) -> list[Path]:
+    root = (repo_root or REPO_ROOT).resolve()
+    found: list[Path] = []
+    for scan_root in _SCAN_ROOTS:
+        base = root / scan_root
+        if not base.is_dir():
+            continue
+        found.extend(base.rglob("*.py"))
+    unique = sorted({path.resolve() for path in found if path.is_file()})
+    return [
+        path
+        for path in unique
+        if not _rel(path, root).startswith(_CONTROL_PLANE_PACKAGE)
+        and not any(_rel(path, root).startswith(prefix) for prefix in _SKIP_PATH_PREFIXES)
+    ]
+
+
+def _stores_for_context(context: str) -> set[str]:
+    stores: set[str] = set()
+    if _WRITE_OWNERSHIP.search(context):
+        stores.add("write_ownership")
+    if _SESSION_STREAMS.search(context):
+        stores.add("session_streams")
+    fleet_hit = bool(_FLEET_COMMS.search(context))
+    legacy_hit = bool(_LEGACY.search(context))
+    if (
+        fleet_hit
+        and not (legacy_hit and "comms_plane" not in context and "plane_db" not in context)
+        and (
+            not legacy_hit
+            or re.search(r"comms_plane|plane_db|default_plane_root|_plane_db", context)
+        )
+    ):
+        stores.add("fleet_comms")
+    if re.search(r"task_index|task-index", context):
+        stores.add("task_index")
+    return stores
+
+
+def _function_context(node: ast.AST, lines: list[str]) -> str:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        start = node.lineno - 1
+        end = getattr(node, "end_lineno", node.lineno) or node.lineno
+        return "\n".join(lines[start:end])
+    return ""
+
+
+def _call_snippet(lines: list[str], line_index: int) -> str:
+    parts: list[str] = []
+    for offset in range(0, 4):
+        idx = line_index + offset
+        if idx >= len(lines):
+            break
+        parts.append(lines[idx])
+        if ")" in lines[idx]:
+            break
+    return " ".join(part.strip() for part in parts).strip()
+
+
+def find_control_plane_connects(repo_root: Path | None = None) -> list[Finding]:
+    """Return direct control-plane ``sqlite3.connect`` findings outside the seam."""
+    root = (repo_root or REPO_ROOT).resolve()
+    findings: list[Finding] = []
+    for path in iter_scan_paths(root):
+        rel = _rel(path, root)
+        try:
+            source = path.read_text(encoding="utf-8")
+            lines = source.splitlines()
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "connect"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "sqlite3"
+            ):
+                continue
+            line_index = node.lineno - 1
+            snippet = lines[line_index].strip() if line_index < len(lines) else ""
+            if not snippet:
+                snippet = _call_snippet(lines, line_index)
+            enclosing = ""
+            for candidate in ast.walk(tree):
+                if isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+                    candidate.lineno <= node.lineno
+                    and (getattr(candidate, "end_lineno", candidate.lineno) or candidate.lineno)
+                    >= node.lineno
+                ):
+                    enclosing = _function_context(candidate, lines)
+            context = f"{enclosing}\n{snippet}"
+            stores = _stores_for_context(context)
+            if not stores:
+                continue
+            for store in sorted(stores):
+                findings.append(Finding(rel, node.lineno, snippet, store))
+    return findings
+
+
+def find_unallowlisted_connects(repo_root: Path | None = None) -> list[tuple[str, str]]:
+    """Return ``(path:line, detail)`` for hits not covered by the allowlist."""
+    allowlist = _allowlist_lookup()
+    usage: Counter[tuple[str, str]] = Counter()
+    violations: list[tuple[str, str]] = []
+    for finding in find_control_plane_connects(repo_root):
+        key = (finding.rel_path, finding.snippet)
+        max_allowed = allowlist.get(key)
+        if max_allowed is not None:
+            usage[key] += 1
+            if usage[key] <= max_allowed:
+                continue
+            violations.append(
+                (
+                    f"{finding.rel_path}:{finding.line_no}",
+                    f"allowlist exceeded for {finding.store}: {finding.snippet}",
+                )
+            )
+            continue
+        violations.append(
+            (
+                f"{finding.rel_path}:{finding.line_no}",
+                f"new direct {finding.store} open: {finding.snippet}",
+            )
+        )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+    violations = find_unallowlisted_connects()
+    if not violations:
+        print("OK: no unallowlisted control-plane sqlite3.connect opens")
+        return 0
+    print(
+        "Unallowlisted control-plane sqlite3.connect (route through scripts/control_plane/):",
+        file=sys.stderr,
+    )
+    for key, detail in violations:
+        print(f"  {key}: {detail}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/control_plane/test_storage.py
+++ b/tests/control_plane/test_storage.py
@@ -1,0 +1,96 @@
+"""Phase 0 control-plane storage seam tests (sqlite authority)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.control_plane.storage import (
+    ControlPlanePgDsnMissingError,
+    ControlPlaneSqliteRefusedError,
+    ControlPlaneStoreUnavailableError,
+    StoreId,
+    connect,
+    resolve_authority,
+    sqlite_path,
+)
+from scripts.guardrails.delegate_ownership import OwnershipLedger
+from scripts.hygiene import lint_control_plane_sqlite
+
+pytestmark = pytest.mark.repo_invariant
+
+
+def test_default_authority_is_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LEARN_UKRAINIAN_CP_AUTHORITY", raising=False)
+    monkeypatch.delenv("LEARN_UKRAINIAN_CP_AUTHORITY_WRITE_OWNERSHIP", raising=False)
+    assert resolve_authority(StoreId.WRITE_OWNERSHIP).value == "sqlite"
+
+
+def test_ownership_ledger_uses_seam_and_begin_immediate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger_path = tmp_path / "write-ownership.sqlite3"
+    monkeypatch.setenv("LEARN_UKRAINIAN_OWNERSHIP_LEDGER", str(ledger_path))
+    ledger = OwnershipLedger(task_state_dir=tmp_path / "tasks")
+    with ledger._connect() as conn:
+        assert isinstance(conn, sqlite3.Connection)
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT 1").fetchone()
+        assert row is not None
+        conn.execute("COMMIT")
+
+
+def test_pg_without_dsn_fails_closed_no_sqlite_created(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LEARN_UKRAINIAN_CP_AUTHORITY_WRITE_OWNERSHIP", "pg")
+    monkeypatch.delenv("LEARN_UKRAINIAN_CP_PG_DSN", raising=False)
+    target = tmp_path / "would-not-create.sqlite3"
+    with pytest.raises(ControlPlanePgDsnMissingError, match="write_ownership"):
+        connect(StoreId.WRITE_OWNERSHIP, path=target)
+    assert not target.exists()
+
+
+def test_pg_with_dsn_still_refuses_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LEARN_UKRAINIAN_CP_AUTHORITY_WRITE_OWNERSHIP", "pg")
+    monkeypatch.setenv("LEARN_UKRAINIAN_CP_PG_DSN", "postgresql://example.invalid/db")
+    target = tmp_path / "still-not-created.sqlite3"
+    with pytest.raises(ControlPlaneSqliteRefusedError, match="write_ownership"):
+        connect(StoreId.WRITE_OWNERSHIP, path=target)
+    assert not target.exists()
+
+
+def test_task_index_has_no_sqlite_path() -> None:
+    with pytest.raises(ControlPlaneStoreUnavailableError, match="task_index"):
+        sqlite_path(StoreId.TASK_INDEX)
+
+
+def test_control_plane_lint_allowlists_remaining_direct_opens() -> None:
+    violations = lint_control_plane_sqlite.find_unallowlisted_connects()
+    assert violations == [], f"unallowlisted control-plane sqlite opens: {violations}"
+
+
+def test_control_plane_lint_detects_new_direct_open(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts" / "evil"
+    scripts.mkdir(parents=True)
+    (scripts / "rogue.py").write_text(
+        "\n".join(
+            [
+                "import sqlite3",
+                "def open_ledger():",
+                '    return sqlite3.connect("batch_state/tasks/write-ownership.sqlite3")',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    violations = lint_control_plane_sqlite.find_unallowlisted_connects(repo_root=tmp_path)
+    assert len(violations) == 1
+    assert "write-ownership.sqlite3" in violations[0][1]

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -163,3 +163,10 @@ def test_raw_rm_rf_lint_allowlist_keyed_by_content_not_line(tmp_path: Path) -> N
     assert len(findings) == 1
     assert findings[0][1] == lockdir_rm
     assert findings[0][0].startswith("services.sh:")
+
+
+def test_control_plane_sqlite_lint_allowlists_remaining_direct_opens() -> None:
+    from scripts.hygiene import lint_control_plane_sqlite
+
+    violations = lint_control_plane_sqlite.find_unallowlisted_connects()
+    assert violations == [], f"unallowlisted control-plane sqlite opens: {violations}"


### PR DESCRIPTION
Closes nothing yet — Phase 0 of stamped HA v3 (#7365). Sqlite remains the live authority.

## What
- `scripts/control_plane/` resolver (`sqlite` | `shadow` | `pg`) with env overrides
- First consumer: `delegate_ownership.py` writes through the seam
- Hygiene ratchet `lint_control_plane_sqlite.py` allowlists remaining fleet_comms / session_streams opens
- Docs: `docs/design/control-plane-storage-seam.md`
- Packet SHA-256 `d29a13cedcdc50c6e97516b237155dad9f53116051aba29211b73bfb058c3bcc`

## Not in this PR
Patroni, 3rd VPS, k8s, dual-write, moving fleet-comms traffic.

## Tests
`tests/control_plane/test_storage.py tests/test_path_safety.py tests/test_delegate_ownership.py` — 51 passed.

X-Agent: cursor/phase0-control-plane-seam