### PR TITLE
refactor(api): migrate comms_router to MonitorContext (#7323)

### DIFF
--- a/docs/design/count_opsec_fixture_seams.py
+++ b/docs/design/count_opsec_fixture_seams.py
@@ -189,14 +189,11 @@ def replay_isolated_fixture(monkeypatch: MonkeypatchRecorder, root: Path) -> Non
         lambda: (_ for _ in ()).throw(FileNotFoundError("fixture")),
     )
 
-    importlib.import_module("scripts.ai_agent_bridge._db")
     importlib.import_module("scripts.fleet_comms.legacy_broker_report")
     importlib.import_module("scripts.telemetry.legacy_bridge")
     importlib.import_module("wiki.state")
     for module_name, module in tuple(sys.modules.items()):
-        if module is None or not module_name.startswith(
-            ("scripts.ai_agent_bridge", "scripts.telemetry", "wiki")
-        ):
+        if module is None or not module_name.startswith(("scripts.telemetry", "wiki")):
             continue
         for name, value in tuple(vars(module).items()):
             if not isinstance(value, Path) or not value.is_absolute():
@@ -245,7 +242,7 @@ def replay_isolated_fixture(monkeypatch: MonkeypatchRecorder, root: Path) -> Non
         del repo_root
         return isolated_plane_root
 
-    monkeypatch.setattr(message_plane, "default_plane_root", isolated_plane_resolver)
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(isolated_plane_root))
     monkeypatch.setattr(cold_start_board, "default_plane_root", isolated_plane_resolver)
     for module_name, module in tuple(sys.modules.items()):
         if not module_name.startswith("scripts.api") or module is None:

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -35,7 +35,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse
 
 try:
@@ -53,17 +53,17 @@ from scripts.fleet_comms.message_plane import read_plane_status, resolve_plane_m
 from scripts.fleet_comms.migrations import apply_migrations
 from scripts.fleet_comms.opsec_store import COMMS_RESPONSE_SCHEMA_VERSION, legacy_broker_store
 
-from .config import CURRICULUM_ROOT, MESSAGE_DB, PROJECT_ROOT
-from .resilience import connect_sqlite
+from .monitor_context import MonitorContext, get_ctx, production_context
 from .state_helpers import cache_get, cache_set
 from .telemetry.legacy_comms import LegacyCommsTelemetryRoute
 
 router = APIRouter(tags=["comms"], route_class=LegacyCommsTelemetryRoute)
 
 # ==================== DB HELPERS ====================
+#
+# Roots and store handles are read from MonitorContext via Depends(get_ctx)
+# (#7269 step 5): this module keeps no module-global Path seams.
 
-PID_DIR = PROJECT_ROOT / ".mcp" / "servers" / "message-broker" / "pids"
-LOG_DIR = PROJECT_ROOT / "logs" / "research-preseed"
 BATCH_LOG_TAIL_BYTES = 256 * 1024
 DEFAULT_ACTIVITY_AGENTS = (
     "claude",
@@ -95,15 +95,20 @@ def _tune_db_connection(conn: sqlite3.Connection, *, writable: bool) -> None:
     conn.row_factory = sqlite3.Row
 
 
-def ensure_broker_db_ready() -> None:
+def ensure_broker_db_ready(ctx: MonitorContext | None = None) -> None:
     """Run idempotent broker startup tuning and migrations."""
-    if not MESSAGE_DB.exists():
+    if ctx is None:
+        ctx = production_context()
+    message_db = ctx.roots.message_db_path
+    if not message_db.exists():
         return
 
-    conn = sqlite3.connect(str(MESSAGE_DB))
+    conn = ctx.stores.message_db.connect() if ctx.stores.message_db is not None else None
+    if conn is None:
+        return
     try:
         _tune_db_connection(conn, writable=True)
-        migration_path = PROJECT_ROOT / "scripts" / "migrations" / "2026-05-06-broker-indexes.py"
+        migration_path = ctx.roots.project_root / "scripts" / "migrations" / "2026-05-06-broker-indexes.py"
         if migration_path.exists():
             spec = importlib_util.spec_from_file_location("broker_indexes_20260506", migration_path)
             if spec is not None and spec.loader is not None:
@@ -116,11 +121,12 @@ def ensure_broker_db_ready() -> None:
         conn.close()
 
 
-def _get_db() -> sqlite3.Connection | None:
+def _get_db(ctx: MonitorContext) -> sqlite3.Connection | None:
     """Get read-only broker DB connection. Returns None if DB missing."""
-    if not MESSAGE_DB.exists():
+    handle = ctx.stores.message_db
+    if handle is None or not handle.path.exists():
         return None
-    conn = connect_sqlite(f"file:{MESSAGE_DB}?mode=ro", uri=True)
+    conn = handle.connect(read_only=True)
     _tune_db_connection(conn, writable=False)
     return conn
 
@@ -151,7 +157,7 @@ _expire_sweep_lock = threading.Lock()
 _expire_sweep_thread: threading.Thread | None = None
 
 
-def _maybe_run_delivery_expiry_sweep() -> None:
+def _maybe_run_delivery_expiry_sweep(ctx: MonitorContext) -> None:
     """Lazily trigger the channel-delivery TTL + dead-lane expire sweep.
 
     Non-blocking: the sweep runs in a daemon thread so a slow SQLite
@@ -167,12 +173,13 @@ def _maybe_run_delivery_expiry_sweep() -> None:
     router's DB happens to resemble (e.g. an older/synthetic fixture) is
     not — it must look exactly like a current, real broker DB first.
     """
-    if resolve_plane_mode(None) == "authority" or not MESSAGE_DB.exists():
+    message_db = ctx.roots.message_db_path
+    if resolve_plane_mode(None) == "authority" or not message_db.exists():
         return
     if cache_get("bridge_expire_sweep", ttl=_EXPIRE_SWEEP_INTERVAL_S) is not None:
         return
 
-    conn = _get_db()
+    conn = _get_db(ctx)
     if conn is None:
         return
     try:
@@ -191,10 +198,10 @@ def _maybe_run_delivery_expiry_sweep() -> None:
     with _expire_sweep_lock:
         if _expire_sweep_thread is not None and _expire_sweep_thread.is_alive():
             return
-        # Snapshot MESSAGE_DB on the request thread (respects test patches of
-        # this module's MESSAGE_DB) and hand it to the sweep explicitly.
+        # Snapshot the message DB path from the request's context (respects
+        # the app's MonitorContext) and hand it to the sweep explicitly.
         _expire_sweep_thread = threading.Thread(
-            target=_run_delivery_expiry_sweep, args=(MESSAGE_DB,), daemon=True
+            target=_run_delivery_expiry_sweep, args=(message_db,), daemon=True
         )
         _expire_sweep_thread.start()
 
@@ -379,6 +386,7 @@ async def list_messages(
     offset: int = Query(0, ge=0),
     since: str | None = Query(None, description="Only messages with timestamp > this ISO-8601 value"),
     cursor: int | None = Query(None, ge=1, description="Keyset cursor: return messages older than this id"),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """**Deprecated (#1190 B.5).** All broker messages with optional filters.
 
@@ -386,7 +394,7 @@ async def list_messages(
     conversations. The former comms.html page now redirects to the Fleet
     observer; direct ask-* CLI calls bypass this route.
     """
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return {"messages": [], "total": 0, "error": "Broker DB not found"}
 
@@ -438,13 +446,16 @@ async def list_messages(
 
 
 @router.get("/conversations", deprecated=True)
-async def list_conversations(limit: int = Query(50, ge=1, le=200)):
+async def list_conversations(
+    limit: int = Query(50, ge=1, le=200),
+    ctx: MonitorContext = Depends(get_ctx),
+):
     """**Deprecated (#1190 B.5).** Broker messages grouped by task_id.
 
     Use /api/comms/channels/{name}/threads/{thread_id} for
     channel-based threads.
     """
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return {"conversations": []}
 
@@ -476,13 +487,14 @@ async def get_conversation(
     limit: int = Query(100, ge=1, le=500),
     since: str | None = Query(None, description="Only messages with timestamp > this ISO-8601 value"),
     cursor: int | None = Query(None, ge=1, description="Keyset cursor: return messages older than this id"),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """**Deprecated (#1190 B.5).** Full broker thread for one task_id.
 
     Use /api/comms/channels/{name}/threads/{thread_id} for
     channel-based threads.
     """
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return {"messages": []}
 
@@ -533,13 +545,14 @@ async def get_conversation(
 
 
 @router.get("/active-processes")
-async def active_processes():
+async def active_processes(ctx: MonitorContext = Depends(get_ctx)):
     """Live bridge PIDs with health status."""
-    if not PID_DIR.exists():
+    pid_dir = ctx.roots.pid_dir
+    if not pid_dir.exists():
         return {"processes": [], "count": 0}
 
     processes = []
-    for pf in sorted(PID_DIR.glob("*.json")):
+    for pf in sorted(pid_dir.glob("*.json")):
         try:
             data = json.loads(pf.read_text())
             pid = data.get("pid", 0)
@@ -585,9 +598,10 @@ async def active_processes():
 async def detect_zombies(
     stale_hours: float = Query(2.0, description="Unacked messages older than this = stale"),
     pingpong_threshold: int = Query(5, description="Round-trips on same task in 1h = loop"),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """Auto-detect stuck patterns."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     zombies = []
 
     if conn:
@@ -669,8 +683,9 @@ async def detect_zombies(
         conn.close()
 
     # 4. Orphan PID files
-    if PID_DIR.exists():
-        for pf in PID_DIR.glob("*.json"):
+    pid_dir = ctx.roots.pid_dir
+    if pid_dir.exists():
+        for pf in pid_dir.glob("*.json"):
             try:
                 data = json.loads(pf.read_text())
                 pid = data.get("pid", 0)
@@ -696,9 +711,9 @@ async def detect_zombies(
 
 
 @router.get("/stats")
-async def comms_stats():
+async def comms_stats(ctx: MonitorContext = Depends(get_ctx)):
     """Message rate, latency, error %, per-agent breakdown."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return {"error": "Broker DB not found"}
 
@@ -742,30 +757,35 @@ async def comms_stats():
 
 
 @router.get("/health")
-async def broker_health():
+async def broker_health(ctx: MonitorContext = Depends(get_ctx)):
     """Broker DB writable, queue depth."""
+    message_db = ctx.roots.message_db_path
+    pid_dir = ctx.roots.pid_dir
     health = {
-        "db_exists": MESSAGE_DB.exists(),
+        "db_exists": message_db.exists(),
         "db_writable": False,
         "db_size_kb": 0,
         "queue_depth": 0,
-        "pid_dir_exists": PID_DIR.exists(),
+        "pid_dir_exists": pid_dir.exists(),
         "alive_processes": 0,
     }
 
-    if MESSAGE_DB.exists():
-        health["db_size_kb"] = round(MESSAGE_DB.stat().st_size / 1024, 1)
+    if message_db.exists():
+        health["db_size_kb"] = round(message_db.stat().st_size / 1024, 1)
         try:
-            conn = connect_sqlite(str(MESSAGE_DB))
-            conn.execute("SELECT 1")
-            health["db_writable"] = True
-            health["queue_depth"] = conn.execute("SELECT COUNT(*) FROM messages WHERE acknowledged = 0").fetchone()[0]
-            conn.close()
+            conn = ctx.stores.message_db.connect() if ctx.stores.message_db is not None else None
+            if conn is not None:
+                conn.execute("SELECT 1")
+                health["db_writable"] = True
+                health["queue_depth"] = conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE acknowledged = 0"
+                ).fetchone()[0]
+                conn.close()
         except Exception:
             pass
 
-    if PID_DIR.exists():
-        for pf in PID_DIR.glob("*.json"):
+    if pid_dir.exists():
+        for pf in pid_dir.glob("*.json"):
             try:
                 data = json.loads(pf.read_text())
                 os.kill(data.get("pid", 0), 0)
@@ -777,7 +797,7 @@ async def broker_health():
 
 
 @router.get("/v1/plane-status")
-async def message_plane_status():
+async def message_plane_status(ctx: MonitorContext = Depends(get_ctx)):
     """Read-only fleet message-plane status (PR-K-ish / #5512 parity surface).
 
     Reports ``FLEET_COMMS_MESSAGE_PLANE`` mode (default off), schema migration
@@ -785,19 +805,25 @@ async def message_plane_status():
     recent parity telemetry summary when the optional JSONL file is present.
     Never writes or migrates.
     """
-    return read_plane_status(repo_root=PROJECT_ROOT)
+    return read_plane_status(repo_root=ctx.roots.project_root)
 
 
 # ==================== BATCH PROGRESS ====================
 
 
-def _scan_preseed_logs() -> list[dict]:
+def _preseed_log_dir(ctx: MonitorContext):
+    """Research-preseed log directory under the context's logs root."""
+    return ctx.roots.logs_dir / "research-preseed"
+
+
+def _scan_preseed_logs(ctx: MonitorContext) -> list[dict]:
     """Scan preseed log files for progress info."""
-    if not LOG_DIR.exists():
+    log_dir = _preseed_log_dir(ctx)
+    if not log_dir.exists():
         return []
 
     # Find the most recent batch of logs (same timestamp suffix)
-    log_files = sorted(LOG_DIR.glob("*.log"), key=lambda f: f.stat().st_mtime, reverse=True)
+    log_files = sorted(log_dir.glob("*.log"), key=lambda f: f.stat().st_mtime, reverse=True)
     if not log_files:
         return []
 
@@ -813,7 +839,7 @@ def _scan_preseed_logs() -> list[dict]:
         return []
 
     results = []
-    for lf in LOG_DIR.glob(f"*-{latest_ts}.log"):
+    for lf in log_dir.glob(f"*-{latest_ts}.log"):
         track = lf.name.replace(f"-{latest_ts}.log", "")
         stat = lf.stat()
 
@@ -855,10 +881,11 @@ def _scan_preseed_logs() -> list[dict]:
     return sorted(results, key=lambda r: r["track"])
 
 
-def _scan_track_progress(track: str) -> dict:
+def _scan_track_progress(ctx: MonitorContext, track: str) -> dict:
     """Count research files and check running processes for a track."""
+    curriculum_root = ctx.roots.curriculum_root
     try:
-        track_dir = safe_join(CURRICULUM_ROOT, track)
+        track_dir = safe_join(curriculum_root, track)
         research_dir = safe_join(track_dir, "research")
     except ValueError:
         return {
@@ -884,7 +911,7 @@ def _scan_track_progress(track: str) -> dict:
     # Count total expected from curriculum.yaml
     total_expected = 0
     try:
-        curriculum_yaml = CURRICULUM_ROOT / "curriculum.yaml"
+        curriculum_yaml = curriculum_root / "curriculum.yaml"
         if curriculum_yaml.exists():
             data = yaml.safe_load(curriculum_yaml.read_text()) or {}
             modules = data.get("levels", {}).get(track, {}).get("modules", [])
@@ -950,18 +977,18 @@ def _check_build_processes() -> list[dict]:
 
 
 @router.get("/batch-progress")
-async def batch_progress():
+async def batch_progress(ctx: MonitorContext = Depends(get_ctx)):
     """Live batch progress: logs + research files + running processes.
 
     This is the main endpoint for monitoring overnight/background builds.
     """
-    cache_key = f"comms_batch_progress_{LOG_DIR}_{PID_DIR}"
+    cache_key = f"comms_batch_progress_{_preseed_log_dir(ctx)}_{ctx.roots.pid_dir}"
     cached = cache_get(cache_key, ttl=10.0)
     if cached is not None:
         return cached
 
     logs, processes = await asyncio.gather(
-        asyncio.to_thread(_scan_preseed_logs),
+        asyncio.to_thread(_scan_preseed_logs, ctx),
         asyncio.to_thread(_check_build_processes),
     )
 
@@ -975,7 +1002,7 @@ async def batch_progress():
     # Scan each track's actual file progress
     track_progress = {}
     for track in sorted(all_tracks):
-        tp = await asyncio.to_thread(_scan_track_progress, track)
+        tp = await asyncio.to_thread(_scan_track_progress, ctx, track)
 
         # Find matching log
         log = next((l for l in logs if l["track"] == track), None)
@@ -1010,13 +1037,13 @@ async def batch_progress():
 
 
 @router.get("/batch-progress/{track}")
-async def batch_progress_track(track: str):
+async def batch_progress_track(track: str, ctx: MonitorContext = Depends(get_ctx)):
     """Detailed progress for one track."""
-    tp = await asyncio.to_thread(_scan_track_progress, track)
+    tp = await asyncio.to_thread(_scan_track_progress, ctx, track)
 
     # Get research file timeline (last 20 files)
     try:
-        research_dir = safe_join(CURRICULUM_ROOT, track, "research")
+        research_dir = safe_join(ctx.roots.curriculum_root, track, "research")
     except ValueError:
         return {**tp, "recent_files": []}
     timeline = []
@@ -1039,17 +1066,18 @@ async def batch_progress_track(track: str):
 # ==================== LIVE ACTIVITY ====================
 
 
-def _scan_live_activity(minutes: int = 15) -> list[dict]:
+def _scan_live_activity(ctx: MonitorContext, minutes: int = 15) -> list[dict]:
     """Scan legacy and v6 state files for live module-level activity."""
     now = time.time()
     cutoff = now - (minutes * 60)
     activities = []
+    curriculum_root = ctx.roots.curriculum_root
 
     # 1. Scan all orchestration state files modified recently
-    if not CURRICULUM_ROOT.is_dir():
+    if not curriculum_root.is_dir():
         return activities
 
-    for track_dir in CURRICULUM_ROOT.iterdir():
+    for track_dir in curriculum_root.iterdir():
         if not track_dir.is_dir():
             continue
         orch_dir = track_dir / "orchestration"
@@ -1125,16 +1153,17 @@ def _scan_live_activity(minutes: int = 15) -> list[dict]:
     return activities
 
 
-def _scan_recent_completions(minutes: int = 60) -> list[dict]:
+def _scan_recent_completions(ctx: MonitorContext, minutes: int = 60) -> list[dict]:
     """Scan research files created recently for a completion feed."""
     now = time.time()
     cutoff = now - (minutes * 60)
     completions = []
+    curriculum_root = ctx.roots.curriculum_root
 
-    if not CURRICULUM_ROOT.is_dir():
+    if not curriculum_root.is_dir():
         return completions
 
-    for track_dir in CURRICULUM_ROOT.iterdir():
+    for track_dir in curriculum_root.iterdir():
         if not track_dir.is_dir():
             continue
         research_dir = track_dir / "research"
@@ -1167,6 +1196,7 @@ async def live_activity(
     limit: int = Query(30, ge=1, le=500, description="Maximum recent broker dispatches"),
     since: str | None = Query(None, description="Only dispatches with timestamp > this ISO-8601 value"),
     cursor: int | None = Query(None, ge=1, description="Keyset cursor: return dispatches older than this id"),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """What's being built RIGHT NOW — module-level live feed.
 
@@ -1190,12 +1220,12 @@ async def live_activity(
     )
 
     acts, completions = await asyncio.gather(
-        asyncio.to_thread(_scan_live_activity, minutes),
-        asyncio.to_thread(_scan_recent_completions, 60),
+        asyncio.to_thread(_scan_live_activity, ctx, minutes),
+        asyncio.to_thread(_scan_recent_completions, ctx, 60),
     )
 
     # Also get recent broker messages for the dispatch feed
-    conn = _get_db()
+    conn = _get_db(ctx)
     dispatches = []
     rows = []
     if conn:
@@ -1310,12 +1340,12 @@ class ChannelPostRequest(BaseModel):
 
 
 @router.get("/channels")
-async def list_channels_endpoint():
+async def list_channels_endpoint(ctx: MonitorContext = Depends(get_ctx)):
     """List all channels with row counts and last activity.
 
     Read-only. Safe to poll from the frontend every few seconds.
     """
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return {"channels": [], "error": "Broker DB not found"}
 
@@ -1361,7 +1391,7 @@ async def list_channels_endpoint():
 
 
 @router.get("/channels/{name}")
-async def get_channel_endpoint(name: str):
+async def get_channel_endpoint(name: str, ctx: MonitorContext = Depends(get_ctx)):
     """Channel metadata + context preview + pending delivery count."""
     from scripts.ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — canonical identity (#6812)
 
@@ -1372,7 +1402,7 @@ async def get_channel_endpoint(name: str):
         # (CodeQL py/stack-trace-exposure).
         return JSONResponse(status_code=400, content={"error": "invalid_channel_name"})
 
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return JSONResponse(status_code=500, content={"error": "Broker DB not found"})
 
@@ -1425,9 +1455,10 @@ async def get_channel_endpoint(name: str):
 async def list_channel_messages(
     name: str,
     tail: int = Query(20, ge=1, le=500),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """Most recent messages in a channel, ordered oldest-first."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return JSONResponse(status_code=500, content={"error": "Broker DB not found"})
     try:
@@ -1479,9 +1510,9 @@ async def list_channel_messages(
 
 
 @router.get("/channels/{name}/threads/{thread_id}")
-async def get_thread(name: str, thread_id: str):
+async def get_thread(name: str, thread_id: str, ctx: MonitorContext = Depends(get_ctx)):
     """All messages in a thread, ordered by round_index then created_at."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return JSONResponse(status_code=500, content={"error": "Broker DB not found"})
     try:
@@ -1535,9 +1566,10 @@ async def channel_deliveries(
     name: str,
     status: str | None = Query(None, description="Filter by status"),
     limit: int = Query(50, ge=1, le=500),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """Delivery status for messages in a channel."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return JSONResponse(status_code=500, content={"error": "Broker DB not found"})
 
@@ -1595,9 +1627,14 @@ async def post_to_channel(name: str, req: ChannelPostRequest, request: Request):
     )
 
 @router.get("/by-module/{track}/{slug}")
-async def messages_by_module(track: str, slug: str, limit: int = 30):
+async def messages_by_module(
+    track: str,
+    slug: str,
+    limit: int = 30,
+    ctx: MonitorContext = Depends(get_ctx),
+):
     """Full communication trail for a module. Shows all broker messages where task_id contains the slug."""
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return JSONResponse(status_code=500, content={"error": "DB not available"})
 
@@ -1652,6 +1689,7 @@ def agent_activity(
         description="Comma-separated agent names. Defaults to core CLI + desktop agents.",
     ),
     limit: int = Query(5, ge=1, le=25, description="Max recent rows per section."),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """Compact read-only channel activity snapshot for orchestrators.
 
@@ -1663,9 +1701,9 @@ def agent_activity(
     item 4) — this is the endpoint dashboards poll to see per-agent
     pending counts, so it doubles as the sweep's periodic trigger.
     """
-    _maybe_run_delivery_expiry_sweep()
+    _maybe_run_delivery_expiry_sweep(ctx)
     selected_agents = _parse_agent_csv(agents)
-    conn = _get_db()
+    conn = _get_db(ctx)
     if not conn:
         return _empty_agent_activity_response(
             selected_agents,
@@ -1758,6 +1796,7 @@ def agent_activity(
 def comms_inbox(
     agent: str = Query(..., description="Target agent name (e.g. 'claude', 'claude-infra', 'codex')."),
     limit: int = Query(10, ge=1, le=50, description="Max deliveries to return."),
+    ctx: MonitorContext = Depends(get_ctx),
 ):
     """Per-agent unread channel deliveries, oldest first.
 
@@ -1790,6 +1829,7 @@ def comms_inbox(
     ``ai_agent_bridge`` to actually drain messages.
     """
     try:
+        from scripts.ai_agent_bridge import _db as _bridge_db  # noqa: PLC0415 — optional broker bridge
         from scripts.ai_agent_bridge._channels import pending_deliveries_for  # noqa: PLC0415 — optional broker bridge
     except ImportError:
         return JSONResponse(
@@ -1797,6 +1837,15 @@ def comms_inbox(
             content={"error": "channel bridge not importable"},
         )
 
+    # ``_db.get_db()`` reads its own module-level DB_PATH, bound once from
+    # AB_DB_PATH at first import — it does not track this router's
+    # MonitorContext. Point it at the context's broker DB for the duration
+    # of the query so the bridge can never land on a different file than
+    # every other comms route (same save/restore discipline as the
+    # delivery-expiry sweep below).
+    message_db = ctx.roots.message_db_path
+    previous_db_path = _bridge_db.DB_PATH
+    _bridge_db.DB_PATH = message_db
     try:
         all_pending = pending_deliveries_for(agent)
     except ValueError as exc:
@@ -1812,6 +1861,8 @@ def comms_inbox(
             status_code=500,
             content={"error": "bridge query failed", "error_id": error_id},
         )
+    finally:
+        _bridge_db.DB_PATH = previous_db_path
 
     total = len(all_pending)
     truncated = total > limit
@@ -1845,10 +1896,12 @@ def comms_inbox(
 async def comms_v1_backlog(
     limit: int = Query(100, ge=1, le=500),
     exclude_retired: bool = Query(True),
+    ctx: MonitorContext = Depends(get_ctx),
 ) -> dict:
     """Pending delivery backlog (no message content). Sol PR-M."""
-    store = legacy_broker_store(reachable=MESSAGE_DB.is_file())
-    if not MESSAGE_DB.exists():
+    message_db = ctx.roots.message_db_path
+    store = legacy_broker_store(reachable=message_db.is_file())
+    if not message_db.exists():
         return {
             "response_schema_version": COMMS_RESPONSE_SCHEMA_VERSION,
             "total": 0,
@@ -1859,7 +1912,7 @@ async def comms_v1_backlog(
             "store": store,
         }
     payload = collect_delivery_backlog(
-        MESSAGE_DB, limit=limit, exclude_retired=exclude_retired
+        message_db, limit=limit, exclude_retired=exclude_retired
     )
     payload["response_schema_version"] = COMMS_RESPONSE_SCHEMA_VERSION
     payload["store"] = store
@@ -1868,10 +1921,14 @@ async def comms_v1_backlog(
 
 
 @router.get("/v1/dead-letters")
-async def comms_v1_dead_letters(limit: int = Query(100, ge=1, le=500)) -> dict:
+async def comms_v1_dead_letters(
+    limit: int = Query(100, ge=1, le=500),
+    ctx: MonitorContext = Depends(get_ctx),
+) -> dict:
     """Dead-letter inventory (metadata only). Sol PR-M."""
-    store = legacy_broker_store(reachable=MESSAGE_DB.is_file())
-    if not MESSAGE_DB.exists():
+    message_db = ctx.roots.message_db_path
+    store = legacy_broker_store(reachable=message_db.is_file())
+    if not message_db.exists():
         return {
             "response_schema_version": COMMS_RESPONSE_SCHEMA_VERSION,
             "total": 0,
@@ -1880,7 +1937,7 @@ async def comms_v1_dead_letters(limit: int = Query(100, ge=1, le=500)) -> dict:
             "db_missing": True,
             "store": store,
         }
-    payload = collect_dead_letters(MESSAGE_DB, limit=limit)
+    payload = collect_dead_letters(message_db, limit=limit)
     payload["response_schema_version"] = COMMS_RESPONSE_SCHEMA_VERSION
     payload["store"] = store
     payload["content_included"] = False
@@ -1888,17 +1945,18 @@ async def comms_v1_dead_letters(limit: int = Query(100, ge=1, le=500)) -> dict:
 
 
 @router.get("/v1/metrics")
-async def comms_v1_metrics() -> dict:
+async def comms_v1_metrics(ctx: MonitorContext = Depends(get_ctx)) -> dict:
     """Efficiency metrics from durable timestamps (no content). Sol PR-M."""
-    store = legacy_broker_store(reachable=MESSAGE_DB.is_file())
-    if not MESSAGE_DB.exists():
+    message_db = ctx.roots.message_db_path
+    store = legacy_broker_store(reachable=message_db.is_file())
+    if not message_db.exists():
         return {
             "response_schema_version": COMMS_RESPONSE_SCHEMA_VERSION,
             "content_included": False,
             "db_missing": True,
             "store": store,
         }
-    payload = collect_efficiency_metrics(MESSAGE_DB)
+    payload = collect_efficiency_metrics(message_db)
     payload["response_schema_version"] = COMMS_RESPONSE_SCHEMA_VERSION
     payload["store"] = store
     return payload

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -221,9 +221,9 @@ def _run_delivery_expiry_sweep(message_db: "os.PathLike[str]") -> None:
 
     # `_db.get_db()` reads its own module-level DB_PATH, bound once from
     # AB_DB_PATH at first import — it does not track this router's
-    # MESSAGE_DB. Point it at the exact same broker DB this router already
-    # resolved so the sweep can never land on a different file (this is
-    # also what makes the sweep respect test patches of MESSAGE_DB).
+    # MonitorContext. Point it at the exact same broker DB this router
+    # already resolved from the app's context so the sweep can never land
+    # on a different file.
     previous_db_path = _ch_db.DB_PATH
     _ch_db.DB_PATH = message_db
     try:

--- a/scripts/api/fleet_router.py
+++ b/scripts/api/fleet_router.py
@@ -21,7 +21,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from scripts.fleet_comms.cli import fleet_help_payload, fleet_status_payload
@@ -40,6 +40,7 @@ from scripts.orchestration import reap_worktrees
 
 from . import comms_router as legacy_comms
 from .config import LIVE_REPO_ROOT, PROJECT_ROOT
+from .monitor_context import MonitorContext, get_ctx
 from .runtime_router import get_acp_conversation, list_acp_conversations, recent_runtime_records
 
 router = APIRouter(tags=["fleet"])
@@ -762,14 +763,14 @@ def _non_negative_float(value: Any) -> float:
     return max(0.0, round(number, 1))
 
 
-def _legacy_broker_snapshot() -> dict[str, Any]:
+def _legacy_broker_snapshot(ctx: MonitorContext) -> dict[str, Any]:
     """Read the legacy broker with an explicit query-only connection.
 
     The legacy health route opens a normal connection so that it can report
     writability. This consolidated observer deliberately does not reuse that
     behavior: a GET must never create, migrate, or journal the broker database.
     """
-    db_path = Path(legacy_comms.MESSAGE_DB)
+    db_path = ctx.roots.message_db_path
     result: dict[str, Any] = {
         "availability": "db_missing",
         "db_exists": False,
@@ -777,7 +778,7 @@ def _legacy_broker_snapshot() -> dict[str, Any]:
         "size_kb": 0.0,
         "unacknowledged_depth": 0,
     }
-    if not db_path.is_file():
+    if db_path is None or not db_path.is_file():
         return result
 
     result["db_exists"] = True
@@ -914,9 +915,9 @@ def _safe_batch_projection(raw: Any) -> dict[str, Any]:
     }
 
 
-def _legacy_batch_snapshot() -> dict[str, Any]:
+def _legacy_batch_snapshot(ctx: MonitorContext) -> dict[str, Any]:
     """Collect the existing batch read models without populating their cache."""
-    logs = legacy_comms._scan_preseed_logs()
+    logs = legacy_comms._scan_preseed_logs(ctx)
     processes = legacy_comms._check_build_processes()
     all_tracks = {
         str(item.get("track"))
@@ -925,7 +926,7 @@ def _legacy_batch_snapshot() -> dict[str, Any]:
     }
     tracks: dict[str, dict[str, Any]] = {}
     for track in sorted(all_tracks):
-        progress = legacy_comms._scan_track_progress(track)
+        progress = legacy_comms._scan_track_progress(ctx, track)
         log = next(
             (item for item in logs if isinstance(item, dict) and item.get("track") == track),
             None,
@@ -961,13 +962,13 @@ def _legacy_batch_snapshot() -> dict[str, Any]:
 
 
 @router.get("/operations")
-async def fleet_operations() -> dict[str, Any]:
+async def fleet_operations(ctx: MonitorContext = Depends(get_ctx)) -> dict[str, Any]:
     """Sanitized legacy broker, zombie, and batch operations projection."""
     broker_result, process_result, zombie_result, batch_result = await asyncio.gather(
-        asyncio.to_thread(_legacy_broker_snapshot),
-        legacy_comms.active_processes(),
-        legacy_comms.detect_zombies(stale_hours=2.0, pingpong_threshold=5),
-        asyncio.to_thread(_legacy_batch_snapshot),
+        asyncio.to_thread(_legacy_broker_snapshot, ctx),
+        legacy_comms.active_processes(ctx=ctx),
+        legacy_comms.detect_zombies(stale_hours=2.0, pingpong_threshold=5, ctx=ctx),
+        asyncio.to_thread(_legacy_batch_snapshot, ctx),
         return_exceptions=True,
     )
 

--- a/tests/api/opsec_sweep/test_opsec_route_sweep.py
+++ b/tests/api/opsec_sweep/test_opsec_route_sweep.py
@@ -428,12 +428,15 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
     # stores outside ``scripts.api``. Repoint those module-level paths before
     # installing the global guard, so missing fixture state is handled by each
     # route's documented empty/read-only envelope instead of as a 500.
-    importlib.import_module("scripts.ai_agent_bridge._db")
+    # ``scripts.ai_agent_bridge`` is deliberately absent here (#7269 step 5):
+    # comms routes now hand the bridge the MonitorContext's broker DB
+    # explicitly, so the bridge's import-time default DB_PATH globals are no
+    # longer seams this sweep must repoint.
     importlib.import_module("scripts.fleet_comms.legacy_broker_report")
     importlib.import_module("scripts.telemetry.legacy_bridge")
     importlib.import_module("wiki.state")
     for module_name, module in tuple(sys.modules.items()):
-        if module is None or not module_name.startswith(("scripts.ai_agent_bridge", "scripts.telemetry", "wiki")):
+        if module is None or not module_name.startswith(("scripts.telemetry", "wiki")):
             continue
         for name, value in tuple(vars(module).items()):
             if not isinstance(value, Path) or not value.is_absolute():
@@ -461,6 +464,15 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
     monkeypatch.setattr(images_router, "_page_cache", images_router.OrderedDict())
     monkeypatch.setattr(images_router, "_pdf_page_count_cache", {})
 
+    # NOTE (#7269 step 5): the step-5 inventory row originally attributed
+    # this seam to comms_router, but its only sweep consumer is the
+    # still-unmigrated fleet facade route (fleet_router.py:598 ->
+    # build_legacy_broker_report -> default_routes_db()). Deleting it here
+    # was verified to fail the sweep with "GET /api/fleet/facade/broker-report
+    # status=500" on any machine whose primary checkout has a live
+    # data/telemetry/legacy_comms_routes.db (the deny-connect backstop
+    # correctly rejects the real-DB open). It migrates with step 4
+    # (fleet_router), not step 5.
     broker_report = importlib.import_module("scripts.fleet_comms.legacy_broker_report")
     monkeypatch.setattr(broker_report, "main_checkout_root", lambda _repo_root: root)
 
@@ -503,16 +515,20 @@ def isolated_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Isolate
     monkeypatch.setattr(docs_router, "DASHBOARDS_DIR", dashboards_root)
 
     # Facade/status readers retain imported references to the resolver;
-    # redirect every such reference and the resolver's own global into the
-    # disposable tree instead of consulting the retired local plane.
+    # redirect every such reference into the disposable tree instead of
+    # consulting the retired local plane. The resolver's own module global
+    # no longer needs a setattr seam (#7269 step 5): default_plane_root
+    # honors the documented FLEET_COMMS_ROOT operator override, which the
+    # migrated comms routes and every still-unmigrated internal caller
+    # (read_plane_status in fleet/runtime routers) resolve through.
     isolated_plane_root = root / "stores" / "fleet-comms"
     isolated_plane_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(isolated_plane_root))
 
     def isolated_plane_resolver(repo_root: Path | None = None) -> Path:
         del repo_root
         return isolated_plane_root
 
-    monkeypatch.setattr(message_plane, "default_plane_root", isolated_plane_resolver)
     monkeypatch.setattr(cold_start_board, "default_plane_root", isolated_plane_resolver)
     for module_name, module in tuple(sys.modules.items()):
         if not module_name.startswith("scripts.api") or module is None:

--- a/tests/api/test_app_factory.py
+++ b/tests/api/test_app_factory.py
@@ -30,12 +30,13 @@ DB_ACCESS_PATTERNS = (
 
 # The exact pre-migration inventory from design §4.1: 22 access sites in 21
 # unique files. Infrastructure files are listed too so the denominator cannot
-# silently shrink when the exemptions below are changed.
+# silently shrink when the exemptions below are changed. #7269 step 5 removed
+# scripts/api/comms_router.py deliberately: its routes now read every DB
+# through the app's MonitorContext DatabaseHandle (20 -> 19 files).
 DB_ACCESS_ALLOWLIST = frozenset(
     {
         "scripts/api/admin_router.py",
         "scripts/api/agent_monitor_router.py",
-        "scripts/api/comms_router.py",
         "scripts/api/dashboard_comms.py",
         "scripts/api/delegate_router.py",
         "scripts/api/discussions_router.py",
@@ -269,7 +270,7 @@ def test_step1_session_streams_cluster_isolation(tmp_path: Path) -> None:
 
 
 def test_db_access_patterns_have_the_step_one_allowlist() -> None:
-    assert len(DB_ACCESS_ALLOWLIST) == 20
+    assert len(DB_ACCESS_ALLOWLIST) == 19
     files = sorted((REPO_ROOT / "scripts/api").rglob("*.py"))
     files.append(REPO_ROOT / "agents_extensions/shared/session_streams/db.py")
     findings: list[str] = []

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -4,20 +4,34 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from scripts.api.monitor_context import DatabaseHandle, MonitorContext, fixture_context, production_context
 from scripts.fleet_comms.message_plane import read_plane_status
 from scripts.fleet_comms.migrations import MIGRATIONS, apply_migrations
 
 
-def _client() -> TestClient:
+def _message_ctx(root: Path, message_db: Path) -> MonitorContext:
+    """Fixture context whose broker DB is pinned to ``message_db``."""
+    ctx = fixture_context(root)
+    return replace(
+        ctx,
+        roots=replace(ctx.roots, message_db_path=message_db),
+        stores=replace(ctx.stores, message_db=DatabaseHandle(message_db, ctx._open_db)),
+    )
+
+
+def _client(ctx: MonitorContext | None = None) -> TestClient:
     from scripts.api.comms_router import router
 
     app = FastAPI()
+    # comms_router resolves all roots/stores from the app context (#7269
+    # step 5); a bare app must still carry the same state production sets.
+    app.state.ctx = ctx or production_context()
     app.include_router(router, prefix="/api/comms")
     return TestClient(app)
 
@@ -128,10 +142,8 @@ def test_api_plane_status_invalid_mode(monkeypatch, tmp_path: Path) -> None:
 
 def test_comms_v1_collectors_emit_store_not_db_path(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("scripts.api.comms_router.MESSAGE_DB", tmp_path / "missing.db")
-    client = _client()
+    client = _client(_message_ctx(tmp_path, tmp_path / "missing.db"))
     for path in ("/api/comms/v1/backlog", "/api/comms/v1/dead-letters", "/api/comms/v1/metrics"):
         response = client.get(path)
         assert response.status_code == 200
@@ -144,7 +156,6 @@ def test_comms_v1_collectors_emit_store_not_db_path(
 
 def test_comms_v1_collectors_with_seeded_broker(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker = tmp_path / "messages.db"
     conn = sqlite3.connect(broker)
@@ -171,8 +182,7 @@ def test_comms_v1_collectors_with_seeded_broker(
         """
     )
     conn.close()
-    monkeypatch.setattr("scripts.api.comms_router.MESSAGE_DB", broker)
-    client = _client()
+    client = _client(_message_ctx(tmp_path, broker))
     backlog = client.get("/api/comms/v1/backlog").json()
     dead = client.get("/api/comms/v1/dead-letters").json()
     metrics = client.get("/api/comms/v1/metrics").json()

--- a/tests/test_comms_router_expiry_sweep.py
+++ b/tests/test_comms_router_expiry_sweep.py
@@ -2,18 +2,20 @@
 
 The sweep is a lazy, codexbar-style background trigger hooked to
 GET /api/comms/agent-activity (scripts/api/comms_router.py). The critical
-property under test: it must operate on THIS router's own `MESSAGE_DB`
-(so it respects test patches and never diverges from what the router
-reports), and must NEVER touch `ai_agent_bridge`'s own default DB path —
-a real production risk since `ai_agent_bridge._db.get_db()` resolves its
-own DB_PATH independently and would silently create + migrate a fresh
-broker DB if ever pointed at a path that doesn't exist yet.
+property under test: it must operate on THIS router's own broker DB as
+resolved from the app's MonitorContext (so it respects fixture contexts
+and never diverges from what the router reports), and must NEVER touch
+``ai_agent_bridge``'s own default DB path — a real production risk since
+``ai_agent_bridge._db.get_db()`` resolves its own DB_PATH independently
+and would silently create + migrate a fresh broker DB if ever pointed at
+a path that doesn't exist yet.
 """
 
 from __future__ import annotations
 
 import sqlite3
 import sys
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -25,7 +27,18 @@ from scripts.ai_agent_bridge import _channels
 from scripts.ai_agent_bridge import _config as ab_config
 from scripts.ai_agent_bridge import _db as ab_db
 from scripts.api import comms_router
+from scripts.api.monitor_context import DatabaseHandle, MonitorContext, fixture_context
 from scripts.api.state_helpers import cache_invalidate
+
+
+def _message_ctx(root: Path, message_db: Path) -> MonitorContext:
+    """Fixture context whose broker DB is pinned to ``message_db``."""
+    ctx = fixture_context(root)
+    return replace(
+        ctx,
+        roots=replace(ctx.roots, message_db_path=message_db),
+        stores=replace(ctx.stores, message_db=DatabaseHandle(message_db, ctx._open_db)),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -43,8 +56,7 @@ def test_authority_mode_never_mutates_legacy_delivery_state(tmp_path, monkeypatc
     ids = _seed_channel_db(db_path)
     monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "authority")
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        comms_router._maybe_run_delivery_expiry_sweep()
+    comms_router._maybe_run_delivery_expiry_sweep(_message_ctx(tmp_path, db_path))
 
     assert comms_router._expire_sweep_thread is None
     assert _delivery_status(db_path, ids["stale_delivery_id"]) == "pending"
@@ -92,11 +104,10 @@ def test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db(tmp_path):
         real_default_db_path.read_bytes() if real_default_db_path.exists() else None
     )
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        comms_router._maybe_run_delivery_expiry_sweep()
-        assert comms_router._expire_sweep_thread is not None
-        comms_router._expire_sweep_thread.join(timeout=5)
-        assert not comms_router._expire_sweep_thread.is_alive()
+    comms_router._maybe_run_delivery_expiry_sweep(_message_ctx(tmp_path, db_path))
+    assert comms_router._expire_sweep_thread is not None
+    comms_router._expire_sweep_thread.join(timeout=5)
+    assert not comms_router._expire_sweep_thread.is_alive()
 
     assert _delivery_status(db_path, ids["stale_delivery_id"]) == "expired"
     assert _delivery_status(db_path, ids["dead_delivery_id"]) == "expired"
@@ -114,8 +125,7 @@ def test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db(tmp_path):
 
 def test_sweep_is_noop_when_message_db_missing(tmp_path):
     missing = tmp_path / "does-not-exist.db"
-    with patch.object(comms_router, "MESSAGE_DB", missing):
-        comms_router._maybe_run_delivery_expiry_sweep()
+    comms_router._maybe_run_delivery_expiry_sweep(_message_ctx(tmp_path, missing))
     assert comms_router._expire_sweep_thread is None
     assert not missing.exists()
 
@@ -129,8 +139,7 @@ def test_sweep_is_noop_when_channel_tables_missing(tmp_path):
     conn.commit()
     conn.close()
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        comms_router._maybe_run_delivery_expiry_sweep()
+    comms_router._maybe_run_delivery_expiry_sweep(_message_ctx(tmp_path, db_path))
 
     assert comms_router._expire_sweep_thread is None
     conn = sqlite3.connect(str(db_path))
@@ -180,8 +189,7 @@ def test_sweep_is_noop_on_pre_priority_column_schema(tmp_path):
     conn.commit()
     conn.close()
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        comms_router._maybe_run_delivery_expiry_sweep()
+    comms_router._maybe_run_delivery_expiry_sweep(_message_ctx(tmp_path, db_path))
 
     assert comms_router._expire_sweep_thread is None
     assert _delivery_status(db_path, "d1") == "pending"
@@ -197,14 +205,14 @@ def test_sweep_triggers_at_most_once_per_interval(tmp_path):
     db_path = tmp_path / "messages.db"
     _seed_channel_db(db_path)
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        comms_router._maybe_run_delivery_expiry_sweep()
-        first_thread = comms_router._expire_sweep_thread
-        first_thread.join(timeout=5)
+    ctx = _message_ctx(tmp_path, db_path)
+    comms_router._maybe_run_delivery_expiry_sweep(ctx)
+    first_thread = comms_router._expire_sweep_thread
+    first_thread.join(timeout=5)
 
-        comms_router._maybe_run_delivery_expiry_sweep()
-        # Cache still warm — no second thread spawned.
-        assert comms_router._expire_sweep_thread is first_thread
+    comms_router._maybe_run_delivery_expiry_sweep(ctx)
+    # Cache still warm — no second thread spawned.
+    assert comms_router._expire_sweep_thread is first_thread
 
 
 def test_agent_activity_endpoint_triggers_sweep(tmp_path):
@@ -215,15 +223,15 @@ def test_agent_activity_endpoint_triggers_sweep(tmp_path):
     ids = _seed_channel_db(db_path)
 
     app = FastAPI()
+    app.state.ctx = _message_ctx(tmp_path, db_path)
     app.include_router(comms_router.router, prefix="/api/comms")
     client = TestClient(app)
 
-    with patch.object(comms_router, "MESSAGE_DB", db_path):
-        resp = client.get("/api/comms/agent-activity")
-        assert resp.status_code == 200
-        thread = comms_router._expire_sweep_thread
-        assert thread is not None
-        thread.join(timeout=5)
+    resp = client.get("/api/comms/agent-activity")
+    assert resp.status_code == 200
+    thread = comms_router._expire_sweep_thread
+    assert thread is not None
+    thread.join(timeout=5)
 
     assert _delivery_status(db_path, ids["stale_delivery_id"]) == "expired"
     assert _delivery_status(db_path, ids["dead_delivery_id"]) == "expired"

--- a/tests/test_coverage_api_routers.py
+++ b/tests/test_coverage_api_routers.py
@@ -83,16 +83,19 @@ def _insert_messages(db_path, messages):
 
 @pytest.fixture()
 def _patch_config(mock_project_root, broker_db):
-    """Patch config module paths to use tmp_path."""
+    """Patch config module paths to use tmp_path.
+
+    comms_router itself keeps no path globals since #7269 step 5 — it
+    resolves everything from the app's MonitorContext — so steering comms
+    routes at the fixture root happens via ``app.state.ctx`` (see
+    ``comms_client`` and ``_comms_ctx``). The config patches below remain
+    for the routers that still read config directly (admin, images) and
+    for helpers that read ``scripts.api.config`` at call time.
+    """
     with (
         patch("scripts.api.config.PROJECT_ROOT", mock_project_root),
         patch("scripts.api.config.CURRICULUM_ROOT", mock_project_root / "curriculum" / "l2-uk-en"),
         patch("scripts.api.config.MESSAGE_DB", broker_db),
-        patch("scripts.api.comms_router.PROJECT_ROOT", mock_project_root),
-        patch("scripts.api.comms_router.CURRICULUM_ROOT", mock_project_root / "curriculum" / "l2-uk-en"),
-        patch("scripts.api.comms_router.MESSAGE_DB", broker_db),
-        patch("scripts.api.comms_router.PID_DIR", mock_project_root / ".mcp" / "servers" / "message-broker" / "pids"),
-        patch("scripts.api.comms_router.LOG_DIR", mock_project_root / "logs" / "research-preseed"),
         patch("scripts.api.admin_router.PROJECT_ROOT", mock_project_root),
         patch("scripts.api.admin_router.MESSAGE_DB", broker_db),
         patch("scripts.api.admin_router.BACKUP_DIR", mock_project_root / "data" / "backups"),
@@ -108,11 +111,30 @@ def _patch_config(mock_project_root, broker_db):
         yield
 
 
+def _comms_ctx(project_root, **root_overrides):
+    """Build the comms app context for the fixture root (#7269 step 5).
+
+    Same pattern as ``tests/test_comms_router_expiry_sweep.py``: a fixture
+    context whose roots all live under the test's project root.
+    ``root_overrides`` replace individual ``MonitorRoots`` fields (e.g.
+    ``pid_dir=Path("/nonexistent")``).
+    """
+    from dataclasses import replace
+
+    from scripts.api.monitor_context import fixture_context
+
+    ctx = fixture_context(project_root)
+    if root_overrides:
+        ctx = replace(ctx, roots=replace(ctx.roots, **root_overrides))
+    return ctx
+
+
 @pytest.fixture()
-def comms_client(_patch_config):
+def comms_client(_patch_config, mock_project_root):
     """TestClient for comms router."""
     from scripts.api.comms_router import router
     app = FastAPI()
+    app.state.ctx = _comms_ctx(mock_project_root)
     app.include_router(router, prefix="/api/comms")
     return TestClient(app)
 
@@ -170,8 +192,7 @@ class TestCommsMessages:
         """When DB doesn't exist, return empty with error."""
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/messages")
+        r = comms_client.get("/api/comms/messages")
         assert r.status_code == 200
         assert r.json()["error"] == "Broker DB not found"
 
@@ -259,8 +280,7 @@ class TestCommsConversations:
     def test_conversations_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/conversations")
+        r = comms_client.get("/api/comms/conversations")
         assert r.json()["conversations"] == []
 
     def test_conversations_grouped(self, comms_client, broker_db):
@@ -314,8 +334,7 @@ class TestCommsConversationDetail:
     def test_conversation_detail_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/conversation/task-X")
+        r = comms_client.get("/api/comms/conversation/task-X")
         assert r.json()["messages"] == []
 
     def test_conversation_not_found(self, comms_client, broker_db):
@@ -326,9 +345,9 @@ class TestCommsConversationDetail:
 class TestCommsActiveProcesses:
     """Tests for /api/comms/active-processes endpoint."""
 
-    def test_no_pid_dir(self, comms_client):
-        with patch("scripts.api.comms_router.PID_DIR", Path("/nonexistent")):
-            r = comms_client.get("/api/comms/active-processes")
+    def test_no_pid_dir(self, comms_client, mock_project_root):
+        comms_client.app.state.ctx = _comms_ctx(mock_project_root, pid_dir=Path("/nonexistent"))
+        r = comms_client.get("/api/comms/active-processes")
         assert r.json()["count"] == 0
 
     def test_with_pid_files(self, comms_client, mock_project_root):
@@ -387,11 +406,8 @@ class TestCommsZombies:
     def test_zombies_no_db_no_pids(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with (
-            patch("scripts.api.comms_router.MESSAGE_DB", db_path),
-            patch("scripts.api.comms_router.PID_DIR", Path("/nonexistent")),
-        ):
-            r = comms_client.get("/api/comms/zombies")
+        comms_client.app.state.ctx = _comms_ctx(mock_project_root, pid_dir=Path("/nonexistent"))
+        r = comms_client.get("/api/comms/zombies")
         assert r.json()["count"] == 0
 
     def test_stale_messages(self, comms_client, broker_db):
@@ -462,8 +478,7 @@ class TestCommsStats:
     def test_stats_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/stats")
+        r = comms_client.get("/api/comms/stats")
         assert r.json()["error"] == "Broker DB not found"
 
     def test_stats_with_data(self, comms_client, broker_db):
@@ -510,8 +525,7 @@ class TestCommsHealth:
     def test_health_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/health")
+        r = comms_client.get("/api/comms/health")
         data = r.json()
         assert data["db_exists"] is False
 
@@ -521,9 +535,9 @@ class TestCommsHealth:
         r = comms_client.get("/api/comms/health")
         assert r.json()["alive_processes"] == 1
 
-    def test_health_pid_dir_missing(self, comms_client):
-        with patch("scripts.api.comms_router.PID_DIR", Path("/nonexistent")):
-            r = comms_client.get("/api/comms/health")
+    def test_health_pid_dir_missing(self, comms_client, mock_project_root):
+        comms_client.app.state.ctx = _comms_ctx(mock_project_root, pid_dir=Path("/nonexistent"))
+        r = comms_client.get("/api/comms/health")
         assert r.json()["pid_dir_exists"] is False
 
 
@@ -597,11 +611,8 @@ class TestCommsActions:
     def test_cleanup_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with (
-            patch("scripts.api.comms_router.MESSAGE_DB", db_path),
-            patch("scripts.api.comms_router.PID_DIR", Path("/nonexistent")),
-        ):
-            r = comms_client.post("/api/comms/cleanup")
+        comms_client.app.state.ctx = _comms_ctx(mock_project_root, pid_dir=Path("/nonexistent"))
+        r = comms_client.post("/api/comms/cleanup")
         self._assert_retired(r, "legacy comms writes retired; use fleet-comms authority tooling")
 
     def test_acknowledge_message(self, comms_client, broker_db):
@@ -612,8 +623,7 @@ class TestCommsActions:
     def test_acknowledge_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.post("/api/comms/acknowledge/1")
+        r = comms_client.post("/api/comms/acknowledge/1")
         self._assert_retired(r, "legacy acknowledge retired; use fleet-comms delivery receipts")
 
     def test_send_message(self, comms_client, broker_db):
@@ -629,10 +639,9 @@ class TestCommsActions:
     def test_send_message_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.post("/api/comms/send", json={
-                "from_llm": "a", "to_llm": "b", "content": "c",
-            })
+        r = comms_client.post("/api/comms/send", json={
+            "from_llm": "a", "to_llm": "b", "content": "c",
+        })
         self._assert_retired(r, "legacy send retired; use fleet-comms authority")
 
     def test_send_message_defaults(self, comms_client, broker_db):
@@ -661,8 +670,7 @@ class TestCommsByModule:
     def test_by_module_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
         db_path.unlink()
-        with patch("scripts.api.comms_router.MESSAGE_DB", db_path):
-            r = comms_client.get("/api/comms/by-module/a1/greetings")
+        r = comms_client.get("/api/comms/by-module/a1/greetings")
         assert r.status_code == 500
 
     def test_by_module_no_matches(self, comms_client, broker_db):
@@ -1430,15 +1438,14 @@ class TestImagesHelpers:
 class TestCommsInternalHelpers:
     """Tests for internal helper functions in comms_router."""
 
-    def test_scan_preseed_logs_no_dir(self, _patch_config):
+    def test_scan_preseed_logs_no_dir(self, _patch_config, mock_project_root):
         from scripts.api.comms_router import _scan_preseed_logs
-        with patch("scripts.api.comms_router.LOG_DIR", Path("/nonexistent")):
-            result = _scan_preseed_logs()
+        result = _scan_preseed_logs(_comms_ctx(mock_project_root, logs_dir=Path("/nonexistent")))
         assert result == []
 
     def test_scan_preseed_logs_no_files(self, _patch_config, mock_project_root):
         from scripts.api.comms_router import _scan_preseed_logs
-        result = _scan_preseed_logs()
+        result = _scan_preseed_logs(_comms_ctx(mock_project_root))
         assert result == []
 
     def test_check_build_processes(self, _patch_config):
@@ -1456,7 +1463,7 @@ class TestCommsInternalHelpers:
 
     def test_scan_track_progress_no_dir(self, _patch_config, mock_project_root):
         from scripts.api.comms_router import _scan_track_progress
-        result = _scan_track_progress("nonexistent")
+        result = _scan_track_progress(_comms_ctx(mock_project_root), "nonexistent")
         assert result["research_done"] == 0
 
     def test_scan_track_progress_with_files(self, _patch_config, mock_project_root):
@@ -1464,7 +1471,7 @@ class TestCommsInternalHelpers:
         research_dir = mock_project_root / "curriculum" / "l2-uk-en" / "hist" / "research"
         research_dir.mkdir(parents=True)
         (research_dir / "topic-research.md").write_text("# Research")
-        result = _scan_track_progress("hist")
+        result = _scan_track_progress(_comms_ctx(mock_project_root), "hist")
         assert result["research_done"] == 1
         assert result["last_created"] is not None
         assert result["last_created"]["slug"] == "topic"
@@ -1614,7 +1621,7 @@ class TestCommsPreseedLogParsing:
             "Last meaningful line here\n"
         )
         (log_dir / "hist-20260301-0100.log").write_text(log_content)
-        result = _scan_preseed_logs()
+        result = _scan_preseed_logs(_comms_ctx(mock_project_root))
         assert len(result) == 1
         assert result[0]["passed"] == 1
         assert result[0]["failed"] == 2  # FAIL + ERROR
@@ -1625,5 +1632,5 @@ class TestCommsPreseedLogParsing:
         from scripts.api.comms_router import _scan_preseed_logs
         log_dir = mock_project_root / "logs" / "research-preseed"
         (log_dir / "random.log").write_text("no timestamp\n")
-        result = _scan_preseed_logs()
+        result = _scan_preseed_logs(_comms_ctx(mock_project_root))
         assert result == []

--- a/tests/test_fleet_observer_api.py
+++ b/tests/test_fleet_observer_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -11,14 +12,29 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import scripts.api.fleet_router as fleet_router
+from scripts.api.monitor_context import DatabaseHandle, MonitorContext, fixture_context
 from scripts.fleet_comms.migrations import MIGRATIONS, apply_migrations
 
 
 @pytest.fixture()
-def client() -> TestClient:
+def client(tmp_path: Path) -> TestClient:
     app = FastAPI()
+    # The /operations route resolves the broker DB and read-model roots from
+    # the app's MonitorContext (same as production); keep every root under the
+    # test's tmp_path unless a test pins a broker DB explicitly.
+    app.state.ctx = fixture_context(tmp_path)
     app.include_router(fleet_router.router, prefix="/api/fleet")
     return TestClient(app)
+
+
+def _broker_ctx(root: Path, broker_path: Path) -> MonitorContext:
+    """Fixture context whose legacy broker DB is pinned to ``broker_path``."""
+    ctx = fixture_context(root)
+    return replace(
+        ctx,
+        roots=replace(ctx.roots, message_db_path=broker_path),
+        stores=replace(ctx.stores, message_db=DatabaseHandle(broker_path, ctx._open_db)),
+    )
 
 
 @pytest.fixture()
@@ -810,9 +826,9 @@ def test_operations_projection_is_bounded_read_only_and_source_blind(
     finally:
         connection.close()
     before = broker_path.read_bytes()
-    monkeypatch.setattr(fleet_router.legacy_comms, "MESSAGE_DB", broker_path)
+    monkeypatch.setattr(client.app.state, "ctx", _broker_ctx(tmp_path, broker_path))
 
-    async def fake_processes() -> dict:
+    async def fake_processes(*, ctx: MonitorContext | None = None) -> dict:
         return {
             "alive": 2,
             "processes": [
@@ -820,7 +836,12 @@ def test_operations_projection_is_bounded_read_only_and_source_blind(
             ],
         }
 
-    async def fake_zombies(*, stale_hours: float, pingpong_threshold: int) -> dict:
+    async def fake_zombies(
+        *,
+        stale_hours: float,
+        pingpong_threshold: int,
+        ctx: MonitorContext | None = None,
+    ) -> dict:
         assert stale_hours == 2.0
         assert pingpong_threshold == 5
         return {
@@ -840,7 +861,7 @@ def test_operations_projection_is_bounded_read_only_and_source_blind(
             ],
         }
 
-    def fake_batches() -> dict:
+    def fake_batches(ctx: MonitorContext | None = None) -> dict:
         return {
             "generated_at": "2026-08-02T00:00:00Z",
             "running_processes": 3,
@@ -917,15 +938,15 @@ def test_operations_missing_store_does_not_create_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker_path = tmp_path / "missing" / "legacy-broker.db"
-    monkeypatch.setattr(fleet_router.legacy_comms, "MESSAGE_DB", broker_path)
+    monkeypatch.setattr(client.app.state, "ctx", _broker_ctx(tmp_path, broker_path))
 
-    async def empty_processes() -> dict:
+    async def empty_processes(*, ctx: MonitorContext | None = None) -> dict:
         return {"alive": 0, "processes": []}
 
     async def empty_zombies(**_kwargs: object) -> dict:
         return {"count": 0, "zombies": []}
 
-    def empty_batches() -> dict:
+    def empty_batches(ctx: MonitorContext | None = None) -> dict:
         return {"running_processes": 0, "tracks": {}}
 
     monkeypatch.setattr(fleet_router.legacy_comms, "active_processes", empty_processes)
@@ -950,12 +971,12 @@ def test_operations_dependency_outages_fail_as_sanitized_unavailable_sections(
 ) -> None:
     broker_path = tmp_path / "broken-broker.db"
     broker_path.write_bytes(b"not-a-sqlite-database private-outage-detail")
-    monkeypatch.setattr(fleet_router.legacy_comms, "MESSAGE_DB", broker_path)
+    monkeypatch.setattr(client.app.state, "ctx", _broker_ctx(tmp_path, broker_path))
 
     async def unavailable(*_args: object, **_kwargs: object) -> dict:
         raise RuntimeError("private dependency path and credential")
 
-    def unavailable_batch() -> dict:
+    def unavailable_batch(ctx: MonitorContext | None = None) -> dict:
         raise RuntimeError("private dependency path and credential")
 
     monkeypatch.setattr(fleet_router.legacy_comms, "active_processes", unavailable)
@@ -976,12 +997,14 @@ def test_operations_dependency_outages_fail_as_sanitized_unavailable_sections(
 
 
 def test_operations_batch_snapshot_reuses_uncached_read_models(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    ctx = fixture_context(tmp_path)
     monkeypatch.setattr(
         fleet_router.legacy_comms,
         "_scan_preseed_logs",
-        lambda: [
+        lambda ctx: [
             {
                 "track": "hist",
                 "complete": False,
@@ -999,7 +1022,7 @@ def test_operations_batch_snapshot_reuses_uncached_read_models(
     monkeypatch.setattr(
         fleet_router.legacy_comms,
         "_scan_track_progress",
-        lambda track: {
+        lambda ctx, track: {
             "track": track,
             "total_expected": 10,
             "research_done": 3,
@@ -1015,7 +1038,7 @@ def test_operations_batch_snapshot_reuses_uncached_read_models(
         lambda *_args, **_kwargs: pytest.fail("operations snapshot must not write cache state"),
     )
 
-    snapshot = fleet_router._legacy_batch_snapshot()
+    snapshot = fleet_router._legacy_batch_snapshot(ctx)
 
     assert snapshot["running_processes"] == 1
     assert snapshot["tracks"]["hist"]["health"] == "healthy"

--- a/tests/test_legacy_comms_telemetry.py
+++ b/tests/test_legacy_comms_telemetry.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 import stat
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from scripts.api import comms_router, telemetry_router
+from scripts.api.monitor_context import fixture_context
 from scripts.api.telemetry import legacy_comms
 
 
@@ -26,9 +28,14 @@ def telemetry_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 @pytest.fixture()
-def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, telemetry_db: Path):
-    monkeypatch.setattr(comms_router, "MESSAGE_DB", tmp_path / "missing-broker.db")
+def client(tmp_path: Path, telemetry_db: Path):
+    # comms_router resolves its broker DB from the app's MonitorContext
+    # (#7269 step 5); pin the context at a missing broker DB exactly like
+    # the old MESSAGE_DB patch did.
+    base = fixture_context(tmp_path)
+    ctx = replace(base, roots=replace(base.roots, message_db_path=tmp_path / "missing-broker.db"))
     app = FastAPI()
+    app.state.ctx = ctx
     app.include_router(comms_router.router, prefix="/api/comms")
     app.include_router(telemetry_router.router)
     with TestClient(app, raise_server_exceptions=False) as test_client:

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+from dataclasses import replace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -19,7 +20,7 @@ from fastapi.testclient import TestClient
 import scripts.api.main as api_main
 import scripts.api.rules_router as rules_router
 import scripts.api.state_router as state_router
-from scripts.api.monitor_context import fixture_context
+from scripts.api.monitor_context import DatabaseHandle, fixture_context
 
 client = TestClient(api_main.app, raise_server_exceptions=False)
 
@@ -481,8 +482,6 @@ def test_inbox_400_on_invalid_agent(monkeypatch):
 
 def test_agent_activity_summarizes_deliveries_and_events(monkeypatch, tmp_path):
     """The activity endpoint gives orchestrators one compact bridge snapshot."""
-    import scripts.api.comms_router as comms_router
-
     db_path = tmp_path / "messages.db"
     conn = sqlite3.connect(db_path)
     conn.executescript("""
@@ -588,7 +587,16 @@ def test_agent_activity_summarizes_deliveries_and_events(monkeypatch, tmp_path):
     conn.commit()
     conn.close()
 
-    monkeypatch.setattr(comms_router, "MESSAGE_DB", db_path)
+    # comms_router keeps no path globals since #7269 step 5 — it resolves
+    # its broker DB from the app's MonitorContext. Pin the context's message
+    # DB onto this fixture broker exactly like the old MESSAGE_DB patch did.
+    base_ctx = fixture_context(tmp_path)
+    broker_ctx = replace(
+        base_ctx,
+        roots=replace(base_ctx.roots, message_db_path=db_path),
+        stores=replace(base_ctx.stores, message_db=DatabaseHandle(db_path, base_ctx._open_db)),
+    )
+    monkeypatch.setattr(api_main.app.state, "ctx", broker_ctx)
 
     resp = client.get("/api/comms/agent-activity?agents=codex,gemini&limit=2")
     assert resp.status_code == 200

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 import sqlite3
 import time
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 import scripts.api.admin_router as admin_router
-import scripts.api.comms_router as comms_router
 import scripts.api.dashboard_comms as dashboard_comms
 import scripts.api.images_router as images_router
 import scripts.api.state_helpers as state_helpers
 from scripts.ai_agent_bridge import _db
 from scripts.api.main import app
+from scripts.api.monitor_context import DatabaseHandle, production_context
 from tests.latency_budget import assert_under_budget
 
 SAMPLE_COUNT = 3
@@ -249,7 +250,17 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
     broker_db = tmp_path / "messages.db"
     _init_broker_db(broker_db)
     monkeypatch.setattr(admin_router, "MESSAGE_DB", broker_db)
-    monkeypatch.setattr(comms_router, "MESSAGE_DB", broker_db)
+    # comms_router keeps no path globals since #7269 step 5 — it resolves
+    # its broker DB from the app's MonitorContext. Pin the context's message
+    # DB onto this smoke broker while keeping every other production root
+    # intact for the non-comms dashboards this test also exercises.
+    base_ctx = production_context()
+    broker_ctx = replace(
+        base_ctx,
+        roots=replace(base_ctx.roots, message_db_path=broker_db),
+        stores=replace(base_ctx.stores, message_db=DatabaseHandle(broker_db, base_ctx._open_db)),
+    )
+    monkeypatch.setattr(app.state, "ctx", broker_ctx)
     monkeypatch.setattr(dashboard_comms, "MESSAGE_DB", broker_db)
     monkeypatch.setattr(state_helpers, "MESSAGE_DB", broker_db)
     image_root = tmp_path / "textbook_images"


### PR DESCRIPTION
Fixes #7323 (step 5 of #7269). Migrates `scripts/api/comms_router.py` onto `MonitorContext`.

## Tests
`tests/test_comms_router_expiry_sweep.py tests/api/opsec_sweep/test_opsec_route_sweep.py` — 20 passed after rebase onto `origin/main`.

X-Agent: glm/fix-7269-step5-comms